### PR TITLE
Migrating existing references to session getters to use the useUser composable

### DIFF
--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -30,8 +30,8 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   const userRoles = [
     'admin',
@@ -44,6 +44,10 @@
 
   export default {
     name: 'AuthMessage',
+    setup() {
+      const { isUserLoggedIn } = useUser();
+      return { isUserLoggedIn };
+    },
     props: {
       authorizedRole: {
         type: String,
@@ -64,7 +68,6 @@
       },
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       detailsText() {
         return this.details || this.$tr(this.authorizedRole);
       },

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -58,6 +58,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { isTouchDevice } from 'kolibri.utils.browserInfo';
   import useUserSyncStatus from 'kolibri.coreVue.composables.useUserSyncStatus';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import AppBar from '../AppBar';
   import SideNav from '../SideNav';
   import ScrollingHeader from '../ScrollingHeader';
@@ -73,10 +74,12 @@
     setup() {
       const userDeviceStatus = useUserSyncStatus().deviceStatus;
       const { windowBreakpoint, windowIsSmall } = useKResponsiveWindow();
+      const { isAppContext } = useUser();
       return {
         userDeviceStatus,
         windowBreakpoint,
         windowIsSmall,
+        isAppContext,
       };
     },
     props: {
@@ -110,7 +113,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext', 'isPageLoading']),
+      ...mapGetters(['isPageLoading']),
       isAppContextAndTouchDevice() {
         return this.isAppContext && isTouchDevice;
       },

--- a/kolibri/core/assets/src/views/ExamReport/AttemptTextDiff.vue
+++ b/kolibri/core/assets/src/views/ExamReport/AttemptTextDiff.vue
@@ -10,10 +10,14 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'AttemptTextDiff',
+    setup() {
+      const { currentUserId } = useUser();
+      return { currentUserId };
+    },
     props: {
       correct: {
         type: Number,
@@ -29,7 +33,6 @@
       },
     },
     computed: {
-      ...mapGetters(['currentUserId']),
       isSecondPersonPerspective() {
         return this.userId === this.currentUserId;
       },

--- a/kolibri/core/assets/src/views/ExamReport/CurrentTryOverview.vue
+++ b/kolibri/core/assets/src/views/ExamReport/CurrentTryOverview.vue
@@ -100,12 +100,12 @@
   import get from 'lodash/get';
   import isPlainObject from 'lodash/isPlainObject';
   import isUndefined from 'lodash/isUndefined';
-  import { mapGetters } from 'vuex';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import MasteryModel from 'kolibri.coreVue.components.MasteryModel';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { tryValidator } from './utils';
 
   export default {
@@ -117,6 +117,10 @@
       MasteryModel,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { currentUserId } = useUser();
+      return { currentUserId };
+    },
     props: {
       // This should be an object with the following properties:
       // id: the unique id for the mastery log for this try
@@ -160,7 +164,6 @@
       },
     },
     computed: {
-      ...mapGetters(['currentUserId']),
       currentTryDefined() {
         return isPlainObject(this.currentTry);
       },

--- a/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptTextDiff.spec.js
+++ b/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptTextDiff.spec.js
@@ -1,15 +1,13 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import AttemptTextDiff from '../AttemptTextDiff.vue';
+
+jest.mock('kolibri.coreVue.composables.useUser');
 
 const renderComponent = props => {
   return render(AttemptTextDiff, {
     props,
-    store: {
-      getters: {
-        currentUserId: () => 'mockUser1',
-      },
-    },
   });
 };
 
@@ -59,6 +57,10 @@ const testCases = [
 ];
 
 describe('AttemptTextDiff', () => {
+  beforeAll(() => {
+    useUser.mockImplementation(() => useUserMock({ currentUserId: 'mockUser1' }));
+  });
+
   testCases.forEach(({ caseName, correct, diff, userId, expectedMessage }) => {
     test(caseName, () => {
       renderComponent({ correct, diff, userId });

--- a/kolibri/core/assets/src/views/NotificationsRoot.vue
+++ b/kolibri/core/assets/src/views/NotificationsRoot.vue
@@ -42,7 +42,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import Lockr from 'lockr';
   import { UPDATE_MODAL_DISMISSED } from 'kolibri.coreVue.vuex.constants';
   import { currentLanguage, defaultLanguage } from 'kolibri.utils.i18n';
@@ -50,6 +50,7 @@
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import AppError from 'kolibri-common/components/AppError';
   import GlobalSnackbar from 'kolibri-common/components/GlobalSnackbar';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import UpdateNotification from './UpdateNotification.vue';
 
   export default {
@@ -60,6 +61,14 @@
       AuthMessage,
       GlobalSnackbar,
       UpdateNotification,
+    },
+    setup() {
+      const { isAdmin, isSuperuser } = useUser();
+
+      return {
+        isAdmin,
+        isSuperuser,
+      };
     },
     props: {
       authorized: {
@@ -90,7 +99,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isAdmin', 'isSuperuser']),
       ...mapState({
         error: state => state.core.error,
         notifications: state => state.core.notifications,

--- a/kolibri/core/assets/src/views/TotalPoints.vue
+++ b/kolibri/core/assets/src/views/TotalPoints.vue
@@ -31,11 +31,16 @@
 <script>
 
   import { mapGetters, mapActions } from 'vuex';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'TotalPoints',
+    setup() {
+      const { currentUserId, isUserLoggedIn } = useUser();
+      return { currentUserId, isUserLoggedIn };
+    },
     computed: {
-      ...mapGetters(['totalPoints', 'currentUserId', 'isUserLoggedIn']),
+      ...mapGetters(['totalPoints']),
     },
     watch: {
       currentUserId() {

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -33,11 +33,16 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { mapGetters, mapActions, mapMutations } from 'vuex';
+  import { mapActions, mapMutations } from 'vuex';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'UpdateNotification',
     mixins: [commonCoreStrings],
+    setup() {
+      const { isSuperuser } = useUser();
+      return { isSuperuser };
+    },
     props: {
       id: {
         type: String,
@@ -64,9 +69,6 @@
       return {
         dontShowNotificationAgain: false,
       };
-    },
-    computed: {
-      ...mapGetters(['isSuperuser']),
     },
     methods: {
       ...mapMutations({

--- a/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
+++ b/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
@@ -1,8 +1,11 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import TotalPoints from '../TotalPoints.vue';
 import '@testing-library/jest-dom';
 
 let store, storeActions;
+
+jest.mock('kolibri.coreVue.composables.useUser');
 
 // Create a mock Vuex store with the required getters and actions
 // This is a helper function to avoid create a new store for each test and not reuse the same object
@@ -10,8 +13,6 @@ const getMockStore = () => {
   return {
     getters: {
       totalPoints: () => store.totalPoints,
-      currentUserId: () => store.currentUserId,
-      isUserLoggedIn: () => store.isUserLoggedIn,
     },
     actions: {
       fetchPoints: storeActions.fetchPoints,
@@ -28,18 +29,19 @@ const renderComponent = store => {
 
 describe('TotalPoints', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    useUser.mockImplementation(() => useUserMock());
     store = {
       totalPoints: 0,
-      currentUserId: 1,
-      isUserLoggedIn: false,
     };
+
     storeActions = {
       fetchPoints: jest.fn(),
     };
   });
 
   test('renders when user is logged in', async () => {
-    store.isUserLoggedIn = true;
+    useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
     store.totalPoints = 100;
     renderComponent(getMockStore());
 
@@ -48,7 +50,7 @@ describe('TotalPoints', () => {
   });
 
   test('does not render when user is not logged in', async () => {
-    store.isUserLoggedIn = false;
+    useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: false }));
     store.totalPoints = 100;
     renderComponent(getMockStore());
 
@@ -57,7 +59,7 @@ describe('TotalPoints', () => {
   });
 
   test('fetchPoints method is called on created', async () => {
-    store.isUserLoggedIn = true;
+    useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
     const mockedStore = getMockStore();
     renderComponent(mockedStore);
 
@@ -65,7 +67,7 @@ describe('TotalPoints', () => {
   });
 
   test('tooltip message is displayed correctly when the mouse hovers over the icon', async () => {
-    store.isUserLoggedIn = true;
+    useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
     store.totalPoints = 100;
     renderComponent(getMockStore());
 

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -2,10 +2,12 @@ import urls from 'kolibri.urls';
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import AuthMessage from '../../src/views/AuthMessage';
 import { stubWindowLocation } from 'testUtils'; // eslint-disable-line
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
+import AuthMessage from '../../src/views/AuthMessage';
 
 jest.mock('urls', () => ({}));
+jest.mock('kolibri.coreVue.composables.useUser');
 
 const localVue = createLocalVue();
 
@@ -15,14 +17,7 @@ localVue.use(VueRouter);
 const router = new VueRouter();
 
 function makeWrapper(options) {
-  const store = new Vuex.Store({
-    getters: {
-      isUserLoggedIn() {
-        return false;
-      },
-    },
-  });
-  return shallowMount(AuthMessage, { store, localVue, router, ...options });
+  return shallowMount(AuthMessage, { localVue, router, ...options });
 }
 
 // prettier-ignore
@@ -37,6 +32,8 @@ describe('auth message component', () => {
   stubWindowLocation(beforeAll, afterAll);
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    useUser.mockImplementation(() => useUserMock());
     window.location.href = 'http://localhost:8000/#/test_url';
   });
 
@@ -125,14 +122,8 @@ describe('auth message component', () => {
   });
 
   it('does not show a link if the user is logged in', () => {
-    const store = new Vuex.Store({
-      getters: {
-        isUserLoggedIn() {
-          return true;
-        },
-      },
-    });
-    const wrapper = makeWrapper({ store });
+    useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
+    const wrapper = makeWrapper();
     expect(wrapper.find('kexternallink-stub').exists()).toBe(false);
   });
 });

--- a/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
+++ b/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
@@ -23,7 +23,7 @@ export default function useCoreCoach(store) {
     // Using coachStrings.$tr() here because mixins are not applied
     // prior to props being processed.
     const { facility_id, name } = store.state.classSummary;
-    if (facility_id && store.state.core.facilities.length > 1 && isSuperuser) {
+    if (facility_id && store.state.core.facilities.length > 1 && get(isSuperuser)) {
       const match = find(store.state.core.facilities, { id: facility_id }) || {};
       facilityName = match.name;
     }

--- a/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
+++ b/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
@@ -3,6 +3,7 @@ import logger from 'kolibri.lib.logging';
 import { get } from '@vueuse/core';
 import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
 import { currentLanguage, isRtl } from 'kolibri.utils.i18n';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { coachStrings } from '../views/common/commonCoachStrings';
 
 const logging = logger.getLogger(__filename);
@@ -15,13 +16,14 @@ export default function useCoreCoach(store) {
   const authorized = computed(() => store.getters.userIsAuthorizedForCoach);
   const classId = computed(() => get(route).params.classId);
   const groups = computed(() => store.getters['classSummary/groups']);
+  const { isSuperuser } = useUser();
 
   function getAppBarTitle() {
     let facilityName;
     // Using coachStrings.$tr() here because mixins are not applied
     // prior to props being processed.
     const { facility_id, name } = store.state.classSummary;
-    if (facility_id && store.state.core.facilities.length > 1 && store.getters.isSuperuser) {
+    if (facility_id && store.state.core.facilities.length > 1 && isSuperuser) {
       const match = find(store.state.core.facilities, { id: facility_id }) || {};
       facilityName = match.name;
     }

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -14,7 +14,7 @@ export function useGroups() {
   async function showGroupsPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      useUser().isSuperuser && store.state.core.facilities.length === 0
+      useUser().isSuperuser.value && store.state.core.facilities.length === 0
         ? store.dispatch('getFacilities').catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -1,6 +1,7 @@
 import { ref } from 'kolibri.lib.vueCompositionApi';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { LearnerGroupResource, FacilityUserResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 // Place outside the function to keep the state
 const groupsAreLoading = ref(false);
@@ -13,7 +14,7 @@ export function useGroups() {
   async function showGroupsPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      store.getters.isSuperuser && store.state.core.facilities.length === 0
+      useUser().isSuperuser && store.state.core.facilities.length === 0
         ? store.dispatch('getFacilities').catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -1,5 +1,6 @@
 import { ref } from 'kolibri.lib.vueCompositionApi';
 import { LearnerGroupResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { LessonsPageNames } from '../constants/lessonsConstants';
 
 // Place outside the function to keep the state
@@ -14,7 +15,7 @@ export function useLessons() {
   async function showLessonsRootPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      store.getters.isSuperuser && store.state.core.facilities.length === 0
+      useUser().isSuperuser && store.state.core.facilities.length === 0
         ? store.dispatch('getFacilities').catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -15,7 +15,7 @@ export function useLessons() {
   async function showLessonsRootPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      useUser().isSuperuser && store.state.core.facilities.length === 0
+      useUser().isSuperuser.value && store.state.core.facilities.length === 0
         ? store.dispatch('getFacilities').catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -41,6 +41,7 @@
 
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonCoach from './common';
   import CoachAppBarPage from './CoachAppBarPage';
 
@@ -51,6 +52,10 @@
       CoreTable,
     },
     mixins: [commonCoach, commonCoreStrings],
+    setup() {
+      const { facility_id, userIsMultiFacilityAdmin } = useUser();
+      return { facility_id, userIsMultiFacilityAdmin };
+    },
     props: {
       subtopicName: {
         type: String,
@@ -64,8 +69,8 @@
       },
     },
     beforeMount() {
-      if (!this.$store.getters.userIsMultiFacilityAdmin) {
-        const singleFacility = { id: this.$store.getters.userFacilityId };
+      if (!this.userIsMultiFacilityAdmin) {
+        const singleFacility = { id: this.facility_id };
         this.$router.replace(this.coachClassListPageLink(singleFacility));
       }
     },

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -65,10 +65,11 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
   import find from 'lodash/find';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames } from '../constants';
   import CoachAppBarPage from './CoachAppBarPage';
   import commonCoach from './common';
@@ -79,6 +80,10 @@
       CoachAppBarPage,
     },
     mixins: [commonCoach, commonCoreStrings],
+    setup() {
+      const { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin } = useUser();
+      return { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin };
+    },
     props: {
       subtopicName: {
         type: String,
@@ -87,7 +92,6 @@
       },
     },
     computed: {
-      ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach', 'userIsMultiFacilityAdmin']),
       ...mapState(['classList', 'dataLoading']),
       // Message that shows up when state.classList is empty
       emptyStateDetails() {

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -13,6 +13,7 @@ import MasteryModel from 'kolibri.coreVue.components.MasteryModel';
 import filter from 'lodash/filter';
 import get from 'lodash/get';
 import orderBy from 'lodash/orderBy';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { PageNames } from '../constants';
 import { LastPages } from '../constants/lastPagesConstants';
 import { STATUSES } from '../modules/classSummary/constants';
@@ -66,8 +67,15 @@ export default {
     TimeDuration,
   },
   mixins: [coachStringsMixin],
+  setup() {
+    const { isAdmin, isCoach, isSuperuser } = useUser();
+    return {
+      isAdmin,
+      isCoach,
+      isSuperuser,
+    };
+  },
   computed: {
-    ...mapGetters(['isAdmin', 'isCoach', 'isSuperuser']),
     ...mapState('classSummary', { classId: 'id', className: 'name' }),
     ...mapState('classSummary', [
       'adHocGroupsMap',

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -62,6 +62,7 @@
   import { mapGetters } from 'vuex';
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { ClassesPageNames } from '../../../../../../learn/assets/src/constants';
   import commonCoach from '../../common';
   import { LastPages } from '../../../constants/lastPagesConstants';
@@ -69,8 +70,12 @@
   export default {
     name: 'OverviewBlock',
     mixins: [commonCoach, commonCoreStrings],
+    setup() {
+      const { userIsMultiFacilityAdmin } = useUser();
+      return { userIsMultiFacilityAdmin };
+    },
     computed: {
-      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
+      ...mapGetters(['classListPageEnabled']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
       },
@@ -79,7 +84,7 @@
       },
       classListLink() {
         let facility_id;
-        if (this.$store.getters.userIsMultiFacilityAdmin) {
+        if (this.userIsMultiFacilityAdmin) {
           facility_id = this.$store.state.classSummary.facility_id;
         }
         return this.$router.getRoute('CoachClassListPage', { facility_id });

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
@@ -49,7 +49,7 @@
     created() {
       const initClassInfoPromise = this.$store.dispatch('initClassInfo', this.classId);
       const getFacilitiesPromise =
-        this.$store.getters.isSuperuser && this.$store.state.core.facilities.length === 0
+        this.isSuperuser && this.$store.state.core.facilities.length === 0
           ? this.$store.dispatch('getFacilities').catch(() => {})
           : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
@@ -36,6 +36,7 @@
   import isEqual from 'lodash/isEqual';
   import { LessonResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
   import CoachImmersivePage from '../../CoachImmersivePage';
   import AssignmentDetailsModal from '../assignments/AssignmentDetailsModal';
@@ -49,6 +50,10 @@
       ResourceListTable,
     },
     mixins: [coachStringsMixin, commonCoreStrings],
+    setup() {
+      const { isSuperuser } = useUser();
+      return { isSuperuser };
+    },
     props: {
       showResourcesTable: {
         type: Boolean,
@@ -96,7 +101,7 @@
         this.$route.params.classId,
       );
       const getFacilitiesPromise =
-        this.$store.getters.isSuperuser && this.$store.state.core.facilities.length === 0
+        this.isSuperuser && this.$store.state.core.facilities.length === 0
           ? this.$store.dispatch('getFacilities').catch(() => {})
           : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -117,6 +117,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonCoach from '../../common';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import CoachImmersivePage from '../../CoachImmersivePage';
@@ -149,8 +150,10 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
+      const { getUserPermissions } = useUser();
       return {
         windowIsSmall,
+        getUserPermissions,
       };
     },
     data() {
@@ -180,7 +183,6 @@
         'ancestors',
       ]),
       ...mapGetters('lessonSummary/resources', ['numRemainingSearchResults']),
-      ...mapGetters(['getUserPermissions']),
       toolbarRoute() {
         if (this.$route.query.last) {
           return this.$router.getRoute(this.$route.query.last);

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -29,6 +29,7 @@
 
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonCoach from '../common';
   import { PageNames } from '../../constants';
   import { LessonsPageNames } from '../../constants/lessonsConstants';
@@ -40,9 +41,11 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
+      const { userIsMultiFacilityAdmin } = useUser();
       return {
         saveTabsClick,
         wereTabsClickedRecently,
+        userIsMultiFacilityAdmin,
       };
     },
     props: {
@@ -57,7 +60,7 @@
       };
     },
     computed: {
-      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
+      ...mapGetters(['classListPageEnabled']),
       LessonsPageNames() {
         return LessonsPageNames;
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -31,6 +31,7 @@
 
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonCoach from '../common';
   import { REPORTS_TABS_ID, ReportsTabs } from '../../constants/tabsConstants';
   import { useCoachTabs } from '../../composables/useCoachTabs';
@@ -40,9 +41,11 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
+      const { userIsMultiFacilityAdmin } = useUser();
       return {
         saveTabsClick,
         wereTabsClickedRecently,
+        userIsMultiFacilityAdmin,
       };
     },
     props: {
@@ -61,7 +64,7 @@
       };
     },
     computed: {
-      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
+      ...mapGetters(['classListPageEnabled']),
       reportTitle() {
         return this.title || this.coachString('reportsLabel');
       },

--- a/kolibri/plugins/device/assets/src/composables/useContentTasks.js
+++ b/kolibri/plugins/device/assets/src/composables/useContentTasks.js
@@ -11,7 +11,7 @@ export default function useContentTasks() {
   }, 1000);
 
   function startTaskPolling() {
-    if (canManageContent) {
+    if (canManageContent.value) {
       polling.resume();
     }
   }

--- a/kolibri/plugins/device/assets/src/composables/useContentTasks.js
+++ b/kolibri/plugins/device/assets/src/composables/useContentTasks.js
@@ -1,15 +1,17 @@
 import { useIntervalFn } from '@vueuse/core';
 import { getCurrentInstance, onMounted, onUnmounted } from 'kolibri.lib.vueCompositionApi';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 export default function useContentTasks() {
   const $store = getCurrentInstance().proxy.$store;
+  const { canManageContent } = useUser();
 
   const polling = useIntervalFn(() => {
     $store.dispatch('manageContent/refreshTaskList');
   }, 1000);
 
   function startTaskPolling() {
-    if ($store.getters.canManageContent) {
+    if (canManageContent) {
       polling.resume();
     }
   }

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -21,13 +21,14 @@
 <script>
 
   import Cookies from 'js-cookie';
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
   import find from 'lodash/find';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { IsPinAuthenticated } from 'kolibri.coreVue.vuex.constants';
   import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import urls from 'kolibri.urls';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames } from '../constants';
 
   import PinAuthenticationModal from './PinAuthenticationModal';
@@ -40,6 +41,13 @@
       PinAuthenticationModal,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { isUserLoggedIn, userFacilityId } = useUser();
+      return {
+        isUserLoggedIn,
+        userFacilityId,
+      };
+    },
     data() {
       return {
         showModal: false,
@@ -47,7 +55,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'userFacilityId']),
       ...mapState(['authenticateWithPin', 'grantPluginAccess']),
       facilities() {
         return this.$store.state.core.facilities;

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -378,6 +378,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { checkCapability } from 'kolibri.utils.appCapabilities';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonDeviceStrings from '../commonDeviceStrings';
   import DeviceAppBarPage from '../DeviceAppBarPage';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
@@ -416,6 +417,7 @@
     },
     mixins: [commonCoreStrings, commonDeviceStrings],
     setup() {
+      const { isAppContext, isLearnerOnlyImport, isSuperuser } = useUser();
       const { canRestart, restart, restarting } = useDeviceRestart();
       const { plugins, fetchPlugins, togglePlugin } = usePlugins();
       const { windowIsSmall } = useKResponsiveWindow();
@@ -446,6 +448,9 @@
       }
 
       return {
+        isAppContext,
+        isLearnerOnlyImport,
+        isSuperuser,
         canRestart,
         restart,
         restarting,
@@ -492,7 +497,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext', 'isPageLoading', 'snackbarIsVisible', 'isLearnerOnlyImport']),
+      ...mapGetters(['isPageLoading', 'snackbarIsVisible']),
       ...mapGetters('deviceInfo', ['isRemoteContent']),
       InfoDescriptionColor() {
         return {
@@ -506,7 +511,7 @@
         return this.$store.getters.facilities;
       },
       isMultiFacilitySuperuser() {
-        return this.$store.getters.isSuperuser && this.facilities.length > 1;
+        return this.isSuperuser && this.facilities.length > 1;
       },
       languageOptions() {
         const languages = sortLanguages(Object.values(availableLanguages), currentLanguage).map(

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/RemoveFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/RemoveFacilityModal.vue
@@ -44,10 +44,15 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'RemoveFacilityModal',
     mixins: [commonCoreStrings, commonSyncElements],
+    setup() {
+      const { session } = useUser();
+      return { session };
+    },
     props: {
       facility: {
         type: Object,
@@ -78,7 +83,7 @@
         return this.formatNameAndId(this.facility.name, this.facility.id);
       },
       canRemove() {
-        return this.$store.state.core.session.facility_id !== this.facility.id;
+        return this.session.facility_id !== this.facility.id;
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -90,6 +90,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import DeviceAppBarPage from '../DeviceAppBarPage';
   import taskNotificationMixin from '../taskNotificationMixin';
   import useContentTasks from '../../composables/useContentTasks';
@@ -123,6 +124,8 @@
     mixins: [commonCoreStrings, taskNotificationMixin],
     setup() {
       useContentTasks();
+      const { isLearnerOnlyImport } = useUser();
+      return { isLearnerOnlyImport };
     },
     data() {
       return {
@@ -136,7 +139,6 @@
         'channelIsBeingDeleted',
         'managedTasks',
       ]),
-      ...mapGetters(['isLearnerOnlyImport']),
       ...mapState('manageContent/wizard', ['pageName']),
       ...mapState('manageContent', ['channelListLoading']),
       ...mapState({

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -71,6 +71,7 @@
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'UserGrid',
@@ -79,6 +80,10 @@
       CoreTable,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { currentUserId } = useUser();
+      return { currentUserId };
+    },
     props: {
       filterText: {
         type: String,
@@ -99,7 +104,7 @@
       },
     },
     computed: {
-      ...mapGetters(['facilities', 'currentUserId']),
+      ...mapGetters(['facilities']),
       emptyMessage() {
         return this.$tr('noUsersMatching', { searchFilter: this.filterText });
       },

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -39,9 +39,9 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { SelectDeviceForm, AddDeviceForm } from 'kolibri.coreVue.componentSets.sync';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
@@ -64,6 +64,10 @@
       SelectDeviceForm,
     },
     mixins: [commonSyncElements],
+    setup() {
+      const { isUserLoggedIn } = useUser();
+      return { isUserLoggedIn };
+    },
     props: {
       isOnMyOwnUser: {
         type: Boolean,
@@ -79,7 +83,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       importedFacility() {
         const [facility] = this.$store.state.core.facilities;
         if (facility && window.sessionStorage.getItem(facilityImported) === 'true') {

--- a/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
@@ -67,6 +67,7 @@
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import DeviceChannelResource from '../apiResources/deviceChannel';
   import useContentTasks from '../composables/useContentTasks';
   import { PageNames } from '../constants';
@@ -87,6 +88,8 @@
     },
     setup() {
       useContentTasks();
+      const { canManageContent } = useUser();
+      return { canManageContent };
     },
     data() {
       return {
@@ -107,7 +110,7 @@
       },
     },
     beforeMount() {
-      if (!this.$store.getters.canManageContent) {
+      if (!this.canManageContent) {
         return this.$router.replace(this.$router.getRoute('MANAGE_CONTENT_PAGE'));
       }
       this.fetchChannels()

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -122,6 +122,7 @@
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames } from '../../constants';
 
   export default {
@@ -137,6 +138,10 @@
       UserTypeDisplay,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { currentUserId } = useUser();
+      return { currentUserId };
+    },
     data() {
       return {
         devicePermissionsChecked: undefined,
@@ -146,7 +151,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isPageLoading', 'facilities', 'currentUserId']),
+      ...mapGetters(['isPageLoading', 'facilities']),
       ...mapState('userPermissions', ['user', 'permissions']),
       backRoute() {
         return { name: PageNames.MANAGE_PERMISSIONS_PAGE };

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -44,6 +44,7 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import cloneDeep from 'lodash/cloneDeep';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'AllFacilitiesPage',
@@ -57,6 +58,10 @@
       CoreTable,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { userIsMultiFacilityAdmin } = useUser();
+      return { userIsMultiFacilityAdmin };
+    },
     props: {
       subtopicName: {
         type: String,
@@ -65,7 +70,7 @@
       },
     },
     computed: {
-      ...mapGetters(['facilityPageLinks', 'userIsMultiFacilityAdmin']),
+      ...mapGetters(['facilityPageLinks']),
       facilities() {
         return this.$store.state.core.facilities;
       },

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -231,7 +231,8 @@
     setup() {
       const { windowIsMedium, windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
-      return { windowIsMedium, windowIsSmall, isAppContext };
+      const { userIsMultiFacilityAdmin } = useUser();
+      return { windowIsMedium, windowIsSmall, isAppContext, userIsMultiFacilityAdmin };
     },
     data() {
       return {
@@ -252,7 +253,7 @@
         'inSummaryCSVCreation',
         'firstLogDate',
       ]),
-      ...mapGetters(['activeFacilityId', 'userIsMultiFacilityAdmin', 'facilityPageLinks']),
+      ...mapGetters(['activeFacilityId', 'facilityPageLinks']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       // NOTE: We disable CSV file upload/download on embedded web views like the Mac
       // and Android apps

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -14,11 +14,16 @@
   import { mapGetters } from 'vuex';
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'FacilityAppBarPage',
     components: { AppBarPage },
     mixins: [commonCoreStrings],
+    setup() {
+      const { userIsMultiFacilityAdmin } = useUser();
+      return { userIsMultiFacilityAdmin };
+    },
     props: {
       appBarTitle: {
         type: String,
@@ -26,7 +31,7 @@
       },
     },
     computed: {
-      ...mapGetters(['userIsMultiFacilityAdmin', 'currentFacilityName']),
+      ...mapGetters(['currentFacilityName']),
       /* Returns the given appBarTitle prop if given, otherwise will return
          the facility label appropriate to whether there are multiple facilities
          and the current user is the correct kind of admin */

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -236,6 +236,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
@@ -291,7 +292,13 @@
     mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
-      return { windowIsSmall };
+      const { isAppContext, isSuperuser, userIsMultiFacilityAdmin } = useUser();
+      return {
+        windowIsSmall,
+        isAppContext,
+        isSuperuser,
+        userIsMultiFacilityAdmin,
+      };
     },
     data() {
       return {
@@ -312,12 +319,7 @@
         'facilityNameSaved',
         'facilityNameError',
       ]),
-      ...mapGetters([
-        'isAppContext',
-        'isSuperuser',
-        'userIsMultiFacilityAdmin',
-        'facilityPageLinks',
-      ]),
+      ...mapGetters(['facilityPageLinks']),
       ...mapGetters('facilityConfig', ['getFacilityDataLoading']),
       settingsList: () => settingsList,
       settingsHaveChanged() {

--- a/kolibri/plugins/facility/assets/src/views/FacilityIndex.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityIndex.vue
@@ -15,6 +15,7 @@
   import { mapGetters } from 'vuex';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames } from '../constants';
 
   export default {
@@ -23,8 +24,17 @@
       NotificationsRoot,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { isAdmin, isSuperuser, session } = useUser();
+
+      return {
+        isAdmin,
+        isSuperuser,
+        session,
+      };
+    },
     computed: {
-      ...mapGetters(['isAdmin', 'isSuperuser', 'activeFacilityId']),
+      ...mapGetters(['activeFacilityId']),
       pageName() {
         return this.$route.name;
       },
@@ -40,7 +50,7 @@
             return false;
           }
           // Admins can only see the facility they belong to
-          return this.$store.state.core.session.facility_id === this.activeFacilityId;
+          return this.session.facility_id === this.activeFacilityId;
         }
         return false;
       },

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -124,6 +124,7 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import orderBy from 'lodash/orderBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ClassCreateModal from './ClassCreateModal';
@@ -146,15 +147,17 @@
     mixins: [commonCoreStrings],
     setup() {
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
+      const { userIsMultiFacilityAdmin } = useUser();
       return {
         classToDelete,
         selectClassToDelete,
         clearClassToDelete,
+        userIsMultiFacilityAdmin,
       };
     },
     computed: {
       ...mapState('classManagement', ['modalShown', 'classes', 'dataLoading']),
-      ...mapGetters(['userIsMultiFacilityAdmin', 'facilityPageLinks']),
+      ...mapGetters(['facilityPageLinks']),
       Modals: () => Modals,
       sortedClassrooms() {
         return orderBy(this.classes, [classroom => classroom.name.toUpperCase()], ['asc']);

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -149,6 +149,7 @@
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import IdentifierTextbox from './IdentifierTextbox';
 
   export default {
@@ -169,6 +170,10 @@
       ExtraDemographics,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { currentUserId } = useUser();
+      return { currentUserId };
+    },
     data() {
       return {
         fullName: '',
@@ -190,7 +195,7 @@
       };
     },
     computed: {
-      ...mapGetters(['currentUserId', 'facilityConfig']),
+      ...mapGetters(['facilityConfig']),
       ...mapState('userManagement', ['facilityUsers']),
       formDisabled() {
         return this.status === 'BUSY';

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -119,6 +119,7 @@
   import UserTable from 'kolibri.coreVue.components.UserTable';
   import cloneDeep from 'lodash/cloneDeep';
   import PaginatedListContainerWithBackend from 'kolibri-common/components/PaginatedListContainerWithBackend';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ResetUserPasswordModal from './ResetUserPasswordModal';
@@ -142,6 +143,14 @@
       PaginatedListContainerWithBackend,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { currentUserId, isSuperuser, userIsMultiFacilityAdmin } = useUser();
+      return {
+        currentUserId,
+        isSuperuser,
+        userIsMultiFacilityAdmin,
+      };
+    },
     data() {
       return {
         selectedUser: null,
@@ -149,12 +158,7 @@
       };
     },
     computed: {
-      ...mapGetters([
-        'currentUserId',
-        'isSuperuser',
-        'userIsMultiFacilityAdmin',
-        'facilityPageLinks',
-      ]),
+      ...mapGetters(['facilityPageLinks']),
       ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount', 'dataLoading']),
       Modals: () => Modals,
       userKinds() {

--- a/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import FacilityAppBarPage from '../../src/views/FacilityAppBarPage';
 
 function makeWrapper({ propsData = {}, getters = {} }) {
@@ -16,8 +17,12 @@ function makeWrapper({ propsData = {}, getters = {} }) {
 }
 jest.mock('kolibri.urls');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('kolibri.coreVue.composables.useUser');
 
 describe('FacilityAppBarPage', function () {
+  beforeEach(() => {
+    useUser.mockImplementation(() => useUserMock());
+  });
   beforeAll(() => {
     useKResponsiveWindow.mockImplementation(() => ({
       windowIsSmall: false,
@@ -35,10 +40,10 @@ describe('FacilityAppBarPage', function () {
     });
     describe('the user is an admin of multiple facilities, and a current facility name is defined', () => {
       it("should return the string 'Facility – ' with the current facility name", () => {
+        useUser.mockImplementation(() => useUserMock({ userIsMultiFacilityAdmin: true }));
         const wrapper = makeWrapper({
           propsData: { appBarTitle: null },
           getters: {
-            userIsMultiFacilityAdmin: true,
             currentFacilityName: 'currentFacilityName',
           },
         });
@@ -49,9 +54,9 @@ describe('FacilityAppBarPage', function () {
   });
   describe('the user is not an admin of multiple facilities', () => {
     it('should return the value of appBarTitle prop when provided', () => {
+      useUser.mockImplementation(() => useUserMock({ userIsMultiFacilityAdmin: false }));
       const wrapper = makeWrapper({
         getters: {
-          userIsMultiFacilityAdmin: false,
           currentFacilityName: 'currentFacilityName',
         },
       });

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -10,6 +10,7 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import urls from 'kolibri.urls';
 import client from 'kolibri.client';
 import Vue from 'kolibri.lib.vue';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { currentDeviceData } from '../composables/useDevices';
 
 const downloadRequestsTranslator = createTranslator('DownloadRequests', {
@@ -127,7 +128,7 @@ export default function useDownloadRequests(store) {
     const data = {
       contentnode_id: contentNode.id,
       metadata,
-      source_id: store.getters.currentUserId,
+      source_id: useUser().currentUserId.value,
       source_instance_id: get(instanceId),
       reason: 'USER_INITIATED',
       facility: store.getters.currentFacilityId,

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -78,10 +78,10 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import ChannelThumbnail from './ChannelThumbnail';
 
   export default {
@@ -92,8 +92,11 @@
     },
     setup() {
       const { windowGutter } = useKResponsiveWindow();
+      const { isUserLoggedIn, isLearner } = useUser();
       return {
         windowGutter,
+        isUserLoggedIn,
+        isLearner,
       };
     },
     props: {
@@ -142,7 +145,6 @@
       },
     },
     computed: {
-      ...mapGetters(['isLearner', 'isUserLoggedIn']),
       overallHeight() {
         return 270;
       },

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -24,8 +24,9 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { setContentNodeProgress } from '../../composables/useContentNodeProgress';
   import useProgressTracking from '../../composables/useProgressTracking';
   import AssessmentWrapper from '../AssessmentWrapper';
@@ -48,6 +49,7 @@
         startTrackingProgress,
         stopTrackingProgress,
       } = useProgressTracking();
+      const { currentUserId } = useUser();
       return {
         progress,
         time_spent,
@@ -59,6 +61,7 @@
         updateContentSession,
         startTracking: startTrackingProgress,
         stopTracking: stopTrackingProgress,
+        currentUserId,
       };
     },
     props: {
@@ -74,7 +77,6 @@
       };
     },
     computed: {
-      ...mapGetters(['currentUserId']),
       ...mapState({
         fullName: state => state.core.session.full_name,
       }),

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -158,6 +158,7 @@
   import FocusTrap from 'kolibri.coreVue.components.FocusTrap';
   import { ContentNodeResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { currentDeviceData } from '../../composables/useDevices';
   import useDeviceSettings from '../../composables/useDeviceSettings';
   import useLearnerResources from '../../composables/useLearnerResources';
@@ -191,6 +192,7 @@
       const { genContentLinkKeepCurrentBackLink } = useContentLink();
       const { baseurl } = currentDeviceData();
       const { windowBreakpoint, windowHeight, windowWidth } = useKResponsiveWindow();
+      const { isAdmin, isCoach, isSuperuser } = useUser();
       return {
         baseurl,
         canAccessUnassignedContent,
@@ -199,6 +201,9 @@
         windowBreakpoint,
         windowHeight,
         windowWidth,
+        isAdmin,
+        isCoach,
+        isSuperuser,
       };
     },
     props: {
@@ -372,10 +377,7 @@
             ? this.contentNode.ancestors.slice(-2)[0].id
             : this.contentNode.parent,
           params: {
-            include_coach_content:
-              this.$store.getters.isAdmin ||
-              this.$store.getters.isCoach ||
-              this.$store.getters.isSuperuser,
+            include_coach_content: this.isAdmin || this.isCoach || this.isSuperuser,
             depth: fetchGrandparent ? 2 : 1,
             baseurl: this.baseurl,
           },

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -103,12 +103,13 @@
 <script>
 
   import get from 'lodash/get';
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import { ContentNodeResource } from 'kolibri.resources';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import router from 'kolibri.coreVue.router';
   import Modalities from 'kolibri-constants/Modalities';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { setContentNodeProgress } from '../composables/useContentNodeProgress';
   import useProgressTracking from '../composables/useProgressTracking';
   import useContentLink from '../composables/useContentLink';
@@ -158,6 +159,7 @@
         return Promise.resolve();
       };
       const { windowIsSmall } = useKResponsiveWindow();
+      const { isUserLoggedIn, currentUserId, full_name } = useUser();
       return {
         errored,
         progress,
@@ -173,6 +175,9 @@
         stopTracking: stopTrackingProgress,
         genContentLinkKeepCurrentBackLink,
         windowIsSmall,
+        isUserLoggedIn,
+        currentUserId,
+        full_name,
       };
     },
     props: {
@@ -204,13 +209,10 @@
         showCompletionModal: false,
         wasComplete: false,
         sessionReady: false,
+        fullName: this.full_name,
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'currentUserId']),
-      ...mapState({
-        fullName: state => state.core.session.full_name,
-      }),
       ...mapState(['showCompleteContentModal']),
       practiceQuiz() {
         return get(this, ['content', 'options', 'modality']) === Modalities.QUIZ;

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -19,8 +19,8 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import LearnAppBarPage from './LearnAppBarPage';
   import commonLearnStrings from './commonLearnStrings';
 
@@ -35,9 +35,14 @@
       LearnAppBarPage,
     },
     mixins: [commonLearnStrings],
-
+    setup() {
+      const { canManageContent, isLearner } = useUser();
+      return {
+        canManageContent,
+        isLearner,
+      };
+    },
     computed: {
-      ...mapGetters(['canManageContent', 'isLearner']),
       deviceContentUrl() {
         const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
         if (deviceContentUrl && this.canManageContent) {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -324,6 +324,7 @@
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import { annotateSections } from 'kolibri.utils.exams';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import ResourceSyncingUiAlert from '../ResourceSyncingUiAlert';
   import useProgressTracking from '../../composables/useProgressTracking';
   import { PageNames, ClassesPageNames } from '../../constants';
@@ -354,6 +355,7 @@
         startTrackingProgress,
         stopTrackingProgress,
       } = useProgressTracking();
+      const { currentUserId } = useUser();
       const { windowBreakpoint, windowIsMedium, windowIsLarge, windowIsSmall } =
         useKResponsiveWindow();
       const { quizSectionsLabel$, questionsLabel$ } = enhancedQuizManagementStrings;
@@ -371,6 +373,7 @@
         windowIsLarge,
         windowIsSmall,
         windowIsMedium,
+        currentUserId,
       };
     },
     data() {
@@ -562,7 +565,7 @@
             return this.router.replace({
               name: ClassesPageNames.EXAM_REPORT_VIEWER,
               params: {
-                userId: this.$store.getters.currentUserId,
+                userId: this.currentUserId,
                 examId: this.exam.id,
                 questionNumber: 0,
                 questionInteraction: 0,

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -94,11 +94,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import ProgressBar from '../ProgressBar';
   import commonLearnStrings from '../commonLearnStrings';
   import useDownloadRequests from '../../composables/useDownloadRequests';
@@ -115,7 +115,14 @@
     setup() {
       const { addDownloadRequest, downloadRequestMap, removeDownloadRequest } =
         useDownloadRequests();
-      return { addDownloadRequest, downloadRequestMap, removeDownloadRequest };
+      const { isLearner, isUserLoggedIn } = useUser();
+      return {
+        addDownloadRequest,
+        downloadRequestMap,
+        removeDownloadRequest,
+        isLearner,
+        isUserLoggedIn,
+      };
     },
     props: {
       contentNode: {
@@ -139,7 +146,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isLearner', 'isUserLoggedIn']),
       isTopic() {
         return !this.contentNode.is_leaf;
       },

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -58,13 +58,7 @@
     },
     setup() {
       const { full_name, user_id } = useUser();
-      return { full_name, user_id };
-    },
-    data() {
-      return {
-        userName: this.full_name,
-        userId: this.user_id,
-      };
+      return { userName: full_name, userId: user_id };
     },
     computed: {
       ...mapState('examReportViewer', [

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -42,6 +42,7 @@
   import { mapState } from 'vuex';
   import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames, ClassesPageNames } from '../constants';
 
   export default {
@@ -54,6 +55,16 @@
     components: {
       ExamReport,
       ImmersivePage,
+    },
+    setup() {
+      const { full_name, user_id } = useUser();
+      return { full_name, user_id };
+    },
+    data() {
+      return {
+        userName: this.full_name,
+        userId: this.user_id,
+      };
     },
     computed: {
       ...mapState('examReportViewer', [
@@ -69,8 +80,6 @@
         selectedInteractionIndex: state => state.interactionIndex,
       }),
       ...mapState({
-        userName: state => state.core.session.full_name,
-        userId: state => state.core.session.user_id,
         loading: state => state.core.loading,
       }),
       homePageLink() {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -12,9 +12,10 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import plugin_data from 'plugin_data';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { PageNames } from '../constants';
 
   export default {
@@ -22,8 +23,13 @@
     components: {
       NotificationsRoot,
     },
+    setup() {
+      const { isUserLoggedIn } = useUser();
+      return {
+        isUserLoggedIn,
+      };
+    },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       ...mapState({
         loading: state => state.core.loading,
       }),

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -169,7 +169,7 @@
   import useUser from 'kolibri.coreVue.composables.useUser';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import { ContentNodeResource } from 'kolibri.resources';
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import MeteredConnectionNotificationModal from 'kolibri-common/components/MeteredConnectionNotificationModal.vue';
   import appCapabilities, { checkCapability } from 'kolibri.utils.appCapabilities';
   import LearningActivityChip from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityChip.vue';
@@ -225,7 +225,14 @@
       const store = currentInstance.$store;
       const router = currentInstance.$router;
 
-      const { isUserLoggedIn, isCoach, isAdmin, isSuperuser } = useUser();
+      const {
+        isUserLoggedIn,
+        isCoach,
+        isAdmin,
+        isSuperuser,
+        canManageContent,
+        isLearnerOnlyImport,
+      } = useUser();
       const { allowDownloadOnMeteredConnection } = useDeviceSettings();
       const {
         searchTerms,
@@ -316,7 +323,7 @@
 
       function _showLibrary(baseurl) {
         return fetchChannels({ baseurl }).then(channels => {
-          if (!channels.length && !store.getters.isUserLoggedIn) {
+          if (!channels.length && isUserLoggedIn) {
             router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
             return;
           }
@@ -401,6 +408,8 @@
         rootNodesLoading,
         rootNodes,
         isUserLoggedIn,
+        canManageContent,
+        isLearnerOnlyImport,
       };
     },
     props: {
@@ -418,7 +427,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isLearnerOnlyImport', 'canManageContent']),
       ...mapState({
         welcomeModalVisibleState: 'welcomeModalVisible',
       }),

--- a/kolibri/plugins/learn/assets/src/views/StorageNotification.vue
+++ b/kolibri/plugins/learn/assets/src/views/StorageNotification.vue
@@ -58,7 +58,6 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { mapGetters } from 'vuex';
   import useUser from 'kolibri.coreVue.composables.useUser';
   import { useLocalStorage } from '@vueuse/core';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
@@ -75,7 +74,7 @@
       const local_storage_last_synced = useLocalStorage('last_synced', '');
       const local_storage_lastDownloadRemoved = useLocalStorage('last_download_removed', '');
 
-      const { isLearnerOnlyImport } = useUser();
+      const { isAdmin, isLearner, isLearnerOnlyImport, canManageContent } = useUser();
 
       const setLastSyncedValue = newLastSyncValue => {
         local_storage_last_synced.value = newLastSyncValue;
@@ -103,7 +102,10 @@
         deviceStatusSentiment,
         hasDownloads,
         lastDownloadRemoved,
+        isAdmin,
+        isLearner,
         isLearnerOnlyImport,
+        canManageContent,
         local_storage_last_synced,
         local_storage_lastDownloadRemoved,
         setLastSyncedValue,
@@ -117,7 +119,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isLearner', 'isAdmin', 'canManageContent']),
       message() {
         let message = '';
         if (this.isAdmin) {

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -21,10 +21,11 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import YourClasses from '../YourClasses';
   import { PageNames } from '../../constants';
   import commonLearnStrings from './../commonLearnStrings';
@@ -44,8 +45,13 @@
       LearnAppBarPage,
     },
     mixins: [commonCoreStrings, commonLearnStrings],
+    setup() {
+      const { isUserLoggedIn } = useUser();
+      return {
+        isUserLoggedIn,
+      };
+    },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       ...mapState('classes', ['classrooms']),
       ...mapState({
         loading: state => state.core.loading,

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -166,6 +166,7 @@
   import { validateUsername } from 'kolibri.utils.validators';
   import UiAutocompleteSuggestion from 'kolibri-design-system/lib/keen/UiAutocompleteSuggestion';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { ComponentMap } from '../../constants';
   import getUrlParameter from '../getUrlParameter';
   import AuthBase from '../AuthBase';
@@ -190,6 +191,10 @@
       UsersList,
     },
     mixins: [commonCoreStrings, commonUserStrings],
+    setup() {
+      const { isAppContext } = useUser();
+      return { isAppContext };
+    },
     data() {
       return {
         username: '',
@@ -208,7 +213,7 @@
       };
     },
     computed: {
-      ...mapGetters(['selectedFacility', 'isAppContext']),
+      ...mapGetters(['selectedFacility']),
       ...mapState('signIn', ['hasMultipleFacilities']),
       backToFacilitySelectionRoute() {
         const facilityRoute = this.$router.getRoute(ComponentMap.FACILITY_SELECT);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -1,19 +1,15 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import CreateAccount from '../index.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
+jest.mock('kolibri.coreVue.composables.useUser');
+
 const sendMachineEvent = jest.fn();
-function makeWrapper({ targetFacility, fullName } = {}) {
-  const store = new Vuex.Store({
-    getters: {
-      session: () => {
-        return { full_name: fullName };
-      },
-    },
-  });
+function makeWrapper({ targetFacility } = {}) {
   return mount(CreateAccount, {
     provide: {
       changeFacilityService: {
@@ -26,7 +22,6 @@ function makeWrapper({ targetFacility, fullName } = {}) {
       },
     },
     localVue,
-    store,
   });
 }
 
@@ -47,6 +42,7 @@ const setPasswordTextboxValue = (wrapper, value) => {
 describe(`ChangeFacility/CreateAccount`, () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useUser.mockImplementation(() => useUserMock());
   });
 
   it(`smoke test`, () => {
@@ -56,9 +52,9 @@ describe(`ChangeFacility/CreateAccount`, () => {
 
   it(`shows the message about creating a new account in the target facility
     that contains user's full name and the target facility name`, () => {
+    useUser.mockImplementation(() => useUserMock({ session: { full_name: 'Test User' } }));
     const wrapper = makeWrapper({
       targetFacility: { name: 'Test Facility' },
-      fullName: 'Test User',
     });
     expect(wrapper.text()).toContain(
       "New account for 'Test User' in 'Test Facility' learning facility",

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -54,12 +54,12 @@
 <script>
 
   import get from 'lodash/get';
-  import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonProfileStrings from '../../commonProfileStrings';
 
   export default {
@@ -76,6 +76,10 @@
       PrivacyLinkAndModal,
     },
     mixins: [commonCoreStrings, commonProfileStrings],
+    setup() {
+      const { session } = useUser();
+      return { session };
+    },
     inject: ['changeFacilityService', 'state'],
     data() {
       return {
@@ -89,7 +93,6 @@
       };
     },
     computed: {
-      ...mapGetters(['session']),
       description() {
         return this.$tr('description', {
           fullName: get(this.session, 'full_name', ''),

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreatePassword.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreatePassword.vue
@@ -44,10 +44,10 @@
 <script>
 
   import get from 'lodash/get';
-  import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'CreatePassword',
@@ -62,6 +62,10 @@
     },
     mixins: [commonCoreStrings],
     inject: ['changeFacilityService', 'state'],
+    setup() {
+      const { session } = useUser();
+      return { session };
+    },
     data() {
       return {
         formData: {
@@ -72,8 +76,6 @@
       };
     },
     computed: {
-      ...mapGetters(['session']),
-
       description() {
         return this.$tr('description', {
           username: get(this.session, 'username', ''),

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -22,7 +22,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { computed } from 'kolibri.lib.vueCompositionApi';
   import { interpret } from 'xstate';
-  import { mapGetters } from 'vuex';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { changeFacilityMachine } from '../../machines/changeFacilityMachine';
 
   export default {
@@ -34,6 +34,10 @@
     },
     components: { NotificationsRoot, ImmersivePage },
     mixins: [commonCoreStrings],
+    setup() {
+      const { session, getUserKind } = useUser();
+      return { session, getUserKind };
+    },
     data() {
       return {
         service: interpret(changeFacilityMachine),
@@ -52,7 +56,6 @@
     },
 
     computed: {
-      ...mapGetters(['session', 'getUserKind']),
       wrapperStyles() {
         return {
           maxWidth: '1064px',

--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -103,8 +103,8 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { isLearnerOnlyImport } = useUser();
-      return { isLearnerOnlyImport };
+      const { isLearnerOnlyImport, isLearner } = useUser();
+      return { isLearnerOnlyImport, isLearner };
     },
     data() {
       return {
@@ -121,7 +121,7 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig', 'isLearner']),
+      ...mapGetters(['facilityConfig']),
       formDisabled() {
         return this.status === 'BUSY';
       },

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -223,26 +223,32 @@
       const showPasswordModal = ref(false);
       const showLearnModal = ref(false);
       const { currentUser } = useCurrentUser();
-      const { isLearnerOnlyImport } = useUser();
+      const {
+        isLearnerOnlyImport,
+        getUserKind,
+        getUserPermissions,
+        isCoach,
+        isSuperuser,
+        userHasPermissions,
+        userFacilityId,
+      } = useUser();
       const { onMyOwnSetup } = useOnMyOwnSetup();
       return {
         currentUser,
         onMyOwnSetup,
         isLearnerOnlyImport,
+        getUserKind,
+        getUserPermissions,
+        isCoach,
+        isSuperuser,
+        userHasPermissions,
+        userFacilityId,
         showLearnModal,
         showPasswordModal,
       };
     },
     computed: {
-      ...mapGetters([
-        'facilityConfig',
-        'getUserKind',
-        'getUserPermissions',
-        'isCoach',
-        'isSuperuser',
-        'totalPoints',
-        'userHasPermissions',
-      ]),
+      ...mapGetters(['facilityConfig', 'totalPoints']),
       profileEditRoute() {
         return this.$router.getRoute(RoutesMap.PROFILE_EDIT);
       },
@@ -251,7 +257,7 @@
       },
       facilityName() {
         const match = find(this.$store.getters.facilities, {
-          id: this.$store.getters.userFacilityId,
+          id: this.userFacilityId,
         });
         return match ? match.name : '';
       },

--- a/kolibri/plugins/user_profile/assets/test/views/profile-page.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/profile-page.spec.js
@@ -2,6 +2,7 @@ import { FacilityUserResource } from 'kolibri.resources';
 import { mount, RouterLinkStub, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import ProfilePage from '../../src/views/ProfilePage';
 import makeStore from '../makeStore';
 import useOnMyOwnSetup, {
@@ -12,6 +13,7 @@ import useOnMyOwnSetup, {
 jest.mock('kolibri.resources');
 jest.mock('../../src/composables/useOnMyOwnSetup');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('kolibri.coreVue.composables.useUser');
 
 FacilityUserResource.fetchModel = jest.fn().mockResolvedValue({});
 
@@ -43,6 +45,7 @@ describe('profilePage component', () => {
     useKResponsiveWindow.mockImplementation(() => ({
       windowIsSmall: false,
     }));
+    useUser.mockImplementation(() => useUserMock());
   });
 
   it('smoke test', () => {

--- a/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
+++ b/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
@@ -32,12 +32,12 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
   import client from 'kolibri.client';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import appCapabilities, { checkCapability } from 'kolibri.utils.appCapabilities';
   import logger from 'kolibri.lib.logging';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   const logging = logger.getLogger(__filename);
 
@@ -51,6 +51,10 @@
   export default {
     name: 'MeteredConnectionNotificationModal',
     mixins: [commonCoreStrings],
+    setup() {
+      const { isSuperuser } = useUser();
+      return { isSuperuser };
+    },
     data() {
       return {
         Options,
@@ -62,7 +66,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isSuperuser']),
       displayMeteredConnectionWarning() {
         return (
           this.originalSettingDisallows &&

--- a/packages/kolibri-tools/test/fixtures/TestComponent.vue
+++ b/packages/kolibri-tools/test/fixtures/TestComponent.vue
@@ -77,16 +77,20 @@
 
   /* eslint-disable */
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
   import commonCoach from './common';
+  import useUser from 'kolibri.coreVue.composables.useUser';
 
   export default {
     name: 'TestComponent',
     mixins: [commonCoach, commonCoreStrings],
+    setup() {
+      const { isClassCoach, isFacilityCoach } = useUser();
+      return { isClassCoach, isFacilityCoach };
+    },
     computed: {
-      ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach']),
       ...mapState(['classList']),
       // Message that shows up when state.classList is empty
       emptyStateDetails() {

--- a/packages/kolibri-tools/test/fixtures/TestComponentScript.js
+++ b/packages/kolibri-tools/test/fixtures/TestComponentScript.js
@@ -12,16 +12,20 @@
 
 /* eslint-disable */
 
-import { mapGetters, mapState } from 'vuex';
+import { mapState } from 'vuex';
 import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 import urls from 'kolibri.urls';
 import commonCoach from './common';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 export default {
   name: 'TestComponent',
   mixins: [commonCoach, commonCoreStrings],
+  setup() {
+    const { isClassCoach, isFacilityCoach } = useUser();
+    return { isClassCoach, isFacilityCoach };
+  },
   computed: {
-    ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach']),
     ...mapState(['classList']),
     // Message that shows up when state.classList is empty
     emptyStateDetails() {

--- a/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
+++ b/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
@@ -16,6 +16,7 @@
 import { DevicePermissionsResource, FacilityUserResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { createTranslator } from 'kolibri.utils.i18n';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 const translator = createTranslator('UserPermissionToolbarTitles', {
   loading: 'Loading user permissions…',
@@ -67,7 +68,7 @@ export function showUserPermissionsPage(store, userId) {
   const stopLoading = () => store.commit('CORE_SET_PAGE_LOADING', false);
 
   // Don't request any data if not an Admin
-  if (!store.getters.isSuperuser) {
+  if (!useUser().isSuperuser.value) {
     setUserPermissionsState({ user: null, permissions: {} });
     setAppBarTitle(translator.$tr('goBackTitle'));
     stopLoading();


### PR DESCRIPTION
## Summary
This change migrates most references to session getters to the useUser composable in each of the plugins. Unit tests that depended on the session vuex module were also updated to use mocks of the composable. Otherwise, any changes that created failing tests were reverted.

## References
- #12203 

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
