### PR TITLE
Ensure skip to main content logic is working

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -28,6 +28,7 @@
     </ScrollingHeader>
 
     <div
+      id="main"
       class="main-wrapper"
       :style="wrapperStyles"
     >

--- a/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
+++ b/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
@@ -20,6 +20,7 @@
       />
     </ScrollingHeader>
     <div
+      id="main"
       class="main-wrapper"
       :style="wrapperStyles"
     >

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -1,10 +1,7 @@
 <template>
 
   <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
-    <div
-      id="main"
-      role="main"
-    >
+    <div role="main">
       <h1>
         {{ $tr('bookmarksHeader') }}
       </h1>

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -3,7 +3,6 @@
   <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
     <div
       v-if="!loading"
-      id="main"
       role="main"
     >
       <ResourceSyncingUiAlert

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -51,7 +51,6 @@
 
     <div
       v-else-if="!loading && content"
-      id="main"
       role="main"
       tabindex="-1"
       class="main"

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -4,7 +4,6 @@
     <KCircularLoader v-if="loading" />
     <div
       v-else
-      id="main"
       role="main"
     >
       <KBreadcrumbs

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -3,7 +3,6 @@
   <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
     <div
       v-if="!$store.state.core.loading"
-      id="main"
       role="main"
     >
       <KBreadcrumbs

--- a/kolibri/plugins/user_auth/assets/src/views/UserAuthLayout.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/UserAuthLayout.vue
@@ -27,7 +27,6 @@
 
       <div
         v-else
-        id="main"
         role="main"
         tabindex="-1"
         class="main"


### PR DESCRIPTION
## Summary
Adds `id=main` on the div immediately surrounding the `<slot/>` in AppBarPage where the index page goes. 

Note that this does not resolve some lingering semantic page structure issues where there are some ambiguous `<main>` elements in various plugins/pages, as the existing logic was not actually based on the HTML element but rather the id. My browser extension suggests that the addition of `id=main` on this div does not add additional `main` elements to the page that would be confusing (i.e. potentially multiple in a section, if a nested page already has an HTML `<main>`)

## Reviewer guidance
Does skip to main work in all plugins? 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
