### PR TITLE
Handle edge cases for resource selection in quizzes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -116,7 +116,11 @@
           zIndex: '4',
         }"
       >
-        {{ cannotSelectSomeTopicWarning$({ count: maxSectionQuestionOptions }) }}
+        {{
+          cannotSelectSomeTopicWarning$({
+            count: Math.max(maxSectionQuestionOptions, workingPoolUnusedQuestions),
+          })
+        }}
       </div>
 
       <ContentCardList


### PR DESCRIPTION
## Summary
* Ensure that a single exercise can always be selected when no exercises are selected.
* More prominently show the max selectable questions warning.


## References
Fixes [#12443](https://github.com/learningequality/kolibri/issues/12443)

## Reviewer guidance
Navigate to a folder in a channel that only has exercises that have more than 10 questions.
Change the number of questions to be selected to "1".
See that each individual resource is still selectable, but that select all is not shown, and the warning text is displayed.
Select one resource.
See that all other resources are now disabled for selection.
Scroll down through the folder, and see that the warning text is displayed 'stickily', so that the warning is displayed prominently. (Note, this may not work on all browsers, but is intended as a progressive enhancement where supported).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
