### PR TITLE
Fix pex filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,8 @@ dist: setrequirements writeversion staticdeps staticdeps-cext strip-staticdeps b
 	python setup.py bdist_wheel
 	ls -l dist
 
-read-whl-file-version:
-	python ./build_tools/read_whl_version.py ${whlfile} > kolibri/VERSION
-
 pex:
-	ls dist/*.whl | while read whlfile; do $(MAKE) read-whl-file-version whlfile=$$whlfile; pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python3; done
+	ls dist/*.whl | while read whlfile; do version=$$(python ./build_tools/read_whl_version.py $$whlfile); pex $$whlfile --disable-cache -o dist/kolibri-`echo $$version | sed 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python3; done
 
 i18n-extract-backend:
 	cd kolibri && python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*' --all

--- a/build_tools/read_whl_version.py
+++ b/build_tools/read_whl_version.py
@@ -1,16 +1,13 @@
-import logging
 import sys
 
 from pkginfo import Wheel
 
-logger = logging.getLogger(__name__)
-
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        logger.error("Usage: read_whl_version.py <whl_file>")
+        print("Usage: read_whl_version.py <whl_file>")  # noqa: T201
         sys.exit(1)
 
     whl_file = sys.argv[1]
     whl = Wheel(whl_file)
-    logger.info(whl.version)
+    print(whl.version)  # noqa: T201
     sys.exit(0)


### PR DESCRIPTION
## Summary
This appears to have been an inadvertent regression from our introduction of flake8-print - as the logging was not configured, the logging messages went nowhere. Reverts to print and adds noqa flags.

Removes reliance on writing to VERSION file which should only really be used for the whl file, and gets rid of intermediate make step.

## References
Fixes [#12440](https://github.com/learningequality/kolibri/issues/12440)

## Reviewer guidance
Does the pex file have a name? Does the name correlate to the names of the other assets? If so, all is well.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
