### PR TITLE
Update release flow for BCK prerelease and final release

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -160,6 +160,40 @@ jobs:
       with:
         path: 'dist/${{ matrix.filename }}'
         destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}'
+  bck_prerelease_gcs_upload:
+    name: Upload WHL file to Google Cloud Storage for BCK Pre-release
+    runs-on: ubuntu-latest
+    needs: [whl]
+    steps:
+    - name: Download WHL artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.whl.outputs.whl-file-name }}
+        path: dist
+    - name: Zip whl file
+      run: zip -j dist/kolibri.zip dist/${{ needs.whl.outputs.whl-file-name }}
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GH_UPLOADER_GCP_SA_CREDENTIALS }}'
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+    - name: Upload to BCK bucket
+      uses: 'google-github-actions/upload-cloud-storage@v2'
+      with:
+        path: 'dist/kolibri.zip'
+        destination: '${{ secrets.BCK_PRERELEASE_BUILD_ARTIFACT_GCS_BUCKET }}'
+        parent: false
+    - name: Unzip content static files from whl file
+      run: |
+        unzip -j dist/${{ needs.whl.outputs.whl-file-name }} 'kolibri/core/content/static/*' -d static
+        rm static/*.file_size
+        # Ungzip all .gz files in the static folder
+        for f in static/*.gz; do gunzip -f $f; done
+    - name: Upload content static files to BCK bucket
+      uses: 'google-github-actions/upload-cloud-storage@v2'
+      with:
+        path: 'static'
+        destination: '${{ secrets.STUDIO_BCK_CONTENT_STATIC_BUCKET }}'
   block_release_step:
   # This step ties to the release environment which requires manual approval
   # before it can execute. Once manual approval has been granted, the release is

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -5,6 +5,25 @@ on:
     types: [published]
 
 jobs:
+  latest_release:
+    name: Check if this release is the latest release
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest_release: ${{ steps.is_latest_release.outputs.result }}
+    steps:
+      - name: Check if the current release is the latest Kolibri release
+        id: is_latest_release
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+
+            const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+              owner: 'learningequality',
+              repo: 'kolibri',
+            });
+
+            return latestRelease.tag_name === '${{ github.event.release.tag_name }}';
   whl:
     name: Build WHL file
     uses: ./.github/workflows/build_whl.yml
@@ -221,9 +240,9 @@ jobs:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   bck_gcs_upload:
     name: Upload WHL file to Google Cloud Storage for BCK
-    if: ${{ !github.event.release.prerelease && github.event.release.name == 'latest'}}
+    needs: [block_release_step, whl, latest_release]
+    if: ${{ !github.event.release.prerelease && needs.latest_release.outputs.is_latest_release == 'true' }}
     runs-on: ubuntu-latest
-    needs: [block_release_step, whl]
     steps:
     - name: Download WHL artifact
       uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
* Updates the release flow to always release to a BCK prerelease bucket
* Also always adds assets to the global content static folder for use by BCK instances
* Updates the latest/final release workflow to properly check if this is the latest release, and then updates the production BCK bucket if so

## References
Fixes #12240

## Reviewer guidance
The only part of this I was really able to test was the unzipping and ungzipping of the assets into a folder, everything else I have had to do by thinking I got it right.

Particular things to pay attention to:
* Have I done the upload of the static folder to GCS correctly?
* Am I properly evaluating whether the current release tag that we are running the action for matches the tag of the latest release?
* Am I allowed to use an output from a `needs` job in an `if` conditional for the whole job? (I don't know, and Github Actions wouldn't tell me)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
