### PR TITLE
Adjust CSS for button layout in EQM

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -3,9 +3,9 @@
   <div>
     <KGrid :style="tabsWrapperStyles">
       <KGridItem
-        :layout4="{ span: 2 }"
+        :layout4="{ span: 4 }"
         :layout8="{ span: 5 }"
-        :layout12="{ span: 10 }"
+        :layout12="{ span: 8 }"
       >
         <TabsWithOverflow
           tabsId="quizSectionTabs"
@@ -51,15 +51,14 @@
       </KGridItem>
 
       <KGridItem
-        style="position: relative; right: 0; padding: 0 0.5em 0 1em; text-align: right"
-        :layout4="{ span: 2 }"
+        :layout4="{ span: 4 }"
         :layout8="{ span: 3 }"
-        :layout12="{ span: 2 }"
+        :layout12="{ span: 4 }"
+        class="add-more-button"
       >
         <KButton
           appearance="flat-button"
           icon="plus"
-          style="position: relative; right: 0; height: 3rem; padding: 0"
           @click="handleAddSection"
         >
           {{ addSectionLabel$() }}
@@ -503,7 +502,8 @@
         return {
           paddingTop: '1rem',
           borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
-          flexWrap: 'nowrap',
+          justifyContent: 'space-between',
+          // flexWrap: 'nowrap',
         };
       },
       tabs() {
@@ -820,6 +820,14 @@
     height: 3.25em !important;
     margin: 0;
     border-radius: 0 !important;
+  }
+
+  .add-more-button {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    height: 3rem;
+    padding: 0;
   }
 
   /deep/ .ui-menu {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -54,7 +54,7 @@
         :layout4="{ span: 4 }"
         :layout8="{ span: 3 }"
         :layout12="{ span: 4 }"
-        class="add-more-button"
+        class="add-more-button-container"
       >
         <KButton
           appearance="flat-button"
@@ -503,7 +503,6 @@
           paddingTop: '1rem',
           borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
           justifyContent: 'space-between',
-          // flexWrap: 'nowrap',
         };
       },
       tabs() {
@@ -822,7 +821,7 @@
     border-radius: 0 !important;
   }
 
-  .add-more-button {
+  .add-more-button-container {
     display: flex;
     flex-direction: row-reverse;
     align-items: center;


### PR DESCRIPTION
## Summary
Updates `KGrid` span and CSS so that long buttons will fit without being cut off

## References
Fixes [#12449](https://github.com/learningequality/kolibri/issues/12449)

## Reviewer guidance
In German, or another language where the button is longer, does it still fit on all screensizes without cutoff? Is the placement still correct across languages and screensizes (i.e. not additional regressions)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
