### PR TITLE
Adds loose pinning of dev docs requirements to ensure correct builds …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,13 @@ def process_docstring(app, what, name, obj, options, lines):
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "m2r", "notfound.extension"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "m2r",
+    "notfound.extension",
+    "sphinxcontrib.jquery",
+]
 
 linkcheck_ignore = [
     "https://groups.google.com/a/learningequality.org/forum/#!forum/dev"

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,9 +1,12 @@
 -r base.txt
 
 # These are for building the docs
-sphinx
+
+# Sphinx stack requires a version of requests that's incompatible with Morango, so downgrading
+sphinx>=6,<7
 sphinx-intl
-sphinx-rtd-theme
+# We want to ensure the latest version of sphinx-rtd-theme that has sphinxcontrib-jquery as a dependency
+sphinx-rtd-theme~=2.0
 sphinx-autobuild
 m2r
 sphinx-notfound-page


### PR DESCRIPTION
+ add required extension sphinxcontrib.jquery

## Summary

Tested locally and it fixes the issue :+1: 

## References

Fixes https://github.com/learningequality/kolibri/issues/12029

## Reviewer guidance

LMK if there is a build context I'm unaware of. I've assumed that this should build on Read the Docs and for a local developer.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
