### PR TITLE
Fix exam report question selection display

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -46,7 +46,7 @@
           <AttemptLogItem
             class="attempt-option"
             :isSurvey="isSurvey"
-            :attemptLog="attemptLogs[index]"
+            :attemptLog="attemptLogs[sections[currentSectionIndex].startQuestionNumber + index]"
             displayTag="span"
           />
         </template>


### PR DESCRIPTION
## Summary
* Question selection was using the local index within a section
* It was using this index to access an attemptlog from the global list
* Updates this to be the global index by adding the startQuestionNumber for the currently selected section

## References
Fixes #12464

## Reviewer guidance
Replicate the conditions in the issue, confirm that the display and select options for the question selector are now correct.

![Screenshot from 2024-07-17 09-19-11](https://github.com/user-attachments/assets/50d58ee1-ac7b-4f2d-870d-ae324203251d)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
