### PR TITLE
Clean up some deprecation warnings

### DIFF
--- a/kolibri/core/__init__.py
+++ b/kolibri/core/__init__.py
@@ -1,5 +1,0 @@
-"""TODO: Write something about this module (everything in the docstring
-enters the docs)
-
-"""
-default_app_config = "kolibri.core.apps.KolibriCoreConfig"

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -493,7 +493,7 @@ class UsernameAvailableView(views.APIView):
 
 class FacilityUsernameViewSet(ReadOnlyValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
-    filter_fields = ("facility",)
+    filterset_fields = ("facility",)
     search_fields = ("^username",)
 
     values = ("username",)
@@ -527,7 +527,7 @@ class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet)
     queryset = Membership.objects.all()
     serializer_class = MembershipSerializer
     filterset_class = MembershipFilter
-    filter_fields = ["user", "collection", "user_ids"]
+    filterset_fields = ["user", "collection", "user_ids"]
 
 
 class RoleFilter(FilterSet):
@@ -547,7 +547,7 @@ class RoleViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
     queryset = Role.objects.all()
     serializer_class = RoleSerializer
     filterset_class = RoleFilter
-    filter_fields = ["user", "collection", "kind", "user_ids"]
+    filterset_fields = ["user", "collection", "kind", "user_ids"]
 
 
 dataset_keys = [
@@ -771,7 +771,7 @@ class LearnerGroupViewSet(ValuesViewset):
     queryset = LearnerGroup.objects.all()
     serializer_class = LearnerGroupSerializer
 
-    filter_fields = ("parent",)
+    filterset_fields = ("parent",)
 
     values = ("id", "name", "parent", "user_ids")
 

--- a/kolibri/core/bookmarks/api.py
+++ b/kolibri/core/bookmarks/api.py
@@ -44,4 +44,4 @@ class BookmarksViewSet(ValuesViewset):
         KolibriAuthPermissionsFilter,
         DjangoFilterBackend,
     )
-    filter_fields = ("contentnode_id",)
+    filterset_fields = ("contentnode_id",)

--- a/kolibri/core/content/__init__.py
+++ b/kolibri/core/content/__init__.py
@@ -2,9 +2,6 @@ import mimetypes
 import os
 
 
-default_app_config = "kolibri.core.content.apps.KolibriContentConfig"
-
-
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
 # https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
 mimetypes.init(

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -231,7 +231,8 @@ class ContentManifest(object):
         return channel_data
 
     def _set_channel_data(self, channel_data):
-        assert isinstance(channel_data, ContentManifestChannelData)
+        if not isinstance(channel_data, ContentManifestChannelData):
+            raise TypeError("channel_data must be a ContentManifestChannelData")
         self._channels_dict.setdefault(channel_data.channel_id, {})[
             channel_data.channel_version
         ] = channel_data

--- a/kolibri/core/device/__init__.py
+++ b/kolibri/core/device/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "kolibri.core.device.apps.KolibriDeviceAppConfig"

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -28,7 +28,7 @@ class NetworkLocationViewSet(viewsets.ModelViewSet):
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.exclude(location_type=LocationTypes.Reserved)
     filter_backends = [DjangoFilterBackend]
-    filter_fields = [
+    filterset_fields = [
         "id",
         "subset_of_users_device",
         "instance_id",

--- a/kolibri/core/exams/api.py
+++ b/kolibri/core/exams/api.py
@@ -116,14 +116,14 @@ class ExamViewset(ValuesViewset):
             exam_queryset = instantiated_backend.filter_queryset(
                 self.request, exam_queryset, self
             )
-            # Do some special handling if the backend has a get_filter_class method
-            # this is required, as the get_filter_class makes an assertion based on
+            # Do some special handling if the backend has a get_filterset_class method
+            # this is required, as the get_filterset_class makes an assertion based on
             # the model Meta of the FilterSet - which is set to Exam, so this will
             # fail if we try to use the ExamFilter on the DraftExam queryset
             # This is a workaround to allow the DraftExam queryset to be filtered
-            if hasattr(instantiated_backend, "get_filter_class"):
+            if hasattr(instantiated_backend, "get_filterset_class"):
                 # First get the filter class using the exam queryset
-                filter_class = instantiated_backend.get_filter_class(
+                filter_class = instantiated_backend.get_filterset_class(
                     self, exam_queryset
                 )
                 # If the filter class is not None, then we can use it to filter the draft_queryset
@@ -136,7 +136,7 @@ class ExamViewset(ValuesViewset):
                         request=self.request,
                     ).qs
             else:
-                # If the backend doesn't have a get_filter_class method, then we can just
+                # If the backend doesn't have a get_filterset_class method, then we can just
                 # filter the draft_queryset as normal
                 draft_queryset = instantiated_backend.filter_queryset(
                     self.request, draft_queryset, self

--- a/kolibri/core/lessons/viewsets.py
+++ b/kolibri/core/lessons/viewsets.py
@@ -46,7 +46,7 @@ def _map_lesson_classroom(item):
 class LessonViewset(ValuesViewset):
     serializer_class = LessonSerializer
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend)
-    filter_fields = ("collection", "id")
+    filterset_fields = ("collection", "id")
     permission_classes = (LessonPermissions,)
     queryset = Lesson.objects.all().order_by("-date_created")
 

--- a/kolibri/core/logger/__init__.py
+++ b/kolibri/core/logger/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "kolibri.core.logger.apps.KolibriLoggerConfig"

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -36,7 +36,7 @@ class BulkDeleteMixin(object):
         """
         # Only let a bulk destroy if the queryset is being filtered by a valid filter_field parameter
         return any(
-            key in self.filter_fields for key in self.request.query_params.keys()
+            key in self.filterset_fields for key in self.request.query_params.keys()
         )
 
     def bulk_destroy(self, request, *args, **kwargs):

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -341,7 +341,7 @@ class SyncQueueAPIView(APIView):
 
 class FacilitySearchUsernameViewSet(BaseValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
-    filter_fields = ("facility",)
+    filterset_fields = ("facility",)
     search_fields = ("^username",)
 
     values = ("id", "username")

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.db.utils import DatabaseError
 from sqlalchemy import exc
+from sqlalchemy import text
 
 from kolibri.deployment.default.sqlite_db_names import NOTIFICATIONS
 
@@ -61,7 +62,7 @@ def check_sqlite_integrity(connection):
         conn = connection.cursor()
 
     try:
-        result = conn.execute("PRAGMA integrity_check;").fetchall()
+        result = conn.execute(text("PRAGMA integrity_check;")).fetchall()
     except (DatabaseError, exc.DatabaseError):
         raise
     finally:

--- a/kolibri/core/tasks/validation.py
+++ b/kolibri/core/tasks/validation.py
@@ -122,7 +122,6 @@ class JobValidator(serializers.Serializer):
             enqueue_args = value.pop("enqueue_args", {})
             value = self.validate(value)
             value["enqueue_args"] = enqueue_args
-            assert value is not None, ".validate() should return the validated data"
         except (ValidationError, DjangoValidationError) as exc:
             raise ValidationError(detail=serializers.as_serializer_error(exc))
 

--- a/kolibri/core/test/test_drf_mixins.py
+++ b/kolibri/core/test/test_drf_mixins.py
@@ -19,7 +19,7 @@ class LanguageViewSet(ModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     queryset = Language.objects.all()
     serializer_class = LanguageSerializer
-    filter_fields = ("id",)
+    filterset_fields = ("id",)
 
 
 class BulkDeleteView(BulkDeleteMixin, LanguageViewSet):

--- a/kolibri/plugins/app/api.py
+++ b/kolibri/plugins/app/api.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth import login
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.http import urlunquote
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException
@@ -70,7 +70,9 @@ class InitializeAppView(APIView):
                 logger.error(e)
         redirect_url = request.GET.get("next", "/")
         # Copied and modified from https://github.com/django/django/blob/stable/1.11.x/django/views/i18n.py#L40
-        if (redirect_url or not request.is_ajax()) and not is_safe_url(
+        if (
+            redirect_url or not request.is_ajax()
+        ) and not url_has_allowed_host_and_scheme(
             url=redirect_url,
             allowed_hosts={request.get_host()},
             require_https=request.is_secure(),
@@ -78,7 +80,7 @@ class InitializeAppView(APIView):
             redirect_url = request.META.get("HTTP_REFERER")
             if redirect_url:
                 redirect_url = urlunquote(redirect_url)  # HTTP_REFERER may be encoded.
-            if not is_safe_url(
+            if not url_has_allowed_host_and_scheme(
                 url=redirect_url,
                 allowed_hosts={request.get_host()},
                 require_https=request.is_secure(),


### PR DESCRIPTION
## Summary
The migration to Django 3.2 left some deprecation warnings, this cleans up the following:
* We no longer need to define the default app config in the app's __init__.py, Django automagically discovers it in the apps.py
* The DRF `filter_fields` has been deprecated in favour of `filterset_fields`
* Django will soon disallow objects that are not compatible with `copy.deepcopy()` from being set on the class object during `setUpTestData` - the workaround for this is to do it in `setUpClass`. If needed in `setUpTestData` as it is here, this is done prior to the super call (during which `setUpTestData` is called).
* DRF has deprecated the `get_filter_class` method in favour of `get_filterset_class` method
* SQLAlchemy has deprecated a large range of its API, especially around its ORM, so I have made numerous updates to our use of SQLAlchemy here, in line with https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings
* Removed our usage of most bare assert statements outside of tests, except where it was very clearly intended to be a developer only warning

## References
There is no open issue for this, I just got sick of seeing these warnings when running tests locally.

## Reviewer guidance
If tests all pass, this _should_ give some decent confidence - but I am targeting this to a patch release to defer the risk slightly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
