### PR TITLE
Fix KSelect overflow in exam page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -10,7 +10,7 @@
       <KGrid :gridStyle="gridStyle">
         <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
         <KGridItem
-          v-if="windowIsLarge"
+          v-if="showQuestionsList"
           ref="questionListWrapper"
           :layout12="{ span: 4 }"
           class="column-pane"
@@ -33,6 +33,7 @@
         <KGridItem
           :layout12="{ span: 8 }"
           class="column-pane"
+          :style="!showQuestionsList ? { overflow: 'unset' } : {}"
         >
           <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
             <KPageContainer
@@ -526,6 +527,9 @@
         return this.displayNavigationButtonLabel
           ? { position: 'relative', top: '3px', left: '-4px' }
           : {};
+      },
+      showQuestionsList() {
+        return this.windowIsLarge;
       },
     },
     watch: {


### PR DESCRIPTION
## Summary

Fix KSelect overflow in exam page. The question column had an `overflow-y: auto` set, which is only useful when we have multiple columns: the question list column and the question column on the page. But when the screen is small, and we only show a single column, its overflow can be handled by the immersive page, so it is safe to remove the overflowY in this case.

Before:
![image](https://github.com/user-attachments/assets/95d44f79-af0e-4d28-8a40-ad8e97346807)

After:
![image](https://github.com/user-attachments/assets/a69ba2ff-30b0-42e9-a72b-0f8fd046b646)


## References
Closes #12476

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
