### PR TITLE
Limit max questions per section to 25.

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -197,4 +197,4 @@ export const Presets = Object.freeze({
 
 // This should be kept in sync with the value in
 // kolibri/core/exams/constants.py
-export const MAX_QUESTIONS_PER_QUIZ_SECTION = 50;
+export const MAX_QUESTIONS_PER_QUIZ_SECTION = 25;

--- a/kolibri/core/exams/constants.py
+++ b/kolibri/core/exams/constants.py
@@ -1,3 +1,3 @@
 # This should be kept in sync with the value in
 # kolibri/core/assets/src/constants.js
-MAX_QUESTIONS_PER_QUIZ_SECTION = 50
+MAX_QUESTIONS_PER_QUIZ_SECTION = 25

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -687,7 +687,8 @@
           !workingPoolHasChanged.value ||
           workingPoolUnusedQuestions.value < questionCount.value ||
           questionCount.value < 1 ||
-          tooManyQuestions.value
+          tooManyQuestions.value ||
+          questionCount.value > maxQuestions.value
         );
       });
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -70,6 +70,7 @@
     </h5>
 
     <KRouterLink
+      v-if="showResourceButton"
       appearance="raised-button"
       :to="selectResourcesRoute"
       style="margin-bottom: 1em"
@@ -77,7 +78,9 @@
     >
       {{ resourceButtonLabel }}
     </KRouterLink>
-
+    <p v-else>
+      {{ maxQuestionsLabel }}
+    </p>
     <div class="bottom-navigation">
       <KButton
         :text="deleteSectionLabel$()"
@@ -128,6 +131,7 @@
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri.coreVue.vuex.constants';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import Draggable from 'kolibri.coreVue.components.Draggable';
   import DragContainer from 'kolibri.coreVue.components.DragContainer';
@@ -170,6 +174,7 @@
         addQuestionsLabel$,
         addMoreQuestionsLabel$,
         sectionDeletedNotification$,
+        maxNumberOfQuestions$,
       } = enhancedQuizManagementStrings;
 
       const {
@@ -279,6 +284,14 @@
         }
       });
 
+      const showResourceButton = computed(() => {
+        return activeQuestions.value.length < MAX_QUESTIONS_PER_QUIZ_SECTION;
+      });
+
+      const maxQuestionsLabel = computed(() => {
+        return maxNumberOfQuestions$({ count: MAX_QUESTIONS_PER_QUIZ_SECTION });
+      });
+
       return {
         reorderedSectionIndex,
         sectionTitleInvalidText,
@@ -309,6 +322,8 @@
         description,
         section_title,
         resourceButtonLabel,
+        showResourceButton,
+        maxQuestionsLabel,
         // Responsiveness
         windowIsLarge,
         windowIsSmall,


### PR DESCRIPTION
## Summary
* Limits max questions per section to 25
* Hides add more questions button in section editor when section already has the max number of questions

## Reviewer guidance
Does this make the learner and coach experience better?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
