### PR TITLE
stop infinite reloads

### DIFF
--- a/kolibri/core/templates/kolibri/loading_page.html
+++ b/kolibri/core/templates/kolibri/loading_page.html
@@ -103,11 +103,7 @@
         req.open('GET', latest_url, true);
         req.timeout = 1000;
         req.onload = function() {
-          if (this.status >= 200 && this.status < 400) {
-            location.reload();
-          } else {
-            setTimeout(retry, 2000);
-          }
+          setTimeout(retry, 2000);
         }
         req.ontimeout = function() {
           setTimeout(retry, 2000);


### PR DESCRIPTION
## Summary
Testing error pages on nginx, I could see the error page was blinking very fast. Kolibri logo didn't appear because of the fast reloading.
It happens that once the error page is loaded, status code=200, this was causing an infinite reload.
This PR removes the immediate reload and rely on a 2 seconds reload for all the cases



## Reviewer guidance
just loading kolibri/core/templates/kolibri/loading_page.html in the browser should be enough to test it


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
