### PR TITLE
Bug fixes discovered while investigating issues in change facility workflow

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeDifferentAccounts/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeDifferentAccounts/index.vue
@@ -24,7 +24,7 @@
       autocomplete="off"
       :label="coreString('usernameLabel')"
       :invalid="userDoesNotExist"
-      showInvalidText="true"
+      :showInvalidText="true"
       :invalidText="$tr('userDoesNotExist')"
       @input="userDoesNotExist = false"
       @keydown.enter="handleContinue"


### PR DESCRIPTION
## Summary
* Fixes warning shown because a prop was being passed as a text string `true` rather than boolean `true`
* Catches errors raised by trying to save a UserSessionLog for a user that has been deleted by the background mergeuser task

## References
Discovered while investigating #12486

## Reviewer guidance
This is just a prop fix and a defensive programming check, should be evaluable by code review.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
