### PR TITLE
set_as_super_user is a function param

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -198,7 +198,6 @@ def mergeuser(
         pass
 
     # check if current user should be set as superuser:
-    set_as_super_user = kwargs.get("set_as_super_user")
     if set_as_super_user and local_user.is_superuser:
         DevicePermissions.objects.create(
             user=remote_user, is_superuser=True, can_manage_content=True


### PR DESCRIPTION
## Summary

mergeuser function have `set_as_super_user` as a param, it's not in the kwargs dict


## References
Closes: 12486

## Reviewer guidance
Follow steps in #12486 to check if merged user has superadmin capabilities

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
