### PR TITLE
Restore preseeded database behaviour

### DIFF
--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -195,6 +195,10 @@ def sqlite_check_foreign_keys():
     ]
 
     for name in DATABASE_NAMES:
+        # Don't inadvertently create the database if
+        # it doesn't exist
+        if not os.path.exists(name):
+            continue
         db_connection = sqlite3.connect(name)
         with sqlite3.connect(name) as db_connection:
             cursor = db_connection.cursor()


### PR DESCRIPTION
## Summary
* Our sqlite foreign key integrity checks didn't first check if the database file existed
* So when the connection was opened, the file was created
* This was preventing the preseeded database setup from happening

## References
Helps to fix [#227](https://github.com/learningequality/kolibri-installer-android/issues/227)

## Reviewer guidance
Ensure when running kolibri in a fresh env, that database migrations don't happen, and instead it goes straight to setup.

Should also reduce loading times considerably for the Android app.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
