### PR TITLE
Nav alignment

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -8,7 +8,6 @@
       <SkipNavigationLink />
 
       <UiToolbar
-        :title="title"
         :removeNavIcon="showAppNavView"
         type="clear"
         textColor="black"
@@ -17,6 +16,10 @@
         :raised="false"
         :removeBrandDivider="true"
       >
+        <KTextTruncator
+          :text="windowIsSmall ? truncateText(title, 20) : truncateText(title, 50)"
+          :maxLines="1"
+        />
         <template
           v-if="!showAppNavView"
           #icon
@@ -235,6 +238,12 @@
         if ((event.key == 'Tab' || event.key == 'Escape') && this.pointsDisplayed) {
           this.pointsDisplayed = false;
         }
+      },
+      truncateText(value, maxLength) {
+        if (value && value.length > maxLength) {
+          return value.substring(0, maxLength) + '...';
+        }
+        return value;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -160,6 +160,7 @@
   .navbar-positioning {
     position: relative;
     display: flex;
+    align-items: center;
   }
 
 </style>


### PR DESCRIPTION
## Summary
Fixes the text truncation and alignment of nav bar elements


## References
Fixes #12282

|  Description | Screenshot  |
|---|---|
| Facility Small |  <img width="504" alt="Screenshot 2024-07-29 at 3 28 54 PM" src="https://github.com/user-attachments/assets/38d5c689-50b6-49b3-8d61-881dc07025e0"> |
| Coach Small | <img width="412" alt="Screenshot 2024-07-29 at 3 28 13 PM" src="https://github.com/user-attachments/assets/43105657-471c-4eb4-bb8f-18ce079a257f"> |
| Coach medium with overflow items | <img width="839" alt="Screenshot 2024-07-29 at 3 04 12 PM" src="https://github.com/user-attachments/assets/0eb9a2b9-15b2-4402-b8fa-1df33653f99d"> |


## Reviewer guidance
Choose a class with a long name, that also includes a facility (i.e. I tested with one that was imported and also had a class name)

- check in Coach and Facility on small, medium, and large screen sizes 
- ensure the text truncation is present and doesn't overlap with any other screen elements 
- ensure that the options button for the "overflow" of menu items is always present when needed and is not ever covered by anything else 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
