### PR TITLE
Allow management of learner sync on remote content enabled devices.

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -203,7 +203,6 @@
             :label="$tr('enableAutoDownload')"
             :checked="enableAutomaticDownload"
             :description="$tr('enableAutoDownloadDescription')"
-            :disabled="isRemoteContent"
             @change="handleCheckAutodownload('enableAutomaticDownload', $event)"
           />
           <div class="fieldset left-margin">
@@ -211,14 +210,12 @@
               :label="$tr('allowLearnersDownloadResources')"
               :checked="allowLearnerDownloadResources"
               :description="$tr('allowLearnersDownloadDescription')"
-              :disabled="isRemoteContent"
               @change="handleCheckAutodownload('allowLearnerDownloadResources', $event)"
             />
             <KCheckbox
               :label="$tr('setStorageLimit')"
               :checked="setLimitForAutodownload"
               :description="$tr('setStorageLimitDescription')"
-              :disabled="isRemoteContent"
               @change="handleCheckAutodownload('setLimitForAutodownload', $event)"
             />
             <div


### PR DESCRIPTION
## Summary
* Removes block on managing automatic syncing on devices that use the remote content option

## References
Fixes issue blocking toggling of this option on these devices

## Reviewer guidance
Does the automatic syncing functionality still display as enabled when the `Deployment` option `REMOTE_CONTENT` is set to `True`? Alternatively run with the env var `KOLIBRI_REMOTE_CONTENT=True`.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
