### PR TITLE
Add more error handling for facility user merging and facility deletion

### DIFF
--- a/kolibri/core/auth/permissions/general.py
+++ b/kolibri/core/auth/permissions/general.py
@@ -126,9 +126,12 @@ def _user_is_admin_for_own_facility(user, obj=None):
     if obj:
         if not hasattr(obj, "dataset_id") or not user.dataset_id == obj.dataset_id:
             return False
-
-    facility = Facility.objects.get(dataset_id=user.dataset_id)
-    return user.has_role_for_collection(role_kinds.ADMIN, facility)
+    try:
+        facility = Facility.objects.get(dataset_id=user.dataset_id)
+        return user.has_role_for_collection(role_kinds.ADMIN, facility)
+    except Facility.DoesNotExist:
+        # Handle the edge case where a facility has been deleted
+        return False
 
 
 class IsAdminForOwnFacility(BasePermissions):

--- a/kolibri/core/tasks/permissions.py
+++ b/kolibri/core/tasks/permissions.py
@@ -177,14 +177,6 @@ class IsAdminForJob(PermissionsFromAny):
         super(IsAdminForJob, self).__init__(IsSuperAdmin(), IsFacilityAdminForJob())
 
 
-class IsSelf(BasePermission):
-    def user_can_run_job(self, user, job):
-        return user.id == job.kwargs.get("local_user_id", None)
-
-    def user_can_read_job(self, user, job):
-        return user.id == job.kwargs.get("local_user_id", None)
-
-
 class NotProvisioned(BasePermission):
     def user_can_run_job(self, user, job):
         from kolibri.core.device.utils import device_provisioned

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -63,7 +63,7 @@
 <script>
 
   import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
-  import { get } from '@vueuse/core';
+  import { get, set } from '@vueuse/core';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
   import useUser from 'kolibri.coreVue.composables.useUser';
@@ -75,6 +75,7 @@
     setResumableContentNodes,
   } from '../../composables/useLearnerResources';
   import { setContentNodeProgress } from '../../composables/useContentNodeProgress';
+  import { inClasses } from '../../composables/useCoreLearn';
   import { PageNames } from '../../constants';
   import AssignedLessonsCards from '../classes/AssignedLessonsCards';
   import AssignedQuizzesCards from '../classes/AssignedQuizzesCards';
@@ -171,6 +172,9 @@
         return client({ url: urls['kolibri:kolibri.plugins.learn:homehydrate']() }).then(
           response => {
             setClasses(response.data.classrooms);
+            // Update our hydrated class membership boolean in case it has changed
+            // since the learn page was opened.
+            set(inClasses, Boolean(response.data.classrooms.length));
             setResumableContentNodes(
               response.data.resumable_resources.results || [],
               response.data.resumable_resources.more || null,

--- a/kolibri/plugins/user_profile/utils.py
+++ b/kolibri/plugins/user_profile/utils.py
@@ -13,6 +13,13 @@ class TokenGenerator(PasswordResetTokenGenerator):
       - expires the token after some seconds, instead of one day
     """
 
+    def _make_hash_value(self, user_id, timestamp):
+        """
+        Override the hash value to only need the user_id and timestamp
+        to allow us to calculate before we have imported the remote user.
+        """
+        return f"{user_id}{timestamp}"
+
     def make_token(self, user):
         """
         Returns a token that can be used for TOKEN_EXPIRE_LIMIT seconds

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -90,7 +90,7 @@ class LoginMergedUserViewset(APIView):
         pk = request.data.get("pk", None)
         token = request.data.get("token", None)
         new_user = FacilityUser.objects.get(pk=pk)
-        if not TokenGenerator().check_token(new_user, token):
+        if not TokenGenerator().check_token(new_user.id, token):
             return Response({"error": "Unauthorized"}, status=401)
         login(request, new_user)
         return Response({"success": True})

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
+setuptools
 -r base.txt
 ipdb==0.13.2
 flake8==3.8.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+setuptools
 # These are for testing
 beautifulsoup4==4.8.2
 factory-boy==2.7.0


### PR DESCRIPTION
## Summary
* Moves IsSelf permissions check into tasks.py as it is specific to the arguments for the mergeuser task
* Updates it to check _either_ the local user id or the remote user id, so after merge, the user is still able to check the task.
* Handles an edge case where we were trying to check if the user was an admin for a facility that no longer existed
* Tries to prevent more weirdness by adding an explicit signal to clear the request.user cache when a user is deleted
* Calls this signal explicitly after calling `delete_facility` in the mergeuser task because the `delete_facility` function disables post_delete signals.
* Updates token generation for merge user flow to use only the user_id, so we can set this when first creating the task
* Updated handling for 403s to assume success, as it generally indicates that the user has been deleted and thus successfully merged
* Opportunistically update the global learn `inClasses` boolean when we fetch class data from the backend.

## References
Attempts to fix #12486 

## Reviewer guidance
While this only seems to happen on Android, I think it's more to do with unhandled errors arising from the process taking longer on Android, so hitting certain coincidences on Android that we might not see elsewhere.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
