### PR TITLE
Fix keypad and tab navigation issues in exercises

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -122,6 +122,7 @@ oriented data synchronization.
                 />
                 <KButton
                   v-else
+                  ref="nextButton"
                   appearance="raised-button"
                   :text="$tr('next')"
                   :primary="true"
@@ -418,6 +419,11 @@ oriented data synchronization.
         }
         this.complete = correct === 1;
         this.updateAttempt({ answerState, simpleAnswer });
+        if (this.complete) {
+          this.$nextTick(() => {
+            this.$refs.nextButton.$el.focus();
+          });
+        }
       },
       hintTaken({ answerState }) {
         this.hintWasTaken = true;

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -4,7 +4,7 @@
     v-if="itemId || itemData"
     class="bibliotron-exercise perseus-root"
     :class="{ 'perseus-mobile': isMobile }"
-    @keydown.enter="answerGiven"
+    @keydown.enter.prevent="answerGiven"
   >
     <div
       class="framework-perseus"

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -57,6 +57,7 @@
   const keypadStyle = StyleSheet.create({
     keypadContainer: {
       zIndex: 20,
+      pointerEvents: 'none',
     },
   });
 
@@ -429,7 +430,16 @@
             createPortal(
               e(MobileKeypad, {
                 style: keypadStyle.keypadContainer,
-                onElementMounted: setKeypadElement,
+                onElementMounted: el => {
+                  // We need to add the class to the container element
+                  // but the MobileKeypad component does not pass through
+                  // React's className prop to the root element.
+                  const domNode = el.getDOMNode();
+                  if (domNode) {
+                    domNode.classList.add('perseus-keypad-container');
+                  }
+                  setKeypadElement(el);
+                },
                 onDismiss: () => renderer && renderer.blur(),
                 onAnalyticsEvent: async () => {},
               }),
@@ -971,6 +981,10 @@
       border-radius: 3px;
       transition: box-shadow ease-in-out 0.15s;
     }
+  }
+
+  .perseus-keypad-container > div > div {
+    pointer-events: auto;
   }
 
 </style>


### PR DESCRIPTION
## Summary
* Prevents the container divs around the keypad element from capturing click events, allowing the check button behind to still be clicked
* Ensures that when an answer is submitted - either through the 'check' button being pressed, or by 'enter' being pressed within the perseus question, that the 'next' button is then focused if the question is completed

## References
Bug reported on slack
Issue observed while manually testing fix

## Reviewer guidance
Ensure that the keypad is still completely usable.
Ensure that the 'Check' button can be clicked while the keypad is open.
Ensure that using keyboard navigation to press the check button keeps the next button focused if the answer was correct.
Ensure that pressing enter while the question is in focus and correct causes the next button to display focused.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
