### PR TITLE
Fix error that occurs if facilityDatasetExtraFields is null.

### DIFF
--- a/packages/kolibri-common/components/ExtraDemographics/index.vue
+++ b/packages/kolibri-common/components/ExtraDemographics/index.vue
@@ -41,7 +41,7 @@
     },
     computed: {
       customSchema() {
-        return this.facilityDatasetExtraFields.demographic_fields || [];
+        return this.facilityDatasetExtraFields?.demographic_fields || [];
       },
     },
     methods: {


### PR DESCRIPTION
## Summary
* Prevents property access on null or undefined for facilityDatasetExtraFields

## References
Fixes https://github.com/learningequality/kolibri/issues/12533

## Reviewer guidance
Make sure that you can still load the demographic editing in the user editing in the admin UI.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
