### PR TITLE
Fix static paths for hashi and h5p static file upload

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -204,10 +204,12 @@ jobs:
         parent: false
     - name: Unzip content static files from whl file
       run: |
-        unzip -j dist/${{ needs.whl.outputs.whl-file-name }} 'kolibri/core/content/static/*' -d static
-        rm static/*.file_size
+        unzip dist/${{ needs.whl.outputs.whl-file-name }} 'kolibri/core/content/static/*' -d static
+        mv static/kolibri/core/content/static/** static
+        rm -rf static/kolibri
+        rm static/**/*.file_size
         # Ungzip all .gz files in the static folder
-        for f in static/*.gz; do gunzip -f $f; done
+        for f in static/**/*.gz; do gunzip -f $f; done
     - name: Upload content static files to BCK bucket
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -221,7 +221,7 @@ jobs:
   # unblocked and all the subsequent steps in this workflow will happen.
     name: Job to block publish of a release until it has been manually approved
     if: ${{ !github.event.release.prerelease }}
-    needs: [whl, pex, dmg, deb, exe, test_pypi_upload]
+    needs: [whl, pex, dmg, deb, exe, zip, apk, test_pypi_upload]
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
## Summary
* Fixes issue where paths were discarded (because of the `-j` flag) during unzipping of static file assets
* Removes use of `-j` flag and instead uses an appropriately deeply targeted `mv` to put files in the correct place
* Fixes minor issue where the final release block step was not waiting on the APK and Raspberry Pi image jobs

## References
Fixes #12515

## Reviewer guidance
I tested this by doing this with the actual 0.17.0 whl file asset downloaded into my dist folder and then doing the steps in the actions job. This is what allowed me to have the properly formatted files in the correct folders for manual upload to GCS.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
