### PR TITLE
Revert use of network client in test utils.

### DIFF
--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -9,16 +9,16 @@ import tempfile
 import time
 import uuid
 
+import requests
 from django.conf import settings
 from django.db import connection
 from django.db import connections
 from django.utils.functional import wraps
 from morango.models.core import DatabaseIDModel
+from requests.exceptions import RequestException
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.discovery.utils.network.client import NetworkClient
-from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 
 # custom Morango instance info used in tests
 CUSTOM_INSTANCE_INFO = {"kolibri": "0.14.7"}
@@ -119,13 +119,12 @@ class KolibriServer(object):
         )
 
     def _wait_for_server_start(self, timeout=20):
-        client = NetworkClient.build_for_address(self.baseurl, timeout=3)
         for i in range(timeout * 2):
             try:
-                resp = client.get("api/public/info/")
+                resp = requests.get(self.baseurl + "api/public/info/", timeout=3)
                 if resp.status_code > 0:
                     return
-            except NetworkLocationResponseFailure:
+            except RequestException:
                 pass
             time.sleep(0.5)
 


### PR DESCRIPTION
## Summary
* Reverts use of the network client in the test utils

## References
Fixes test failures in morango integration tests seen after merging #12096 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
