### PR TITLE
reload on connect in quizsummarypage; avoid possible error w/ missing…

### DIFF
--- a/kolibri/plugins/coach/assets/src/routes/examRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/examRoutes.js
@@ -47,6 +47,9 @@ export default [
     name: PageNames.EXAM_CREATION_ROOT,
     path: CLASS + QUIZ + '/edit/:sectionIndex',
     component: CreateExamPage,
+    meta: {
+      titleParts: [],
+    },
     children: [
       {
         name: PageNames.QUIZ_SECTION_EDITOR,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -100,6 +100,7 @@
   import ExamResource from 'kolibri-common/apiResources/ExamResource';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { convertExamQuestionSources } from 'kolibri-common/quizzes/utils';
   import { QUIZZES_TABS_ID, QuizzesTabs } from '../../../constants/tabsConstants';
   import { useCoachTabs } from '../../../composables/useCoachTabs';
 
@@ -275,7 +276,7 @@
       closeModal() {
         this.currentAction = '';
       },
-      handleSubmitCopy({ classroomId, groupIds, adHocLearnerIds, examTitle }) {
+      async handleSubmitCopy({ classroomId, groupIds, adHocLearnerIds, examTitle }) {
         const title = examTitle.trim().substring(0, 100).trim();
 
         const assignments = serverAssignmentPayload(groupIds, classroomId);
@@ -286,7 +287,8 @@
           collection: classroomId,
           assignments,
           learner_ids: adHocLearnerIds,
-          question_sources: this.quiz.question_sources,
+          // This ensures backward compatibility for all question_sources versions
+          question_sources: (await convertExamQuestionSources(this.exam)).question_sources,
         };
 
         ExamResource.saveModel({ data: newQuiz })

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -79,7 +79,7 @@
     </KGrid>
     <ManageExamModals
       :currentAction="currentAction"
-      :quiz="quiz"
+      :quiz="exam"
       @submit_delete="handleSubmitDelete"
       @submit_copy="handleSubmitCopy"
       @cancel="closeModal"
@@ -100,7 +100,6 @@
   import ExamResource from 'kolibri-common/apiResources/ExamResource';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { PageNames } from '../../../constants';
   import { QUIZZES_TABS_ID, QuizzesTabs } from '../../../constants/tabsConstants';
   import { useCoachTabs } from '../../../composables/useCoachTabs';
 
@@ -148,19 +147,11 @@
     },
     data() {
       return {
-        quiz: {
-          active: false,
-          assignments: [],
-          learners_see_fixed_order: false,
-          question_sources: [],
-          title: '',
-        },
         loading: true,
         currentAction: '',
         QUIZZES_TABS_ID,
         QuizzesTabs,
         difficultQuestions: [],
-        PageNames,
       };
     },
     computed: {
@@ -208,7 +199,7 @@
 
         tabsList.forEach(tab => {
           tab.to = this.classRoute(
-            this.group ? PageNames.GROUP_EXAM_SUMMARY : PageNames.EXAM_SUMMARY,
+            this.group ? this.PageNames.GROUP_EXAM_SUMMARY : this.PageNames.EXAM_SUMMARY,
             { tabId: tab.id },
           );
         });
@@ -260,8 +251,7 @@
     methods: {
       // @public
       setData(data) {
-        const { exam, difficultQuestions } = data;
-        this.quiz = exam;
+        const { difficultQuestions } = data;
         this.difficultQuestions = difficultQuestions;
         this.loading = false;
         this.$store.dispatch('notLoading');
@@ -275,7 +265,7 @@
       setCurrentAction(action) {
         if (action === 'EDIT_DETAILS') {
           this.$router.push({
-            name: PageNames.EXAM_CREATION_ROOT,
+            name: this.PageNames.EXAM_CREATION_ROOT,
             params: { ...this.$route.params, sectionIndex: 0 },
           });
         } else {
@@ -339,10 +329,10 @@
           });
       },
       handleSubmitDelete() {
-        return deleteExam(this.quiz.id)
+        return deleteExam(this.quizId)
           .then(() => {
-            this.$store.commit('classSummary/DELETE_ITEM', { map: 'examMap', id: this.quiz.id });
-            this.$router.replace(this.classRoute(PageNames.EXAMS_ROOT), () => {
+            this.$store.commit('classSummary/DELETE_ITEM', { map: 'examMap', id: this.quizId });
+            this.$router.replace(this.classRoute(this.PageNames.EXAMS_ROOT), () => {
               this.showSnackbarNotification('quizDeleted');
             });
           })
@@ -351,7 +341,7 @@
           });
       },
       detailLink(learnerId) {
-        return this.classRoute(PageNames.QUIZ_LEARNER_PAGE_ROOT, {
+        return this.classRoute(this.PageNames.QUIZ_LEARNER_PAGE_ROOT, {
           learnerId,
         });
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Closes #12388 

I was only able to replicate the error described there by @AlexVelezLl when I forced specifically a 502 error within the `size` endpoint's handler. I don't know any way that a 502 would come through unless the server is disconnected somehow during the page load.

I could not replicate it naturally, however, so I cannot be 100% this addresses the issue at hand here.

But, ultimately, what it came down to was that if the page got a 502 error, it would show the proper "disconnected" snackbar & backdrop. In this case, the value used `this.quizId` was not yet initialized.

The change here ensures that when the user regains connection to the server, their page will reload, hopefully successfully.

---

**One thing of concern is that if there is a way in which we could end up getting some kind of unjustified 502, then this could just result in an infinite loop of failing to connect and reloading.**

The only way that I can think of that the size endpoint's handler would cause a 502 is if it's crashing the server. I've made some large quizzes during development on EQM and I've not had any issues with it and trying it didn't help replicate the issue.

Without some kind of stack trace for the error from a naturally occurring replication of the error this will be hard to debug, as there are several calls within that could cause the failure:

```python
    @action(detail=False)
    def size(self, request, **kwargs):
        exams, draft_exams = self.filter_querysets(
            self.get_queryset(), self.get_draft_queryset()
        )
        exams_sizes_set = []
        for exam in list(exams) + list(draft_exams):
            quiz_size = {}

            quiz_nodes = ContentNode.objects.filter(
                id__in=[question["exercise_id"] for question in exam.get_questions()]
            )

            quiz_size[exam.id] = total_file_size(quiz_nodes)
            exams_sizes_set.append(quiz_size)

        return Response(exams_sizes_set)
```

Also worth noting that my first thought was to force an error within the function there, but that just resulted in the expected `400 Bad request` rather than the `502` that is the direct cause of this issue.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

#### Code review

- Is there any kind of additional handing I should add in the size handler?
- Any thoughts on how to better replicate this particular issue -- are there any quirks to our disconnection handling that might come into play here?

#### QA


**Path 1: Fake replication**
- With Network Throttling enabled, click to view a Quiz's details (click it's name link on the quiz list page). Throttling will help buy you time to kill your server in the next step :) 
- Then, quickly kill your server `kolibri stop`, causing the backend to no longer be available
- Restart the Kolibri server, click to reconnect on the snackbar message in your browser, and the page should reload when you reconnect successfully
- Now you should be able to delete the quiz without issue

**Path 2: Possibly replicate it naturally**
- Maybe try once more with a very large quiz w/ lots of exercises in it that would have a large size
- Don't do the "kill your server" thing manually and see if you can get it to naturally occur that you get a 502 somehow?