### PR TITLE
Docs: Remove legacy stuff from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@ import sys
 from datetime import datetime
 
 import django
-import sphinx_rtd_theme
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
 
@@ -100,7 +99,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "m2r",
     "notfound.extension",
-    "sphinxcontrib.jquery",
 ]
 
 linkcheck_ignore = [
@@ -144,7 +142,6 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
I didn't notice this while I was fixing the jquery issue... but it originated from having this legacy setup.

The reason that sphinxcontrib.jquery is added to extentions is because the `html_theme_path` definition (from old old instructions) disables some other things that the theme adds (like jquery).

Can wait for the docs to build, and it should probably still work :+1: 