### PR TITLE
Ensure linting errors trigger a non-zero exit code.

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -385,15 +385,11 @@ program
             return Promise.all(
               matches.map(globbedFile => {
                 if (!patternCheck || patternCheck.match(globbedFile)) {
-                  return runLinting(globbedFile)
-                    .then(formatted => {
-                      return formatted.code;
-                    })
-                    .catch(error => {
-                      logging.error(`Error processing file: ${globbedFile}`);
-                      logging.error(error.error ? error.error : error);
-                      return error.code;
-                    });
+                  return runLinting(globbedFile).catch(error => {
+                    logging.error(`Error processing file: ${globbedFile}`);
+                    logging.error(error.error ? error.error : error);
+                    return error.code;
+                  });
                 } else {
                   return Promise.resolve(0);
                 }


### PR DESCRIPTION
## Summary
Fixes error from #9698 where the CLI calling the linting function was not properly reading the return code, so was always returning a falsy value even when there were linting errors, meaning that the exit code was always 0.

## References
Root cause of the missed linting here: #12428

## Reviewer guidance
Deliberately introduce a linting error.
Run `yarn run lint-frontend`.
Ensure that the exit code is 1.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
