### PR TITLE
Move core module registration out of the core store module.

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -15,6 +15,7 @@ import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import heartbeat from 'kolibri.heartbeat';
 import ContentRenderer from '../views/ContentRenderer';
 import initializeTheme from '../styles/initializeTheme';
+import coreModule from '../state/modules/core';
 import { i18nSetup } from '../utils/i18n';
 import setupPluginMediator from './pluginMediator';
 import apiSpec from './apiSpec';
@@ -65,6 +66,9 @@ Vue.use(VueCompositionApi);
 Vue.use(KThemePlugin);
 
 Vue.component('ContentRenderer', ContentRenderer);
+
+// Register core module
+store.registerModule('core', coreModule);
 
 // Start the heartbeat polling here, as any URL needs should be set by now
 heartbeat.startPolling();

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -1,7 +1,6 @@
 import forEach from 'lodash/forEach';
 import Vuex from 'vuex';
 import Vue from 'vue';
-import coreModule from './modules/core';
 
 Vue.use(Vuex);
 
@@ -35,9 +34,6 @@ export function coreStoreFactory(pluginModule) {
       store.registerModule(name, module);
     });
   }
-
-  // Register core module last
-  store.registerModule('core', coreModule);
 
   return store;
 }

--- a/kolibri/core/assets/test/heartbeat.spec.js
+++ b/kolibri/core/assets/test/heartbeat.spec.js
@@ -5,12 +5,15 @@ import * as serverClock from 'kolibri.utils.serverClock';
 import { HeartBeat } from '../src/heartbeat.js';
 import disconnectionErrorCodes from '../src/disconnectionErrorCodes';
 import { trs } from '../src/disconnection';
+import coreModule from '../src/state/modules/core';
 import { stubWindowLocation } from 'testUtils'; // eslint-disable-line
 
 jest.mock('kolibri.lib.logging');
 jest.mock('kolibri.utils.redirectBrowser');
 jest.mock('kolibri.urls');
 jest.mock('lockr');
+
+coreStore.registerModule('core', coreModule);
 
 describe('HeartBeat', function () {
   stubWindowLocation(beforeAll, afterAll);

--- a/kolibri/core/assets/test/kolibri_app.spec.js
+++ b/kolibri/core/assets/test/kolibri_app.spec.js
@@ -50,19 +50,9 @@ class TestApp extends KolibriApp {
 }
 
 describe('KolibriApp', function () {
-  it('it should register the core vuex component', () => {
-    const app = new TestApp();
-    expect(app.store.state.core).toMatchObject(coreModule.state());
-    // just checking on keys, since vuex transforms the actions
-    expect(Object.keys(app.store._actions)).toEqual(Object.keys(coreModule.actions));
-    // only checks intersection with core getters; doesn't include sub-modules
-    expect(Object.keys(app.store.getters)).toEqual(
-      expect.arrayContaining(Object.keys(coreModule.getters)),
-    );
-  });
-
   it('it should register the plugin vuex components', async function () {
     const app = new TestApp();
+    app.store.registerModule('core', coreModule);
     app.store.hotUpdate({
       modules: {
         core: {

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -3,6 +3,7 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import client from 'kolibri.client';
 import * as constants from '../../src/constants';
 import { coreStoreFactory as makeStore } from '../../src/state/store';
+import coreModule from '../../src/state/modules/core';
 import { stubWindowLocation } from 'testUtils'; // eslint-disable-line
 
 jest.mock('kolibri.urls');
@@ -15,6 +16,7 @@ describe('Vuex store/actions for core module', () => {
     Vue.prototype.$formatMessage = () => errorMessage;
     it('handleError action updates core state', () => {
       const store = makeStore();
+      store.registerModule('core', coreModule);
       store.dispatch('handleError', 'catastrophic failure');
       expect(store.state.core.error).toEqual('catastrophic failure');
       expect(store.state.core.loading).toBeFalsy();
@@ -22,6 +24,7 @@ describe('Vuex store/actions for core module', () => {
 
     it('handleApiError action updates core state', () => {
       const store = makeStore();
+      store.registerModule('core', coreModule);
       const apiError = { message: 'Too Bad' };
       try {
         store.dispatch('handleApiError', { error: apiError });
@@ -40,6 +43,7 @@ describe('Vuex store/actions for core module', () => {
 
     beforeEach(() => {
       store = makeStore();
+      store.registerModule('core', coreModule);
     });
 
     afterEach(() => {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
@@ -7,6 +7,7 @@ import makeStore from '../../../../../test/makeStore';
 jest.mock('kolibri.client');
 jest.mock('kolibri.urls');
 jest.mock('kolibri.resources');
+jest.mock('kolibri.coreVue.composables.useUser');
 
 const router = new VueRouter({
   routes: [

--- a/kolibri/plugins/coach/assets/test/makeStore.js
+++ b/kolibri/plugins/coach/assets/test/makeStore.js
@@ -1,12 +1,15 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore(patch) {
-  return coreStoreFactory({
+  const store = coreStoreFactory({
     ...pluginModule,
     modules: {
       ...pluginModule.modules,
       ...patch,
     },
   });
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/kolibri/plugins/device/assets/src/views/__test__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/RearrangeChannelsPage.spec.js
@@ -1,8 +1,10 @@
 import { shallowMount } from '@vue/test-utils';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import makeStore from '../../../test/utils/makeStore';
 import RearrangeChannelsPage from '../RearrangeChannelsPage';
 
 jest.mock('../../composables/useContentTasks');
+jest.mock('kolibri.coreVue.composables.useUser');
 
 RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
 RearrangeChannelsPage.methods.fetchChannels = () => {
@@ -13,7 +15,7 @@ RearrangeChannelsPage.methods.fetchChannels = () => {
 };
 async function makeWrapper() {
   const store = makeStore();
-  store.state.core.session.can_manage_content = true;
+  useUser.mockImplementation(() => useUserMock({ canManageContent: true }));
   const wrapper = shallowMount(RearrangeChannelsPage, {
     store,
   });

--- a/kolibri/plugins/device/assets/test/utils/makeStore.js
+++ b/kolibri/plugins/device/assets/test/utils/makeStore.js
@@ -1,5 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
+import coreModule from '../../../../../core/assets/src/state/modules/core';
 import pluginModule from '../../src/modules/pluginModule';
 import { contentNodeGranularPayload } from './data';
 
@@ -64,13 +65,15 @@ const channelsOnDevice = [
 ];
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }
-
 // Use for availableChannelsPage and all children:
 // channel-list-item
 export function makeAvailableChannelsPageStore() {
   const store = coreStoreFactory(cloneDeep(pluginModule));
+  store.registerModule('core', coreModule);
   store.state.manageContent.channelList = [...channelsOnDevice];
   store.state.core.loading = false;
   Object.assign(store.state.manageContent.wizard, {

--- a/kolibri/plugins/facility/assets/test/makeStore.js
+++ b/kolibri/plugins/facility/assets/test/makeStore.js
@@ -1,6 +1,9 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -2,6 +2,7 @@ import { FacilityResource, FacilityDatasetResource } from 'kolibri.resources';
 import client from 'kolibri.client';
 import { showFacilityConfigPage } from '../../src/modules/facilityConfig/handlers';
 import makeStore from '../makeStore';
+import coreModule from '../../../../../core/assets/src/state/modules/core';
 
 jest.mock('kolibri.client');
 jest.mock('kolibri.urls');
@@ -65,6 +66,7 @@ describe('facility config page actions', () => {
 
   beforeEach(() => {
     store = makeStore();
+    store.registerModule('core', coreModule);
     commitStub = jest.spyOn(store, 'commit');
     store.state.route = { params: {} };
     Object.assign(store.state.core, {

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -1,9 +1,11 @@
 import { mount } from '@vue/test-utils';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import ConfigPage from '../../src/views/FacilityConfigPage';
 import makeStore from '../makeStore';
 
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('kolibri.coreVue.composables.useUser');
 jest.mock('../../../../device/assets/src/views/DeviceSettingsPage/api.js', () => ({
   getDeviceSettings: jest.fn(),
 }));
@@ -143,8 +145,8 @@ describe('facility config page view', () => {
   describe(`in the Android app mode`, () => {
     let wrapper;
     beforeAll(() => {
+      useUser.mockImplementation(() => useUserMock({ isAppContext: true }));
       wrapper = makeWrapper();
-      wrapper.vm.$store.state.core.session.app_context = true;
     });
 
     it(`reset and save buttons are in the bottom bar`, () => {

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -3,12 +3,14 @@ import omit from 'lodash/omit';
 import client from 'kolibri.client';
 import { coreStoreFactory as makeStore } from 'kolibri.coreVue.vuex.store';
 import useProgressTracking from '../useProgressTracking';
+import coreModule from '../../../../../../core/assets/src/state/modules/core';
 
 jest.mock('kolibri.urls');
 jest.mock('kolibri.client');
 
 function setUp() {
   const store = makeStore();
+  store.registerModule('core', coreModule);
   return { store, ...useProgressTracking(store) };
 }
 

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
@@ -6,6 +6,7 @@ import { ContentNodeResource } from 'kolibri.resources';
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import { AllCategories, NoCategories } from 'kolibri.coreVue.vuex.constants';
 import useSearch from '../useSearch';
+import coreModule from '../../../../../../core/assets/src/state/modules/core';
 
 Vue.use(VueRouter);
 
@@ -25,6 +26,7 @@ function prep(query = {}, descendant = null) {
       },
     },
   });
+  store.registerModule('core', coreModule);
   const router = new VueRouter();
   router.push = jest.fn().mockReturnValue(Promise.resolve());
   return {

--- a/kolibri/plugins/learn/assets/test/makeStore.js
+++ b/kolibri/plugins/learn/assets/test/makeStore.js
@@ -1,8 +1,10 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore(options = {}) {
   const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
   if (options.pageName) {
     store.state.pageName = options.pageName;
   }

--- a/kolibri/plugins/learn/assets/test/util/makeStore.js
+++ b/kolibri/plugins/learn/assets/test/util/makeStore.js
@@ -1,6 +1,9 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../../src/modules/pluginModule';
+import coreModule from '../../../../../core/assets/src/state/modules/core';
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/kolibri/plugins/setup_wizard/assets/test/makeStore.js
+++ b/kolibri/plugins/setup_wizard/assets/test/makeStore.js
@@ -1,6 +1,9 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/kolibri/plugins/user_auth/assets/test/makeStore.js
+++ b/kolibri/plugins/user_auth/assets/test/makeStore.js
@@ -1,6 +1,9 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -1,10 +1,12 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import { shallowMount, mount } from '@vue/test-utils';
 import ChooseAdmin from '../index.vue';
+import coreModule from '../../../../../../../../core/assets/src/state/modules/core';
 
 const sendMachineEvent = jest.fn();
 function makeWrapper({ userId, sourceFacilityUsers } = {}) {
   const store = coreStoreFactory();
+  store.registerModule('core', coreModule);
   store.dispatch('notLoading');
   return mount(ChooseAdmin, {
     store,

--- a/kolibri/plugins/user_profile/assets/test/makeStore.js
+++ b/kolibri/plugins/user_profile/assets/test/makeStore.js
@@ -1,6 +1,9 @@
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import pluginModule from '../src/modules/pluginModule';
+import coreModule from '../../../../core/assets/src/state/modules/core';
 
 export default function makeStore() {
-  return coreStoreFactory(pluginModule);
+  const store = coreStoreFactory(pluginModule);
+  store.registerModule('core', coreModule);
+  return store;
 }

--- a/packages/kolibri-common/components/AppError/__test__/AppError.spec.js
+++ b/packages/kolibri-common/components/AppError/__test__/AppError.spec.js
@@ -1,9 +1,11 @@
 import { mount } from '@vue/test-utils';
 import AppError from '../index.vue';
 import { coreStoreFactory as makeStore } from '../../../../../kolibri/core/assets/src/state/store';
+import coreModule from '../../../../../kolibri/core/assets/src/state/modules/core';
 
 function makeWrapper() {
   const store = makeStore();
+  store.registerModule('core', coreModule);
   const wrapper = mount(AppError, {
     store,
   });


### PR DESCRIPTION
## Summary
* Moves registration of the core vuex module out of the core store to decouple the core module from the core API
* Updates all tests as needed to handle this

## References
Fixes #12558

## Reviewer guidance
Do all tests still pass? A quick smoke test of Kolibri should suffice as additional testing.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
