### PR TITLE
Move core channel state into coach - the only place it is still used.

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -5,7 +5,6 @@ import logger from 'kolibri.lib.logging';
 import {
   FacilityResource,
   FacilityDatasetResource,
-  ChannelResource,
   UserProgressResource,
   UserSyncStatusResource,
   PingbackNotificationResource,
@@ -37,20 +36,6 @@ const logging = logger.getLogger(__filename);
  * The methods below help map data from
  * the API to state in the Vuex store
  */
-
-function _channelListState(data) {
-  return data.map(channel => ({
-    id: channel.id,
-    title: channel.name,
-    description: channel.description,
-    tagline: channel.tagline,
-    root_id: channel.root,
-    last_updated: channel.last_updated,
-    version: channel.version,
-    thumbnail: channel.thumbnail,
-    num_coach_contents: channel.num_coach_contents,
-  }));
-}
 
 function _notificationListState(data) {
   return data.map(notification => ({
@@ -259,19 +244,6 @@ export function getFacilityConfig(store, facilityId) {
     }
     store.commit('CORE_SET_FACILITY_CONFIG', config);
   });
-}
-
-export function setChannelInfo(store) {
-  return ChannelResource.fetchCollection({ getParams: { available: true } }).then(
-    channelsData => {
-      store.commit('SET_CORE_CHANNEL_LIST', _channelListState(channelsData));
-      return channelsData;
-    },
-    error => {
-      store.dispatch('handleApiError', { error });
-      return error;
-    },
-  );
 }
 
 export function fetchPoints(store) {

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -10,16 +10,6 @@ export function facilities(state) {
   return state.facilities;
 }
 
-export function getChannels(state) {
-  return state.channels.list;
-}
-
-export function getChannelObject(state) {
-  return function getter(channelId) {
-    return getChannels(state).find(channel => channel.id === channelId);
-  };
-}
-
 export function totalPoints(state) {
   return state.totalProgress * MaxPointsPerContent;
 }

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -12,10 +12,6 @@ export default {
       pageSessionId: 0,
       totalProgress: null,
       notifications: [],
-      channels: {
-        list: [],
-        currentId: null,
-      },
       allowRemoteAccess: plugin_data.allowRemoteAccess,
       // facility
       facilityConfig: {},

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -21,9 +21,6 @@ export default {
   INCREMENT_TOTAL_PROGRESS(state, progress) {
     state.totalProgress += progress;
   },
-  SET_CORE_CHANNEL_LIST(state, channelList) {
-    state.channels.list = channelList;
-  },
   CORE_SET_NOTIFICATIONS(state, notifications) {
     state.notifications = notifications;
   },

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -1,8 +1,8 @@
 import { get } from '@vueuse/core';
 import useUser from 'kolibri.coreVue.composables.useUser';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
-import { setChannelInfo } from 'kolibri.coreVue.vuex.actions';
 import router from 'kolibri.coreVue.router';
+import { ChannelResource } from 'kolibri.resources';
 import KolibriApp from 'kolibri_app';
 import useSnackbar from 'kolibri.coreVue.composables.useSnackbar';
 import { PageNames } from './constants';
@@ -15,6 +15,33 @@ import GroupMembersPage from './views/plan/GroupMembersPage';
 import GroupEnrollPage from './views/plan/GroupEnrollPage';
 import pages from './views/reports/allReportsPages';
 import HomeActivityPage from './views/home/HomeActivityPage';
+
+function _channelListState(data) {
+  return data.map(channel => ({
+    id: channel.id,
+    title: channel.name,
+    description: channel.description,
+    tagline: channel.tagline,
+    root_id: channel.root,
+    last_updated: channel.last_updated,
+    version: channel.version,
+    thumbnail: channel.thumbnail,
+    num_coach_contents: channel.num_coach_contents,
+  }));
+}
+
+export function setChannelInfo(store) {
+  return ChannelResource.fetchCollection({ getParams: { available: true } }).then(
+    channelsData => {
+      store.commit('SET_CHANNEL_LIST', _channelListState(channelsData));
+      return channelsData;
+    },
+    error => {
+      store.dispatch('handleApiError', { error });
+      return error;
+    },
+  );
+}
 
 class CoachToolsModule extends KolibriApp {
   get stateSetters() {

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
@@ -16,7 +16,7 @@ export default {
   getters: {
     getChannelForNode(state, getters, rootState) {
       return function getter(node) {
-        return rootState.core.channels.list.find(({ id }) => id === node.channel_id);
+        return rootState.channels.list.find(({ id }) => id === node.channel_id);
       };
     },
   },

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -25,6 +25,10 @@ export default {
       pageName: '',
       toolbarRoute: {},
       toolbarTitle: '',
+      channels: {
+        list: [],
+        currentId: null,
+      },
     };
   },
   mutations: {
@@ -42,6 +46,9 @@ export default {
     },
     SET_TOOLBAR_ROUTE(state, toolbarRoute) {
       state.toolbarRoute = toolbarRoute;
+    },
+    SET_CHANNEL_LIST(state, channelList) {
+      state.channels.list = channelList;
     },
   },
   getters: {
@@ -61,6 +68,14 @@ export default {
         );
       }
       return false;
+    },
+    getChannels(state) {
+      return state.channels.list;
+    },
+    getChannelObject(state, getters) {
+      return function getter(channelId) {
+        return getters.getChannels(state).find(channel => channel.id === channelId);
+      };
     },
   },
   actions: {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/__tests__/LessonsSearchFilters.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/__tests__/LessonsSearchFilters.spec.js
@@ -46,7 +46,7 @@ describe('LessonsSearchFilters', () => {
 
   it('has the correct channel filter options based on search results', async () => {
     const { wrapper, els } = makeWrapper();
-    wrapper.vm.$store.state.core.channels.list = [{ id: '123', title: 'Channel 123' }];
+    wrapper.vm.$store.state.channels.list = [{ id: '123', title: 'Channel 123' }];
     wrapper.setProps({
       searchResults: {
         channel_ids: ['123'],


### PR DESCRIPTION
## Summary
* Moves core channel state into the coach pluginModule

## References
Fixes #12557

## Reviewer guidance
Does the minimal fix to move the channel fetching logic from the core vuex state into coach.
Will presumably be cleaned up in the future by other changes.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
