### PR TITLE
Add missing `indeterminate` states on Select All checkboxes

### DIFF
--- a/kolibri/core/assets/src/views/UserTable/index.vue
+++ b/kolibri/core/assets/src/views/UserTable/index.vue
@@ -11,6 +11,7 @@
       :label="$tr('selectAllLabel')"
       :showLabel="true"
       :checked="allAreSelected"
+      :indeterminate="allIsIndeterminate"
       :disabled="disabled || !users || users.length === 0"
       class="select-all"
       :style="{ color: $themeTokens.annotation }"
@@ -298,6 +299,14 @@
       },
       showSelectAllCheckbox() {
         return this.selectable && this.enableMultipleSelection;
+      },
+      allIsIndeterminate() {
+        return (
+          this.showSelectAllCheckbox &&
+          Boolean(this.users && this.users.length) &&
+          !this.allAreSelected &&
+          this.users.some(user => this.value.includes(user.id))
+        );
       },
       allAreSelected() {
         return (

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -18,6 +18,7 @@
           :selectAllChecked="addableContent.length === 0"
           :contentCardLink="bookmarkLink"
           :contentIsChecked="contentIsInLesson"
+          :selectAllIndeterminate="selectAllIsIndeterminate"
           :contentHasCheckbox="c => !contentIsDirectoryKind(c)"
           :viewMoreButtonState="viewMoreButtonState"
           :contentCardMessage="selectionMetadata"
@@ -82,6 +83,7 @@
           :showSelectAll="selectAllIsVisible"
           :viewMoreButtonState="viewMoreButtonState"
           :selectAllChecked="addableContent.length === 0"
+          :selectAllIndeterminate="selectAllIsIndeterminate"
           :contentIsChecked="contentIsInLesson"
           :contentHasCheckbox="c => !contentIsDirectoryKind(c)"
           :contentCardMessage="selectionMetadata"
@@ -241,6 +243,14 @@
       },
       debouncedSaveResources() {
         return debounce(this.saveResources, 1000);
+      },
+      selectAllIsIndeterminate() {
+        return Boolean(
+          // If anything is in the lesson, then something is selected
+          this.contentList.filter(this.contentIsInLesson).length &&
+            // if addableContent has length, something can still be added
+            this.addableContent.length,
+        );
       },
       selectAllIsVisible() {
         // Do not show 'Select All' if on Search Results, on Channels Page,

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -40,6 +40,7 @@
                   key="selectAllOnPage"
                   :label="$tr('selectAllLabel')"
                   :checked="selectAllCheckboxProps.checked"
+                  :indeterminate="selectAllCheckboxProps.indeterminate"
                   :disabled="selectAllCheckboxProps.disabled"
                   @change="selectVisiblePage"
                 />
@@ -184,9 +185,13 @@
             return 'unchecked';
           }
         });
+        const disabled = currentCount === counts.disabled || currentCount === 0;
+        const checked = currentCount !== 0 && !counts.unchecked;
+
         return {
-          disabled: currentCount === counts.disabled || currentCount === 0,
-          checked: currentCount !== 0 && !counts.unchecked,
+          disabled,
+          checked,
+          indeterminate: !checked && !disabled && counts.checked < currentCount,
         };
       },
       itemsPerPage() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -43,6 +43,7 @@
         class="select-all-checkbox"
         :label="$tr('selectAll')"
         :checked="selectAllIsChecked"
+        :indeterminate="selectAllIsIndeterminate"
         @change="handleChangeSelectAll({ isSelected: $event })"
       />
     </template>
@@ -107,6 +108,10 @@
     computed: {
       selectAllIsChecked() {
         return differenceBy(this.filteredItems, this.selectedChannels, 'id').length === 0;
+      },
+      selectAllIsIndeterminate() {
+        const diff = differenceBy(this.filteredItems, this.selectedChannels, 'id').length;
+        return diff > 0 && diff < this.filteredItems.length;
       },
       showItem() {
         return function (channel) {

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -18,6 +18,7 @@
             <KCheckbox
               :label="$tr('selectAll')"
               :checked="nodeIsChecked(annotatedTopicNode)"
+              :indeterminate="selectAllIndeterminate"
               :disabled="disableSelectAll"
               @change="toggleSelectAll"
             />
@@ -106,6 +107,16 @@
     },
     computed: {
       ...mapState('manageContent/wizard', ['nodesForTransfer']),
+      selectAllIndeterminate() {
+        if (this.annotatedChildNodes.every(n => this.nodeIsChecked(n))) {
+          // Be sure that we don't set indeterminate if every node is checked first
+          // because we'll use `some` below to return true
+          return false;
+        }
+        return this.annotatedChildNodes.some(
+          n => this.nodeIsChecked(n) || this.nodeIsIndeterminate(n),
+        );
+      },
       currentTopicNode() {
         if (this.node) {
           return this.node;

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
@@ -17,9 +17,9 @@
         <p>{{ $tr('deleteEverywhereExplanationMultipleResources') }}</p>
       </template>
       <KCheckbox
-        v-model="deleteEverywhere"
+        :checked="deleteEverywhere"
         :label="$tr('deleteEverywhereLabel')"
-        @change="deleteEverywhere = $event"
+        @change="deleteEverywhere = !deleteEverywhere"
       />
       <p>{{ coreString('cannotUndoActionWarning') }}</p>
     </div>


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds handling for indeterminate state in places where it previously was not.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Re-test the checkboxes listed by @pcenov below:

```
Device > Channels > Options > Delete/Export channels
Facility > Class > Enroll learners/Assign coaches
Coach > Plan > Lesson > Manage resources
Coach > Plan > Groups > New group > Enroll learners
```

