### PR TITLE
Handle Studio 404s

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -77,8 +77,10 @@ from kolibri.core.decorators import query_params_required
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.discovery.utils.network.errors import ResourceGoneError
+from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
@@ -86,7 +88,6 @@ from kolibri.core.query import SQSum
 from kolibri.core.utils.pagination import ValuesViewsetCursorPagination
 from kolibri.core.utils.pagination import ValuesViewsetLimitOffsetPagination
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
-from kolibri.utils import conf
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.urls import validator
 
@@ -1856,12 +1857,15 @@ class RemoteChannelViewSet(viewsets.ViewSet):
     @no_cache_on_method
     def kolibri_studio_status(self, request, **kwargs):
         try:
-            baseurl = conf.OPTIONS["Urls"]["CENTRAL_CONTENT_BASE_URL"]
-            client = NetworkClient.build_for_address(baseurl)
+            client = NetworkClient.build_for_address(CENTRAL_CONTENT_BASE_URL)
             resp = client.get("/api/public/info")
             data = resp.json()
             data["available"] = True
             data["status"] = "online"
             return Response(data)
-        except (NetworkLocationResponseFailure, NetworkLocationConnectionFailure):
+        except (
+            NetworkLocationResponseFailure,
+            NetworkLocationConnectionFailure,
+            NetworkLocationNotFound,
+        ):
             return Response({"status": "offline", "available": False})


### PR DESCRIPTION
## Summary
* Use well known import for studio base url.
* Handle the unlikely case where Studio 404s.

## References
Fixes unhandled edge case when the Studio URL 404s

## Reviewer guidance
To test this, set your CENTRAL_CONTENT_BASE_URL option to a url that will 404, and load the Library page as a superadmin. The kolibri_studio_status response should no longer 500.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
