### PR TITLE
Fix linting on develop.

### DIFF
--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -6,7 +6,9 @@ import KCircularLoader from 'kolibri-design-system/lib/loaders/KCircularLoader';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import { ContentNodeResource } from 'kolibri.resources';
 import useUser from 'kolibri.coreVue.composables.useUser';
+/* eslint-disable import/named */
 import useBaseSearch, { useBaseSearchMock } from 'kolibri-common/composables/useBaseSearch';
+/* eslint-enable import/named */
 import { PageNames } from '../../src/constants';
 import LibraryPage from '../../src/views/LibraryPage';
 import OtherLibraries from '../../src/views/LibraryPage/OtherLibraries';

--- a/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
@@ -7,12 +7,12 @@ import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { useDevicesWithFilter } from 'kolibri.coreVue.componentSets.sync';
 import { ContentNodeResource } from 'kolibri.resources';
 import plugin_data from 'plugin_data';
+// eslint-disable-next-line import/named
 import useBaseSearch, { useBaseSearchMock } from 'kolibri-common/composables/useBaseSearch';
 import makeStore from '../makeStore';
 import CustomContentRenderer from '../../src/views/ChannelRenderer/CustomContentRenderer';
 import { PageNames } from '../../src/constants';
 import TopicsPage from '../../src/views/TopicsPage';
-// eslint-disable-next-line import/named
 // eslint-disable-next-line import/named
 import useChannels, { useChannelsMock } from '../../src/composables/useChannels';
 


### PR DESCRIPTION
## Summary
* Ignores mock imports that will resolve, because mocks.

## References
Follow up to linting being fixed in general, and recent refactor work of useSearch.

## Reviewer guidance
Does the linting check now pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
