### PR TITLE
Remove unnecessary thumbnail setting when it is set on the API response.

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -98,7 +98,6 @@ import useNow from '../composables/useNow';
 
 // webpack optimization
 import CoreInfoIcon from '../views/CoreInfoIcon';
-import * as contentNode from '../utils/contentNodeUtils';
 import InteractionList from '../views/InteractionList';
 import ExamReport from '../views/ExamReport';
 import SlotTruncator from '../views/SlotTruncator';
@@ -217,7 +216,6 @@ export default {
     bytesForHumans,
     CatchErrors,
     clientFactory,
-    contentNode,
     coreBannerContent,
     exams,
     filterUsersByNames,

--- a/kolibri/core/assets/src/utils/contentNodeUtils.js
+++ b/kolibri/core/assets/src/utils/contentNodeUtils.js
@@ -1,27 +1,5 @@
 import { MasteryModelTypes } from 'kolibri.coreVue.vuex.constants';
 
-/*
- * Given a ContentNode, returns the thumbnail URL.
- * A thumbnail URL is commonly saved in file objects of `files` attribute
- * however some simplified endpoints return it only in `thumbnail` attribute.
- * Therefore, if `thumbnail` attribute is availabe, its value is returned.
- * If it's not available, then the first file (if any) with a thumbnail
- * from `files` is returned.
- */
-export function getContentNodeThumbnail(contentnode) {
-  if (contentnode.thumbnail) {
-    return contentnode.thumbnail;
-  }
-  if (!contentnode.files || !contentnode.files.length) {
-    return null;
-  }
-  const fileWithThumbnail = contentnode.files.find(file => file.thumbnail && file.available);
-  if (fileWithThumbnail) {
-    return fileWithThumbnail.storage_url;
-  }
-  return null;
-}
-
 export function masteryModelValidator({ type, m, n }) {
   let isValid = true;
   const typeIsValid = Object.values(MasteryModelTypes).includes(type);

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -5,7 +5,6 @@ import {
   ContentNodeSearchResource,
 } from 'kolibri.resources';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import chunk from 'lodash/chunk';
 import { LessonsPageNames } from '../../constants/lessonsConstants';
 
@@ -124,14 +123,10 @@ export function showLessonResourceSelectionTopicPage(store, params) {
     ];
 
     return Promise.all(loadRequirements).then(([topicNode, childNodes, descendantCounts]) => {
-      const topicContentList = childNodes.map(node => {
-        return { ...node, thumbnail: getContentNodeThumbnail(node) };
-      });
-
       return showResourceSelectionPage(store, {
         classId: params.classId,
         lessonId: params.lessonId,
-        contentList: topicContentList,
+        contentList: childNodes,
         pageName: LessonsPageNames.SELECTION,
         descendantCounts,
         ancestors: [...topicNode.ancestors, topicNode],
@@ -148,14 +143,10 @@ export function showLessonResourceBookmarks(store, params) {
     ];
 
     return Promise.all(loadRequirements).then(([topicNode, childNodes]) => {
-      const topicContentList = childNodes.map(node => {
-        return { ...node, thumbnail: getContentNodeThumbnail(node) };
-      });
-
       return showResourceSelectionPage(store, {
         classId: params.classId,
         lessonId: params.lessonId,
-        bookmarksList: topicContentList,
+        bookmarksList: childNodes,
         pageName: LessonsPageNames.SELECTION,
         ancestors: [...topicNode.ancestors, topicNode],
       });
@@ -297,13 +288,10 @@ export function showLessonResourceSearchPage(store, params, query = {}) {
         }),
       },
     }).then(results => {
-      const contentList = results.results.map(node => {
-        return { ...node, thumbnail: getContentNodeThumbnail(node) };
-      });
       return showResourceSelectionPage(store, {
         classId: params.classId,
         lessonId: params.lessonId,
-        contentList,
+        contentList: results.results,
         searchResults: results,
         pageName: LessonsPageNames.SELECTION_SEARCH,
       });

--- a/kolibri/plugins/learn/assets/src/views/thumbnails/ContentNodeThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/thumbnails/ContentNodeThumbnail.vue
@@ -26,7 +26,6 @@
 
 <script>
 
-  import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
   import useChannels from '../../composables/useChannels';
   import Thumbnail from './Thumbnail';
@@ -63,7 +62,7 @@
     },
     computed: {
       thumbnailUrl() {
-        const thumbnail = getContentNodeThumbnail(this.contentNode);
+        const thumbnail = this.contentNode.thumbnail;
         if (!thumbnail) {
           const parent = this.contentNode.parent;
           if (!parent) {


### PR DESCRIPTION
## Summary
* Removes the content node utility for setting the thumbnail - unnecessary as it is set on the API response from the backend already

## References
Fixes #12603

## Reviewer guidance
Double check that lesson creation in coach and resource browsing in learn still both show thumbnails properly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
