### PR TITLE
Moving remaining references to session getters to the useUser composable

### DIFF
--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -5,7 +5,7 @@ import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
 import { get, useTimeoutPoll } from '@vueuse/core';
 import useUser from './useUser';
 
-const { isLearnerOnlyImport, isUserLoggedIn } = useUser();
+const { isLearnerOnlyImport, isUserLoggedIn, currentUserId } = useUser();
 
 const status = ref(SyncStatus.NOT_CONNECTED);
 const queued = ref(false);
@@ -41,7 +41,7 @@ export function pollUserSyncStatusTask() {
   if (!get(isUserLoggedIn) || !get(isLearnerOnlyImport)) {
     return Promise.resolve();
   }
-  return fetchUserSyncStatus({ user: store.state.core.session.user_id }).then(syncData => {
+  return fetchUserSyncStatus({ user: get(currentUserId) }).then(syncData => {
     if (syncData && syncData[0]) {
       queued.value = syncData[0].queued;
       lastSynced.value = syncData[0].last_synced ? new Date(syncData[0].last_synced) : null;

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -4,6 +4,7 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import Lockr from 'lockr';
 import urls from 'kolibri.urls';
 import { get, set } from '@vueuse/core';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import useConnection from './composables/useConnection';
 import clientFactory from './core-app/baseClient';
 import { SIGNED_OUT_DUE_TO_INACTIVITY } from './constants';
@@ -158,7 +159,7 @@ export class HeartBeat {
    * @return {Promise} promise that resolves when the endpoint check is complete.
    */
   _checkSession() {
-    const { currentUserId } = store.getters;
+    const { id, currentUserId } = useUser();
     // Record the current user id to check if a different one is returned by the server.
     if (!get(this._connection.connected)) {
       // If not currently connected to the server, flag that we are currently trying to reconnect.
@@ -183,7 +184,7 @@ export class HeartBeat {
         const pollEnd = Date.now();
         const session = response.data;
         // If our session is already defined, check the user id in the response
-        if (store.state.core.session.id && session.user_id !== currentUserId) {
+        if (get(id) && session.user_id !== get(currentUserId)) {
           if (session.user_id === null) {
             // If it is different, and the user_id is now null then our user has been signed out.
             return this.signOutDueToInactivity();

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -17,7 +17,8 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import CatchErrors from 'kolibri.utils.CatchErrors';
 import Vue from 'kolibri.lib.vue';
 import Lockr from 'lockr';
-import { set } from '@vueuse/core';
+import { set, get } from '@vueuse/core';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { baseSessionState } from '../session';
 import { LoginErrors, ERROR_CONSTANTS, UPDATE_MODAL_DISMISSED } from '../../../constants';
 import { browser, os } from '../../../utils/browserInfo';
@@ -191,7 +192,8 @@ export function setPageVisibility(store) {
 }
 
 export function getNotifications(store) {
-  if (store.getters.isAdmin || store.getters.isSuperuser) {
+  const { isAdmin, isSuperuser } = useUser();
+  if (get(isAdmin) || get(isSuperuser)) {
     return PingbackNotificationResource.fetchCollection()
       .then(notifications => {
         logging.info('Notifications set.');
@@ -205,8 +207,9 @@ export function getNotifications(store) {
 }
 
 export function saveDismissedNotification(store, notification_id) {
+  const { user_id } = useUser();
   const dismissedNotificationData = {
-    user: store.getters.session.user_id,
+    user: get(user_id),
     notification: notification_id,
   };
   return PingbackNotificationDismissedResource.saveModel({ data: dismissedNotificationData })

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -1,3 +1,5 @@
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { MaxPointsPerContent } from '../../../constants';
 
 export function facilityConfig(state) {
@@ -26,8 +28,9 @@ export function pageSessionId(state) {
   return state.pageSessionId;
 }
 
-export function allowAccess(state, getters, rootState, rootGetters) {
-  return state.allowRemoteAccess || rootGetters.isAppContext;
+export function allowAccess(state) {
+  const { isAppContext } = useUser();
+  return state.allowRemoteAccess || get(isAppContext);
 }
 
 export function isPageLoading(state) {

--- a/kolibri/core/assets/src/utils/appCapabilities.js
+++ b/kolibri/core/assets/src/utils/appCapabilities.js
@@ -1,7 +1,8 @@
 import client from 'kolibri.client';
-import store from 'kolibri.coreVue.vuex.store';
 import logger from 'kolibri.lib.logging';
 import urls from 'kolibri.urls';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import plugin_data from 'plugin_data';
 
 const logging = logger.getLogger(__filename);
@@ -11,7 +12,10 @@ const appCapabilities = plugin_data.appCapabilities || {};
 // Check that we are in an appcontext, if not disable all capabilities
 // this means that consumers of this API can rely solely on the existence
 // check of methods in this API to know if they can call these or not.
-export const checkCapability = key => store.getters.isAppContext && appCapabilities[key];
+export const checkCapability = key => {
+  const { isAppContext } = useUser();
+  return get(isAppContext) && appCapabilities[key];
+};
 
 // Use a janky getter to return a method here to only expose functions
 // that are available so that we have a single API for both existence

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -27,8 +27,8 @@ class CoachToolsModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
-    const { snackbarIsVisibile, clearSnackbar } = useSnackbar();
-    const { isLearnerOnlyImport } = useUser();
+    const { snackbarIsVisible, clearSnackbar } = useSnackbar();
+    const { isLearnerOnlyImport, isSuperuser } = useUser();
     router.beforeEach((to, from, next) => {
       if (get(isLearnerOnlyImport)) {
         redirectBrowser();
@@ -56,7 +56,7 @@ class CoachToolsModule extends KolibriApp {
 
       // Clear the snackbar at every navigation to prevent it from re-appearing
       // when the next page component mounts.
-      if (get(snackbarIsVisibile) && !skipLoading.includes(to.name)) {
+      if (get(snackbarIsVisible) && !skipLoading.includes(to.name)) {
         clearSnackbar();
       }
 
@@ -107,7 +107,7 @@ class CoachToolsModule extends KolibriApp {
         promises.push(this.store.dispatch('initClassInfo', to.params.classId));
       }
 
-      if (this.store.getters.isSuperuser && this.store.state.core.facilities.length === 0) {
+      if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
         promises.push(this.store.dispatch('getFacilities').catch(() => {}));
       }
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -6,6 +6,8 @@ import {
 } from 'kolibri.resources';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import chunk from 'lodash/chunk';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { LessonsPageNames } from '../../constants/lessonsConstants';
 
 async function showResourceSelectionPage(store, params) {
@@ -20,8 +22,9 @@ async function showResourceSelectionPage(store, params) {
   const pendingSelections = store.state.lessonSummary.workingResources || [];
   const cache = store.state.lessonSummary.resourceCache || {};
   const initClassInfoPromise = store.dispatch('initClassInfo', params.classId);
+  const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    store.getters.isSuperuser && store.state.core.facilities.length === 0
+    get(isSuperuser) && store.state.core.facilities.length === 0
       ? store.dispatch('getFacilities').catch(() => {})
       : Promise.resolve();
 
@@ -183,8 +186,9 @@ function getBookmarks() {
 export async function showLessonResourceContentPreview(store, params) {
   const { classId, lessonId, contentId } = params;
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
+  const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    store.getters.isSuperuser && store.state.core.facilities.length === 0
+    get(isSuperuser) && store.state.core.facilities.length === 0
       ? store.dispatch('getFacilities').catch(() => {})
       : Promise.resolve();
 
@@ -199,8 +203,9 @@ export async function showLessonResourceContentPreview(store, params) {
 export async function showLessonSelectionContentPreview(store, params, query = {}) {
   const { classId, lessonId, contentId } = params;
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
+  const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    store.getters.isSuperuser && store.state.core.facilities.length === 0
+    get(isSuperuser) && store.state.core.facilities.length === 0
       ? store.dispatch('getFacilities').catch(() => {})
       : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -1,4 +1,6 @@
 import { LearnerGroupResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { LessonsPageNames } from '../../constants/lessonsConstants';
 
 export async function setLessonSummaryState(store, params) {
@@ -12,8 +14,9 @@ export async function setLessonSummaryState(store, params) {
     lessonsModalSet: null,
   });
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
+  const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    store.getters.isSuperuser && store.state.core.facilities.length === 0
+    get(isSuperuser) && store.state.core.facilities.length === 0
       ? store.dispatch('getFacilities').catch(() => {})
       : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -1,5 +1,7 @@
 import { ClassroomResource } from 'kolibri.resources';
 import logger from 'kolibri.lib.logging';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { pageNameToModuleMap } from '../constants';
 import { LessonsPageNames } from '../constants/lessonsConstants';
 import examReportDetail from './examReportDetail';
@@ -49,11 +51,12 @@ export default {
       return state.classList.length !== 1;
     },
     userIsAuthorizedForCoach(state, getters, rootState) {
-      if (getters.isSuperuser) {
+      const { isAdmin, isSuperuser, isCoach, facility_id } = useUser();
+      if (get(isSuperuser)) {
         return true;
-      } else if (getters.isCoach || getters.isAdmin) {
+      } else if (get(isCoach) || get(isAdmin)) {
         return (
-          rootState.route.params.facilityId === rootState.core.session.facility_id ||
+          rootState.route.params.facilityId === get(facility_id) ||
           !rootState.route.params.facilityId
         );
       }

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -1,5 +1,7 @@
 import store from 'kolibri.coreVue.vuex.store';
 import router from 'kolibri.coreVue.router';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import AllFacilitiesPage from '../views/AllFacilitiesPage';
 import CoachClassListPage from '../views/CoachClassListPage';
 import ClassLearnersListPage from '../views/ClassLearnersListPage';
@@ -15,8 +17,9 @@ import { classIdParamRequiredGuard } from './utils';
 
 function showHomePage(toRoute) {
   const initClassInfoPromise = store.dispatch('initClassInfo', toRoute.params.classId);
+  const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    store.getters.isSuperuser && store.state.core.facilities.length === 0
+    get(isSuperuser) && store.state.core.facilities.length === 0
       ? store.dispatch('getFacilities').catch(() => {})
       : Promise.resolve();
 
@@ -44,7 +47,8 @@ export default [
       store.dispatch('notLoading');
       // if user only has access to one facility, facility_id will not be accessible from URL,
       // but always defaulting to userFacilityId would cause problems for multi-facility admins
-      const facilityId = toRoute.params.facility_id || store.getters.userFacilityId;
+      const { userFacilityId } = useUser();
+      const facilityId = toRoute.params.facility_id || get(userFacilityId);
       store.dispatch('setClassList', facilityId).then(
         () => {
           if (!store.getters.classListPageEnabled) {
@@ -116,7 +120,8 @@ export default [
     path: '/',
     // Redirect to AllFacilitiesPage if a superuser and device has > 1 facility
     beforeEnter(to, from, next) {
-      if (store.getters.userIsMultiFacilityAdmin) {
+      const { userIsMultiFacilityAdmin } = useUser();
+      if (get(userIsMultiFacilityAdmin)) {
         next({ name: 'AllFacilitiesPage', replace: true });
       } else {
         next({ name: 'CoachClassListPage', replace: true });

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -1,10 +1,11 @@
 import store from 'kolibri.coreVue.vuex.store';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 export function classIdParamRequiredGuard(toRoute, subtopicName, next) {
   if (!toRoute.params.classId) {
-    const redirectPage = store.getters.userIsMultiFacilityAdmin
-      ? 'AllFacilitiesPage'
-      : 'CoachClassListPage';
+    const { userIsMultiFacilityAdmin } = useUser();
+    const redirectPage = get(userIsMultiFacilityAdmin) ? 'AllFacilitiesPage' : 'CoachClassListPage';
 
     next({
       name: redirectPage,

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -24,11 +24,12 @@ class DeviceManagementModule extends KolibriApp {
     return Cookies.get(IsPinAuthenticated) === 'true';
   }
   checkIfPinAuthenticationIsRequired(store, grantPluginAccess) {
-    const { isLearnerOnlyImport } = useUser();
-    const isSuperuser = store.getters.isSuperuser;
-    const isFacilityAdmin = store.getters.isFacilityAdmin;
-    const userCanManageContent = store.getters.canManageContent;
-    if (get(isLearnerOnlyImport) && !isFacilityAdmin && (isSuperuser || userCanManageContent)) {
+    const { isLearnerOnlyImport, isSuperuser, isFacilityAdmin, canManageContent } = useUser();
+    if (
+      get(isLearnerOnlyImport) &&
+      !get(isFacilityAdmin) &&
+      (get(isSuperuser) || get(canManageContent))
+    ) {
       //While browsing within the device plugin, prevent expiry.
       //On page refresh within plugin, show pin prompt if cookie has expired.
       viewPlugin = viewPlugin ? viewPlugin : this.isPinAuthenticated;

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -42,7 +42,8 @@ export function getDeviceInfo() {
  * @returns Promise<void>
  */
 export function showDeviceInfoPage(store) {
-  if (store.getters.canManageContent) {
+  const { canManageContent } = useUser();
+  if (get(canManageContent)) {
     const shouldResolve = samePageCheckGenerator(store);
     const promises = Promise.all([getDeviceInfo()]);
     return promises

--- a/kolibri/plugins/device/assets/src/modules/manageContent/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/handlers.js
@@ -1,7 +1,11 @@
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
+
 export function showManageContentPage(store) {
   store.commit('manageContent/RESET_STATE');
   store.commit('manageContent/wizard/RESET_STATE');
-  if (store.getters.canManageContent) {
+  const { canManageContent } = useUser();
+  if (get(canManageContent)) {
     return Promise.all([
       store.dispatch('manageContent/refreshTaskList'),
       store.dispatch('manageContent/refreshChannelList'),

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -1,5 +1,7 @@
 import { DevicePermissionsResource, FacilityUserResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 /**
  * Serially fetches Permissions, then FacilityUser. If returned Promise rejects,
@@ -44,7 +46,8 @@ export function showUserPermissionsPage(store, userId) {
   const stopLoading = () => store.dispatch('notLoading');
 
   // Don't request any data if not an Admin
-  if (!store.getters.isSuperuser) {
+  const { isSuperuser } = useUser();
+  if (!get(isSuperuser)) {
     setUserPermissionsState({ user: null, permissions: {} });
     stopLoading();
     return Promise.resolve();

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -1,6 +1,8 @@
 import store from 'kolibri.coreVue.vuex.store';
 import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyncSchedule';
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { showDeviceInfoPage } from '../modules/deviceInfo/handlers';
 import { showManagePermissionsPage } from '../modules/managePermissions/handlers';
 import { showManageContentPage } from '../modules/manageContent/handlers';
@@ -82,7 +84,8 @@ const routes = [
     component: withAuthMessage(ManageSyncSchedule, 'superuser'),
     path: '/facilities/:facilityId/managesync',
     props: route => {
-      const facilityId = route.params.facilityId || store.getters.userFacilityId;
+      const { userFacilityId } = useUser();
+      const facilityId = route.params.facilityId || get(userFacilityId);
       return {
         goBackRoute: { name: PageNames.FACILITIES_PAGE },
         facilityId,
@@ -103,9 +106,10 @@ const routes = [
     component: withAuthMessage(EditDeviceSyncSchedule, 'superuser'),
     path: '/facilities/:device_id/:facilityId/editdevice',
     props: route => {
+      const { userFacilityId } = useUser();
       return {
         goBackRoute: { name: PageNames.MANAGE_SYNC_SCHEDULE },
-        facilityId: route.params.facilityId || store.getters.userFacilityId,
+        facilityId: route.params.facilityId || get(userFacilityId),
         deviceId: route.params.device_id,
       };
     },

--- a/kolibri/plugins/facility/assets/src/app.js
+++ b/kolibri/plugins/facility/assets/src/app.js
@@ -18,13 +18,13 @@ class FacilityManagementModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
-    const { isLearnerOnlyImport } = useUser();
+    const { isLearnerOnlyImport, isSuperuser } = useUser();
     router.beforeEach((to, from, next) => {
       if (get(isLearnerOnlyImport)) {
         redirectBrowser();
         return;
       }
-      if (this.store.getters.isSuperuser && this.store.state.core.facilities.length === 0) {
+      if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
         this.store.dispatch('getFacilities').then(next, next);
       } else {
         next();

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -1,4 +1,6 @@
 import find from 'lodash/find';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { pageNameToModuleMap, PageNames } from '../constants';
 import classAssignMembers from './classAssignMembers';
 import classEditManagement from './classEditManagement';
@@ -34,16 +36,17 @@ export default {
     },
   },
   getters: {
-    activeFacilityId(state, getters, rootState, rootGetters) {
+    activeFacilityId(state, getters, rootState) {
       // Return either the facility_id param in the route module,
       // or the userFacilityId value from core.session
 
       // For multi-facility case, only use facility_id if in route because userFacilityId
       // fallback would always navigate to our default facility, not multi-facility landing page
-      if (getters.userIsMultiFacilityAdmin) {
+      const { userIsMultiFacilityAdmin, userFacilityId } = useUser();
+      if (get(userIsMultiFacilityAdmin)) {
         return rootState.route.params.facility_id;
       }
-      return rootState.route.params.facility_id || rootGetters.userFacilityId;
+      return rootState.route.params.facility_id || get(userFacilityId);
     },
     currentFacilityName(state, getters, rootState) {
       const match = find(rootState.core.facilities, { id: getters.activeFacilityId });
@@ -53,7 +56,8 @@ export default {
       // Use this getter to get Link objects that have the optional 'facility_id'
       // parameter if we're in a multi-facility situation
       const params = {};
-      if (getters.userIsMultiFacilityAdmin) {
+      const { userIsMultiFacilityAdmin } = useUser();
+      if (get(userIsMultiFacilityAdmin)) {
         params.facility_id = getters.activeFacilityId;
       }
       return {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -5,6 +5,8 @@ import VueRouter from 'vue-router';
 import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyncSchedule';
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
 import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import ClassEditPage from './views/ClassEditPage';
 import CoachClassAssignmentPage from './views/CoachClassAssignmentPage';
 import LearnerClassEnrollmentPage from './views/LearnerClassEnrollmentPage';
@@ -30,7 +32,8 @@ const logging = logger.getLogger(__filename);
 
 function facilityParamRequiredGuard(toRoute, subtopicName) {
   const { isNavigationFailure, NavigationFailureType } = VueRouter;
-  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+  const { userIsMultiFacilityAdmin } = useUser();
+  if (get(userIsMultiFacilityAdmin) && !toRoute.params.facility_id) {
     router
       .replace({
         name: 'ALL_FACILITIES_PAGE',
@@ -156,7 +159,8 @@ export default [
     path: '/',
     // Redirect to AllFacilitiesPage if a superuser and device has > 1 facility
     beforeEnter(to, from, next) {
-      if (store.getters.userIsMultiFacilityAdmin) {
+      const { userIsMultiFacilityAdmin } = useUser();
+      if (get(userIsMultiFacilityAdmin)) {
         next(store.getters.facilityPageLinks.AllFacilitiesPage);
       } else {
         next(store.getters.facilityPageLinks.ManageClassPage);
@@ -166,7 +170,8 @@ export default [
   {
     path: '/:facility_id?/managesync',
     props: route => {
-      const facilityId = route.params.facility_id || store.getters.userFacilityId;
+      const { userFacilityId } = useUser();
+      const facilityId = route.params.facility_id || get(userFacilityId);
       return {
         facilityId,
         goBackRoute: {
@@ -192,8 +197,9 @@ export default [
     component: EditDeviceSyncSchedule,
     name: SyncPageNames.EDIT_SYNC_SCHEDULE,
     props: route => {
+      const { userFacilityId } = useUser();
       return {
-        facilityId: route.params.facility_id || store.getters.userFacilityId,
+        facilityId: route.params.facility_id || get(userFacilityId),
         deviceId: route.params.deviceId,
         goBackRoute: {
           name: SyncPageNames.MANAGE_SYNC_SCHEDULE,

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -1,5 +1,7 @@
 import router from 'kolibri.coreVue.router';
 import KolibriApp from 'kolibri_app';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import RootVue from './views/LearnIndex';
 import routes from './routes';
 import { prepareLearnApp } from './composables/useCoreLearn';
@@ -23,10 +25,11 @@ class LearnModule extends KolibriApp {
     // If we are not logged in and are forbidden from accessing as guest
     // redirect to CONTENT_UNAVAILABLE.
     router.beforeEach((to, from, next) => {
+      const { isUserLoggedIn } = useUser();
       if (
         to.name !== PageNames.CONTENT_UNAVAILABLE &&
         !this.store.state.allowGuestAccess &&
-        !this.store.getters.isUserLoggedIn
+        !get(isUserLoggedIn)
       ) {
         // Pass the ?next param on to AuthMessage
         const currentURL = window.encodeURIComponent(window.location.href);

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -2,11 +2,13 @@ import { get, set } from '@vueuse/core';
 import omit from 'lodash/omit';
 import client from 'kolibri.client';
 import { coreStoreFactory as makeStore } from 'kolibri.coreVue.vuex.store';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import useProgressTracking from '../useProgressTracking';
 import coreModule from '../../../../../../core/assets/src/state/modules/core';
 
 jest.mock('kolibri.urls');
 jest.mock('kolibri.client');
+jest.mock('kolibri.coreVue.composables.useUser');
 
 function setUp() {
   const store = makeStore();
@@ -22,6 +24,9 @@ const node = {
 };
 
 describe('useProgressTracking composable', () => {
+  beforeEach(() => {
+    useUser.mockImplementation(() => useUserMock());
+  });
   describe('initContentSession', () => {
     it('should throw an error if no context provided', async () => {
       const { initContentSession } = setUp();
@@ -479,6 +484,7 @@ describe('useProgressTracking composable', () => {
     });
     it('should update total progress if the backend returns complete and was not complete and user is logged in', async () => {
       const { updateContentSession, store } = await initStore();
+      useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
       store.commit('CORE_SET_SESSION', { kind: ['learner'] });
       store.commit('SET_TOTAL_PROGRESS', 0);
       client.__setPayload({

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
@@ -5,10 +5,13 @@ import { ref } from 'kolibri.lib.vueCompositionApi';
 import { ContentNodeResource } from 'kolibri.resources';
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import { AllCategories, NoCategories } from 'kolibri.coreVue.vuex.constants';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import useSearch from '../useSearch';
 import coreModule from '../../../../../../core/assets/src/state/modules/core';
 
 Vue.use(VueRouter);
+
+jest.mock('kolibri.coreVue.composables.useUser');
 
 const name = 'not important';
 
@@ -40,6 +43,7 @@ describe(`useSearch`, () => {
   beforeEach(() => {
     ContentNodeResource.fetchCollection = jest.fn();
     ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
+    useUser.mockImplementation(() => useUserMock());
   });
   describe(`searchTerms computed ref`, () => {
     it(`returns an object with all relevant keys when query params are empty`, () => {

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -15,6 +15,7 @@ import Modalities from 'kolibri-constants/Modalities';
 import client from 'kolibri.client';
 import logger from 'kolibri.lib.logging';
 import urls from 'kolibri.urls';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 const logging = logger.getLogger(__filename);
 
@@ -287,7 +288,8 @@ export default function useProgressTracking(store) {
       if (response.data.complete) {
         set(complete, true);
         set(progress_state, 1);
-        if (store.getters.isUserLoggedIn && !wasComplete) {
+        const { isUserLoggedIn } = useUser();
+        if (get(isUserLoggedIn) && !wasComplete) {
           store.commit('INCREMENT_TOTAL_PROGRESS', 1);
         }
       }

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
@@ -1,9 +1,11 @@
-export function canAccessUnassignedContent(state, getters) {
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
+
+export function canAccessUnassignedContent(state) {
+  const { isCoach, isAdmin, isSuperuser } = useUser();
+
   return (
-    state.canAccessUnassignedContentSetting ||
-    getters.isCoach ||
-    getters.isAdmin ||
-    getters.isSuperUser
+    state.canAccessUnassignedContentSetting || get(isCoach) || get(isAdmin) || get(isSuperuser)
   );
 }
 

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -2,6 +2,8 @@ import { ExamResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { fetchExamWithContent } from 'kolibri.utils.exams';
 import shuffled from 'kolibri.utils.shuffled';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import { ClassesPageNames } from '../../constants';
 import { LearnerClassroomResource } from '../../apiResources';
 
@@ -13,9 +15,9 @@ export function showExam(store, params, alreadyOnQuiz) {
   }
   store.commit('SET_PAGE_NAME', ClassesPageNames.EXAM_VIEWER);
 
-  const userId = store.getters.currentUserId;
+  const { currentUserId } = useUser();
 
-  if (!userId) {
+  if (!get(currentUserId)) {
     store.commit('CORE_SET_ERROR', 'You must be logged in as a learner to view this page');
     store.commit('CORE_SET_PAGE_LOADING', false);
   } else {
@@ -36,13 +38,13 @@ export function showExam(store, params, alreadyOnQuiz) {
               // Seed based on the user ID so they see a consistent order each time.
               for (const section of question_sources) {
                 if (!section.learners_see_fixed_order) {
-                  section.questions = shuffled(section.questions, store.state.core.session.user_id);
+                  section.questions = shuffled(section.questions, get(currentUserId));
                 }
               }
               // When necessary randomize the order of the sections
               // Seed based on the user ID so they see a consistent order each time.
               if (!converted.learners_see_fixed_order) {
-                question_sources = shuffled(question_sources, store.state.core.session.user_id);
+                question_sources = shuffled(question_sources, get(currentUserId));
               }
               // If necessary, convert the question source info
               const allQuestions = question_sources.reduce((acc, section) => {

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
@@ -1,4 +1,6 @@
 import { ContentNodeResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import useContentNodeProgress from '../../composables/useContentNodeProgress';
 import { LearnerLessonResource } from '../../apiResources';
 import { ClassesPageNames } from '../../constants';
@@ -9,7 +11,8 @@ const { fetchContentNodeProgress } = useContentNodeProgress();
 export function showLessonPlaylist(store, { lessonId }) {
   return store.dispatch('loading').then(() => {
     // Only load contentnode progress if the user is logged in
-    if (store.getters.isUserLoggedIn) {
+    const { isUserLoggedIn } = useUser();
+    if (get(isUserLoggedIn)) {
       fetchContentNodeProgress({ lesson: lessonId });
     }
     const contentNodePromise = ContentNodeResource.fetchLessonResources(lessonId);

--- a/kolibri/plugins/learn/assets/src/my_downloads/routes.js
+++ b/kolibri/plugins/learn/assets/src/my_downloads/routes.js
@@ -1,5 +1,6 @@
-import store from 'kolibri.coreVue.vuex.store';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import MyDownloadsPage from './views/MyDownloads';
 
 export default [
@@ -8,7 +9,8 @@ export default [
     name: 'MY_DOWNLOADS',
     component: MyDownloadsPage,
     beforeEnter(to, from, next) {
-      if (!store.getters.isUserLoggedIn) {
+      const { isUserLoggedIn } = useUser();
+      if (!get(isUserLoggedIn)) {
         redirectBrowser();
       } else {
         next();

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -152,7 +152,6 @@ oriented data synchronization.
 
 <script>
 
-  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import shuffled from 'kolibri.utils.shuffled';
@@ -161,6 +160,7 @@ oriented data synchronization.
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import { createTranslator, defaultLanguage } from 'kolibri.utils.i18n';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import LessonMasteryBar from './LessonMasteryBar';
   import ExerciseAttempts from './ExerciseAttempts';
 
@@ -192,8 +192,10 @@ oriented data synchronization.
     mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
+      const { currentUserId } = useUser();
       return {
         windowIsSmall,
+        currentUserId,
       };
     },
     props: {
@@ -278,9 +280,6 @@ oriented data synchronization.
       };
     },
     computed: {
-      ...mapState({
-        userid: state => state.core.session.user_id,
-      }),
       currentattempt() {
         return !this.firstAttemptAtQuestion ? this.pastattempts[0] : null;
       },
@@ -458,7 +457,7 @@ oriented data synchronization.
       setItemId() {
         const index = this.totalattempts % this.assessmentIds.length;
         if (this.randomize) {
-          const seed = this.userid ? this.userid : Date.now();
+          const seed = this.currentUserId ? this.currentUserId : Date.now();
           this.itemId = shuffled(this.assessmentIds, seed)[index];
         } else {
           this.itemId = this.assessmentIds[index];

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -24,7 +24,6 @@
 
 <script>
 
-  import { mapState } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import useUser from 'kolibri.coreVue.composables.useUser';
   import { setContentNodeProgress } from '../../composables/useContentNodeProgress';
@@ -49,7 +48,7 @@
         startTrackingProgress,
         stopTrackingProgress,
       } = useProgressTracking();
-      const { currentUserId } = useUser();
+      const { currentUserId, full_name } = useUser();
       return {
         progress,
         time_spent,
@@ -62,6 +61,7 @@
         startTracking: startTrackingProgress,
         stopTracking: stopTrackingProgress,
         currentUserId,
+        full_name,
       };
     },
     props: {
@@ -77,9 +77,6 @@
       };
     },
     computed: {
-      ...mapState({
-        fullName: state => state.core.session.full_name,
-      }),
       contentIsExercise() {
         return this.contentNode.kind === ContentNodeKinds.EXERCISE;
       },
@@ -106,7 +103,7 @@
           extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,
-          userFullName: this.fullName,
+          userFullName: this.full_name,
           timeSpent: this.time_spent,
         };
       },
@@ -126,7 +123,7 @@
           extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,
-          userFullName: this.fullName,
+          userFullName: this.full_name,
           timeSpent: this.time_spent,
           pastattempts: this.pastattempts,
           mastered: this.complete,

--- a/kolibri/plugins/policies/assets/src/modules/policies/actions.js
+++ b/kolibri/plugins/policies/assets/src/modules/policies/actions.js
@@ -1,13 +1,17 @@
 import isEmpty from 'lodash/isEmpty';
 import { FacilityUserResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 export function updateUserProfile(store, { updates }) {
   if (isEmpty(updates)) {
     return Promise.resolve();
   }
 
+  const { currentUserId } = useUser();
+
   return FacilityUserResource.saveModel({
-    id: store.rootGetters.currentUserId,
+    id: get(currentUserId),
     data: updates,
     exists: true,
   }).then(() => {
@@ -16,8 +20,9 @@ export function updateUserProfile(store, { updates }) {
 }
 
 export function updateUserProfilePassword(store, password) {
+  const { currentUserId } = useUser();
   return FacilityUserResource.saveModel({
-    id: store.rootGetters.currentUserId,
+    id: get(currentUserId),
     data: { password },
     exists: true,
   });

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -1,4 +1,6 @@
 import Lockr from 'lockr';
+import { get } from '@vueuse/core';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
 import signIn from './signIn';
 
@@ -41,7 +43,8 @@ export default {
       if (selectedFacility) {
         return selectedFacility;
       } else {
-        return getters.facilities.find(f => f.id === getters.userFacilityId) || null;
+        const { userFacilityId } = useUser();
+        return getters.facilities.find(f => f.id === get(userFacilityId)) || null;
       }
     },
   },

--- a/kolibri/plugins/user_auth/assets/src/modules/signIn/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signIn/handlers.js
@@ -2,6 +2,8 @@ import Lockr from 'lockr';
 import { SIGNED_OUT_DUE_TO_INACTIVITY } from 'kolibri.coreVue.vuex.constants';
 import { createTranslator } from 'kolibri.utils.i18n';
 import useSnackbar from 'kolibri.coreVue.composables.useSnackbar';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 const snackbarTranslator = createTranslator('UserPageSnackbars', {
   dismiss: {
@@ -29,11 +31,12 @@ export function showSignInPage(store) {
   }
   return store.dispatch('setFacilitiesAndConfig').then(() => {
     // Use selected id if available, otherwise get the default facility id from session
+    const { userFacilityId } = useUser();
     let facilityId;
     if (store.getters.facilities.length > 1) {
-      facilityId = store.state.facilityId || store.getters.userFacilityId;
+      facilityId = store.state.facilityId || get(userFacilityId);
     } else {
-      facilityId = store.getters.userFacilityId;
+      facilityId = get(userFacilityId);
     }
     store.commit('SET_FACILITY_ID', facilityId);
     store.commit('signIn/SET_STATE', {

--- a/kolibri/plugins/user_profile/assets/src/composables/useCurrentUser.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useCurrentUser.js
@@ -1,20 +1,20 @@
-import { ref, onMounted, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
+import { ref, onMounted } from 'kolibri.lib.vueCompositionApi';
 import { FacilityUserResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 // A usable that returns the Facility user tied to the session
 export default function useCurrentUser() {
-  const $store = getCurrentInstance().proxy.$store;
+  const { currentUserId } = useUser();
   const currentUser = ref({});
   const isLoading = ref(false);
 
   onMounted(() => {
     isLoading.value = true;
-    return FacilityUserResource.fetchModel({ id: $store.state.core.session.user_id }).then(
-      userModel => {
-        currentUser.value = { ...userModel };
-        isLoading.value = false;
-      },
-    );
+    return FacilityUserResource.fetchModel({ id: get(currentUserId) }).then(userModel => {
+      currentUser.value = { ...userModel };
+      isLoading.value = false;
+    });
   });
 
   return {

--- a/kolibri/plugins/user_profile/assets/src/modules/profile/actions.js
+++ b/kolibri/plugins/user_profile/assets/src/modules/profile/actions.js
@@ -1,13 +1,17 @@
 import isEmpty from 'lodash/isEmpty';
 import { FacilityUserResource } from 'kolibri.resources';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 
 export function updateUserProfile(store, { updates }) {
   if (isEmpty(updates)) {
     return Promise.resolve();
   }
 
+  const { currentUserId } = useUser();
+
   return FacilityUserResource.saveModel({
-    id: store.rootGetters.currentUserId,
+    id: get(currentUserId),
     data: updates,
     exists: true,
   }).then(() => {
@@ -16,8 +20,9 @@ export function updateUserProfile(store, { updates }) {
 }
 
 export function updateUserProfilePassword(store, password) {
+  const { currentUserId } = useUser();
   return FacilityUserResource.saveModel({
-    id: store.rootGetters.currentUserId,
+    id: get(currentUserId),
     data: { password },
     exists: true,
   });

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -1,5 +1,7 @@
 import store from 'kolibri.coreVue.vuex.store';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { get } from '@vueuse/core';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';
@@ -30,7 +32,8 @@ export default [
     name: 'PROFILE',
     component: ProfilePage,
     beforeEnter(to, from, next) {
-      if (!store.getters.isUserLoggedIn) {
+      const { isUserLoggedIn } = useUser();
+      if (!get(isUserLoggedIn)) {
         redirectBrowser();
       } else {
         preload(next);
@@ -42,7 +45,8 @@ export default [
     name: 'PROFILE_EDIT',
     component: ProfileEditPage,
     beforeEnter(to, from, next) {
-      if (!store.getters.isUserLoggedIn) {
+      const { isUserLoggedIn } = useUser();
+      if (!get(isUserLoggedIn)) {
         redirectBrowser();
       } else {
         preload(next);
@@ -55,7 +59,8 @@ export default [
     name: 'CHANGE_FACILITY',
     component: ChangeFacility,
     beforeEnter(to, from, next) {
-      if (!store.getters.isUserLoggedIn) {
+      const { isUserLoggedIn } = useUser();
+      if (!get(isUserLoggedIn)) {
         redirectBrowser();
       } else {
         preload(next);

--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -103,8 +103,8 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { isLearnerOnlyImport, isLearner } = useUser();
-      return { isLearnerOnlyImport, isLearner };
+      const { isLearnerOnlyImport, isLearner, currentUserId } = useUser();
+      return { isLearnerOnlyImport, isLearner, currentUserId };
     },
     data() {
       return {
@@ -160,15 +160,13 @@
     methods: {
       // Have to query FacilityUser again since we don't put demographic info on the session
       setFacilityUser() {
-        FacilityUserResource.fetchModel({ id: this.$store.state.core.session.user_id }).then(
-          facilityUser => {
-            this.birthYear = facilityUser.birth_year;
-            this.gender = facilityUser.gender;
-            this.fullName = facilityUser.full_name;
-            this.username = facilityUser.username;
-            this.userCopy = { ...facilityUser };
-          },
-        );
+        FacilityUserResource.fetchModel({ id: this.currentUserId }).then(facilityUser => {
+          this.birthYear = facilityUser.birth_year;
+          this.gender = facilityUser.gender;
+          this.fullName = facilityUser.full_name;
+          this.username = facilityUser.username;
+          this.userCopy = { ...facilityUser };
+        });
       },
       getUpdates() {
         return pickBy(

--- a/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
@@ -5,10 +5,13 @@ import { ref } from 'kolibri.lib.vueCompositionApi';
 import { ContentNodeResource } from 'kolibri.resources';
 import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import { AllCategories, NoCategories } from 'kolibri.coreVue.vuex.constants';
+import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import useBaseSearch from '../useBaseSearch';
 import coreModule from '../../../../kolibri/core/assets/src/state/modules/core';
 
 Vue.use(VueRouter);
+
+jest.mock('kolibri.coreVue.composables.useUser');
 
 const name = 'not important';
 
@@ -40,6 +43,7 @@ describe(`useBaseSearch`, () => {
   beforeEach(() => {
     ContentNodeResource.fetchCollection = jest.fn();
     ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
+    useUser.mockImplementation(() => useUserMock());
   });
   describe(`searchTerms computed ref`, () => {
     it(`returns an object with all relevant keys when query params are empty`, () => {

--- a/packages/kolibri-common/composables/useBaseSearch.js
+++ b/packages/kolibri-common/composables/useBaseSearch.js
@@ -20,6 +20,7 @@ import {
   NoCategories,
   ResourcesNeededTypes,
 } from 'kolibri.coreVue.vuex.constants';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 import { deduplicateResources } from '../utils/contentNode';
 import { setLanguages } from './useLanguages';
@@ -180,6 +181,8 @@ export default function useBaseSearch({
   const more = ref(null);
   const labels = ref(null);
 
+  const { isAdmin, isCoach, isSuperuser, isUserLoggedIn } = useUser();
+
   const searchTerms = computed({
     get() {
       const searchTerms = {};
@@ -240,8 +243,7 @@ export default function useBaseSearch({
   function search() {
     const currentBaseUrl = get(baseurl);
     const getParams = {
-      include_coach_content:
-        store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+      include_coach_content: get(isAdmin) || get(isCoach) || get(isSuperuser),
       baseurl: currentBaseUrl,
     };
     const descValue = descendant ? get(descendant) : null;
@@ -275,7 +277,7 @@ export default function useBaseSearch({
       if (terms.keywords) {
         getParams.keywords = terms.keywords;
       }
-      if (store.getters.isUserLoggedIn) {
+      if (get(isUserLoggedIn)) {
         fetchContentNodeProgress?.(getParams);
       }
       ContentNodeResource.fetchCollection({ getParams }).then(data => {
@@ -301,7 +303,7 @@ export default function useBaseSearch({
   function searchMore() {
     if (get(displayingSearchResults) && get(more) && !get(moreLoading)) {
       set(moreLoading, true);
-      if (store.getters.isUserLoggedIn) {
+      if (get(isUserLoggedIn)) {
         fetchContentNodeProgress?.(get(more));
       }
       return ContentNodeResource.fetchCollection({ getParams: get(more) }).then(data => {


### PR DESCRIPTION
## Summary
This change moves the remaining references to the session vuex module getters to the `useUser` composable.

## References
- Completes #12203 
- Followup to #12438 

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
