### PR TITLE
Add configuration option to disable Zeroconf in cloud deployments

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -681,6 +681,13 @@ base_option_spec = {
                 The default is to disallow server restarts, so callbacks need to be added to enable restarting.
             """,
         },
+        "ZEROCONF_ENABLED": {
+            "type": "bool",
+            "default": True,
+            "description": """
+                Boolean Flag to check Whether to enable Zeroconf discovery.
+            """,
+        },
     },
     "Python": {
         "PICKLE_PROTOCOL": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -682,7 +682,7 @@ base_option_spec = {
             """,
         },
         "ZEROCONF_ENABLED": {
-            "type": "bool",
+            "type": "boolean",
             "default": True,
             "description": """
                 Boolean Flag to check Whether to enable Zeroconf discovery.

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -759,9 +759,10 @@ class KolibriServicesProcessBus(BaseKolibriProcessBus):
         service_plugin = ServicesPlugin(self)
         service_plugin.subscribe()
 
-        # Setup zeroconf plugin
-        zeroconf_plugin = ZeroConfPlugin(self, self.port)
-        zeroconf_plugin.subscribe()
+        if conf.OPTIONS["Deployment"]["ZEROCONF_ENABLED"]:
+            # Setup zeroconf plugin
+            zeroconf_plugin = ZeroConfPlugin(self, self.port)
+            zeroconf_plugin.subscribe()
 
     def run(self):
         self.graceful()


### PR DESCRIPTION
## Summary
Adds a ZEROCONF_ENABLED option in options.ini, allowing Zeroconf to be disabled in cloud deployments.

## References
closes #10552

## Reviewer guidance


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
