### PR TITLE
Creating useTotalProgress composable and migrating code to use it

### DIFF
--- a/kolibri/core/assets/src/composables/__mocks__/useTotalProgress.js
+++ b/kolibri/core/assets/src/composables/__mocks__/useTotalProgress.js
@@ -1,0 +1,62 @@
+/**
+ * `useTotalProgress` composable function mock.
+ *
+ * If default values are sufficient for tests,
+ * you only need call `jest.mock('<useTotalProgress file path>')`
+ * at the top of a test file.
+ *
+ * If you need to override some default values for some tests,
+ * or if you need to inspect the state of the refs during tests,
+ * you can import a helper function `useTotalProgressMock` that accepts
+ * an object with values to be overriden and use it together
+ * with  `mockImplementation` as follows:
+ *
+ * ```
+ * // eslint-disable-next-line import/named
+ * import useTotalProgress, { useTotalProgressMock } from '<useTotalProgress file path>';
+ *
+ * jest.mock('<useTotalProgress file path>')
+ * describe('describe test', function () {
+ *   let totalProgressMock = { totalProgress: ref(null) }
+ *
+ *   beforeAll(() => {
+ *     useTotalProgress.mockImplementation(() => useTotalProgressMock(totalProgressMock)
+ *   })
+ *
+ *   it('the test', () => {
+ *     expect(get(totalProgressMock.totalProgress)).toEqual(null);
+ *   )
+ * })
+ * ```
+ */
+import { ref, computed } from 'kolibri.lib.vueCompositionApi';
+import { get, set } from '@vueuse/core';
+import { MaxPointsPerContent } from '../../constants';
+
+const MOCK_DEFAULTS = {
+  totalProgress: ref(null),
+};
+
+export function useTotalProgressMock(overrides = {}) {
+  const mocks = {
+    ...MOCK_DEFAULTS,
+    ...overrides,
+  };
+
+  const totalPoints = computed(() => mocks.totalProgress.value * MaxPointsPerContent);
+
+  const fetchPoints = jest.fn();
+
+  const incrementTotalProgress = progress => {
+    set(mocks.totalProgress, get(mocks.totalProgress) + progress);
+  };
+
+  return {
+    totalPoints,
+    fetchPoints,
+    incrementTotalProgress,
+    ...mocks,
+  };
+}
+
+export default jest.fn(() => useTotalProgressMock());

--- a/kolibri/core/assets/src/composables/useTotalProgress.js
+++ b/kolibri/core/assets/src/composables/useTotalProgress.js
@@ -1,0 +1,31 @@
+import { ref, computed } from 'kolibri.lib.vueCompositionApi';
+import { get, set } from '@vueuse/core';
+import useUser from 'kolibri.coreVue.composables.useUser';
+import { UserProgressResource } from 'kolibri.resources';
+import { MaxPointsPerContent } from '../constants';
+
+const totalProgress = ref(null);
+
+export default function useTotalProgress() {
+  const totalPoints = computed(() => totalProgress.value * MaxPointsPerContent);
+
+  const fetchPoints = () => {
+    const { isUserLoggedIn, currentUserId } = useUser();
+    if (get(isUserLoggedIn) && get(totalProgress) === null) {
+      UserProgressResource.fetchModel({ id: get(currentUserId) }).then(progress => {
+        set(totalProgress, progress.progress);
+      });
+    }
+  };
+
+  const incrementTotalProgress = progress => {
+    set(totalProgress, get(totalProgress) + progress);
+  };
+
+  return {
+    totalProgress,
+    totalPoints,
+    fetchPoints,
+    incrementTotalProgress,
+  };
+}

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -92,6 +92,7 @@ import useMinimumKolibriVersion from '../composables/useMinimumKolibriVersion';
 import useUserSyncStatus from '../composables/useUserSyncStatus';
 import useUser from '../composables/useUser';
 import useSnackbar from '../composables/useSnackbar';
+import useTotalProgress from '../composables/useTotalProgress';
 import { registerNavItem } from '../composables/useNav';
 import useNow from '../composables/useNow';
 
@@ -204,6 +205,7 @@ export default {
       useUser,
       useUserSyncStatus,
       useSnackbar,
+      useTotalProgress,
     },
   },
   resources,

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -5,7 +5,6 @@ import logger from 'kolibri.lib.logging';
 import {
   FacilityResource,
   FacilityDatasetResource,
-  UserProgressResource,
   UserSyncStatusResource,
   PingbackNotificationResource,
   PingbackNotificationDismissedResource,
@@ -244,15 +243,6 @@ export function getFacilityConfig(store, facilityId) {
     }
     store.commit('CORE_SET_FACILITY_CONFIG', config);
   });
-}
-
-export function fetchPoints(store) {
-  const { isUserLoggedIn, currentUserId } = store.getters;
-  if (isUserLoggedIn && store.state.totalProgress === null) {
-    UserProgressResource.fetchModel({ id: currentUserId }).then(progress => {
-      store.commit('SET_TOTAL_PROGRESS', progress.progress);
-    });
-  }
 }
 
 export function loading(store) {

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -1,6 +1,5 @@
 import useUser from 'kolibri.coreVue.composables.useUser';
 import { get } from '@vueuse/core';
-import { MaxPointsPerContent } from '../../../constants';
 
 export function facilityConfig(state) {
   return state.facilityConfig;
@@ -8,10 +7,6 @@ export function facilityConfig(state) {
 
 export function facilities(state) {
   return state.facilities;
-}
-
-export function totalPoints(state) {
-  return state.totalProgress * MaxPointsPerContent;
 }
 
 export function pageSessionId(state) {

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -10,7 +10,6 @@ export default {
       error: '',
       loading: true,
       pageSessionId: 0,
-      totalProgress: null,
       notifications: [],
       allowRemoteAccess: plugin_data.allowRemoteAccess,
       // facility

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -15,12 +15,6 @@ export default {
   CORE_SET_ERROR(state, error) {
     state.error = error;
   },
-  SET_TOTAL_PROGRESS(state, progress) {
-    state.totalProgress = progress;
-  },
-  INCREMENT_TOTAL_PROGRESS(state, progress) {
-    state.totalProgress += progress;
-  },
   CORE_SET_NOTIFICATIONS(state, notifications) {
     state.notifications = notifications;
   },

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -127,7 +127,6 @@
 
 <script>
 
-  import { mapActions, mapGetters } from 'vuex';
   import { get } from '@vueuse/core';
   import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -135,6 +134,7 @@
   import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
   import themeConfig from 'kolibri.themeConfig';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import useTotalProgress from 'kolibri.coreVue.composables.useTotalProgress';
   import useNav from '../composables/useNav';
   import useUser from '../composables/useUser';
   import SkipNavigationLink from './SkipNavigationLink';
@@ -157,6 +157,7 @@
       const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       const { topBarHeight, navItems } = useNav();
       const { isLearner, isUserLoggedIn, username, full_name } = useUser();
+      const { totalPoints, fetchPoints } = useTotalProgress();
       const links = computed(() => {
         const currentItem = navItems.find(nc => nc.url === window.location.pathname);
         if (!currentItem || !currentItem.routes) {
@@ -179,6 +180,8 @@
         isLearner,
         username,
         fullName: full_name,
+        totalPoints,
+        fetchPoints,
       };
     },
     props: {
@@ -201,7 +204,6 @@
       };
     },
     computed: {
-      ...mapGetters(['totalPoints']),
       // temp hack for the VF plugin
       usernameForDisplay() {
         return !hashedValuePattern.test(this.username) ? this.username : this.fullName;
@@ -219,7 +221,6 @@
       window.removeEventListener('keydown', this.handlePopoverByKeyboard, true);
     },
     methods: {
-      ...mapActions(['fetchPoints']),
       handleWindowClick(event) {
         if (this.$refs.pointsButton && this.$refs.pointsButton.$el) {
           if (!this.$refs.pointsButton.$el.contains(event.target) && this.pointsDisplayed) {

--- a/kolibri/core/assets/src/views/TotalPoints.vue
+++ b/kolibri/core/assets/src/views/TotalPoints.vue
@@ -30,17 +30,20 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'vuex';
   import useUser from 'kolibri.coreVue.composables.useUser';
+  import useTotalProgress from 'kolibri.coreVue.composables.useTotalProgress';
 
   export default {
     name: 'TotalPoints',
     setup() {
       const { currentUserId, isUserLoggedIn } = useUser();
-      return { currentUserId, isUserLoggedIn };
-    },
-    computed: {
-      ...mapGetters(['totalPoints']),
+      const { fetchPoints, totalPoints } = useTotalProgress();
+      return {
+        currentUserId,
+        isUserLoggedIn,
+        fetchPoints,
+        totalPoints,
+      };
     },
     watch: {
       currentUserId() {
@@ -49,9 +52,6 @@
     },
     created() {
       this.fetchPoints();
-    },
-    methods: {
-      ...mapActions(['fetchPoints']),
     },
     $trs: {
       pointsTooltip: {

--- a/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
+++ b/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
@@ -1,77 +1,58 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
-import TotalPoints from '../TotalPoints.vue';
+import useTotalProgress, {
+  useTotalProgressMock,
+} from 'kolibri.coreVue.composables.useTotalProgress';
 import '@testing-library/jest-dom';
-
-let store, storeActions;
+import { ref } from 'kolibri.lib.vueCompositionApi';
+import { get, set } from '@vueuse/core';
+import TotalPoints from '../TotalPoints.vue';
 
 jest.mock('kolibri.coreVue.composables.useUser');
-
-// Create a mock Vuex store with the required getters and actions
-// This is a helper function to avoid create a new store for each test and not reuse the same object
-const getMockStore = () => {
-  return {
-    getters: {
-      totalPoints: () => store.totalPoints,
-    },
-    actions: {
-      fetchPoints: storeActions.fetchPoints,
-    },
-  };
-};
-
-// Helper function to render the component with Vuex store
-const renderComponent = store => {
-  return render(TotalPoints, {
-    store,
-  });
-};
+jest.mock('kolibri.coreVue.composables.useTotalProgress');
 
 describe('TotalPoints', () => {
+  let totalPointsMock;
   beforeEach(() => {
     jest.clearAllMocks();
     useUser.mockImplementation(() => useUserMock());
-    store = {
-      totalPoints: 0,
-    };
-
-    storeActions = {
-      fetchPoints: jest.fn(),
-    };
+    totalPointsMock = { totalPoints: ref(0), fetchPoints: jest.fn() };
+    useTotalProgress.mockImplementation(() => useTotalProgressMock(totalPointsMock));
   });
 
   test('renders when user is logged in', async () => {
     useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
-    store.totalPoints = 100;
-    renderComponent(getMockStore());
+    set(totalPointsMock.totalPoints, 100);
+    render(TotalPoints);
 
     expect(screen.getByRole('presentation')).toBeInTheDocument();
-    expect(screen.getByText(store.totalPoints)).toBeInTheDocument();
+    expect(screen.getByText(get(totalPointsMock.totalPoints))).toBeInTheDocument();
   });
 
   test('does not render when user is not logged in', async () => {
     useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: false }));
-    store.totalPoints = 100;
-    renderComponent(getMockStore());
+    set(totalPointsMock.totalPoints, 100);
+    render(TotalPoints);
 
     expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
-    expect(screen.queryByText(store.totalPoints)).not.toBeInTheDocument();
+    expect(screen.queryByText(get(totalPointsMock.totalPoints))).not.toBeInTheDocument();
   });
 
   test('fetchPoints method is called on created', async () => {
     useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
-    const mockedStore = getMockStore();
-    renderComponent(mockedStore);
+    render(TotalPoints);
 
-    expect(mockedStore.actions.fetchPoints).toHaveBeenCalledTimes(1);
+    expect(totalPointsMock.fetchPoints).toHaveBeenCalledTimes(1);
   });
 
   test('tooltip message is displayed correctly when the mouse hovers over the icon', async () => {
     useUser.mockImplementation(() => useUserMock({ currentUserId: 1, isUserLoggedIn: true }));
-    store.totalPoints = 100;
-    renderComponent(getMockStore());
+    set(totalPointsMock.totalPoints, 100);
+    render(TotalPoints);
 
     await fireEvent.mouseOver(screen.getByRole('presentation'));
-    expect(screen.getByText(`You earned ${store.totalPoints} points`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`You earned ${get(totalPointsMock.totalPoints)} points`),
+    ).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -3,12 +3,17 @@ import omit from 'lodash/omit';
 import client from 'kolibri.client';
 import { coreStoreFactory as makeStore } from 'kolibri.coreVue.vuex.store';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
+import useTotalProgress, {
+  useTotalProgressMock,
+} from 'kolibri.coreVue.composables.useTotalProgress';
+import { ref } from 'kolibri.lib.vueCompositionApi';
 import useProgressTracking from '../useProgressTracking';
 import coreModule from '../../../../../../core/assets/src/state/modules/core';
 
 jest.mock('kolibri.urls');
 jest.mock('kolibri.client');
 jest.mock('kolibri.coreVue.composables.useUser');
+jest.mock('kolibri.coreVue.composables.useTotalProgress');
 
 function setUp() {
   const store = makeStore();
@@ -24,8 +29,11 @@ const node = {
 };
 
 describe('useProgressTracking composable', () => {
+  let totalProgressMock;
   beforeEach(() => {
     useUser.mockImplementation(() => useUserMock());
+    totalProgressMock = { totalProgress: ref(null) };
+    useTotalProgress.mockImplementation(() => useTotalProgressMock(totalProgressMock));
   });
   describe('initContentSession', () => {
     it('should throw an error if no context provided', async () => {
@@ -474,24 +482,24 @@ describe('useProgressTracking composable', () => {
       expect(get(complete)).toBe(true);
     });
     it('should not update total progress if the backend returns complete and was not complete and user is not logged in', async () => {
-      const { updateContentSession, store } = await initStore();
+      const { updateContentSession } = await initStore();
       client.__setPayload({
         complete: true,
       });
-      store.commit('SET_TOTAL_PROGRESS', 0);
+      set(totalProgressMock.totalProgress, 0);
       await updateContentSession({ contentState: { test: 'test' } });
-      expect(store.state.core.totalProgress).toEqual(0);
+      expect(get(totalProgressMock.totalProgress)).toEqual(0);
     });
     it('should update total progress if the backend returns complete and was not complete and user is logged in', async () => {
       const { updateContentSession, store } = await initStore();
       useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
       store.commit('CORE_SET_SESSION', { kind: ['learner'] });
-      store.commit('SET_TOTAL_PROGRESS', 0);
+      set(totalProgressMock.totalProgress, 0);
       client.__setPayload({
         complete: true,
       });
       await updateContentSession({ contentState: { test: 'test' } });
-      expect(store.state.core.totalProgress).toEqual(1);
+      expect(get(totalProgressMock.totalProgress)).toEqual(1);
     });
     it('should update progress_state if the backend returns complete', async () => {
       const { updateContentSession, progress } = await initStore();
@@ -504,12 +512,12 @@ describe('useProgressTracking composable', () => {
     it('should not update total progress if the backend returns complete and was already complete', async () => {
       const { updateContentSession, store } = await initStore({ complete: true });
       store.commit('CORE_SET_SESSION', { kind: ['learner'] });
-      store.commit('SET_TOTAL_PROGRESS', 0);
+      set(totalProgressMock.totalProgress, 0);
       client.__setPayload({
         complete: true,
       });
       await updateContentSession({ contentState: { test: 'test' } });
-      expect(store.state.core.totalProgress).toEqual(0);
+      expect(get(totalProgressMock.totalProgress)).toEqual(0);
     });
     it('should update progress and progress_delta if progress is updated under threshold', async () => {
       const { updateContentSession, progress, progress_delta } = await initStore();

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -16,6 +16,7 @@ import client from 'kolibri.client';
 import logger from 'kolibri.lib.logging';
 import urls from 'kolibri.urls';
 import useUser from 'kolibri.coreVue.composables.useUser';
+import useTotalProgress from 'kolibri.coreVue.composables.useTotalProgress';
 
 const logging = logger.getLogger(__filename);
 
@@ -289,8 +290,9 @@ export default function useProgressTracking(store) {
         set(complete, true);
         set(progress_state, 1);
         const { isUserLoggedIn } = useUser();
+        const { incrementTotalProgress } = useTotalProgress();
         if (get(isUserLoggedIn) && !wasComplete) {
-          store.commit('INCREMENT_TOTAL_PROGRESS', 1);
+          incrementTotalProgress(1);
         }
       }
       return response.data;

--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -5,6 +5,10 @@ import Vuex from 'vuex';
 import { useDevicesWithFilter } from 'kolibri.coreVue.componentSets.sync';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import useTotalProgress, {
+  useTotalProgressMock,
+} from 'kolibri.coreVue.composables.useTotalProgress';
+import { ref } from 'kolibri.lib.vueCompositionApi';
 import { ClassesPageNames, PageNames } from '../../../constants';
 import HomePage from '../index';
 /* eslint-disable import/named */
@@ -25,6 +29,7 @@ jest.mock('../../../composables/useContentLink');
 // Needed to test anything using mount() where children use this composable
 jest.mock('../../../composables/useLearningActivities');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('kolibri.coreVue.composables.useTotalProgress');
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -106,6 +111,7 @@ describe(`HomePage`, () => {
     }));
   });
 
+  let totalProgressMock;
   beforeEach(() => {
     jest.clearAllMocks();
     // set back to default values defined in __mocks__
@@ -125,6 +131,8 @@ describe(`HomePage`, () => {
         fetchChannels: jest.fn(() => Promise.resolve([{ id: 'channel-1', name: 'Channel 1' }])),
       }),
     );
+    totalProgressMock = { totalProgress: ref(null) };
+    useTotalProgress.mockImplementation(() => useTotalProgressMock(totalProgressMock));
   });
 
   it(`smoke test`, () => {

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -197,6 +197,7 @@
   import useUser from 'kolibri.coreVue.composables.useUser';
   import GenderDisplayText from 'kolibri.coreVue.components.GenderDisplayText';
   import BirthYearDisplayText from 'kolibri.coreVue.components.BirthYearDisplayText';
+  import useTotalProgress from 'kolibri.coreVue.composables.useTotalProgress';
   import { RoutesMap } from '../../constants';
   import useCurrentUser from '../../composables/useCurrentUser';
   import useOnMyOwnSetup from '../../composables/useOnMyOwnSetup';
@@ -233,6 +234,7 @@
         userFacilityId,
       } = useUser();
       const { onMyOwnSetup } = useOnMyOwnSetup();
+      const { fetchPoints, totalPoints } = useTotalProgress();
       return {
         currentUser,
         onMyOwnSetup,
@@ -245,10 +247,12 @@
         userFacilityId,
         showLearnModal,
         showPasswordModal,
+        fetchPoints,
+        totalPoints,
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig', 'totalPoints']),
+      ...mapGetters(['facilityConfig']),
       profileEditRoute() {
         return this.$router.getRoute(RoutesMap.PROFILE_EDIT);
       },
@@ -285,7 +289,7 @@
       },
     },
     created() {
-      this.$store.dispatch('fetchPoints');
+      this.fetchPoints();
     },
     methods: {
       getPermissionString(permission) {


### PR DESCRIPTION
## Summary
This change creates a new composable for tracking total progress and migrates existing code to use it.

## References
- Fixes #12619

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
