### PR TITLE
Add searchAndFilterStrings translator into kolibri-common

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -6,8 +6,8 @@
     role="region"
     :class="windowIsLarge ? 'side-panel' : ''"
     :closeButtonIconType="closeButtonIcon"
-    :aria-label="learnString('filterAndSearchLabel')"
-    :ariaLabel="learnString('filterAndSearchLabel')"
+    :aria-label="filterAndSearchLabel$()"
+    :ariaLabel="filterAndSearchLabel$()"
     :style="
       windowIsLarge
         ? {
@@ -128,12 +128,12 @@
 
   import { NoCategories } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import { injectBaseSearch } from 'kolibri-common/composables/useBaseSearch';
   import SearchBox from '../SearchBox';
   import SidePanelModal from '../SidePanelModal';
-  import commonLearnStrings from '../commonLearnStrings';
   import useContentLink from '../../composables/useContentLink';
   import ActivityButtonsGroup from './ActivityButtonsGroup';
   import CategorySearchModal from './CategorySearchModal';
@@ -148,7 +148,7 @@
       CategorySearchModal,
       SidePanelModal,
     },
-    mixins: [commonLearnStrings, commonCoreStrings],
+    mixins: [commonCoreStrings],
     setup() {
       const { windowIsLarge } = useKResponsiveWindow();
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
@@ -159,7 +159,9 @@
         activeSearchTerms,
       } = injectBaseSearch();
       const currentCategory = ref(null);
+      const { filterAndSearchLabel$ } = searchAndFilterStrings;
       return {
+        filterAndSearchLabel$,
         availableLibraryCategories,
         availableResourcesNeeded,
         currentCategory,

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -1,0 +1,10 @@
+import { createTranslator } from 'kolibri.utils.i18n';
+
+export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings', {
+  // Labels
+  filterAndSearchLabel: {
+    message: 'Filter and search',
+    context:
+      'Label for a section of the page that contains options for searching and filtering content',
+  },
+});


### PR DESCRIPTION
## Summary

Create searchAndFIlterStrings translator, and migrate existing commonLearnStrings from SearchFiltersPanel.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #12609

## Reviewer guidance

There was just one string from commonLearnStrings in the SearchFiltersPanel folder. So just check that this string is visible in the UI, and that no more strings from commonLearnStrings are in the SearchFiltersPanel.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
