### PR TITLE
Fix Mismatch between coach Reports and generated CSV

### DIFF
--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -89,6 +89,16 @@ export function helpNeeded() {
   ];
 }
 
+export function allLearners(key = 'all') {
+  return [
+    {
+      name: FieldsMixinStrings.$tr('allLearners'),
+      key,
+      format: row => get(row, key) || '',
+    },
+  ];
+}
+
 export function lastActivity(key = 'lastActivity') {
   return [
     {

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -89,17 +89,19 @@ export function helpNeeded() {
   ];
 }
 
-export function lastActivity() {
+export function lastActivity(key = 'lastActivity') {
   return [
     {
       name: coachStrings.$tr('lastActivityLabel'),
-      key: 'lastActivity',
+      key,
       format(row) {
-        if (!row[this.key]) {
+        const value = get(row, key);
+
+        if (!value) {
           return '';
         }
 
-        return row[this.key].toISOString();
+        return value.toISOString();
       },
     },
   ];

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -228,10 +228,10 @@ export function tally() {
   ];
 }
 
-export function timeSpent(key, label = 'timeSpentLabel') {
+export function timeSpent(key, label = coreStrings.$tr('timeSpentLabel')) {
   return [
     {
-      name: coachStrings.$tr(label),
+      name: label,
       key,
       format(row) {
         const value = get(row, key);

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -228,7 +228,8 @@ export function tally() {
   ];
 }
 
-export function timeSpent(key, label = coreStrings.$tr('timeSpentLabel')) {
+export function timeSpent(key, label) {
+  label = label || coreStrings.$tr('timeSpentLabel');
   return [
     {
       name: label,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -93,7 +93,7 @@
           ...csvFields.learnerProgress('statusObj.status'),
           ...csvFields.timeSpent('statusObj.time_spent'),
           ...csvFields.list('groups', 'groupsLabel'),
-          ...csvFields.lastActivity(),
+          ...csvFields.lastActivity('statusObj.last_activity'),
         ];
 
         const exporter = new CSVExporter(columns, this.className);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -79,7 +79,7 @@
           ...csvFields.learnerProgress('statusObj.status'),
           ...csvFields.timeSpent('statusObj.time_spent'),
           ...csvFields.list('groups', 'groupsLabel'),
-          ...csvFields.lastActivity(),
+          ...csvFields.lastActivity('statusObj.last_activity'),
         ];
 
         const exporter = new CSVExporter(columns, this.className);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -87,11 +87,12 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const { coachReportsLesson$ } = coachStrings;
+      const { coachReportsLesson$, avgTimeSpentLabel$ } = coachStrings;
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
       return {
         saveTabsClick,
         wereTabsClickedRecently,
+        avgTimeSpentLabel$,
         coachReportsLesson$,
       };
     },
@@ -220,7 +221,7 @@
           const columns = [
             ...csvFields.title(),
             ...csvFields.tally(),
-            ...csvFields.timeSpent('avgTimeSpent', 'avgTimeSpentLabel'),
+            ...csvFields.timeSpent('avgTimeSpent', this.avgTimeSpentLabel$()),
           ];
 
           const exporter = new CSVExporter(columns, this.className);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -245,7 +245,7 @@
         );
 
         if (!this.viewByGroups) {
-          columns.push(...csvFields.list('groupNames', 'groupsLabel'));
+          columns.push(...csvFields.list('groups', 'groupsLabel'));
         }
 
         columns.push(...csvFields.lastActivity('statusObj.last_activity'));

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -248,7 +248,7 @@
           columns.push(...csvFields.list('groupNames', 'groupsLabel'));
         }
 
-        columns.push(...csvFields.lastActivity());
+        columns.push(...csvFields.lastActivity('statusObj.last_activity'));
 
         const exporter = new CSVExporter(columns, this.className);
         exporter.addNames({
@@ -271,8 +271,8 @@
           .reduce((entries, groupEntries) => entries.concat(groupEntries), []);
 
         if (this.ungroupedEntries.length) {
-          data.concat(
-            this.ungroupedEntries.map(entry => {
+          data.push(
+            ...this.ungroupedEntries.map(entry => {
               entry.groupName = '';
               return entry;
             }),

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -262,6 +262,7 @@
           ...csvFields.title(),
           ...csvFields.recipients(this.className),
           ...csvFields.tally(),
+          ...csvFields.allLearners('totalLearners'),
         ];
         const fileName = this.$tr('printLabel', { className: this.className });
         new CSVExporter(columns, fileName).export(this.table);

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -238,7 +238,7 @@
           columns.push(...csvFields.list('groupNames', 'groupsLabel'));
         }
 
-        columns.push(...csvFields.lastActivity());
+        columns.push(...csvFields.lastActivity('statusObj.last_activity'));
 
         const exporter = new CSVExporter(columns, this.className);
         exporter.addNames({

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -261,8 +261,8 @@
           .reduce((entries, groupEntries) => entries.concat(groupEntries), []);
 
         if (this.ungroupedEntries.length) {
-          data.concat(
-            this.ungroupedEntries.map(entry => {
+          data.push(
+            ...this.ungroupedEntries.map(entry => {
               entry.groupName = '';
               return entry;
             }),

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -235,7 +235,7 @@
         );
 
         if (!this.viewByGroups) {
-          columns.push(...csvFields.list('groupNames', 'groupsLabel'));
+          columns.push(...csvFields.list('groups', 'groupsLabel'));
         }
 
         columns.push(...csvFields.lastActivity('statusObj.last_activity'));

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -308,6 +308,7 @@
           ...csvFields.avgScore(),
           ...csvFields.recipients(this.className),
           ...csvFields.tally(),
+          ...csvFields.allLearners('totalLearners'),
         ];
 
         const fileName = this.$tr('printLabel', { className: this.className });


### PR DESCRIPTION
## Summary

Fix mismatch between coach Reports and generated CSV.

Fixes:

* Now `ReportsLessonExerciseLearnerListPage` and `ReportsLessonResourceLearnerListPage` show ungrouped learners if "view by groups" checkbox is toggled.
* Fix `ReportsLessonExerciseLearnerListPage` and `ReportsLessonResourceLearnerListPage` to show groups names if we download a report without checking "view by groups".
* Fix empty "last activity" column in `ReportsLessonExerciseLearnerListPage`, `ReportsGroupReportLessonExerciseLearnerListPage`, `ReportsGroupReportLessonResourceLearnerListPage`, `ReportsLessonResourceLearnerListPage`.
* New column "All Learners" in `ReportsQuizListPage` and `ReportsLessonListPage`.
* Fix time spent label not displaying correctly in `ReportsGroupReportLessonExerciseLearnerListPage`, `ReportsGroupReportLessonResourceLearnerListPage`, `ReportsLearnerReportLessonPage`, `ReportsLessonExerciseLearnerListPage`, `ReportsLessonLearnerBase`, `ReportsLessonResourceLearnerListPage`.


Things that have already been fixed in the past:

* ReportsQuizLearnerListPage already shows the columns total/answered/correct questions.
* No issues found in the option to export a quiz report as CSV.
* No issues found about Average score value not displaying correctly in groups reports.

## References

Closes #6642


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
