### PR TITLE
Remove Hardcoded Color for Button Hover State in `QuizStatus.vue`

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -340,11 +340,6 @@
         return {
           color: this.$themeTokens.textInverted,
           'background-color': this.$themePalette.red.v_1100,
-          // We need to use a darker color for hover than
-          // palette.red.v_1100 but at the same time,
-          // palette.red.v_1100 is the darkest available red
-          // in the palette. Using this hardcoded color was
-          // agreed with designers.
           ':hover': { 'background-color': this.$darken1(this.$themePalette.red.v_1100) },
         };
       },

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -1,5 +1,4 @@
 <template>
-
   <KPageContainer :topMargin="$isPrint ? 0 : 16">
     <KGrid gutter="16">
       <!-- Quiz Open button -->
@@ -277,12 +276,9 @@
       />
     </KModal>
   </KPageContainer>
-
 </template>
 
-
 <script>
-
   import { ExamResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
@@ -349,7 +345,7 @@
           // palette.red.v_1100 is the darkest available red
           // in the palette. Using this hardcoded color was
           // agreed with designers.
-          ':hover': { 'background-color': '#A81700' },
+          ':hover': { 'background-color': this.$darken1(this.$themePalette.red.v_1100) },
         };
       },
       examDateArchived() {
@@ -487,12 +483,9 @@
       },
     },
   };
-
 </script>
 
-
 <style scoped lang="scss">
-
   .grid-item {
     font-size: 14px;
 
@@ -526,5 +519,4 @@
       }
     }
   }
-
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -1,4 +1,5 @@
 <template>
+
   <KPageContainer :topMargin="$isPrint ? 0 : 16">
     <KGrid gutter="16">
       <!-- Quiz Open button -->
@@ -276,9 +277,12 @@
       />
     </KModal>
   </KPageContainer>
+
 </template>
 
+
 <script>
+
   import { ExamResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
@@ -478,9 +482,12 @@
       },
     },
   };
+
 </script>
 
+
 <style scoped lang="scss">
+
   .grid-item {
     font-size: 14px;
 
@@ -514,4 +521,5 @@
       }
     }
   }
+
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -1,4 +1,5 @@
 <template>
+
   <KPageContainer :topMargin="$isPrint ? 0 : 16">
     <KGrid gutter="16">
       <!-- Quiz Open button -->
@@ -276,9 +277,12 @@
       />
     </KModal>
   </KPageContainer>
+
 </template>
 
+
 <script>
+
   import { ExamResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
@@ -483,9 +487,12 @@
       },
     },
   };
+
 </script>
 
+
 <style scoped lang="scss">
+
   .grid-item {
     font-size: 14px;
 
@@ -519,4 +526,5 @@
       }
     }
   }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
This PR removes the hardcoded hover background color in the `QuizStatus.vue` component and replaces it with a dynamic color using the new `$darken` utility functions provided by the Kolibri Design System.

...

### **Context**:  
The hover background color for buttons in the `QuizStatus.vue` component was previously hardcoded (`#A81700`). This approach reduces flexibility and maintainability, especially when applying theme variations. To address this, the newly implemented `$darken` utilities (`$darken1`, `$darken2`, `$darken3`) will be used to generate a darker shade of the base red color, ensuring consistent theming throughout the UI.

### Code Changes:
1. Removed the hardcoded hover color `#A81700`.
2. Applied the `$darken1` utility to derive the hover color dynamically based on the existing red color (`$themePalette.red.v_1100`).

**Example of the changes made**:
```javascript
// Before: Hardcoded color
':hover': { 'background-color': '#A81700' },

// After: Using the $darken utility
':hover': { 'background-color': $darken1($themePalette.red.v_1100) },
```

…

## References

#12553 
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
