### PR TITLE
KModal appendToRoot changed to appendToOverlay

### DIFF
--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -5,7 +5,7 @@
     @shouldFocusLastEl="focusLastEl"
   >
     <KModal
-      appendToRoot
+      appendToOverlay
       :title="coreString('changeLanguageOption')"
       :submitText="coreString('confirmAction')"
       :cancelText="coreString('cancelAction')"

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/index.vue
@@ -3,7 +3,7 @@
   <div>
     <KModal
       v-if="windowIsLarge"
-      appendToRoot
+      appendToOverlay
       :title="$tr('title')"
       :cancelText="coreString('closeAction')"
       size="large"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Previously changed from `appendToBody` to `appendToRoot` https://github.com/learningequality/kolibri/commit/671ccf1c4012cf6e56dd63f88dad9b9935aa99b2

@MisRob pointed out these should be `appendToOverlay` now instead.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Tests on https://github.com/learningequality/kolibri/pull/12651 should pass after this is merged and that dependabot branch is rebased. 

Also is blocking https://github.com/learningequality/kolibri/pull/12571 to some degree so it should be rebased when this is merged.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Tests pass?
