### PR TITLE
Simplify saving to device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 List of the most important changes for each release.
 
+## 0.17.2
+
+### Changed
+- Make 'save to device' file downloads initiate immediately by @rtibbles in [#12675](https://github.com/learningequality/kolibri/pull/12675)
+
+
 ## 0.17.1
 
 ### Added

--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -11,7 +11,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 17, 1)
+VERSION = (0, 17, 2)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -53,13 +53,17 @@
       fileOptions() {
         const options = this.files.map(file => {
           const label = getFilePresetString(file);
+          const fileId =
+            file.preset === 'video_subtitle' && file?.lang.lang_name
+              ? file?.lang.lang_name
+              : file.checksum.slice(0, 6);
           return {
             label,
             url: file.storage_url,
             fileName: this.$tr('downloadFilename', {
               resourceTitle: this.nodeTitle.length ? this.nodeTitle : file.checksum,
               fileExtension: file.extension,
-              fileId: file.checksum.slice(0, 6),
+              fileId,
             }),
           };
         });
@@ -68,26 +72,12 @@
     },
     methods: {
       download(file) {
-        const req = new XMLHttpRequest();
-        req.open('GET', file.url, true);
-        req.responseType = 'blob';
-
-        req.onload = function () {
-          const blob = req.response;
-          const blobUrl = window.URL.createObjectURL(blob);
-          try {
-            const a = document.createElement('a');
-            a.download = file.fileName;
-            a.href = blobUrl;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-          } catch (e) {
-            window.open(file.url, '_blank');
-          }
-        };
-
-        req.send();
+        const a = document.createElement('a');
+        a.download = file.fileName;
+        a.href = file.url;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
* Simplifies the logic for saving to device to remove attempt at IE11 compatibility
* Adds language information to disambiguate subtitle files, rather than using a slice of the checksum
* Updates version to 0.17.2

## References
Fixes #12668

## Reviewer guidance
Open a resource (preferable a KA video with lots of subtitles) and ensure in the info side panel that 'save to device' is working for several different files.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
