### PR TITLE
Update pre-commit for python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,21 @@
 exclude: (\.git/|\.tox/|\.venv/|build/|static/|dist/|node_modules/|kolibripip\.pex)
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
-    -   id: flake8
-        additional_dependencies: [
-            'flake8-print==5.0.0'
-        ]
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements
     -   id: end-of-file-fixer
         exclude: '^.+?(\.json|\.po)$'
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [
+            'flake8-print==5.0.0'
+        ]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.3.3
     hooks:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ setuptools
 ipdb==0.13.2
 flake8==3.8.3
 flake8-print==5.0.0
-pre-commit==1.15.1
+pre-commit==3.8.0
 tox==3.1.3
 django-debug-panel==0.8.3
 django-debug-toolbar==1.9.1


### PR DESCRIPTION
## Summary

Current pre-commit version does not support Python 3.12 because Python 3.12  removes the deprecated argument to random.shuffle. 

This PR updates pre-commit package and applies needed changes to our pre-commit rules to be compatible with it

## References
This error appears when pre-commit is run on Python 3.12 
`TypeError: Random.shuffle() got an unexpected keyword argument 'random'`

## Reviewer guidance
Is this compatible with all the supported python versions?
any possible side effect?


## Testing checklist

- [x ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
