### PR TITLE
Delete resource from everywhere when force_delete is selected

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -487,6 +487,15 @@ def diskexport(
 class DeleteChannelValidator(ChannelResourcesValidator):
     force_delete = serializers.BooleanField(default=False)
 
+    def validate(self, data):
+        job_data = super(ChannelResourcesValidator, self).validate(data)
+        job_data["kwargs"].update(
+            {
+                "force_delete": data.get("force_delete"),
+            }
+        )
+        return job_data
+
 
 @register_task(
     validator=DeleteChannelValidator,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
1. Whenever force_delete is selected, the ContentNodes with same content_id is appended to the node_ids so the content can be deleted from everywhere
2. Adds a validate method to DeleteChannelValidator so force_delete wont be ignored in the validation process


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #12606 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Try and replicate [this](https://github.com/learningequality/kolibri/issues/12606#issue-2487883921), if it doesn't replicate then we are good to go.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
