### PR TITLE
Settings is not correct after tzlocal update

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -15,7 +15,7 @@ from urllib.parse import urljoin
 import pytz
 from django.conf import locale
 from morango.constants import settings as morango_settings
-from tzlocal import get_localzone
+from tzlocal import get_localzone_name
 from tzlocal.utils import ZoneInfoNotFoundError
 
 import kolibri
@@ -309,7 +309,7 @@ LANGUAGE_CODE = (
 )
 
 try:
-    TIME_ZONE = get_localzone().zone
+    TIME_ZONE = get_localzone_name()
 except (pytz.UnknownTimeZoneError, ValueError, ZoneInfoNotFoundError):
     # Do not fail at this point because a timezone was not
     # detected.


### PR DESCRIPTION
## Summary
After upgrading to kolibri 0.17.1, KDP deployments are failing: https://console.cloud.google.com/cloud-build/builds;region=global/f396424e-059e-4e1c-ba35-103fbf971628?authuser=2&project=kolibri-data-portal
The reason is `tzlocal` library has been updated in https://github.com/learningequality/kolibri/pull/12165  and its api has changed

This PR fixes it.

## References
Related: #12165



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
