### PR TITLE
Update preview plan quiz

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -324,7 +324,7 @@ class QuizDifficultiesPermissions(permissions.BasePermission):
             return False
         try:
             collection = Exam.objects.get(id=exam_id).collection
-        except Exam.DoesNotExist:
+        except (Exam.DoesNotExist, ValueError):
             return False
         allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
         try:

--- a/kolibri/plugins/coach/assets/src/modules/questionList/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionList/index.js
@@ -1,3 +1,4 @@
+import { getDifficultQuestions } from '../../utils';
 import * as actions from './actions';
 
 function defaultState() {
@@ -8,37 +9,13 @@ function defaultState() {
   };
 }
 
-function ratio(stat) {
-  return stat.correct / stat.total;
-}
-
 export default {
   namespaced: true,
   state: defaultState(),
   actions,
   getters: {
     difficultQuestions(state) {
-      return state.itemStats
-        .filter(stat => {
-          // Arbitrarily filter out questions that have higher than 80% correct rate
-          return stat.correct / stat.total < 0.8;
-        })
-        .sort((stat1, stat2) => {
-          // Sort first by raw correct
-          if (ratio(stat1) > ratio(stat2)) {
-            return 1;
-          } else if (ratio(stat2) > ratio(stat1)) {
-            return -1;
-            // If they are equal, prioritize questions in which we have the highest
-            // number of answers
-          } else if (stat1.total > stat2.total) {
-            return -1;
-          } else if (stat2.total > stat1.total) {
-            return 1;
-          }
-          // Nothing between them!
-          return 0;
-        });
+      return getDifficultQuestions(state.itemStats);
     },
   },
   mutations: {

--- a/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
@@ -6,6 +6,7 @@ import ReplaceQuestions from '../views/plan/CreateExamPage/ReplaceQuestions.vue'
 import CoachExamsPage from '../views/plan/CoachExamsPage';
 import QuizSummaryPage from '../views/plan/QuizSummaryPage';
 import SectionOrder from '../views/plan/CreateExamPage/SectionOrder';
+import { generateQuestionListHandler } from '../modules/questionList/handlers';
 
 export default [
   {
@@ -55,6 +56,7 @@ export default [
     name: QuizSummaryPage.name,
     path: '/:classId/plan/quizzes/:quizId/:tabId?',
     component: QuizSummaryPage,
+    handler: generateQuestionListHandler(['quizId']),
     meta: {
       titleParts: ['QUIZ_NAME', 'quizzesLabel', 'CLASS_NAME'],
     },

--- a/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
@@ -53,7 +53,7 @@ export default [
   },
   {
     name: QuizSummaryPage.name,
-    path: '/:classId/plan/quizzes/:quizId',
+    path: '/:classId/plan/quizzes/:quizId/:tabId?',
     component: QuizSummaryPage,
     meta: {
       titleParts: ['QUIZ_NAME', 'quizzesLabel', 'CLASS_NAME'],

--- a/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
@@ -6,7 +6,6 @@ import ReplaceQuestions from '../views/plan/CreateExamPage/ReplaceQuestions.vue'
 import CoachExamsPage from '../views/plan/CoachExamsPage';
 import QuizSummaryPage from '../views/plan/QuizSummaryPage';
 import SectionOrder from '../views/plan/CreateExamPage/SectionOrder';
-import { generateQuestionListHandler } from '../modules/questionList/handlers';
 
 export default [
   {
@@ -56,7 +55,6 @@ export default [
     name: QuizSummaryPage.name,
     path: '/:classId/plan/quizzes/:quizId/:tabId?',
     component: QuizSummaryPage,
-    handler: generateQuestionListHandler(['quizId']),
     meta: {
       titleParts: ['QUIZ_NAME', 'quizzesLabel', 'CLASS_NAME'],
     },

--- a/kolibri/plugins/coach/assets/src/utils/index.js
+++ b/kolibri/plugins/coach/assets/src/utils/index.js
@@ -1,0 +1,27 @@
+const ratio = question => {
+  return question.correct / question.total;
+};
+
+export const getDifficultQuestions = questions => {
+  return questions
+    .filter(question => {
+      // Arbitrarily filter out questions that have higher than 80% correct rate
+      return question.correct / question.total < 0.8;
+    })
+    .sort((question1, question2) => {
+      // Sort first by raw correct
+      if (ratio(question1) > ratio(question2)) {
+        return 1;
+      } else if (ratio(question2) > ratio(question1)) {
+        return -1;
+        // If they are equal, prioritize questions in which we have the highest
+        // number of answers
+      } else if (question1.total > question2.total) {
+        return -1;
+      } else if (question2.total > question1.total) {
+        return 1;
+      }
+      // Nothing between them!
+      return 0;
+    });
+};

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -20,6 +20,7 @@
             />
           </h1>
           <StatusElapsedTime
+            v-if="examOrLesson !== 'exam'"
             v-show="!$isPrint"
             :date="createdDate"
             actionType="created"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -104,30 +104,6 @@
         </KGridItem>
       </div>
 
-      <!-- Class name  -->
-      <div
-        v-show="$isPrint"
-        class="status-item"
-      >
-        <KGridItem
-          class="status-label"
-          :layout4="{ span: 4 }"
-          :layout8="{ span: 4 }"
-          :layout12="layout12Label"
-        >
-          {{ coachString('classLabel') }}
-        </KGridItem>
-        <KGridItem
-          :layout4="{ span: 4 }"
-          :layout8="{ span: 4 }"
-          :layout12="layout12Value"
-        >
-          <div>
-            {{ className }}
-          </div>
-        </KGridItem>
-      </div>
-
       <!-- Recipients  -->
       <div class="status-item">
         <KGridItem
@@ -175,6 +151,27 @@
         </KGridItem>
       </div>
 
+      <!-- Class name  -->
+      <div class="status-item">
+        <KGridItem
+          class="status-label"
+          :layout4="{ span: 4 }"
+          :layout8="{ span: 4 }"
+          :layout12="layout12Label"
+        >
+          {{ coachString('classLabel') }}
+        </KGridItem>
+        <KGridItem
+          :layout4="{ span: 4 }"
+          :layout8="{ span: 4 }"
+          :layout12="layout12Value"
+        >
+          <div>
+            {{ className }}
+          </div>
+        </KGridItem>
+      </div>
+
       <!-- Question Order -->
       <div
         v-if="!$isPrint"
@@ -215,7 +212,29 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 12 }"
         >
-          <p>{{ exam.size_string ? exam.size_string : '--' }}</p>
+          <span>{{ exam.size_string ? exam.size_string : '--' }}</span>
+        </KGridItem>
+      </div>
+
+      <!-- Date created -->
+      <div class="status-item">
+        <KGridItem
+          class="status-label"
+          :layout4="{ span: 4 }"
+          :layout8="{ span: 4 }"
+          :layout12="{ span: 12 }"
+        >
+          {{ coreString('dateCreated') }}
+        </KGridItem>
+        <KGridItem
+          :layout4="{ span: 4 }"
+          :layout8="{ span: 4 }"
+          :layout12="{ span: 12 }"
+        >
+          <ElapsedTime
+            :date="examDateCreated"
+            style="margin-top: 8px"
+          />
         </KGridItem>
       </div>
     </KGrid>
@@ -346,6 +365,13 @@
           'background-color': this.$themePalette.red.v_1100,
           ':hover': { 'background-color': this.$darken1(this.$themePalette.red.v_1100) },
         };
+      },
+      examDateCreated() {
+        if (this.exam.date_created) {
+          return new Date(this.exam.date_created);
+        } else {
+          return null;
+        }
       },
       examDateArchived() {
         if (this.exam.date_archived) {

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -82,16 +82,23 @@
       >
         <KGridItem
           class="status-label"
-          :layout4="{ span: 4 }"
+          style="padding-bottom: 16px"
+          :layout4="{ span: 3 }"
           :layout8="{ span: 4 }"
-          :layout12="{ span: 12 }"
+          :layout12="{ span: 10 }"
         >
-          {{ $tr('reportVisibleToLearnersLabel') }}
+          <span> {{ $tr('reportVisibleToLearnersLabel') }} </span>
+          <StatusElapsedTime
+            v-if="exam.active"
+            :date="examDateOpened"
+            actionType="madeVisible"
+            style="font-weight: normal"
+          />
         </KGridItem>
         <KGridItem
-          :layout4="{ span: 4 }"
+          :layout4="{ span: 1 }"
           :layout8="{ span: 4 }"
-          :layout12="{ span: 12 }"
+          :layout12="{ span: 2 }"
         >
           <KSwitch
             name="toggle-quiz-visibility"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -229,14 +229,14 @@
           class="status-label"
           :layout4="{ span: 4 }"
           :layout8="{ span: 4 }"
-          :layout12="{ span: 12 }"
+          :layout12="layout12Label"
         >
           {{ coreString('dateCreated') }}
         </KGridItem>
         <KGridItem
           :layout4="{ span: 4 }"
           :layout8="{ span: 4 }"
-          :layout12="{ span: 12 }"
+          :layout12="layout12Value"
         >
           <ElapsedTime
             :date="examDateCreated"

--- a/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
@@ -64,6 +64,8 @@
               return this.$tr('closedSecondsAgo', strParams);
             case 'opened':
               return this.$tr('openedSecondsAgo', strParams);
+            case 'madeVisible':
+              return this.$tr('madeVisibleSecondsAgo', strParams);
             default:
               return '';
           }
@@ -78,6 +80,8 @@
               return this.$tr('closedMinutesAgo', strParams);
             case 'opened':
               return this.$tr('openedMinutesAgo', strParams);
+            case 'madeVisible':
+              return this.$tr('madeVisibleMinutesAgo', strParams);
             default:
               return '';
           }
@@ -92,6 +96,8 @@
               return this.$tr('closedHoursAgo', strParams);
             case 'opened':
               return this.$tr('openedHoursAgo', strParams);
+            case 'madeVisible':
+              return this.$tr('madeVisibleHoursAgo', strParams);
             default:
               return '';
           }
@@ -105,6 +111,8 @@
             return this.$tr('closedDaysAgo', strParams);
           case 'opened':
             return this.$tr('openedDaysAgo', strParams);
+          case 'madeVisible':
+            return this.$tr('madeVisibleDaysAgo', strParams);
           default:
             return '';
         }
@@ -181,6 +189,26 @@
       openedDaysAgo: {
         message: 'Started {days} {days, plural, one {day} other {days}} ago',
         context: 'Indicates that a quiz was started a number of days prior to the current date.',
+      },
+      madeVisibleSecondsAgo: {
+        message: 'Made visible {seconds} {seconds, plural, one {second} other {seconds}} ago',
+        context:
+          'Indicates that a quiz was made visible a number of seconds prior to the current time, but is always less than 1 minute ago.',
+      },
+      madeVisibleMinutesAgo: {
+        message: 'Made visible {minutes} {minutes, plural, one {minute} other {minutes}} ago',
+        context:
+          'Indicates that a quiz was made visible a number of minutes prior to the current time, but the time is always less than 1 hour ago.',
+      },
+      madeVisibleHoursAgo: {
+        message: 'Made visible {hours} {hours, plural, one {hour} other {hours}} ago',
+        context:
+          'Indicates that a quiz was made visible a number of hours prior to the current time, but the time is always less than one day ago',
+      },
+      madeVisibleDaysAgo: {
+        message: 'Made visible {days} {days, plural, one {day} other {days}} ago',
+        context:
+          'Indicates that a quiz was made visible a number of days prior to the current date.',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
@@ -18,7 +18,7 @@
   const HOUR = MINUTE * 60;
   const DAY = HOUR * 24;
 
-  const ACTION_TYPES = ['created', 'closed', 'opened'];
+  const ACTION_TYPES = ['created', 'closed', 'opened', 'madeVisible'];
 
   export default {
     name: 'StatusElapsedTime',

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/QuizOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/QuizOptionsDropdownMenu.vue
@@ -1,9 +1,9 @@
 <template>
 
-  <KButton
+  <KIconButton
     hasDropdown
+    icon="optionsHorizontal"
     appearance="flat-button"
-    :text="coreString('optionsLabel')"
   >
     <template #menu>
       <KDropdownMenu
@@ -11,7 +11,7 @@
         @select="$emit('select', $event.value)"
       />
     </template>
-  </KButton>
+  </KIconButton>
 
 </template>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/api.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/api.js
@@ -14,11 +14,10 @@ const fetchDifficultQuestions = async exam => {
     true,
   );
 
-  const allQuestions = exam.question_sources.reduce((qs, section) => {
-    qs = [...qs, ...section.questions];
-
-    return qs;
-  }, []);
+  const allQuestions = exam.question_sources.reduce(
+    (qs, section) => [...qs, ...section.questions],
+    [],
+  );
 
   allQuestions.forEach(question => {
     const questionStats = correctnessStats.find(stat => stat.item === question.item);

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -24,7 +24,7 @@
           </template>
         </QuizLessonDetailsHeader>
       </KGridItem>
-      <KGridItem :layout12="{ span: 4 }">
+      <KGridItem :layout12="{ span: $isPrint ? 12 : 4 }">
         <h2 class="visuallyhidden">
           {{ coachString('generalInformationLabel') }}
         </h2>
@@ -35,10 +35,10 @@
           :exam="exam"
         />
       </KGridItem>
-      <KGridItem :layout12="{ span: 8 }">
+      <KGridItem :layout12="{ span: $isPrint ? 12 : 8 }">
         <KPageContainer
           v-if="!loading"
-          :topMargin="16"
+          :topMargin="$isPrint ? 0 : 16"
         >
           <ReportsControls @export="exportCSV" />
           <HeaderTabs :enablePrint="true">

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -344,7 +344,9 @@
         });
       },
       exportCSV() {
-        this.$refs.table.exportCSV?.();
+        if (typeof this.$refs.table.exportCSV === 'function') {
+          this.$refs.table.exportCSV();
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -12,6 +12,10 @@
           examOrLesson="exam"
         >
           <template #dropdown>
+            <KButton
+              :text="coachString('previewAction')"
+              style="margin-right: 8px"
+            />
             <QuizOptionsDropdownMenu
               optionsFor="plan"
               :draft="exam && exam.draft"

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -86,10 +86,9 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import find from 'lodash/find';
   import sortBy from 'lodash/sortBy';
-  import fromPairs from 'lodash/fromPairs';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -151,20 +150,15 @@
           question_sources: [],
           title: '',
         },
-        selectedExercises: {},
         loading: true,
         currentAction: '',
         QUIZZES_TABS_ID,
         QuizzesTabs,
+        difficultQuestions: [],
       };
     },
     computed: {
       ...mapState(['classList']),
-      ...mapGetters('questionList', ['difficultQuestions']),
-
-      // quizIsRandomized() {
-      //   return !this.quiz.learners_see_fixed_order;
-      // },
       quizId() {
         return this.$route.params.quizId;
       },
@@ -184,11 +178,6 @@
       recipients() {
         return this.getLearnersForExam(this.exam);
       },
-      // orderDescriptionString() {
-      //   return this.quizIsRandomized
-      //     ? this.randomizedSectionOptionDescription$()
-      //     : this.fixedSectionOptionDescription$();
-      // },
       classId() {
         return this.$route.params.classId;
       },
@@ -259,9 +248,9 @@
     methods: {
       // @public
       setData(data) {
-        const { exam, exerciseContentNodes } = data;
+        const { exam, difficultQuestions } = data;
         this.quiz = exam;
-        this.selectedExercises = fromPairs(exerciseContentNodes.map(x => [x.id, x]));
+        this.difficultQuestions = difficultQuestions;
         this.loading = false;
         this.$store.dispatch('notLoading');
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -62,7 +62,6 @@
               <ReportsDifficultQuestionsTable
                 ref="table"
                 :entries="difficultQuestionsTable"
-                :isMissingResource="exam.missing_resource"
               />
             </template>
           </KTabsPanel>

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -103,8 +103,6 @@
   import ReportsControls from '../../reports/ReportsControls';
   import ReportsLearnersTable from '../../reports/ReportsLearnersTable';
   import ReportsDifficultQuestionsTable from '../../reports/ReportsDifficultQuestionsTable';
-  import * as csvFields from '../../../csv/fields';
-  import CSVExporter from '../../../csv/exporter';
   import QuizOptionsDropdownMenu from './QuizOptionsDropdownMenu';
   import ManageExamModals from './ManageExamModals';
   import {
@@ -354,20 +352,7 @@
         });
       },
       exportCSV() {
-        const columns = [
-          ...csvFields.name(),
-          ...csvFields.learnerProgress('statusObj.status'),
-          ...csvFields.score(),
-          ...csvFields.quizQuestionsAnswered(this.exam),
-          ...csvFields.list('groups', 'groupsLabel'),
-        ];
-
-        const exporter = new CSVExporter(columns, this.className);
-        exporter.addNames({
-          resource: this.exam.title,
-        });
-
-        exporter.export(this.table);
+        this.$refs.table.exportCSV?.();
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -196,7 +196,7 @@
         const tabsList = [
           {
             id: QuizzesTabs.REPORT,
-            label: this.coachString('reportLabel'),
+            label: this.coachString('learnersLabel'),
           },
         ];
 
@@ -209,7 +209,7 @@
         }
 
         tabsList.forEach(tab => {
-          tab.to = this.classRoute('QuizSummaryPage', { quizId: this.quizId, tabId: tab.id });
+          tab.to = this.classRoute('QuizSummaryPage', { tabId: tab.id });
         });
 
         return tabsList;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -74,12 +74,13 @@
         return this.isAppContext || this.disableExport;
       },
       isMainReport() {
-        return (
-          this.$route.name === 'ReportsQuizListPage' ||
-          this.$route.name === 'ReportsGroupListPage' ||
-          this.$route.name === 'ReportsLearnerListPage' ||
-          this.$route.name === 'ReportsLessonListPage'
-        );
+        return [
+          'ReportsQuizListPage',
+          'ReportsGroupListPage',
+          'ReportsLearnerListPage',
+          'ReportsLessonListPage',
+          'QuizSummaryPage',
+        ].includes(this.$route.name);
       },
       classLearnersListRoute() {
         const { query } = this.$route;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
@@ -1,0 +1,91 @@
+<template>
+
+  <CoreTable :emptyMessage="questionListEmptyState$()">
+    <template #headers>
+      <th>{{ questionLabel$() }}</th>
+      <th>{{ helpNeededLabel$() }}</th>
+    </template>
+    <template #tbody>
+      <transition-group
+        tag="tbody"
+        name="list"
+      >
+        <tr
+          v-for="(tableRow, index) in entries"
+          :key="tableRow.item + index"
+        >
+          <td>
+            <span v-if="$isPrint">{{ tableRow.title }}</span>
+            <KRouterLink
+              v-if="!isMissingResource"
+              :text="tableRow.title"
+              :to="questionLink(tableRow.item)"
+              icon="question"
+            />
+            <span v-else> <KIcon icon="question" />{{ tableRow.title }} </span>
+          </td>
+          <td>
+            <LearnerProgressRatio
+              :verb="VERBS.needHelp"
+              :icon="ICONS.help"
+              :total="tableRow.total"
+              :count="tableRow.total - tableRow.correct"
+              :verbosity="1"
+            />
+          </td>
+        </tr>
+      </transition-group>
+    </template>
+  </CoreTable>
+
+</template>
+
+
+<script>
+
+  import commonCoach from '../common';
+  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
+  import { coachStrings } from '../common/commonCoachStrings';
+  import { PageNames } from './../../constants';
+
+  export default {
+    name: 'ReportsDifficultQuestionsTable',
+    components: {
+      LearnerProgressRatio,
+    },
+    mixins: [commonCoach],
+    setup() {
+      const { questionListEmptyState$, questionLabel$, helpNeededLabel$ } = coachStrings;
+
+      return {
+        questionListEmptyState$,
+        questionLabel$,
+        helpNeededLabel$,
+      };
+    },
+    props: {
+      entries: {
+        type: Array,
+        default: () => [],
+      },
+      isMissingResource: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    methods: {
+      questionLink(questionId) {
+        return this.classRoute(
+          this.group
+            ? PageNames.REPORTS_GROUP_REPORT_QUIZ_QUESTION_PAGE_ROOT
+            : PageNames.REPORTS_QUIZ_QUESTION_PAGE_ROOT,
+          {
+            questionId,
+            quizId: this.$route.params.quizId,
+          },
+        );
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
@@ -17,7 +17,7 @@
           <td>
             <span v-if="$isPrint">{{ tableRow.title }}</span>
             <KRouterLink
-              v-if="!isMissingResource"
+              v-if="!exam.missing_resource"
               :text="tableRow.title"
               :to="questionLink(tableRow.item)"
               icon="question"
@@ -69,10 +69,6 @@
       entries: {
         type: Array,
         default: () => [],
-      },
-      isMissingResource: {
-        type: Boolean,
-        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
@@ -46,6 +46,8 @@
   import commonCoach from '../common';
   import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
   import { coachStrings } from '../common/commonCoachStrings';
+  import * as csvFields from '../../csv/fields';
+  import CSVExporter from '../../csv/exporter';
   import { PageNames } from './../../constants';
 
   export default {
@@ -73,6 +75,14 @@
         default: false,
       },
     },
+    computed: {
+      exam() {
+        return this.examMap[this.$route.params.quizId];
+      },
+      group() {
+        return this.$route.params.groupId && this.groupMap[this.$route.params.groupId];
+      },
+    },
     methods: {
       questionLink(questionId) {
         return this.classRoute(
@@ -84,6 +94,25 @@
             quizId: this.$route.params.quizId,
           },
         );
+      },
+      /**
+       * @public
+       */
+      exportCSV() {
+        const columns = [...csvFields.questionTitle(), ...csvFields.helpNeeded()];
+
+        const exporter = new CSVExporter(columns, this.className);
+        const names = {
+          resource: this.exam.title,
+          difficultQuestions: this.coachString('difficultQuestionsLabel'),
+        };
+
+        if (this.group) {
+          names.group = this.group.name;
+        }
+        exporter.addNames(names);
+
+        exporter.export(this.entries);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsDifficultQuestionsTable.vue
@@ -15,10 +15,10 @@
           :key="tableRow.item + index"
         >
           <td>
-            <span v-if="$isPrint">{{ tableRow.title }}</span>
+            <span v-if="$isPrint">{{ getQuestionTitle(tableRow) }}</span>
             <KRouterLink
               v-if="!exam.missing_resource"
-              :text="tableRow.title"
+              :text="getQuestionTitle(tableRow)"
               :to="questionLink(tableRow.item)"
               icon="question"
             />
@@ -57,12 +57,14 @@
     },
     mixins: [commonCoach],
     setup() {
-      const { questionListEmptyState$, questionLabel$, helpNeededLabel$ } = coachStrings;
+      const { questionListEmptyState$, questionLabel$, helpNeededLabel$, nthExerciseName$ } =
+        coachStrings;
 
       return {
         questionListEmptyState$,
         questionLabel$,
         helpNeededLabel$,
+        nthExerciseName$,
       };
     },
     props: {
@@ -90,6 +92,12 @@
             quizId: this.$route.params.quizId,
           },
         );
+      },
+      getQuestionTitle(question) {
+        return this.nthExerciseName$({
+          name: question.title,
+          number: question.questionNumber,
+        });
       },
       /**
        * @public

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnersTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnersTable.vue
@@ -103,6 +103,8 @@
   import isUndefined from 'lodash/isUndefined';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
+  import * as csvFields from '../../csv/fields';
+  import CSVExporter from '../../csv/exporter';
 
   export default {
     name: 'ReportsLearnersTable',
@@ -142,6 +144,9 @@
       anyTries() {
         return this.entries.some(entry => !isUndefined(entry.statusObj.tries));
       },
+      exam() {
+        return this.examMap[this.$route.params.quizId];
+      },
     },
     methods: {
       completedQuestionsCountLabel(answered, total) {
@@ -180,6 +185,25 @@
       },
       showQuizStatus(entry) {
         return this.questionCount && !isUndefined(entry.statusObj.num_answered);
+      },
+      /**
+       * @public
+       */
+      exportCSV() {
+        const columns = [
+          ...csvFields.name(),
+          ...csvFields.learnerProgress('statusObj.status'),
+          ...csvFields.score(),
+          ...csvFields.quizQuestionsAnswered(this.exam),
+          ...csvFields.list('groups', 'groupsLabel'),
+        ];
+
+        const exporter = new CSVExporter(columns, this.className);
+        exporter.addNames({
+          resource: this.exam.title,
+        });
+
+        exporter.export(this.entries);
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary

Update quiz summary page to:
* Show learners and difficult questions report
* Show date created, date activated and class name in quiz status section
* Update the options button, and add a `preview` button in the header

Note that I havent updated page back buttons actions, as we will probably reestructure page routes in the future, and dont want to mess with it yet.

## References
Closes #12671.

## Screenshots
![image](https://github.com/user-attachments/assets/d80fe117-7d8e-4b53-9570-2ce3e3396e23)

![image](https://github.com/user-attachments/assets/523aa936-b385-484a-a157-ab4525b8cdbf)


## Reviewer guidance

Check that current quiz summary page match the acceptance criteria described in #12671.


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
