### PR TITLE
0.18: Groups view updates

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -17,6 +17,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Button to cancel an action and return to the previous page. Usually this is the opposite of the save button which saves some piece of information.',
   },
+  learnMoreAction: {
+    message: 'Learn more',
+    context:
+      'Button for link which will show the user information providing more information about the relevant context',
+  },
   cannotUndoActionWarning: {
     message: 'This action cannot be undone',
     context:

--- a/kolibri/plugins/coach/assets/src/constants/index.js
+++ b/kolibri/plugins/coach/assets/src/constants/index.js
@@ -43,6 +43,7 @@ export const PageNames = {
 };
 
 export const GroupModals = {
+  ABOUT_GROUP: 'ABOUT_GROUP',
   CREATE_GROUP: 'CREATE_GROUP',
   RENAME_GROUP: 'RENAME_GROUP',
   DELETE_GROUP: 'DELETE_GROUP',

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -419,11 +419,6 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     message: '{name} ({number, number, integer})',
     context: 'DO NOT TRANSLATE\nCopy the source string.',
   },
-  numberOfLearners: {
-    message: '{value, number, integer} {value, plural, one {learner} other {learners}}',
-    context:
-      "Can refer to number of learners in a group, for example. Only translate 'learner' and 'learners'.",
-  },
   numberOfQuestions: {
     message: '{value, number, integer} {value, plural, one {question} other {questions}}',
     context:

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -40,6 +40,15 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     message: 'Print report',
     context: "Option to print a hard copy of a report in the 'Reports' tab.",
   },
+  renameGroupAction: {
+    message: 'Rename group',
+    context: 'Label for dropdown menu button that allows user to rename a group',
+  },
+  enrollLearnersAction: {
+    message: 'Enroll learners',
+    context:
+      'Label for dropdown menu button that navigates the coach to edit the enrollment for a group',
+  },
   renameAction: {
     message: 'Rename',
     context: 'Generic option to change the name of some element such as a class name. ',

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -210,7 +210,7 @@
           'Indicates next page of results shown on the enroll learners page. This is not seen in the UI.',
       },
       allUsersAlready: {
-        message: 'All users are already enrolled in this class',
+        message: 'All users are already enrolled in this group',
         context:
           'Message that displays on group when all learners in a class have already been added to the group and there are no more to add.',
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -181,6 +181,7 @@
       handleSuccessDeleteGroup() {
         this.showSnackbarNotification('groupDeleted');
         this.displayModal(false);
+        this.$router.push(this.$router.getRoute('GroupsPage'));
       },
       handleOptionSelect(value) {
         switch (value) {

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -38,6 +38,19 @@
               :text="$tr('enrollButton')"
               :to="$router.getRoute('GroupEnrollPage')"
             />
+
+            <KIconButton
+              icon="optionsHorizontal"
+              style="margin-left: 1em"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  position="bottom left"
+                  :options="menuOptions"
+                  @select="handleOptionSelect"
+                />
+              </template>
+            </KIconButton>
           </KFixedGridItem>
         </KFixedGrid>
 
@@ -86,6 +99,21 @@
         />
       </div>
     </KPageContainer>
+    <RenameGroupModal
+      v-if="showRenameGroupModal"
+      :groupName="currentGroup.name"
+      :groupId="currentGroup.id"
+      :groups="groups"
+      @cancel="closeModal"
+    />
+
+    <DeleteGroupModal
+      v-if="showDeleteGroupModal"
+      :groupName="currentGroup.name"
+      :groupId="currentGroup.id"
+      @submit="handleSuccessDeleteGroup"
+      @cancel="closeModal"
+    />
   </CoachAppBarPage>
 
 </template>
@@ -97,7 +125,10 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../../common';
+  import { GroupModals } from '../../../constants';
   import CoachAppBarPage from '../../CoachAppBarPage';
+  import RenameGroupModal from '../GroupsPage/RenameGroupModal';
+  import DeleteGroupModal from '../GroupsPage/DeleteGroupModal';
   import RemoveFromGroupModal from './RemoveFromGroupModal';
 
   export default {
@@ -106,6 +137,8 @@
       CoachAppBarPage,
       CoreTable,
       RemoveFromGroupModal,
+      RenameGroupModal,
+      DeleteGroupModal,
     },
     mixins: [commonCoreStrings, commonCoach],
     data() {
@@ -114,13 +147,22 @@
       };
     },
     computed: {
-      ...mapState('groups', ['groups']),
+      ...mapState('groups', ['groupModalShown', 'groups']),
       currentGroup() {
         return this.groups.find(g => g.id === this.$route.params.groupId);
       },
+      menuOptions() {
+        return [this.coachString('renameGroupAction'), this.$tr('deleteGroup')];
+      },
+      showRenameGroupModal() {
+        return this.groupModalShown === GroupModals.RENAME_GROUP;
+      },
+      showDeleteGroupModal() {
+        return this.groupModalShown === GroupModals.DELETE_GROUP;
+      },
     },
     methods: {
-      ...mapActions('groups', ['removeUsersFromGroup']),
+      ...mapActions('groups', ['removeUsersFromGroup', 'displayModal']),
       removeSelectedUserFromGroup() {
         if (this.userForRemoval) {
           this.removeUsersFromGroup({
@@ -132,12 +174,41 @@
           });
         }
       },
+      closeModal() {
+        this.displayModal(false);
+      },
+      handleSuccessDeleteGroup() {
+        this.showSnackbarNotification('groupDeleted');
+        this.displayModal(false);
+      },
+      handleOptionSelect(value) {
+        switch (value) {
+          case this.coachString('renameGroupAction'):
+            this.openRenameGroupModal(this.currentGroup.name, this.currentGroup.id);
+            break;
+          case this.$tr('deleteGroup'):
+            this.openDeleteGroupModal(this.currentGroup.name, this.currentGroup.id);
+            break;
+          default:
+            break;
+        }
+      },
+      openRenameGroupModal() {
+        this.displayModal(GroupModals.RENAME_GROUP);
+      },
+      openDeleteGroupModal() {
+        this.displayModal(GroupModals.DELETE_GROUP);
+      },
     },
     $trs: {
       enrollButton: {
         message: 'Enroll learners',
         context:
           'Button which allows user to add learners to a group once the group has been created.',
+      },
+      deleteGroup: {
+        message: 'Delete group',
+        context: 'Button allowing user to delete the group',
       },
       groupDoesNotExist: {
         message: 'This group does not exist',

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -22,11 +22,12 @@
         </h1>
 
         <KFixedGrid numCols="2">
-          <KFixedGridItem
-            span="1"
-            class="number-learners"
-          >
-            {{ coachString('numberOfLearners', { value: currentGroup.users.length }) }}
+          <KFixedGridItem span="1">
+            <KIcon
+              icon="classes"
+              class="class-name-icon"
+            />
+            <span>{{ className }}</span>
           </KFixedGridItem>
           <KFixedGridItem
             span="1"
@@ -224,4 +225,17 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .class-name-icon {
+    position: relative;
+    // Aligns icon to class name text
+    top: 0.34em;
+    // Icon was far smaller than text by default, better matches
+    width: 1.5em;
+    height: 1.5em;
+    // Space between icon and text
+    margin-right: 0.5em;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -49,18 +49,31 @@
     },
     computed: {
       menuOptions() {
-        return [this.coachString('renameAction'), this.coreString('deleteAction')];
+        return [
+          this.coachString('renameGroupAction'),
+          this.coachString('enrollLearnersAction'),
+          this.coreString('deleteAction'),
+        ];
       },
     },
     methods: {
       handleSelection(selectedOption) {
-        let emitted;
-        if (selectedOption === this.coachString('renameAction')) {
-          emitted = 'rename';
-        } else if (selectedOption === this.coreString('deleteAction')) {
-          emitted = 'delete';
+        switch (selectedOption) {
+          case this.coachString('renameGroupAction'):
+            this.$emit('rename', this.group.name, this.group.id);
+            break;
+          case this.coachString('enrollLearnersAction'):
+            this.$emit('enroll', this.group.name, this.group.id);
+            break;
+          case this.coreString('deleteAction'):
+            this.$emit('delete', this.group.name, this.group.id);
+            break;
+          default:
+            // eslint-disable-next-line no-console
+            console.warn(
+              `GroupRow: Tried to handleSelection of ${selectedOption}, but that isn't being handled.`,
+            );
         }
-        this.$emit(emitted, this.group.name, this.group.id);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -6,6 +6,14 @@
         <template #header>
           <h1>{{ coachString('groupsLabel') }}</h1>
           <p>
+            <KIcon
+              icon="classes"
+              class="class-name-icon"
+            />
+            <span>{{ className }}</span>
+          </p>
+
+          <p>
             {{ $tr('groupsDescription') }}
             <KButton
               appearance="basic-link"
@@ -218,6 +226,17 @@
 
 
 <style lang="scss" scoped>
+
+  .class-name-icon {
+    position: relative;
+    // Aligns icon to class name text
+    top: 0.34em;
+    // Icon was far smaller than text by default, better matches
+    width: 1.5em;
+    height: 1.5em;
+    // Space between icon and text
+    margin-right: 0.5em;
+  }
 
   .ta-r {
     text-align: right;

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -52,6 +52,9 @@
                 :group="group"
                 @rename="openRenameGroupModal"
                 @delete="openDeleteGroupModal"
+                @enroll="
+                  () => $router.push($router.getRoute('GroupEnrollPage', { groupId: group.id }))
+                "
               />
             </tbody>
           </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -2,7 +2,19 @@
 
   <CoachAppBarPage>
     <KPageContainer>
-      <PlanHeader :activeTabId="PlanTabs.GROUPS" />
+      <PlanHeader :activeTabId="PlanTabs.GROUPS">
+        <template #header>
+          <h1>{{ coachString('groupsLabel') }}</h1>
+          <p>
+            {{ $tr('groupsDescription') }}
+            <KButton
+              appearance="basic-link"
+              :text="coreString('learnMoreAction')"
+              @click="openAboutGroupModal"
+            />
+          </p>
+        </template>
+      </PlanHeader>
       <KTabsPanel
         :tabsId="PLAN_TABS_ID"
         :activeTabId="PlanTabs.GROUPS"
@@ -59,6 +71,20 @@
           @submit="handleSuccessDeleteGroup"
           @cancel="closeModal"
         />
+
+        <KModal
+          v-if="showAboutGroupModal"
+          :title="$tr('aboutGroupsTitle')"
+          @cancel="closeModal"
+          @submit="closeModal"
+        >
+          <p style="overflow-y: visible">{{ $tr('aboutGroupsDescription') }}</p>
+          <template #actions>
+            <KButton @click="closeModal">
+              {{ coreString('closeAction') }}
+            </KButton>
+          </template>
+        </KModal>
       </KTabsPanel>
     </KPageContainer>
   </CoachAppBarPage>
@@ -124,6 +150,9 @@
       showDeleteGroupModal() {
         return this.groupModalShown === GroupModals.DELETE_GROUP;
       },
+      showAboutGroupModal() {
+        return this.groupModalShown === GroupModals.ABOUT_GROUP;
+      },
       sortedGroups() {
         return orderBy(this.groups, [group => group.name.toUpperCase()], ['asc']);
       },
@@ -139,6 +168,10 @@
       openRenameGroupModal(groupName, groupId) {
         this.setSelectedGroup(groupName, groupId);
         this.displayModal(GroupModals.RENAME_GROUP);
+      },
+      openAboutGroupModal(groupName, groupId) {
+        this.setSelectedGroup(groupName, groupId);
+        this.displayModal(GroupModals.ABOUT_GROUP);
       },
       openDeleteGroupModal(groupName, groupId) {
         this.setSelectedGroup(groupName, groupId);
@@ -162,6 +195,21 @@
       noGroups: {
         message: 'You do not have any groups',
         context: 'Message displayed when there are no groups within a class.',
+      },
+      groupsDescription: {
+        message: 'Personalize learning by organizing learners into groups',
+        context:
+          'A brief statement describing the current page. This sentence is to be followed by a button labeled "Learn more" which will open an informative modal',
+      },
+      aboutGroupsTitle: {
+        message: 'About groups',
+        context: 'Title for a modal with information describing the groups feature',
+      },
+      aboutGroupsDescription: {
+        message:
+          'Groups help coaches personalize learning and support differentiated instruction. Organize learners into groups, assign tailored lessons and quizzes to each and monitor their progress.',
+        context:
+          'Shown to the coach when they click the "Learn more" button that follows the groups page description',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -8,8 +8,11 @@
         :text="coreString('classHome')"
       />
     </p>
-    <h1>{{ $tr('planYourClassLabel') }}</h1>
-    <p>{{ $tr('planYourClassDescription') }}</p>
+    <slot name="header"></slot>
+    <div v-if="!$slots.header">
+      <h1>{{ $tr('planYourClassLabel') }}</h1>
+      <p>{{ $tr('planYourClassDescription') }}</p>
+    </div>
     <HeaderTabs :style="{ marginTop: '28px' }">
       <KTabsList
         ref="tabsList"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

https://github.com/user-attachments/assets/da845e9c-6a11-4dfc-8166-a5495f82aa18

- Updates strings to match new designs per #12678 
- "Learn more" link opens new "About groups" modal 
- Adds "Learn more" to common strings
- Adds "header" slot to "PlanHeader" component to permit more flexible display of title/className/description/etc
- Adds "Enroll learners" option in the "GroupsPage/TableRow" component, emitting "enroll" when selected (handling not implemented yet)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #12678 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- [ ] Review the designs in #12678 and look at the Groups tab; see that changes indicated there are in place.
- [ ] Can rename and delete groups from new context menu on manage groups page (where you see users in the group)
- [ ] See "Enroll learners" option in each group's options dropdown in the groups table, clicking it takes you to enroll learners in that row's group
- [ ] Other tabs still work (Lessons, Quizzes)
