### PR TITLE
Add to heartbeat API to keep useConnection composable more tightly encapsulated in the heartbeat module.

### DIFF
--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -320,6 +320,9 @@ export class HeartBeat {
       'MSPointerMove',
     ];
   }
+  setReloadOnReconnect(reloadOnReconnect) {
+    set(this._connection.reloadOnReconnect, reloadOnReconnect);
+  }
 }
 
 const heartbeat = new HeartBeat();

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -1,6 +1,7 @@
 import debounce from 'lodash/debounce';
 import pick from 'lodash/pick';
 import client from 'kolibri.client';
+import heartbeat from 'kolibri.heartbeat';
 import logger from 'kolibri.lib.logging';
 import {
   FacilityResource,
@@ -15,7 +16,7 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import CatchErrors from 'kolibri.utils.CatchErrors';
 import Vue from 'kolibri.lib.vue';
 import Lockr from 'lockr';
-import { set, get } from '@vueuse/core';
+import { get } from '@vueuse/core';
 import useUser from 'kolibri.coreVue.composables.useUser';
 import {
   DisconnectionErrorCodes,
@@ -25,7 +26,6 @@ import {
 } from 'kolibri.coreVue.vuex.constants';
 import { baseSessionState } from '../session';
 import { browser, os } from '../../../utils/browserInfo';
-import useConnection from '../../../composables/useConnection';
 
 const logging = logger.getLogger(__filename);
 
@@ -70,7 +70,7 @@ export function handleApiError(store, { error, reloadOnReconnect = false } = {})
     if (DisconnectionErrorCodes.includes(error.response.status)) {
       // Do not log errors for disconnections, as it disrupts the user experience
       // and should already be being handled by our disconnection overlay.
-      set(useConnection().reloadOnReconnect, reloadOnReconnect);
+      heartbeat.setReloadOnReconnect(reloadOnReconnect);
       return;
     }
     // Reassign object properties here as Axios error objects have built in


### PR DESCRIPTION
## Summary
* Adds to the heartbeat API so it can be imported and used, rather than committing to exposing the useConnection composable more broadly.

## References
In support of [#5488](https://github.com/learningequality/kolibri/issues/5488)

## Reviewer guidance
If you turn the network to 'offline' in the network tab, does the disconnection overlay still properly register the reconnection time?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
