### PR TITLE
Move renderer suffix into core constants.

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -200,3 +200,5 @@ export const Presets = Object.freeze({
 export const MAX_QUESTIONS_PER_QUIZ_SECTION = 25;
 
 export const DisconnectionErrorCodes = [0, 502, 504, 511];
+
+export const RENDERER_SUFFIX = '_renderer';

--- a/kolibri/core/assets/src/core-app/pluginMediator.js
+++ b/kolibri/core/assets/src/core-app/pluginMediator.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import scriptLoader from 'kolibri-common//utils/scriptLoader';
-import { RENDERER_SUFFIX } from '../views/ContentRenderer/constants';
+import { RENDERER_SUFFIX } from 'kolibri.coreVue.vuex.constants';
 import contentRendererMixin from '../views/ContentRenderer/mixin';
 import ContentRendererLoading from '../views/ContentRenderer/ContentRendererLoading';
 import ContentRendererError from '../views/ContentRenderer/ContentRendererError';

--- a/kolibri/core/assets/src/views/ContentRenderer/__tests__/DownloadButton.spec.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/__tests__/DownloadButton.spec.js
@@ -1,8 +1,8 @@
 import Vue from 'vue';
 import { render, screen } from '@testing-library/vue';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
+import { RENDERER_SUFFIX } from 'kolibri.coreVue.vuex.constants';
 import DownloadButton from '../DownloadButton.vue';
-import { RENDERER_SUFFIX } from '../constants';
 
 jest.mock('kolibri.coreVue.composables.useUser');
 

--- a/kolibri/core/assets/src/views/ContentRenderer/__tests__/utils.spec.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/__tests__/utils.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
+import { RENDERER_SUFFIX } from 'kolibri.coreVue.vuex.constants';
 import { canRenderContent, getRenderableFiles, getDefaultFile, getFilePreset } from '../utils';
-import { RENDERER_SUFFIX } from '../constants';
 
 // Add a component to the Vue instance that can be used to test the utility functions
 const addRegisterableComponents = (...presets) => {

--- a/kolibri/core/assets/src/views/ContentRenderer/constants.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/constants.js
@@ -1,1 +1,0 @@
-export const RENDERER_SUFFIX = '_renderer';

--- a/kolibri/core/assets/src/views/ContentRenderer/index.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/index.js
@@ -1,4 +1,4 @@
-import { RENDERER_SUFFIX } from './constants';
+import { RENDERER_SUFFIX } from 'kolibri.coreVue.vuex.constants';
 import ContentRendererError from './ContentRendererError';
 import { canRenderContent, getRenderableFiles, getDefaultFile, getFilePreset } from './utils';
 

--- a/kolibri/core/assets/src/views/ContentRenderer/utils.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/utils.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { RENDERER_SUFFIX } from './constants';
+import { RENDERER_SUFFIX } from 'kolibri.coreVue.vuex.constants';
 
 export const canRenderContent = preset => Boolean(Vue.options.components[preset + RENDERER_SUFFIX]);
 


### PR DESCRIPTION
## Summary
* Moves renderer suffix into core constants to allow easier reference across new packages

## References
In support of https://github.com/learningequality/kolibri/issues/5488

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
