### PR TITLE
0.18: Plan Quizzes view updates

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -99,9 +99,17 @@ export default {
       }
       const groups = getters.getGroupIdsForAssignment(assignment);
       const adHocLearners = assignment.learner_ids;
-      return adHocLearners.length
-        ? uniq(adHocLearners.concat(getters.getLearnersForGroups(groups)))
-        : getters.getLearnersForGroups(groups);
+
+      let learners;
+      const totalLearnersInClass = Object.keys(state.learnerMap).length;
+
+      if (getters.getLearnersForGroups(groups).length === totalLearnersInClass) {
+        learners = adHocLearners;
+      } else {
+        learners = uniq(adHocLearners.concat(getters.getLearnersForGroups(groups)));
+      }
+
+      return adHocLearners.length ? learners : getters.getLearnersForGroups(groups);
     };
   },
   /*

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -100,16 +100,10 @@ export default {
       const groups = getters.getGroupIdsForAssignment(assignment);
       const adHocLearners = assignment.learner_ids;
 
-      let learners;
-      const totalLearnersInClass = Object.keys(state.learnerMap).length;
-
-      if (getters.getLearnersForGroups(groups).length === totalLearnersInClass) {
-        learners = adHocLearners;
-      } else {
-        learners = uniq(adHocLearners.concat(getters.getLearnersForGroups(groups)));
-      }
-
-      return adHocLearners.length ? learners : getters.getLearnersForGroups(groups);
+      // NOTE: getters.getLearnersForGroups returns the learner_ids of the whole class
+      // when no groups exist.
+      const learnersFromGroups = groups.length ? getters.getLearnersForGroups(groups) : [];
+      return uniq(adHocLearners.concat(learnersFromGroups));
     };
   },
   /*

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -8,6 +8,13 @@
         :activeTabId="PlanTabs.QUIZZES"
       >
         <div class="filter-and-button">
+          <div>
+            <KIcon
+              icon="classes"
+              class="class-name-icon"
+            />
+            <span>{{ className }}</span>
+          </div>
           <p v-if="filteredExams.length && filteredExams.length > 0">
             {{ $tr('totalQuizSize', { size: calcTotalSizeOfVisibleQuizzes }) }}
           </p>
@@ -39,7 +46,10 @@
             />
           </div>
         </div>
-        <ReportsControls @export="exportCSV">
+        <ReportsControls
+          class="report-controls"
+          @export="exportCSV"
+        >
           <KSelect
             v-model="statusSelected"
             :label="filterQuizStatus$()"
@@ -536,6 +546,18 @@
 
   .button-col {
     vertical-align: middle;
+  }
+
+  .class-name-icon {
+    position: relative;
+    top: 0.34em;
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: 0.5em;
+  }
+
+  .report-controls {
+    margin-top: 1em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -7,18 +7,14 @@
         :tabsId="PLAN_TABS_ID"
         :activeTabId="PlanTabs.QUIZZES"
       >
-        <div>
-          <KIcon
-            icon="classes"
-            class="class-name-icon"
-          />
-          <span>{{ className }}</span>
-        </div>
-
-        <div class="filter-and-button">
-          <p v-if="filteredExams.length && filteredExams.length > 0">
-            {{ $tr('totalQuizSize', { size: calcTotalSizeOfVisibleQuizzes }) }}
-          </p>
+        <div class="classname-quiz-button-div">
+          <div>
+            <KIcon
+              icon="classes"
+              class="class-name-icon"
+            />
+            <span>{{ className }}</span>
+          </div>
           <KButtonGroup v-if="practiceQuizzesExist">
             <KButton
               primary
@@ -47,6 +43,11 @@
             />
           </div>
         </div>
+
+        <p v-if="filteredExams.length && filteredExams.length > 0">
+          {{ $tr('totalQuizSize', { size: calcTotalSizeOfVisibleQuizzes }) }}
+        </p>
+
         <ReportsControls
           class="report-controls"
           @export="exportCSV"
@@ -542,16 +543,6 @@
 
 <style lang="scss" scoped>
 
-  .filter-and-button {
-    display: flex;
-    flex-wrap: wrap-reverse;
-    justify-content: space-between;
-
-    button {
-      align-self: flex-end;
-    }
-  }
-
   .center-text {
     text-align: center;
   }
@@ -566,6 +557,12 @@
     width: 1.5em;
     height: 1.5em;
     margin-right: 0.5em;
+  }
+
+  .classname-quiz-button-div {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.5em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -8,10 +8,7 @@
         :activeTabId="PlanTabs.QUIZZES"
       >
         <div class="filter-and-button">
-          <p
-            v-if="filteredExams.length && filteredExams.length > 0"
-            class="total-quiz-size"
-          >
+          <p v-if="filteredExams.length && filteredExams.length > 0">
             {{ $tr('totalQuizSize', { size: calcTotalSizeOfVisibleQuizzes }) }}
           </p>
           <KButtonGroup v-if="practiceQuizzesExist">
@@ -531,11 +528,6 @@
     button {
       align-self: flex-end;
     }
-  }
-
-  .total-quiz-size {
-    flex-basis: 50%;
-    margin-bottom: 25px;
   }
 
   .center-text {

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -7,14 +7,15 @@
         :tabsId="PLAN_TABS_ID"
         :activeTabId="PlanTabs.QUIZZES"
       >
+        <div>
+          <KIcon
+            icon="classes"
+            class="class-name-icon"
+          />
+          <span>{{ className }}</span>
+        </div>
+
         <div class="filter-and-button">
-          <div>
-            <KIcon
-              icon="classes"
-              class="class-name-icon"
-            />
-            <span>{{ className }}</span>
-          </div>
           <p v-if="filteredExams.length && filteredExams.length > 0">
             {{ $tr('totalQuizSize', { size: calcTotalSizeOfVisibleQuizzes }) }}
           </p>
@@ -550,14 +551,10 @@
 
   .class-name-icon {
     position: relative;
-    top: 0.34em;
+    top: 0.5em;
     width: 1.5em;
     height: 1.5em;
     margin-right: 0.5em;
-  }
-
-  .report-controls {
-    margin-top: 1em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -207,7 +207,7 @@
   import { ExamResource, UserSyncStatusResource } from 'kolibri.resources';
   import plugin_data from 'plugin_data';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
-  import { mapGetters } from 'kolibri.lib.vuex';
+  import { mapState, mapGetters } from 'kolibri.lib.vuex';
   import useSnackbar from 'kolibri.coreVue.composables.useSnackbar';
   import { PageNames } from '../../../constants';
   import { PLAN_TABS_ID, PlanTabs } from '../../../constants/tabsConstants';
@@ -218,10 +218,11 @@
   import useCoreCoach from '../../../composables/useCoreCoach';
   import useQuizzes from '../../../composables/useQuizzes';
   import AverageScoreTooltip from '../../common/AverageScoreTooltip';
-  import commonCoach from '../../common';
   import ReportsControls from '../../../views/reports/ReportsControls.vue';
   import CSVExporter from '../../../csv/exporter';
   import * as csvFields from '../../../csv/fields';
+  import Score from '../../common/Score.vue';
+  import StatusSummary from '../../common/status/StatusSummary';
 
   export default {
     name: 'CoachExamsPage',
@@ -232,8 +233,10 @@
       Recipients,
       AverageScoreTooltip,
       ReportsControls,
+      Score,
+      StatusSummary,
     },
-    mixins: [commonCoach, commonCoreStrings],
+    mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
       const { classId, initClassInfo, refreshClassSummary } = useCoreCoach();
@@ -336,7 +339,15 @@
       };
     },
     computed: {
-      ...mapGetters('classSummary', ['getRecipientNamesForExam']),
+      ...mapGetters('classSummary', [
+        'learners',
+        'groups',
+        'getExamAvgScore',
+        'getExamStatusTally',
+        'getLearnersForExam',
+        'getRecipientNamesForExam',
+      ]),
+      ...mapState('classSummary', { className: 'name' }),
       practiceQuizzesExist() {
         return plugin_data.practice_quizzes_exist;
       },
@@ -361,23 +372,23 @@
         ];
       },
       recipientOptions() {
+        const groupOptions = this.groups.map(group => ({
+          label: group.name,
+          value: group.name,
+        }));
+
+        const learnerOptions = this.learners.map(learner => ({
+          label: learner.name,
+          value: learner.name,
+        }));
+
         return [
           {
             label: this.entireClassLabel$(),
             value: this.entireClassLabel$(),
           },
-          {
-            label: 'Red',
-            value: 'Red',
-          },
-          {
-            label: 'Green',
-            value: 'Green',
-          },
-          {
-            label: 'Yellow',
-            value: 'Yellow',
-          },
+          ...groupOptions,
+          ...learnerOptions,
         ];
       },
       startedExams() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -434,17 +434,20 @@
         ];
       },
       calcTotalSizeOfVisibleQuizzes() {
-        if (this.filteredExams) {
-          let sum = 0;
-          for (const exam of this.filteredExams) {
-            if (exam.active) {
-              sum += exam.size;
-            }
-          }
-          const size = bytesForHumans(sum);
-          return size;
+        if (!this.filteredExams || this.filteredExams.length === 0) {
+          return '--';
         }
-        return '--';
+        let sum = 0;
+        for (const exam of this.filteredExams) {
+          if (exam.active && exam.size && !isNaN(exam.size)) {
+            sum += exam.size;
+          }
+        }
+        if (sum === 0) {
+          return '--';
+        }
+        const size = bytesForHumans(sum);
+        return size;
       },
     },
     mounted() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -375,12 +375,12 @@
       recipientOptions() {
         const groupOptions = this.groups.map(group => ({
           label: group.name,
-          value: group.name,
+          value: group.id,
         }));
 
         const learnerOptions = this.learners.map(learner => ({
           label: learner.name,
-          value: learner.name,
+          value: learner.id,
         }));
 
         return [
@@ -412,6 +412,15 @@
           selectedExams = this.endedExams;
         } else {
           selectedExams = this.quizzes;
+        }
+
+        const recipientsFilter = this.recipientSelected.value;
+
+        if (recipientsFilter !== this.entireClassLabel$()) {
+          selectedExams = selectedExams.filter(
+            exam =>
+              exam.groups.includes(recipientsFilter) || exam.learner_ids.includes(recipientsFilter),
+          );
         }
 
         return selectedExams.map(quiz => {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -82,7 +82,7 @@
           'QuizSummaryPage',
           'PLAN_LESSONS_ROOT',
           'PLAN_LESSONS_ROOT_BETTER',
-          'EXAMS'
+          'EXAMS',
         ].includes(this.$route.name);
       },
       classLearnersListRoute() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -82,6 +82,7 @@
           'QuizSummaryPage',
           'PLAN_LESSONS_ROOT',
           'PLAN_LESSONS_ROOT_BETTER',
+          'EXAMS'
         ].includes(this.$route.name);
       },
       classLearnersListRoute() {


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/894fff06-9a15-46d9-924b-5680bd700581)

- Adds "average score" and "progress" from reports to the main table.
- Add a filter by recipients drop down without any filtering logic implemented yet.
- Class Title and Icon at the top.
- Adds "view learner devices" and print and download option buttons from the reports.

## References
closes #12670 

## Reviewer guidance
- Try creating quiz and complete them from the learners account.
- Can check the UI matches with whats mentioned in the issue.
- Check the report control functions properly in the UI.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
