### PR TITLE
Fix import channel in Postgresql 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,13 @@ def process_docstring(app, what, name, obj, options, lines):
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "m2r", "notfound.extension"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "m2r",
+    "notfound.extension",
+    "sphinxcontrib.jquery",
+]
 
 linkcheck_ignore = [
     "https://groups.google.com/a/learningequality.org/forum/#!forum/dev"

--- a/kolibri/core/content/fixtures/longdescriptions_content_data.json
+++ b/kolibri/core/content/fixtures/longdescriptions_content_data.json
@@ -93,6 +93,10 @@
       "tag_name": "tag_3"
     },
     {
+      "id": "9e4760e53568402bb287dcdb8466758a",
+      "tag_name": "transformación de energía"
+    },
+    {
       "id": "0c20e2eb254b4070a713da63380ff0a3",
       "tag_name": "velocidad de reacciones químicas"
     }

--- a/kolibri/core/content/fixtures/longdescriptions_content_data.json
+++ b/kolibri/core/content/fixtures/longdescriptions_content_data.json
@@ -91,6 +91,10 @@
     {
       "id": "222455c2cc484298b1501a13e1c7eb5c",
       "tag_name": "tag_3"
+    },
+    {
+      "id": "0c20e2eb254b4070a713da63380ff0a3",
+      "tag_name": "velocidad de reacciones químicas"
     }
   ],
   "content_contentnode": [

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -3,9 +3,11 @@ import json
 import logging
 import os
 import tempfile
+import unittest
 import uuid
 
 import pytest
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 from django.test import TransactionTestCase
@@ -30,6 +32,7 @@ from kolibri.core.content.constants.schema_versions import VERSION_4
 from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import ContentTag
 from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
@@ -832,6 +835,7 @@ class ImportLongDescriptionsTestCase(ContentImportTestBase, TransactionTestCase)
     data_name = "longdescriptions"
 
     longdescription = "soverylong" * 45
+    long_tag_id = "0c20e2eb254b4070a713da63380ff0a3"
 
     def test_long_descriptions(self):
         self.assertEqual(
@@ -844,6 +848,19 @@ class ImportLongDescriptionsTestCase(ContentImportTestBase, TransactionTestCase)
             ContentNode.objects.get(id="2e8bac07947855369fe2d77642dfc870").description,
             self.longdescription,
         )
+
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        != "django.db.backends.postgresql",
+        "Postgresql only test",
+    )
+    def test_import_too_long_content_tags(self):
+        """
+        Test that importing content tags with overly long tag_name fields will truncate correctly.
+        """
+        max_length = ContentTag._meta.get_field("tag_name").max_length
+        long_imported_tag = ContentTag.objects.get(id=self.long_tag_id)
+        assert len(long_imported_tag.tag_name) == max_length
 
 
 class Version4ImportTestCase(NaiveImportTestCase):

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -836,6 +836,8 @@ class ImportLongDescriptionsTestCase(ContentImportTestBase, TransactionTestCase)
 
     longdescription = "soverylong" * 45
     long_tag_id = "0c20e2eb254b4070a713da63380ff0a3"
+    utf_tag_id = "9e4760e53568402bb287dcdb8466758a"
+    utf_tag_name = "transformación de energía"
 
     def test_long_descriptions(self):
         self.assertEqual(
@@ -861,6 +863,19 @@ class ImportLongDescriptionsTestCase(ContentImportTestBase, TransactionTestCase)
         max_length = ContentTag._meta.get_field("tag_name").max_length
         long_imported_tag = ContentTag.objects.get(id=self.long_tag_id)
         assert len(long_imported_tag.tag_name) == max_length
+
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        != "django.db.backends.postgresql",
+        "Postgresql only test",
+    )
+    def test_utf_test_keeps_its_length(self):
+        """
+        Test inserting non-English chars keeps length
+        of the strings as are not decoded into bytes.
+        """
+        imported_tag = ContentTag.objects.get(id=self.utf_tag_id)
+        assert len(imported_tag.tag_name) == len(self.utf_tag_name)
 
 
 class Version4ImportTestCase(NaiveImportTestCase):

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -8,6 +8,7 @@ from django.apps import apps
 from django.db.models.fields.related import ForeignKey
 from sqlalchemy import and_
 from sqlalchemy import or_
+from sqlalchemy import String as sa_String
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import SQLAlchemyError
@@ -598,7 +599,14 @@ class ChannelImport(object):
         def generate_data_with_default(record):
             for col_name, column_obj in columns:
                 default = self.get_and_set_column_default(column_obj)
-                value = row_mapper(record, column_obj.name)
+                value = row_mapper(record, col_name)
+                if not column_obj.primary_key and isinstance(
+                    column_obj.type, sa_String
+                ):
+                    max_length = column_obj.type.length
+                    if max_length is not None:
+                        value = value[:max_length] if value is not None else default
+
                 yield value if value is not None else default
 
         if not merge:
@@ -624,7 +632,6 @@ class ChannelImport(object):
             )
         else:
             # Import here so that we don't need to depend on psycopg2 for Kolibri in general.
-            from psycopg2.extras import execute_values
 
             pk_name = DestinationTable.primary_key.columns.values()[0].name
 
@@ -647,13 +654,11 @@ class ChannelImport(object):
                         )
                     )
                 else:
-                    execute_values(
-                        cursor,
-                        # We want to overwrite new values that we are inserting here, so we use an ON CONFLICT DO UPDATE here
-                        # for the resulting SET statement, we generate a statement for each column we are trying to update
-                        "INSERT INTO {table} AS SOURCE ({column_names}) VALUES %s ON CONFLICT ({pk_name}) DO UPDATE SET {set_statement};".format(
+                    cursor.executemany(
+                        "INSERT INTO {table} AS SOURCE ({column_names}) VALUES ({values_list}) ON CONFLICT ({pk_name}) DO UPDATE SET {set_statement};".format(
                             table=DestinationTable.name,
                             column_names=", ".join(column_names),
+                            values_list=", ".join(["%s"] * len(column_names)),
                             pk_name=pk_name,
                             set_statement=", ".join(
                                 [
@@ -675,7 +680,6 @@ class ChannelImport(object):
                             tuple(datum for datum in generate_data_with_default(record))
                             for record in results_slice
                         ),
-                        template="(" + "%s, " * (len(columns) - 1) + "%s)",
                     )
                 i += BATCH_SIZE
                 results_slice = list(islice(results, i, i + BATCH_SIZE))

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,9 +1,12 @@
 -r base.txt
 
 # These are for building the docs
-sphinx
+
+# Sphinx stack requires a version of requests that's incompatible with Morango, so downgrading
+sphinx>=6,<7
 sphinx-intl
-sphinx-rtd-theme
+# We want to ensure the latest version of sphinx-rtd-theme that has sphinxcontrib-jquery as a dependency
+sphinx-rtd-theme~=2.0
 sphinx-autobuild
 m2r
 sphinx-notfound-page


### PR DESCRIPTION
## Summary
When importing channel data, [psycopg2 execute_values](https://www.psycopg.org/docs/extras.html#psycopg2.extras.execute_values) function was used. This [function code](https://github.com/psycopg/psycopg2/blob/master/lib/extras.py#L1296)  converts to _bytes_ all the _strings_ in order to have a better performance.
However,  converting an utf-8 _char_ to _byte_ results in more than one byte, making some strings unfit in the maximum number of chars of a column limit.

This PR:
- Replaces the use of `execute_values` by `executemany`
- As sqlite does not applies the column char limit, ensures limit is applied to data before is inserted in Postgresql

Note: I had to cherry-pick the commit from  https://github.com/learningequality/kolibri/pull/12466 to fix docs builds in GH

## References
Closes: #11780

## Reviewer guidance
Do tests pass?
In order to test the fix, this channel was failing and can be used in a kolibri installation using PG:
`kolibri manage importchannel network --baseurl=https://studio.learningequality.org 07cd1633691b4473b6fda08caf826253`

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
