### PR TITLE
Upgrade kds rc7

### DIFF
--- a/kolibri/core/assets/src/views/InteractionList/index.vue
+++ b/kolibri/core/assets/src/views/InteractionList/index.vue
@@ -21,13 +21,11 @@
 
 <script>
 
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
   import InteractionItem from './InteractionItem';
 
   export default {
     name: 'InteractionList',
     components: { InteractionItem },
-    mixins: [responsiveElementMixin],
     props: {
       interactions: {
         type: Array,

--- a/kolibri/core/assets/src/views/MultiPaneLayout.vue
+++ b/kolibri/core/assets/src/views/MultiPaneLayout.vue
@@ -56,11 +56,9 @@
 <script>
 
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
 
   export default {
     name: 'MultiPaneLayout',
-    mixins: [responsiveElementMixin],
     setup() {
       const { windowHeight } = useKResponsiveWindow();
       return {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -254,7 +254,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
@@ -299,7 +298,7 @@
       LanguageSwitcherModal,
       BottomNavigationBar,
     },
-    mixins: [commonCoreStrings, responsiveElementMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall, windowIsLarge } = useKResponsiveWindow();
       const {

--- a/kolibri/core/assets/src/views/SlotTruncator.vue
+++ b/kolibri/core/assets/src/views/SlotTruncator.vue
@@ -35,12 +35,19 @@
 <script>
 
   import debounce from 'lodash/debounce';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
+  import useKResponsiveElement from 'kolibri-design-system/lib/composables/useKResponsiveElement';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'SlotTruncator',
-    mixins: [commonCoreStrings, responsiveElementMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { elementWidth, elementHeight } = useKResponsiveElement();
+      return {
+        elementWidth,
+        elementHeight,
+      };
+    },
     props: {
       maxHeight: {
         type: Number,

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.7",
-    "kolibri-design-system": "5.0.0-rc5",
+    "kolibri-design-system": "5.0.0-rc7",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -171,7 +171,6 @@
   import Lockr from 'lockr';
   import FocusLock from 'vue-focus-lock';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import iFrameView from './SandboxIFrameView';
   import LoadingScreen from './LoadingScreen';
@@ -221,7 +220,6 @@
       SearchButton,
       LoadingError,
     },
-    mixins: [responsiveElementMixin],
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
       return {

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -98,7 +98,6 @@
   import throttle from 'lodash/throttle';
   import { languageIdToCode } from 'kolibri.utils.i18n';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import Settings from '../utils/settings';
   import { ReplayButton, ForwardButton } from './customButtons';
@@ -123,7 +122,7 @@
   export default {
     name: 'MediaPlayerIndex',
     components: { MediaPlayerFullscreen, MediaPlayerTranscript },
-    mixins: [commonCoreStrings, responsiveElementMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
       return { windowIsSmall, windowIsPortrait };

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -87,7 +87,6 @@
   import objectFitImages from 'object-fit-images';
   import client from 'kolibri.client';
 
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
@@ -109,7 +108,6 @@
       HooperPagination,
       HooperNavigation,
     },
-    mixins: [responsiveElementMixin],
     setup() {
       const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       return {

--- a/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
@@ -3,7 +3,7 @@
   <KCard
     :to="to"
     :headingLevel="headingLevel"
-    :layout="windowBreakpoint === 0 ? 'vertical' : 'horizontal'"
+    :orientation="windowBreakpoint === 0 ? 'vertical' : 'horizontal'"
     thumbnailDisplay="large"
     :title="contentNode.title"
     :thumbnailSrc="thumbnailSrc"

--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -3,7 +3,7 @@
   <KCard
     :to="to"
     :headingLevel="headingLevel"
-    :layout="windowBreakpoint === 0 ? 'vertical' : 'horizontal'"
+    :orientation="windowBreakpoint === 0 ? 'vertical' : 'horizontal'"
     thumbnailDisplay="large"
     :title="contentNode.title"
     :thumbnailSrc="thumbnailSrc"

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -62,11 +62,10 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
 
   export default {
     name: 'SearchBox',
-    mixins: [commonCoreStrings, responsiveElementMixin],
+    mixins: [commonCoreStrings],
     props: {
       icon: {
         type: String,

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.7",
-    "kolibri-design-system": "5.0.0-rc5",
+    "kolibri-design-system": "5.0.0-rc7",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7778,13 +7778,13 @@ kolibri-constants@0.2.7:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.7.tgz#7441bff81c459e081eeb8125a741745a72a002d1"
   integrity sha512-gzAeXmFCFYxTlvQ4sPdyRdQzm0FTD/ydK8Q7zgqcnooFjwPHw+cov8xmy6OKn/eqF/87fxFAv54bdkmrghkIPQ==
 
-kolibri-design-system@5.0.0-rc5:
-  version "5.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc5.tgz#54daecb859d389a9deee49276d05ba14ebae15ab"
-  integrity sha512-Lam9bwSgKk7Dz6nblvnM/uA0H6BX7pPPGgXCRSyp7m7d9DasqrjArkhXuc5TopSjMfajn3hXzWNg4nhX/w33EQ==
+kolibri-design-system@5.0.0-rc7:
+  version "5.0.0-rc7"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc7.tgz#3a965b6a0ab9042f6e1ad754a6ebcdb5f1b89da6"
+  integrity sha512-30lp0aY7maWXX9nwVDTNM49ittwIQgSbViQNw9RS5DLEXLEyJc212pabIytEGidyxmhpVj4gUM/MdwyM606Mxg==
   dependencies:
     "@vue/composition-api" "1.7.2"
-    aphrodite "git+https://github.com/learningequality/aphrodite.git"
+    aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "3.0.21"
     color "3.2.1"
     css-element-queries "1.2.0"
@@ -10699,16 +10699,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10795,14 +10786,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12150,16 +12134,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary
- Updates to [kds 5.0.0-rc7](https://github.com/learningequality/kolibri-design-system/releases/tag/v5.0.0-rc7) 
- Resolves breaking changes to KResponsiveElementMixin and KCard props

## Reviewer guidance
1. Does everything still build without errors in the terminal or console?
2. Do all tests still pass?
3. Are there any instances of KResponsiveElementMixin that have not been replaced, or places where KCard has props that still need to be updated?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
