### PR TITLE
Prevent access to undefined AttemptLogs while looking at reports

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -263,7 +263,7 @@ export function annotateSections(sections, questions = []) {
   if (!sections) {
     return [
       {
-        title: '',
+        section_title: '',
         questions: questions,
         startQuestionNumber: 0,
         endQuestionNumber: questions.length - 1,

--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -5,7 +5,7 @@
       :is="displayTag"
       class="item"
     >
-      {{ coreString('questionNumberLabel', { questionNumber: attemptLog.questionNumber }) }}
+      {{ coreString('questionNumberLabel', { questionNumber: questionNumber }) }}
     </component>
     <template v-if="!isSurvey">
       <AttemptIconDiff
@@ -90,6 +90,10 @@
       },
       isSurvey: {
         type: Boolean,
+        required: true,
+      },
+      questionNumber: {
+        type: Number,
         required: true,
       },
     },

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -63,7 +63,7 @@
         v-for="(section, index) in sections"
         :id="`section-questions-${index}`"
         :key="`section-questions-${index}`"
-        :title="displaySectionTitle(section, index) || ''"
+        :title="displaySectionTitle(section, index) || sectionLabel$({ sectionNumber: index + 1 })"
         @focus="expand(index)"
       >
         <template
@@ -171,7 +171,7 @@
       AccordionItem,
     },
     setup(props, { emit }) {
-      const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
+      const { questionsLabel$, quizSectionsLabel$, sectionLabel$ } = enhancedQuizManagementStrings;
       const { questionNumberLabel$ } = coreStrings;
       const { currentSectionIndex, sections, selectedQuestionNumber } = toRefs(props);
 
@@ -252,6 +252,7 @@
         displaySectionTitle,
         quizSectionsLabel$,
         questionsLabel$,
+        sectionLabel$,
         expand,
         isExpanded,
         toggle,

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -65,7 +65,7 @@
         v-for="(section, index) in sections"
         :id="`section-questions-${index}`"
         :key="`section-questions-${index}`"
-        :title="displaySectionTitle(section, index) || sectionLabel$({ sectionNumber: index + 1 })"
+        :title="displaySectionTitle(section, index)"
         @focus="expand(index)"
       >
         <template
@@ -174,7 +174,7 @@
       AccordionItem,
     },
     setup(props, { emit }) {
-      const { questionsLabel$, quizSectionsLabel$, sectionLabel$ } = enhancedQuizManagementStrings;
+      const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
       const { questionNumberLabel$ } = coreStrings;
       const { currentSectionIndex, sections, selectedQuestionNumber } = toRefs(props);
 
@@ -249,7 +249,6 @@
         displaySectionTitle,
         quizSectionsLabel$,
         questionsLabel$,
-        sectionLabel$,
         expand,
         isExpanded,
         toggle,

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -39,6 +39,7 @@
             class="attempt-selected"
             :isSurvey="isSurvey"
             :attemptLog="selectedAttemptLog"
+            :questionNumber="selectedQuestionNumber + 1"
             displayTag="span"
           />
         </template>
@@ -48,6 +49,7 @@
             class="attempt-option"
             :isSurvey="isSurvey"
             :attemptLog="attemptLogsForCurrentSection[index]"
+            :questionNumber="index + 1"
             displayTag="span"
           />
         </template>
@@ -135,6 +137,7 @@
                     v-if="attemptLogsForCurrentSection[qIndex]"
                     :isSurvey="isSurvey"
                     :attemptLog="attemptLogsForCurrentSection[qIndex]"
+                    :questionNumber="qIndex + 1"
                     displayTag="p"
                   />
                 </a>
@@ -198,21 +201,15 @@
       // Computed property for attempt logs of the current section
       const attemptLogsForCurrentSection = computed(() => {
         const start = currentSection.value.startQuestionNumber;
-        return currentSection.value.questions.map((_, index) => {
-          return props.attemptLogs[start + index];
-        });
+        return props.attemptLogs.slice(start, start + currentSection.value.questions.length);
       });
 
       const questionSelectOptions = computed(() => {
-        return currentSection.value.questions.reduce((options, question, index) => {
-          if (attemptLogsForCurrentSection.value[index]) {
-            options.push({
-              value: index,
-              label: questionNumberLabel$({ questionNumber: index + 1 }),
-            });
-          }
-          return options;
-        }, []);
+        return currentSection.value.questions.map((question, index) => ({
+          value: index,
+          label: questionNumberLabel$({ questionNumber: index + 1 }),
+          disabled: !attemptLogsForCurrentSection.value[index],
+        }));
       });
 
       // The KSelect-shaped object for the current section


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request fixes the console errors that would appear when viewing learner exercise attempts. The errors occurred because `AttemptLogItem` was being rendered with an undefined `attemptLog` prop and caused runtime errors when it tried to access properties of `attemptLog`. This pull request also addresses an issue where, on mobile screens, the `KSelect` options included selections that did not have associated `attemptLogs` but could still be selected.

- Conditionally render the `AttemptLogItem` component only when `attemptLog` is defined.
- A computed property named `attemptLogsForCurrentSection` has been added for the attempt logs of the current section.
- Added a computed property for the selected attempt log called `selectedAttemptLog` to be displayed as the current `KSelect` item on mobile displays.
- Updated the `questionSelectOptions` computed property to filter out any questions that don't have an associated `attemptLog`.


**Console Errors fixed:**
![attemptLogUndefined](https://github.com/user-attachments/assets/4f5e4657-c2be-4f12-ad8e-3e56c41cd451)
![correctUndefined](https://github.com/user-attachments/assets/2e0c4ece-77fa-45c1-8d93-8660f7e370bd)
![titleUndefined](https://github.com/user-attachments/assets/5a57752f-9340-4110-a73a-bd889ec2fafb)

**Before:**


https://github.com/user-attachments/assets/50ec006f-0af6-4af9-ac2e-adc2b16cf8ac




**After:**


https://github.com/user-attachments/assets/6ceb2864-8686-4aed-8225-0736aa4c1820


![attemptloglist](https://github.com/user-attachments/assets/58bcfbb2-cb6a-4917-9fc8-277ceb6e6b3a)

![attemptloglistmobile](https://github.com/user-attachments/assets/a7d9339f-e475-4ea0-ba90-ab2c2547ce9f)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12550 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Create a lesson using the resource "Make 10 (grids and number bonds)" found within Kolibri QA Channel > Exercises > CK12 Exercises (token: `nakav-mafak`) and assign it to a learner.
2. While signed into the learner account, attempt the lesson.
3. Sign back into Kolibri with an admin/coach account and navigate to Coach > Reports > Lessons and review the learner lesson attempt.
4. Confirm that there are no console errors.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
