### PR TITLE
Update StorageNotification.vue to prevent undefined access if device plugin is disabled

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/StorageNotification.vue
+++ b/kolibri/plugins/learn/assets/src/views/StorageNotification.vue
@@ -180,9 +180,9 @@
         redirectBrowser(downloadsUrl);
       },
       manageChannel() {
-        const deviceManagementUrl = urls['kolibri:kolibri.plugins.device:device_management']();
+        const deviceManagementUrl = urls['kolibri:kolibri.plugins.device:device_management'];
         if (this.canManageContent && deviceManagementUrl) {
-          redirectBrowser(deviceManagementUrl);
+          redirectBrowser(deviceManagementUrl());
         } else {
           this.bannerOpened = false;
         }


### PR DESCRIPTION
## Summary
* Fixes defensive programming check - it is the function that will be undefined, not its return value, so we have to check the truthiness of the function before invoking it.