### PR TITLE
Improve learn folder contents display

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -643,7 +643,11 @@
       topics() {
         return this.contents
           .filter(content => content.kind === ContentNodeKinds.TOPIC)
-          .filter(t => t.children && t.children.results.length)
+          .filter(t => t.children && t.children.results.length);
+      },
+      topicsForDisplay() {
+        return this.topics
+          .filter(t => (this.subTopicId ? t.id === this.subTopicId : true))
           .map(t => {
             let topicChildren = t.children.results;
             const prefixTitles = [];
@@ -655,15 +659,8 @@
               topicChildren = t.children ? t.children.results : [];
             }
             t.prefixTitles = prefixTitles;
-            return t;
-          });
-      },
-      topicsForDisplay() {
-        return this.topics
-          .filter(t => (this.subTopicId ? t.id === this.subTopicId : true))
-          .map(t => {
             let childrenToDisplay;
-            const topicChildren = t.children ? t.children.results : [];
+            topicChildren = t.children ? t.children.results : [];
             if (this.subTopicId || this.topics.length === 1) {
               // If we are in a subtopic display, we should only be displaying this topic
               // so don't bother checking if the ids match.

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -131,6 +131,10 @@
               </template>
 
               <!-- display for each nested topic/folder  -->
+              <hr
+                v-if="topicsForDisplay.length"
+                class="divider"
+              >
               <!-- display all resources at the top level of the folder -->
               <LibraryAndChannelBrowserMainContent
                 v-if="resources.length"
@@ -1042,6 +1046,10 @@
   .page-loader {
     top: $toolbar-height;
     padding-top: 16px;
+  }
+
+  .divider {
+    margin-bottom: 24px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -117,44 +117,37 @@
               data-test="topics"
             >
               <!-- Rows of cards and links / show more for each Topic -->
-              <template v-for="t in topicsForDisplay">
+              <template v-for="(c, i) in contentsForDisplay">
+                <hr
+                  v-if="!c.children && i > 0"
+                  :key="i"
+                  class="divider"
+                >
                 <TopicSubsection
-                  :key="t.id"
-                  :topic="t"
-                  :subTopicLoading="t.id === subTopicLoading"
+                  v-if="c.children"
+                  :key="c.id"
+                  :topic="c"
+                  :subTopicLoading="c.id === subTopicLoading"
                   :gridType="gridType"
                   :allowDownloads="allowDownloads"
                   @showMore="handleShowMore"
                   @loadMoreInSubtopic="handleLoadMoreInSubtopic"
                   @toggleInfoPanel="toggleInfoPanel"
                 />
+                <LibraryAndChannelBrowserMainContent
+                  v-else
+                  :key="i"
+                  :allowDownloads="allowDownloads"
+                  data-test="search-results"
+                  :contents="c"
+                  :gridType="gridType"
+                  currentCardViewStyle="card"
+                  @toggleInfoPanel="toggleInfoPanel"
+                />
               </template>
 
-              <!-- display for each nested topic/folder  -->
-              <hr
-                v-if="topicsForDisplay.length"
-                class="divider"
-              >
-              <!-- display all resources at the top level of the folder -->
-              <LibraryAndChannelBrowserMainContent
-                v-if="resources.length"
-                :allowDownloads="allowDownloads"
-                data-test="search-results"
-                :contents="resourcesDisplayed"
-                :gridType="gridType"
-                currentCardViewStyle="card"
-                @toggleInfoPanel="toggleInfoPanel"
-              />
-              <KButton
-                v-if="moreResources"
-                class="more-after-grid"
-                appearance="basic-link"
-                @click="handleShowMoreResources"
-              >
-                {{ coreString('showMoreAction') }}
-              </KButton>
               <div
-                v-else-if="topicMore"
+                v-if="topicMore"
                 class="end-button-block"
               >
                 <KButton
@@ -263,6 +256,7 @@
 <script>
 
   import { get, set } from '@vueuse/core';
+  import isArray from 'lodash/isArray';
   import isEqual from 'lodash/isEqual';
   import lodashSet from 'lodash/set';
   import lodashGet from 'lodash/get';
@@ -581,7 +575,6 @@
     data: function () {
       return {
         sidePanelStyleOverrides: {},
-        showMoreResources: false,
         metadataSidePanelContent: null,
         expandedTopics: {},
         subTopicLoading: null,
@@ -624,53 +617,58 @@
       channelTitle() {
         return this.channel ? this.channel.name : '';
       },
-      resources() {
-        return this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
-      },
       childrenToDisplay() {
         return this.windowBreakpoint === 2 || this.windowBreakpoint > 4 ? 4 : 3;
       },
       gridType() {
         return this.windowBreakpoint > 4 ? 2 : 1;
       },
-      resourcesDisplayed() {
-        // if no folders are shown at this level, show more resources to fill the space
-        // or if the user has explicitly requested to show more resources
-        if (!this.topics.length || this.showMoreResources) {
-          return this.resources;
-        }
-        return this.resources.slice(0, this.childrenToDisplay);
-      },
-      moreResources() {
-        return this.resourcesDisplayed.length < this.resources.length;
-      },
       topics() {
         return this.contents
           .filter(content => content.kind === ContentNodeKinds.TOPIC)
           .filter(t => t.children && t.children.results.length);
       },
-      topicsForDisplay() {
-        return this.topics
-          .filter(t => (this.subTopicId ? t.id === this.subTopicId : true))
-          .map(t => {
-            let topicChildren = t.children.results;
+      contentsForDisplay() {
+        return this.contents
+          .filter(
+            c =>
+              c.kind !== ContentNodeKinds.TOPIC ||
+              ((this.subTopicId ? c.id === this.subTopicId : true) &&
+                c.children &&
+                c.children.results.length),
+          )
+          .reduce((arr, c) => {
+            // Reduce the list to objects representing topics,
+            // and arrays representing runs of resources positioned between them.
+            if (c.kind !== ContentNodeKinds.TOPIC) {
+              const lastEntry = arr.slice(-1)[0];
+              // The final entry is either undefined or not an array
+              // so we have to create a new array for this run of resources
+              if (!lastEntry || !isArray(lastEntry)) {
+                return [...arr, [c]];
+              }
+              // Otherwise, just add this to the existing array to add to
+              // the ongoing run of resources.
+              return [...arr.slice(0, -1), [...lastEntry, c]];
+            }
+            let topicChildren = c.children.results;
             const prefixTitles = [];
             while (topicChildren.length === 1 && !topicChildren[0].is_leaf) {
               // If the topic has only one child, and that child is also a topic
               // we should collapse the topics to display the child topic instead.
-              prefixTitles.push(t.title);
-              t = topicChildren[0];
-              topicChildren = t.children ? t.children.results : [];
+              prefixTitles.push(c.title);
+              c = topicChildren[0];
+              topicChildren = c.children ? c.children.results : [];
             }
-            t.prefixTitles = prefixTitles;
+            c.prefixTitles = prefixTitles;
             let childrenToDisplay;
-            topicChildren = t.children ? t.children.results : [];
+            topicChildren = c.children ? c.children.results : [];
             if (this.subTopicId || this.topics.length === 1) {
               // If we are in a subtopic display, we should only be displaying this topic
               // so don't bother checking if the ids match.
               // Alternatively, if there is only one topic, we should display all of its children.
               childrenToDisplay = topicChildren.length;
-            } else if (this.expandedTopics[t.id]) {
+            } else if (this.expandedTopics[c.id]) {
               // If topic is expanded show three times as many children.
               childrenToDisplay = this.childrenToDisplay * 3;
             } else {
@@ -682,10 +680,10 @@
               !this.subTopicId &&
               this.topics.length != 1 &&
               topicChildren.length > this.childrenToDisplay &&
-              !this.expandedTopics[t.id];
+              !this.expandedTopics[c.id];
 
             // viewMore is the 'more' object that will be used to load more items from this topic.
-            const viewMore = t.children ? t.children.more : null;
+            const viewMore = c.children ? c.children.more : null;
 
             // viewAll is a flag + link object to link to a subpage which shows all initially
             // loaded topics content
@@ -695,19 +693,22 @@
                   ...this.$route,
                   params: {
                     ...this.$route.params,
-                    subtopic: t.id,
+                    subtopic: c.id,
                   },
                 }
                 : null;
-
-            return {
-              ...t,
-              viewAll,
-              children,
-              showMore,
-              viewMore,
-            };
-          });
+            // Having processed the topic, just add it to the end of the array.
+            return [
+              ...arr,
+              {
+                ...c,
+                viewAll,
+                children,
+                showMore,
+                viewMore,
+              },
+            ];
+          }, []);
       },
       subTopicId() {
         return this.subtopic;
@@ -934,9 +935,6 @@
         this.loadMoreTopics().then(() => {
           this.topicMoreLoading = false;
         });
-      },
-      handleShowMoreResources() {
-        this.showMoreResources = true;
       },
       findFirstEl() {
         if (this.$refs.embeddedPanel) {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -120,7 +120,7 @@
               <template v-for="(c, i) in contentsForDisplay">
                 <hr
                   v-if="!c.children && i > 0"
-                  :key="i"
+                  :key="'divider_' + i"
                   class="divider"
                 >
                 <TopicSubsection
@@ -136,7 +136,7 @@
                 />
                 <LibraryAndChannelBrowserMainContent
                   v-else
-                  :key="i"
+                  :key="'grid_' + i"
                   :allowDownloads="allowDownloads"
                   data-test="search-results"
                   :contents="c"
@@ -632,10 +632,8 @@
         return this.contents
           .filter(
             c =>
-              c.kind !== ContentNodeKinds.TOPIC ||
-              ((this.subTopicId ? c.id === this.subTopicId : true) &&
-                c.children &&
-                c.children.results.length),
+              (this.subTopicId ? c.id === this.subTopicId : true) &&
+              (c.kind !== ContentNodeKinds.TOPIC || (c.children && c.children.results.length)),
           )
           .reduce((arr, c) => {
             // Reduce the list to objects representing topics,
@@ -900,6 +898,7 @@
               this.$store.dispatch('handleApiError', { error: err });
             });
         }
+        return Promise.resolve();
       },
       handleLoadMoreInSubtopic(topicId) {
         this.subTopicLoading = topicId;

--- a/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
@@ -326,7 +326,7 @@ describe('TopicsPage', () => {
           computed: {
             windowIsLarge: () => false,
             windowIsSmall: () => true,
-            topicsForDisplay: () => {
+            contentsForDisplay: () => {
               return [
                 {
                   id: '1',


### PR DESCRIPTION
## Summary
* Reverts the folder side panel to show the topic level contents of the folder, rather than the skip logic folders
* Adds a visual divider between the end of the contents of a subtopic, and resources at the top level of the current topic
* Rejigs content display so that topics and resources are now shown in the proper order in the topic, with each subtopic displayed in-line, and then contiguous sequences of resources displayed together

## References
Fixes #9043
Fixes #10060

## Reviewer guidance
Look at large topics, small topics, deeply nested topics, topics that have resources and topics interspersed.

Good channels to look at: Kolibri QA channel, the HTML5 topic, Ciencia NASA channel - the Ciencia Espacial
 topic.

Folder side panel:

| Before | After |
------------|---------
| ![Screenshot from 2024-10-22 15-48-20](https://github.com/user-attachments/assets/87f75eae-69ee-42f0-a7b9-584a43a1f3ab) | ![Screenshot from 2024-10-22 15-48-08](https://github.com/user-attachments/assets/401aa61b-8cd8-4bbf-8ad1-32e5475c3a66) |


Resources in a topic after a subtopic now have a divider:

![Screenshot from 2024-10-22 16-00-19](https://github.com/user-attachments/assets/39d6b3c8-54cc-4865-8d48-76c4d2198b30)



----

## Testing checklist





- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
