### PR TITLE
Fix creating a quiz without having imported resources or users enrolled in the class

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -32,7 +32,7 @@
         <template #default="{ items }">
           <CoreTable
             :selectable="true"
-            :emptyMessage="$tr('noUsersMatch')"
+            :emptyMessage="emptyMessage"
           >
             <template #headers>
               <th class="table-checkbox-header">
@@ -92,6 +92,7 @@
   import { formatList } from 'kolibri.utils.i18n';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import flatMap from 'lodash/flatMap';
   import forEach from 'lodash/forEach';
@@ -106,6 +107,13 @@
     name: 'IndividualLearnerSelector',
     components: { CoreTable, PaginatedListContainer },
     mixins: [commonCoreStrings, commonCoachStrings],
+    setup() {
+      const { noLearnersEnrolled$ } = enhancedQuizManagementStrings;
+
+      return {
+        noLearnersEnrolled$,
+      };
+    },
     props: {
       // If true, the main checkbox is checked and the list of learners is shown
       isVisible: {
@@ -196,6 +204,11 @@
       },
       itemsPerPage() {
         return DEFAULT_ITEMS_PER_PAGE;
+      },
+      emptyMessage() {
+        return this.allLearners.length
+          ? this.$tr('noUsersMatch')
+          : this.noLearnersEnrolled$({ className: this.className });
       },
     },
     methods: {


### PR DESCRIPTION

## Summary

This pull request adds warning messages for scenarios in which there are no imported channels and/or users associated with the class when a coach attempts to create a quiz.

## References
[#12330](https://github.com/learningequality/kolibri/issues/12330)
## Reviewer guidance

1. Please review the slack conversations for some decisions made whether to use a model or not [here ](https://learningequality.slack.com/archives/CB37UM23A/p1729271450496829)and[ here](https://learningequality.slack.com/archives/CTG8XDTCL/p1729629998736479)
2. Does the changes makes sense ?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
