### PR TITLE
Upgrade dependencies and test matrix for Python 3.13.

### DIFF
--- a/.github/workflows/morango_integration.yml
+++ b/.github/workflows/morango_integration.yml
@@ -30,7 +30,7 @@ jobs:
       INTEGRATION_TEST: 'true'
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.4
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.5
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.4
+      ref: v1.6.5
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -88,11 +88,11 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.4
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.5
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.4
+      ref: v1.6.5
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/kolibri/utils/compat_cgi.py
+++ b/kolibri/utils/compat_cgi.py
@@ -1,0 +1,53 @@
+"""
+A minimal port of the removed cgi module for use in Python 3.13.
+Only imports the specific parts of the module that are used by Django.
+Informed by the PR that removed its use in Django:
+https://github.com/django/django/pull/15679
+"""
+
+
+def _parseparam(s):
+    while s[:1] == ";":
+        s = s[1:]
+        end = s.find(";")
+        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+            end = s.find(";", end + 1)
+        if end < 0:
+            end = len(s)
+        f = s[:end]
+        yield f.strip()
+        s = s[end:]
+
+
+def parse_header(line):
+    """
+    Parse a Content-type like header.
+    Return the main content-type and a dictionary of options.
+    """
+    parts = _parseparam(";" + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find("=")
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i + 1 :].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace("\\\\", "\\").replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict
+
+
+boundary_re = None
+
+
+def valid_boundary(boundary):
+    # Do this import here to avoid importing dependencies in the env module.
+    from django.utils.regex_helper import _lazy_re_compile
+
+    global boundary_re
+
+    if boundary_re is None:
+        boundary_re = _lazy_re_compile(rb"[ -~]{0,200}[!-~]")
+    return boundary_re.fullmatch(boundary) is not None

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -127,6 +127,19 @@ def monkey_patch_distutils():
         sys.modules["distutils.version"] = module
 
 
+def forward_port_cgi_module():
+    """
+    Forward ports the required parts of the removed cgi module.
+    This can be removed when we upgrade to a version of Django that is Python 3.13 compatible.
+    """
+    if sys.version_info < (3, 13):
+        return
+    from importlib import import_module
+
+    module = import_module("kolibri.utils.compat_cgi")
+    sys.modules["cgi"] = module
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -145,6 +158,9 @@ def set_env():
 
     # Add path for c extensions to sys.path
     prepend_cext_path(os.path.realpath(os.path.dirname(kolibri_dist.__file__)))
+
+    # Depends on Django, so we need to wait until our dist has been registered.
+    forward_port_cgi_module()
 
     # Set default env
     for key, value in ENVIRONMENT_VARIABLES.items():

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import shutil
+import sys
 from abc import ABCMeta
 from abc import abstractmethod
 from contextlib import contextmanager
@@ -22,12 +23,27 @@ from kolibri.utils.filesystem import mkdirp
 
 
 try:
+    # Pre-empt the PanicException that importing cryptography can cause
+    # when we are using a non-compatible version of cffi on Python 3.13
+    # this happens because of static depdendency bundling in Kolibri
+    # See the morango.models.fields.crypto module for the source of this code.
+    import cffi
+
+    if sys.version_info > (3, 13):
+        if hasattr(cffi, "__version_info__"):
+            if cffi.__version_info__ < (1, 17, 1):
+                raise ImportError
+
     import OpenSSL
 
     SSLERROR = OpenSSL.SSL.Error
 except ImportError:
     SSLERROR = requests.exceptions.SSLError
-
+except BaseException as e:
+    # Still catch PanicExceptions just in case.
+    if "Python API call failed" not in str(e):
+        raise
+    SSLERROR = requests.exceptions.SSLError
 
 try:
     FileNotFoundError

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-mptt==0.14.0
 requests==2.27.1
 cheroot==10.0.1
 magicbus==4.1.2
-le-utils==0.2.7
+le-utils==0.2.8
 jsonfield==3.1.0
 morango==0.8.2
 tzlocal==4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.8
 jsonfield==3.1.0
-morango==0.8.2
+morango==0.8.3
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     cmdclass={"install_scripts": gen_windows_batch_files},
-    python_requires=">=3.6,  <3.13",
+    python_requires=">=3.6,  <3.14",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12}, postgres
+envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13}, postgres
 
 [testenv]
 usedevelop = True
@@ -21,6 +21,7 @@ basepython =
     py3.10: python3.10
     py3.11: python3.11
     py3.12: python3.12
+    py3.13: python3.13
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
## Summary
* Add cgi forward port compatibility patch.
* Upgrade morango

## References
Fixes [#12682](https://github.com/learningequality/kolibri/issues/12682)

## Reviewer guidance
Do tests pass for the new Python version?
Does the server pass a smoke test in Python 3.13?

The updated version of Morango updates the dependency we use for cryptography on some devices. To test this, install [Python 3.13](https://www.python.org/downloads/release/python-3132/) on a Windows VM, then install the Kolibri windows asset from this PR - hopefully that should try to use the existing Python 3.13 installation.

Then run the server, and go through setup, then register and sync the server with KDP. If that all works, this should be good to go!