### PR TITLE
Final token updates

### DIFF
--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -8,7 +8,7 @@ function _brandColorScaleValidator(value) {
     logging.error(`Expected object but got '${value}'`);
     return false;
   }
-  const COLOR_NAMES = ['v_200', 'v_400', 'v_500', 'v_600', 'v_800'];
+  const COLOR_NAMES = ['v_100', 'v_200', 'v_300', 'v_400', 'v_500', 'v_600'];
   for (const colorName of COLOR_NAMES) {
     if (!value[colorName]) {
       logging.error(`${colorName} '${name}' not defined by theme`);

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -115,7 +115,7 @@
       },
       linkStyle() {
         const hoverBg = this.isFullscreen
-          ? this.$themeBrand.secondary.v_300
+          ? this.$themeBrand.secondary.v_600
           : this.$themePalette.grey.v_700;
         const defaultBg = this.isFullscreen ? this.$themeTokens.appBar : this.$themePalette.black;
         return {

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -63,7 +63,7 @@
         return {
           color: this.$themeTokens.text,
           ':hover': {
-            'background-color': this.$themeBrand.secondary.v_300,
+            'background-color': this.$themeBrand.secondary.v_600,
           },
           ':focus': {
             ...this.$coreOutline,

--- a/kolibri/core/assets/src/views/PermissionsIcon.vue
+++ b/kolibri/core/assets/src/views/PermissionsIcon.vue
@@ -69,7 +69,7 @@
       iconStyle() {
         if (this.hasSuperAdminPermission) {
           return {
-            fill: this.lightIcon ? this.$themePalette.yellow.v_400 : this.$themeTokens.superAdmin,
+            fill: this.lightIcon ? this.$themePalette.yellow.v_200 : this.$themeTokens.superAdmin,
           };
         } else {
           return {

--- a/kolibri/core/assets/src/views/ProgressBar.vue
+++ b/kolibri/core/assets/src/views/ProgressBar.vue
@@ -9,7 +9,7 @@
     </div>
     <div
       class="progress-bar-wrapper"
-      :style="{ backgroundColor: $themePalette.grey.v_200 }"
+      :style="{ backgroundColor: $themePalette.grey.v_300 }"
       role="progressbar"
       aria-labelledby="progress-bar-label"
       :aria-valuenow="percent"

--- a/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/HeaderTabs/HeaderTab.vue
@@ -42,7 +42,7 @@
         return this.$computedClass({
           ':focus': this.$coreOutline,
           ':hover': {
-            backgroundColor: this.$themePalette.blue.v_200,
+            backgroundColor: this.$themePalette.blue.v_100,
           },
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -341,7 +341,7 @@
       cancelStyleOverrides() {
         return {
           color: this.$themeTokens.textInverted,
-          'background-color': this.$themePalette.red.v_300,
+          'background-color': this.$themePalette.red.v_600,
           // We need to use a darker color for hover than
           // palette.red.v_300 but at the same time,
           // palette.red.v_300 is the darkest available red

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -343,8 +343,8 @@
           color: this.$themeTokens.textInverted,
           'background-color': this.$themePalette.red.v_600,
           // We need to use a darker color for hover than
-          // palette.red.v_300 but at the same time,
-          // palette.red.v_300 is the darkest available red
+          // palette.red.v_600 but at the same time,
+          // palette.red.v_600 is the darkest available red
           // in the palette. Using this hardcoded color was
           // agreed with designers.
           ':hover': { 'background-color': '#A81700' },

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -3,7 +3,7 @@
   <div
     v-show="userDevicesUsingIE11"
     class="alert"
-    :style="{ backgroundColor: $themePalette.yellow.v_200 }"
+    :style="{ backgroundColor: $themePalette.yellow.v_100 }"
   >
     <div style="display: flex">
       <div>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
@@ -98,7 +98,7 @@
         return this.$computedClass({
           ':focus': this.$coreOutline,
           ':hover': {
-            backgroundColor: this.$themePalette.blue.v_200,
+            backgroundColor: this.$themePalette.blue.v_100,
           },
         });
       },

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.6",
-    "kolibri-design-system": "4.4.0",
+    "kolibri-design-system": "4.6.0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,15 +3017,6 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-"aphrodite@git+https://github.com/learningequality/aphrodite.git":
-  version "2.2.3"
-  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
-  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
-  dependencies:
-    asap "^2.0.3"
-    inline-style-prefixer "^4.0.2"
-    string-hash "^1.1.3"
-
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
@@ -7716,26 +7707,6 @@ kolibri-constants@0.2.6:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.6.tgz#d13762862505a3a6ec58a104870b21da96778656"
   integrity sha512-gQaY2wFNFrsB+9+xQNeEcLHixNuZEK+GHyKKr78s/hg8gFU3YVsnhlYp0u+du4XeVwewpyN1ajGb4UrrdF8rTA==
 
-kolibri-design-system@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-4.4.0.tgz#4c230a701beafa9c87dc155b81e68128b02a4bfe"
-  integrity sha512-2oYNVkmY1NcXc3mNJVcphfT/glqQEriq72r0LEN3ILpGOitS99x/sGyHNOQmmww9h8/m4KBAAlD0D8IyE1xd0A==
-  dependencies:
-    "@vue/composition-api" "1.7.2"
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "3.0.21"
-    css-element-queries "1.2.0"
-    date-fns "1.30.1"
-    frame-throttle "3.0.0"
-    fuzzysearch "1.0.3"
-    lodash "4.17.21"
-    popper.js "1.16.1"
-    purecss "2.2.0"
-    tippy.js "4.2.1"
-    vue-intl "3.1.0"
-    vue2-teleport "1.1.4"
-    xstate "4.38.3"
-
 kolibri-design-system@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-4.6.0.tgz#9142be6798e5f8c5df9c5f7884f1398f4c9441d3"
@@ -10617,16 +10588,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10685,14 +10647,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12004,16 +11959,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary
Resolves 3 outstanding categories of issues from the KDS upgrade: 
- ensures the second package.json is up to date
- reverts a few changes that were the wrong color, as they had inadvertently been updated twice (from 1100 -> 600, and then 600 -> 300)
- Updates tokens in a handful of missed files

## References
Please see the first PR and the follow up comments for more details https://github.com/learningequality/kolibri/pull/12742

## Reviewer guidance
Manual checks to confirm all is well: 
- does everything build and run properly
- check the `KDateRange` component. Are there any regressions? (This is what tipped me off to the second package.json needing updating.) 
- Check the "end quiz" button - is it the correct shade of red?
- otherwise - any glaring regressions? 

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
