### PR TITLE
Redirect user when loading class summary results in 403

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -139,9 +139,16 @@ class CoachToolsModule extends KolibriApp {
       }
 
       if (promises.length > 0) {
-        Promise.all(promises).then(next, error => {
-          this.store.dispatch('handleApiError', { error });
-        });
+        Promise.all(promises)
+          .catch(error => {
+            this.store.dispatch('handleApiError', { error });
+          })
+          .catch(() => {
+            // We catch here because `handleApiError` throws the error back again, in this case,
+            // we just want things to keep moving so that the AuthMessage shows as expected
+            next();
+          })
+          .then(next);
       } else {
         next();
       }

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -131,9 +131,11 @@ export default {
         return Promise.all([
           // Make sure we load any class list data, so that we know
           // whether this user has access to multiple classes or not.
-          store
-            .dispatch('classSummary/loadClassSummary', classId)
-            .then(summary => store.dispatch('setClassList', summary.facility_id)),
+          store.dispatch('classSummary/loadClassSummary', classId).then(summary => {
+            if (summary?.facility_id) {
+              store.dispatch('setClassList', summary?.facility_id);
+            }
+          }),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
         ]).catch(error => {
           store.dispatch('handleApiError', { error, reloadOnReconnect: true });

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -270,12 +270,12 @@
       setError(error) {
         try {
           this.$store.dispatch('handleApiError', { error });
-          this.loading = false;
-          this.$store.dispatch('notLoading');
         } catch (e) {
           // nothing to do here, just catching the error to avoid
           // unhandled errors in the dispatch to handleApiError
         }
+        this.loading = false;
+        this.$store.dispatch('notLoading');
       },
       setCurrentAction(action) {
         if (action === 'EDIT_DETAILS') {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -268,9 +268,14 @@
       },
       // @public
       setError(error) {
-        this.$store.dispatch('handleApiError', { error });
-        this.loading = false;
-        this.$store.dispatch('notLoading');
+        try {
+          this.$store.dispatch('handleApiError', { error });
+          this.loading = false;
+          this.$store.dispatch('notLoading');
+        } catch (e) {
+          // nothing to do here, just catching the error to avoid
+          // unhandled errors in the dispatch to handleApiError
+        }
       },
       setCurrentAction(action) {
         if (action === 'EDIT_DETAILS') {

--- a/packages/kolibri/components/AuthMessage.vue
+++ b/packages/kolibri/components/AuthMessage.vue
@@ -14,6 +14,7 @@
         :text="linkText"
         :href="signInLink"
         appearance="basic-link"
+        data-test="signinlink"
       />
     </p>
     <p v-else>
@@ -21,6 +22,7 @@
         :text="$tr('goBackToHomeAction')"
         :href="rootUrl"
         appearance="basic-link"
+        data-test="gohomelink"
       />
     </p>
   </div>

--- a/packages/kolibri/components/AuthMessage.vue
+++ b/packages/kolibri/components/AuthMessage.vue
@@ -70,7 +70,6 @@
       },
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn']),
       rootUrl() {
         return urls['kolibri:core:redirect_user']();
       },

--- a/packages/kolibri/components/AuthMessage.vue
+++ b/packages/kolibri/components/AuthMessage.vue
@@ -17,9 +17,9 @@
       />
     </p>
     <p v-else>
-      <KRouterLink
+      <KExternalLink
         :text="$tr('goBackToHomeAction')"
-        :to="{ path: '/' }"
+        :href="rootUrl"
         appearance="basic-link"
       />
     </p>
@@ -68,6 +68,10 @@
       },
     },
     computed: {
+      ...mapGetters(['isUserLoggedIn']),
+      rootUrl() {
+        return urls['kolibri:core:redirect_user']();
+      },
       detailsText() {
         return this.details || this.$tr(this.authorizedRole);
       },

--- a/packages/kolibri/components/__tests__/auth-message.spec.js
+++ b/packages/kolibri/components/__tests__/auth-message.spec.js
@@ -6,7 +6,7 @@ import { stubWindowLocation } from 'testUtils'; // eslint-disable-line
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
 import AuthMessage from '../AuthMessage';
 
-jest.mock('kolibri/urls', () => ({}));
+jest.mock('kolibri/urls');
 jest.mock('kolibri/composables/useUser');
 
 const localVue = createLocalVue();

--- a/packages/kolibri/components/__tests__/auth-message.spec.js
+++ b/packages/kolibri/components/__tests__/auth-message.spec.js
@@ -94,7 +94,7 @@ describe('auth message component', () => {
 
     it('shows correct link text if there is a user plugin', () => {
       const wrapper = makeWrapper();
-      const link = wrapper.find('kexternallink-stub');
+      const link = wrapper.find('[data-test=signinlink]');
       expect(link.attributes()).toMatchObject({
         href: 'http://localhost:8000/en/auth/#/signin?next=http%3A%2F%2Flocalhost%3A8000%2F%23%2Ftest_url',
         text: 'Sign in to Kolibri',
@@ -104,7 +104,7 @@ describe('auth message component', () => {
     it('if the next param is in URL, it is what is used in the sign-in page link', () => {
       window.location.href = 'http://localhost:8000/#/some_other_url';
       const wrapper = makeWrapper();
-      const link = wrapper.find('kexternallink-stub');
+      const link = wrapper.find('[data-test=signinlink]');
       expect(link.attributes()).toMatchObject({
         href: 'http://localhost:8000/en/auth/#/signin?next=http%3A%2F%2Flocalhost%3A8000%2F%23%2Fsome_other_url',
         text: 'Sign in to Kolibri',
@@ -113,8 +113,17 @@ describe('auth message component', () => {
   });
 
   it('shows correct link text if there is not a user plugin', () => {
-    const wrapper = makeWrapper();
-    const link = wrapper.find('kexternallink-stub');
+    // linkText checks to see if `userAuthPluginUrl` is truthy and it's either a
+    // function or undefined and if there is no user plugin, then it needs to be
+    // falsy for this test case
+    const wrapper = makeWrapper({
+      computed: {
+        userAuthPluginUrl() {
+          return false;
+        },
+      },
+    });
+    const link = wrapper.find('[data-test=signinlink]');
     expect(link.attributes()).toMatchObject({
       href: '/',
       text: 'Go to home page',
@@ -124,6 +133,6 @@ describe('auth message component', () => {
   it('does not show a link if the user is logged in', () => {
     useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
     const wrapper = makeWrapper();
-    expect(wrapper.find('kexternallink-stub').exists()).toBe(false);
+    expect(wrapper.find('[data-test=signinlink]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When a coach is doing coach things and they are logged out due to timeout, Kolibri will keep track of the last place the user was in. If a coach is doing coach things, then they timeout, but then a _Learner_ logs in again the Learner is redirected to where the coach previously was.

Since the Learner cannot do Coach things, they get a `403` on the classSummary API call.

So we catch that particular error and redirect the user such that they go to wherever they'd normally have gone after logging in.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12442 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Sign in as admin/coach and go to create a quiz
- Go to your devtools and delete the `kolibri` cookie, see that you are redirected to the sign-in page
- Sign in as a learner

Before the fix:
- The learner would see a blank screen and basically be stuck there

After the fix:
- The learner is ~completely~ virtually unaware that they were initially being redirected to Coach things (unless they're keenly watching the URL bar or their devtools as they are still directed to the Coach URL before being re-redirected)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
