### PR TITLE
Update SearchFiltersPanel for Coach

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -97,12 +97,6 @@
         :topicsLink="topicsLink"
       />
 
-      <KButton
-        v-if="!showBookmarks"
-        text="👁️SEARCH👁️"
-        @click="showSearch = true"
-      />
-
       <div
         v-if="showNumberOfQuestionsWarning"
         class="shadow"
@@ -185,7 +179,7 @@
       data-test="side-panel"
       width="100%"
       :accordion="true"
-      :showActivities="true"
+      :showActivities="false"
       @close="showSearch = false"
     />
 
@@ -227,7 +221,6 @@
   import BookmarkIcon from '../../lessons/LessonResourceSelectionPage/LessonContentCard/BookmarkIcon.vue';
   import useQuizResources from '../../../composables/useQuizResources';
   import { injectQuizCreation } from '../../../composables/useQuizCreation';
-  import LessonsSearchBox from '../../lessons/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue';
   import ContentCardList from '../../lessons/LessonResourceSelectionPage/ContentCardList.vue';
   import ResourceSelectionBreadcrumbs from '../../lessons/LessonResourceSelectionPage/SearchTools/ResourceSelectionBreadcrumbs.vue';
 
@@ -237,7 +230,6 @@
       SearchFiltersPanel,
       ContentCardList,
       BookmarkIcon,
-      LessonsSearchBox,
       ResourceSelectionBreadcrumbs,
     },
     mixins: [commonCoreStrings],
@@ -929,20 +921,6 @@
         return this.questionsUnusedInSection$({
           count,
         });
-      },
-      handleSearchTermChange(searchTerm) {
-        const query = {
-          ...this.$route.query,
-          search: searchTerm,
-        };
-        this.$router.push({ query });
-      },
-      clearSearchTerm() {
-        const query = {
-          ...this.$route.query,
-        };
-        delete query.search;
-        this.$router.push({ query });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -183,7 +183,6 @@
       ref="sidePanel"
       v-model="searchTerms"
       data-test="side-panel"
-      style="position: absolute"
       width="100%"
       :accordion="true"
       :showActivities="true"

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -210,6 +210,7 @@
   import get from 'lodash/get';
   import uniqWith from 'lodash/uniqWith';
   import isEqual from 'lodash/isEqual';
+  import flatMap from 'lodash/flatMap';
   import { useMemoize } from '@vueuse/core';
   import {
     displaySectionTitle,
@@ -242,7 +243,11 @@
     },
     mixins: [commonCoreStrings],
     setup(props, context) {
-      const { searchTerms } = useBaseSearch({});
+      const { searchTerms, search } = useBaseSearch({});
+      // Search if we already have search terms when we load up
+      if (flatMap(searchTerms.value, term => Object.keys(term)).length) {
+        search();
+      }
       const store = getCurrentInstance().proxy.$store;
       const route = computed(() => store.state.route);
       const topicId = computed(() => route.value.params.topic_id);

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -186,7 +186,7 @@
       style="position: absolute"
       width="100%"
       :accordion="true"
-      :showActivities="false"
+      :showActivities="true"
       @close="showSearch = false"
     />
 

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -4,7 +4,7 @@
     <div v-if="loading && !loadingMore">
       <KCircularLoader />
     </div>
-    <div v-else>
+    <div v-else-if="!showSearch">
       <h1
         v-if="selectPracticeQuiz"
         class="select-folder-style"
@@ -67,7 +67,7 @@
         </div>
       </div>
 
-      <div v-if="!isTopicIdSet && bookmarks.length && !showBookmarks">
+      <div v-if="!isTopicIdSet && bookmarks.length && !showBookmarks && !showSearch">
         <p>{{ coreString('selectFromBookmarks') }}</p>
 
         <div>
@@ -97,10 +97,10 @@
         :topicsLink="topicsLink"
       />
 
-      <LessonsSearchBox
+      <KButton
         v-if="!showBookmarks"
-        @clear="clearSearchTerm"
-        @searchterm="handleSearchTermChange"
+        text="👁️SEARCH👁️"
+        @click="showSearch = true"
       />
 
       <div
@@ -124,6 +124,7 @@
       </div>
 
       <ContentCardList
+        v-if="!showSearch"
         :contentList="contentList"
         :showSelectAll="showSelectAll"
         :viewMoreButtonState="viewMoreButtonState"
@@ -176,6 +177,19 @@
         />
       </div>
     </div>
+
+    <SearchFiltersPanel
+      v-if="showSearch"
+      ref="sidePanel"
+      v-model="searchTerms"
+      data-test="side-panel"
+      style="position: absolute"
+      width="100%"
+      :accordion="true"
+      :showActivities="false"
+      @close="showSearch = false"
+    />
+
     <KModal
       v-if="showCloseConfirmation"
       :submitText="coreString('continueAction')"
@@ -206,6 +220,8 @@
   import { ContentNodeResource, ChannelResource } from 'kolibri.resources';
   import { ContentNodeKinds, MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri.coreVue.vuex.constants';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import useBaseSearch from 'kolibri-common/composables/useBaseSearch';
+  import SearchFiltersPanel from 'kolibri-common/components/SearchFiltersPanel';
   import { exerciseToQuestionArray } from '../../../utils/selectQuestions';
   import { PageNames, ViewMoreButtonStates } from '../../../constants/index';
   import BookmarkIcon from '../../lessons/LessonResourceSelectionPage/LessonContentCard/BookmarkIcon.vue';
@@ -218,6 +234,7 @@
   export default {
     name: 'ResourceSelection',
     components: {
+      SearchFiltersPanel,
       ContentCardList,
       BookmarkIcon,
       LessonsSearchBox,
@@ -225,6 +242,7 @@
     },
     mixins: [commonCoreStrings],
     setup(props, context) {
+      const { searchTerms } = useBaseSearch({});
       const store = getCurrentInstance().proxy.$store;
       const route = computed(() => store.state.route);
       const topicId = computed(() => route.value.params.topic_id);
@@ -701,6 +719,7 @@
       }
 
       return {
+        showSearch: ref(false),
         nodeIsSelectableOrUnselectable,
         showCheckbox,
         displaySectionTitle,
@@ -765,6 +784,7 @@
         selectPracticeQuizLabel$,
         numberOfQuestionsLabel$,
         addNumberOfQuestions$,
+        searchTerms,
       };
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ResourceSelection.vue
@@ -203,7 +203,6 @@
   import get from 'lodash/get';
   import uniqWith from 'lodash/uniqWith';
   import isEqual from 'lodash/isEqual';
-  import flatMap from 'lodash/flatMap';
   import { useMemoize } from '@vueuse/core';
   import {
     displaySectionTitle,
@@ -234,11 +233,6 @@
     },
     mixins: [commonCoreStrings],
     setup(props, context) {
-      const { searchTerms, search } = useBaseSearch({});
-      // Search if we already have search terms when we load up
-      if (flatMap(searchTerms.value, term => Object.keys(term)).length) {
-        search();
-      }
       const store = getCurrentInstance().proxy.$store;
       const route = computed(() => store.state.route);
       const topicId = computed(() => route.value.params.topic_id);
@@ -495,6 +489,9 @@
         setResources,
         loadingMore,
       } = useQuizResources({ topicId, practiceQuiz: selectPracticeQuiz.value });
+
+      const { searchTerms, search } = useBaseSearch({ descendant: topic });
+      search();
 
       const _loading = ref(true);
 

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -102,14 +102,25 @@
       </main>
 
       <!-- Side Panels for filtering and searching  -->
-      <SearchFiltersPanel
-        v-if="(!isLocalLibraryEmpty || deviceId) && (windowIsLarge || mobileSidePanelIsOpen)"
-        ref="sidePanel"
-        v-model="searchTerms"
-        data-test="side-panel"
-        :width="`${sidePanelWidth}px`"
-        @close="toggleSidePanelVisibility"
-      />
+      <SidePanelModal
+        v-if="mobileSidePanelIsOpen && !windowIsLarge"
+        @closePanel="toggleSidePanelVisibility"
+      >
+        <SearchFiltersPanel
+          ref="sidePanel"
+          v-model="searchTerms"
+          data-test="side-panel"
+          :width="`${sidePanelWidth}px`"
+        />
+      </SidePanelModal>
+      <div v-else-if="!isLocalLibraryEmpty || deviceId">
+        <SearchFiltersPanel
+          ref="sidePanel"
+          v-model="searchTerms"
+          data-test="side-panel"
+          :width="`${sidePanelWidth}px`"
+        />
+      </div>
 
       <!-- Side Panel for metadata -->
       <SidePanelModal

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -113,10 +113,12 @@
           :width="`${sidePanelWidth}px`"
         />
       </SidePanelModal>
+
       <div v-else-if="!isLocalLibraryEmpty || deviceId">
         <SearchFiltersPanel
           ref="sidePanel"
           v-model="searchTerms"
+          :class="windowIsLarge ? 'side-panel' : ''"
           data-test="side-panel"
           :width="`${sidePanelWidth}px`"
         />
@@ -658,6 +660,27 @@
   .chip {
     margin-bottom: 8px;
     margin-left: 8px;
+  }
+
+  .side-panel {
+    @extend %dropshadow-2dp;
+
+    position: fixed;
+    top: 60px;
+    left: 0;
+    height: 100%;
+    padding: 24px 24px 0;
+    overflow-y: scroll;
+    font-size: 14px;
+  }
+
+  /*
+  * Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=1417667
+  */
+  .side-panel::after {
+    display: block;
+    padding-bottom: 70px;
+    content: '';
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -263,6 +263,7 @@
         setCategory,
         currentRoute,
       } = useSearch();
+      search();
       const {
         resumableContentNodes,
         moreResumableContentNodes,
@@ -534,7 +535,6 @@
     created() {
       const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
-      this.search();
       if (window.sessionStorage.getItem(welcomeDismissalKey) !== 'true') {
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', true);
       }

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -102,20 +102,9 @@
       </main>
 
       <!-- Side Panels for filtering and searching  -->
-      <SidePanelModal
-        v-if="mobileSidePanelIsOpen && !windowIsLarge"
-        @closePanel="toggleSidePanelVisibility"
-      >
+      <div v-if="(!isLocalLibraryEmpty || deviceId) && windowIsLarge">
         <SearchFiltersPanel
-          ref="sidePanel"
-          v-model="searchTerms"
-          data-test="side-panel"
-          :width="`${sidePanelWidth}px`"
-        />
-      </SidePanelModal>
-
-      <div v-else-if="!isLocalLibraryEmpty || deviceId">
-        <SearchFiltersPanel
+          key="hi"
           ref="sidePanel"
           v-model="searchTerms"
           :class="windowIsLarge ? 'side-panel' : ''"
@@ -123,6 +112,20 @@
           :width="`${sidePanelWidth}px`"
         />
       </div>
+
+      <SidePanelModal
+        v-else-if="mobileSidePanelIsOpen && !windowIsLarge"
+        alignment="left"
+        @closePanel="toggleSidePanelVisibility"
+      >
+        <SearchFiltersPanel
+          key="bye"
+          ref="sidePanel"
+          v-model="searchTerms"
+          data-test="side-panel"
+          :width="`${sidePanelWidth}px`"
+        />
+      </SidePanelModal>
 
       <!-- Side Panel for metadata -->
       <SidePanelModal

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -119,7 +119,7 @@
           ref="sidePanel"
           v-model="searchTerms"
           :class="windowIsLarge ? 'side-panel' : ''"
-          data-test="side-panel"
+          data-test="side-panel-local"
           :width="`${sidePanelWidth}px`"
         />
       </div>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -104,7 +104,6 @@
       <!-- Side Panels for filtering and searching  -->
       <div v-if="(!isLocalLibraryEmpty || deviceId) && windowIsLarge">
         <SearchFiltersPanel
-          key="hi"
           ref="sidePanel"
           v-model="searchTerms"
           :class="windowIsLarge ? 'side-panel' : ''"
@@ -119,7 +118,6 @@
         @closePanel="toggleSidePanelVisibility"
       >
         <SearchFiltersPanel
-          key="bye"
           ref="sidePanel"
           v-model="searchTerms"
           data-test="side-panel"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -515,6 +515,14 @@
       searchTerms() {
         this.mobileSidePanelIsOpen = false;
       },
+      windowIsLarge(newVal) {
+        // Be sure we set the side panel closed if the screen size changes
+        // otherwise the watcher on mobileSidePanelIsOpen will leave the
+        // document stuck in `position: fixed;` so we won't see the scrollbar
+        if (newVal) {
+          this.mobileSidePanelIsOpen = false;
+        }
+      },
       mobileSidePanelIsOpen() {
         if (this.mobileSidePanelIsOpen) {
           document.documentElement.style.position = 'fixed';

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -186,26 +186,24 @@
 
         <!-- The full screen side panel is used on smaller screens, and toggles as an overlay -->
         <template v-if="!windowIsLarge && sidePanelIsOpen">
-          <SearchFiltersPanel
-            v-if="searchActive"
-            ref="embeddedPanel"
-            v-model="searchTerms"
-            class="full-screen-side-panel"
-            :showChannels="false"
-            :style="sidePanelStyleOverrides"
-            @close="sidePanelIsOpen = false"
-          />
-          <TopicsPanelModal
-            v-else
-            ref="embeddedPanel"
-            class="full-screen-side-panel"
-            :topics="topics"
-            :topicMore="Boolean(topicMore)"
-            :topicsLoading="topicMoreLoading"
-            :style="sidePanelStyleOverrides"
-            @loadMoreTopics="handleLoadMoreInTopic"
-            @close="sidePanelIsOpen = false"
-          />
+          <SidePanelModal @closePanel="sidePanelIsOpen = false">
+            <SearchFiltersPanel
+              v-if="searchActive"
+              ref="embeddedPanel"
+              v-model="searchTerms"
+              :showChannels="false"
+              :style="sidePanelStyleOverrides"
+            />
+            <TopicsPanelModal
+              v-else
+              ref="embeddedPanel"
+              :topics="topics"
+              :topicMore="Boolean(topicMore)"
+              :topicsLoading="topicMoreLoading"
+              :style="sidePanelStyleOverrides"
+              @loadMoreTopics="handleLoadMoreInTopic"
+            />
+          </SidePanelModal>
         </template>
       </div>
 
@@ -1047,6 +1045,15 @@
 
   .divider {
     margin-bottom: 24px;
+  }
+
+  /deep/ .activities-wrapper {
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  }
+
+  /deep/ .btn-activity {
+    width: 80px;
+    height: 80px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -972,8 +972,11 @@
   .side-panel {
     position: absolute;
     top: $total-height;
+    left: 0;
     min-height: calc(100vh - #{$toolbar-height});
-    padding-top: 16px;
+    // Padding & scroll to ensure user can scroll all the way down
+    padding: 1em 1em 6em;
+    overflow-y: scroll;
   }
 
   .main-content-grid {

--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -140,7 +140,7 @@ describe('LibraryPage', () => {
         options: { stubs: ['SidePanelModal'] },
       });
       // not displayed by default
-      expect(wrapper.findComponent({ name: 'SearchFiltersPanel' }).element).toBeUndefined();
+      expect(wrapper.find('[data-test="side-panel"]').element).toBeUndefined();
       wrapper.find('[data-test="filter-button"]').trigger('click');
       await wrapper.vm.$nextTick();
       expect(wrapper.findComponent({ name: 'SearchFiltersPanel' }).element).toBeTruthy();
@@ -355,7 +355,7 @@ describe('LibraryPage', () => {
         windowIsLarge: true,
       }));
       const wrapper = await makeWrapper();
-      expect(wrapper.find('[data-test="side-panel"').element).toBeTruthy();
+      expect(wrapper.find('[data-test="side-panel-local"').element).toBeTruthy();
     });
   });
 

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -25,7 +25,7 @@
         class="search-input"
         :class="$computedClass(searchInputStyle)"
         dir="auto"
-        :placeholder="coreString(placeholder)"
+        :placeholder="placeholder"
       >
       <div class="search-buttons-wrapper">
         <KIconButton
@@ -62,6 +62,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import coreString from 'kolibri.utils.coreStrings';
 
   export default {
     name: 'SearchBox',
@@ -80,7 +81,7 @@
       },
       placeholder: {
         type: String,
-        default: 'searchLabel',
+        default: coreString.$tr('searchLabel'),
       },
       value: {
         type: String,

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -81,7 +81,7 @@
       },
       placeholder: {
         type: String,
-        default: coreString('searchLabel'),
+        default: coreString.$tr('searchLabel'),
       },
       value: {
         type: String,

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -25,7 +25,7 @@
         class="search-input"
         :class="$computedClass(searchInputStyle)"
         dir="auto"
-        :placeholder="placeholder"
+        :placeholder="placeholder || coreString('searchLabel')"
       >
       <div class="search-buttons-wrapper">
         <KIconButton
@@ -62,7 +62,6 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import coreString from 'kolibri.utils.coreStrings';
 
   export default {
     name: 'SearchBox',
@@ -81,7 +80,7 @@
       },
       placeholder: {
         type: String,
-        default: coreString.$tr('searchLabel'),
+        default: null,
       },
       value: {
         type: String,

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -81,7 +81,7 @@
       },
       placeholder: {
         type: String,
-        default: coreString.$tr('searchLabel'),
+        default: coreString('searchLabel'),
       },
       value: {
         type: String,

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -1,0 +1,327 @@
+<template>
+
+  <div>
+    <AccordionContainer
+      v-if="languageOptionsList.length"
+      class="accordion-select"
+    >
+      <AccordionItem
+        :title="coreString('languageLabel')"
+        :headerAppearanceOverrides="{
+          background: langId ? selectedHighlightColor : $themePalette.grey.v_100,
+        }"
+        :contentAppearanceOverrides="{
+          maxHeight: '256px',
+          overflowY: 'scroll',
+        }"
+      >
+        <template #content>
+          <KRadioButtonGroup>
+            <KRadioButton
+              v-for="lang in languageOptionsList"
+              :key="'lang-' + lang.value"
+              :buttonValue="lang.value"
+              :currentValue="langId || ''"
+              :label="lang.label"
+              @change="handleChange('languages', lang)"
+            />
+          </KRadioButtonGroup>
+        </template>
+      </AccordionItem>
+    </AccordionContainer>
+
+    <AccordionContainer
+      v-if="contentLevelsList.length"
+      class="accordion-select"
+    >
+      <AccordionItem
+        :title="coreString('levelLabel')"
+        :headerAppearanceOverrides="{
+          background: selectedLevel.value ? selectedHighlightColor : $themePalette.grey.v_100,
+        }"
+        :contentAppearanceOverrides="{
+          maxHeight: '256px',
+          overflowY: 'scroll',
+        }"
+      >
+        <template #content>
+          <KRadioButtonGroup>
+            <KRadioButton
+              v-for="level in contentLevelsList"
+              :key="'level-' + level.value"
+              :buttonValue="level.value"
+              :currentValue="selectedLevel['value'] || ''"
+              :label="level.label"
+              @change="handleChange('grade_levels', level)"
+            />
+          </KRadioButtonGroup>
+        </template>
+      </AccordionItem>
+    </AccordionContainer>
+
+    <AccordionContainer
+      v-if="showChannels && channelOptionsList.length"
+      class="accordion-select"
+    >
+      <AccordionItem
+        :title="coreString('channelLabel')"
+        :headerAppearanceOverrides="{
+          background: selectedChannel.value ? selectedHighlightColor : $themePalette.grey.v_100,
+        }"
+        :contentAppearanceOverrides="{
+          maxHeight: '256px',
+          overflowY: 'scroll',
+        }"
+      >
+        <template #content>
+          <KRadioButtonGroup>
+            <KRadioButton
+              v-for="channel in channelOptionsList"
+              :key="'channel-' + channel.value"
+              :buttonValue="channel.value"
+              :currentValue="selectedChannel['value'] || ''"
+              :label="channel.label"
+              @change="handleChange('channels', channel)"
+            />
+          </KRadioButtonGroup>
+        </template>
+      </AccordionItem>
+    </AccordionContainer>
+
+    <AccordionContainer
+      v-if="accessibilityOptionsList.length"
+      class="accordion-select"
+    >
+      <AccordionItem
+        :title="coreString('accessibility')"
+        :headerAppearanceOverrides="{
+          background: selectedAccessibilityFilter.value
+            ? selectedHighlightColor
+            : $themePalette.grey.v_100,
+        }"
+        :contentAppearanceOverrides="{
+          maxHeight: '256px',
+          overflowY: 'scroll',
+        }"
+      >
+        <template #content>
+          <KRadioButtonGroup>
+            <KRadioButton
+            v-for="a11y in accessibilityOptionsList"
+            :key="'a11y-' + a11y.value"
+            :buttonValue="a11y.value"
+            :currentValue"selectedAccessibilityFilter['value'] || ''"
+            :label="a11y.label"
+            @change="handleChange('accessibility_labels', a11y)"
+          />
+          </KRadioButtonGroup>
+        </template>
+      </AccordionItem>
+    </AccordionContainer>
+  </div>
+
+</template>
+
+
+<script>
+
+  import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
+  import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
+  import camelCase from 'lodash/camelCase';
+  import { ContentLevels, AccessibilityCategories } from 'kolibri.coreVue.vuex.constants';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { injectBaseSearch } from 'kolibri-common/composables/useBaseSearch';
+
+  export default {
+    name: 'AccordionSelectGroup',
+    components: { AccordionItem, AccordionContainer },
+    mixins: [commonCoreStrings],
+    setup() {
+      const {
+        availableGradeLevels,
+        availableAccessibilityOptions,
+        availableLanguages,
+        availableChannels,
+        searchableLabels,
+      } = injectBaseSearch();
+      return {
+        availableGradeLevels,
+        availableAccessibilityOptions,
+        availableLanguages,
+        availableChannels,
+        searchableLabels,
+        // This color is not in KDS but was specifically requested in the design
+        selectedHighlightColor: '#ECF0FE',
+      };
+    },
+    props: {
+      value: {
+        type: Object,
+        required: true,
+        validator(value) {
+          const inputKeys = ['channels', 'accessibility_labels', 'languages', 'grade_levels'];
+          return inputKeys.every(k => Object.prototype.hasOwnProperty.call(value, k));
+        },
+      },
+      showChannels: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    computed: {
+      languageOptionsList() {
+        return this.availableLanguages.map(language => {
+          return {
+            value: language.id,
+            disabled:
+              this.searchableLabels && !this.searchableLabels.languages.includes(language.id),
+            label: language.lang_name,
+          };
+        });
+      },
+      enabledLanguageOptions() {
+        return this.languageOptionsList.filter(l => !l.disabled);
+      },
+      accessibilityOptionsList() {
+        return this.availableAccessibilityOptions.map(key => {
+          const value = AccessibilityCategories[key];
+          return {
+            value,
+            disabled:
+              this.searchableLabels && !this.searchableLabels.accessibility_labels.includes(value),
+            label: this.coreString(camelCase(key)),
+          };
+        });
+      },
+      enabledAccessibilityOptions() {
+        return this.accessibilityOptionsList.filter(a => !a.disabled);
+      },
+      contentLevelsList() {
+        return this.availableGradeLevels.map(key => {
+          const value = ContentLevels[key];
+          let translationKey;
+          if (key === 'PROFESSIONAL') {
+            translationKey = 'specializedProfessionalTraining';
+          } else if (key === 'WORK_SKILLS') {
+            translationKey = 'allLevelsWorkSkills';
+          } else if (key === 'BASIC_SKILLS') {
+            translationKey = 'allLevelsBasicSkills';
+          } else {
+            translationKey = camelCase(key);
+          }
+          return {
+            value,
+            disabled: this.searchableLabels && !this.searchableLabels.grade_levels.includes(value),
+            label: this.coreString(translationKey),
+          };
+        });
+      },
+      enabledContentLevels() {
+        return this.contentLevelsList.filter(c => !c.disabled);
+      },
+      channelOptionsList() {
+        return this.availableChannels.map(channel => ({
+          value: channel.id,
+          disabled: this.searchableLabels && !this.searchableLabels.channels.includes(channel.id),
+          label: channel.name,
+        }));
+      },
+      enabledChannelOptions() {
+        return this.channelOptionsList.filter(c => !c.disabled);
+      },
+      langId() {
+        return Object.keys(this.value.languages)[0];
+      },
+      accessId() {
+        return Object.keys(this.value.accessibility_labels)[0];
+      },
+      selectedAccessibilityFilter() {
+        if (!this.accessId && this.enabledAccessibilityOptions.length === 1) {
+          return this.enabledAccessibilityOptions[0];
+        }
+        return this.accessibilityOptionsList.find(o => o.value === this.accessId) || {};
+      },
+      levelId() {
+        return Object.keys(this.value.grade_levels)[0];
+      },
+      selectedLevel() {
+        if (!this.levelId && this.enabledContentLevels.length === 1) {
+          return this.enabledContentLevels[0];
+        }
+        return this.contentLevelsList.find(o => o.value === this.levelId) || {};
+      },
+      channelId() {
+        return Object.keys(this.value.channels)[0];
+      },
+      selectedChannel() {
+        if (!this.channelId && this.enabledChannelOptions.length === 1) {
+          return this.enabledChannelOptions[0];
+        }
+        return this.channelOptionsList.find(o => o.value === this.channelId) || {};
+      },
+    },
+    methods: {
+      handleChange(field, value) {
+        if (value && value.value) {
+          this.$emit('input', { ...this.value, [field]: { [value.value]: true } });
+        } else {
+          this.$emit('input', { ...this.value, [field]: {} });
+        }
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  // Do not let text oveflow in select menu
+  /deep/ .ui-select-content {
+    width: 100%;
+
+    // remove position absolute to prevent text from getting under button
+    .overlay-close-button {
+      position: unset;
+      flex-shrink: 0;
+    }
+  }
+
+  /deep/ .ui-select-label-text.is-inline {
+    position: absolute;
+    bottom: 45px;
+    left: 10px;
+    font-size: 12px;
+  }
+
+  /deep/ .ui-select-label-text.is-floating {
+    position: absolute;
+    bottom: 15px;
+    left: 10px;
+    font-size: 12px;
+  }
+
+  /deep/ .ui-select-display {
+    height: 3rem;
+    border-bottom: inherit;
+  }
+
+  /deep/ .ui-select-display-value {
+    position: relative;
+    top: 12px;
+    flex-grow: 1;
+    height: 32px;
+    padding-top: 10px;
+    padding-left: 20px;
+    font-size: 14px;
+  }
+
+  /deep/ .ui-icon {
+    margin-right: 10px;
+  }
+
+  .accordion-select:not(:last-child) {
+    margin-bottom: 1em;
+  }
+
+</style>

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -448,7 +448,7 @@
             // ALL_CHANNELS is selected
             this.$emit('input', {
               ...this.value,
-              [field]: { [prevFieldValue.value]: false },
+              [field]: {},
             });
           } else if (!prevFieldValue[value.value]) {
             // Channels are a radio button, so only when the user selects a new value

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -400,7 +400,14 @@
     },
     methods: {
       noCategories() {
-        this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
+        if (this.isCategoryActive(NoCategories)) {
+          // NoCategories is it's own key for the "Uncategorized" category
+          const categories = this.value.categories;
+          delete categories[NoCategories];
+          this.$emit('input', { ...this.value, categories });
+        } else {
+          this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
+        }
       },
       anySelectedFor(inputKey, values) {
         return values.some(value => this.isSelected(inputKey, value));

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -152,6 +152,28 @@
         </template>
       </AccordionItem>
     </AccordionContainer>
+
+    <AccordionContainer class="accordion-select">
+      <AccordionItem
+        :title="coreString('showResources')"
+        :headerAppearanceOverrides="accordionHeaderStyles(selectedLevel.value)"
+        :contentAppearanceOverrides="{
+          maxHeight: '256px',
+          overflowY: 'scroll',
+        }"
+      >
+        <template #content>
+          <KCheckbox
+            v-for="need in needsOptionsList"
+            :key="'resource-need-' + need.value"
+            :checked="isChecked('learner_needs', need)"
+            :disabled="need.disabled || isEnabledButNotSelected('learner_needs', need)"
+            :label="need.label"
+            @change="handleChange('learner_needs', need)"
+          />
+        </template>
+      </AccordionItem>
+    </AccordionContainer>
   </div>
 
 </template>
@@ -172,6 +194,7 @@
     mixins: [commonCoreStrings],
     setup() {
       const {
+        availableResourcesNeeded,
         availableGradeLevels,
         availableAccessibilityOptions,
         availableLanguages,
@@ -181,6 +204,7 @@
         activeSearchTerms,
       } = injectBaseSearch();
       return {
+        availableResourcesNeeded,
         activeSearchTerms,
         availableGradeLevels,
         availableAccessibilityOptions,
@@ -215,6 +239,28 @@
       },
     },
     computed: {
+      availableNeeds() {
+        if (this.searchableLabels) {
+          const needs = {};
+          for (const key of this.searchableLabels.learner_needs) {
+            const root = key.split('.')[0];
+            needs[root] = true;
+            needs[key] = true;
+          }
+          return needs;
+        }
+        return [];
+      },
+      needsOptionsList() {
+        return Object.keys(this.availableResourcesNeeded).map(k => {
+          const val = this.availableResourcesNeeded[k];
+          return {
+            value: val,
+            disabled: this.searchableLabels && !this.searchableLabels.learner_needs.includes(val),
+            label: this.coreString(val),
+          };
+        });
+      },
       selectedHighlightColor() {
         // get right color
         return '#D9E1FD';
@@ -228,7 +274,7 @@
           }
           return roots;
         }
-        return null;
+        return [];
       },
       languageOptionsList() {
         return this.availableLanguages.map(language => {

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -119,7 +119,7 @@
               v-for="channel in channelOptionsList"
               :key="'channel-' + channel.value"
               :buttonValue="channel.value"
-              :currentValue="selectedChannel['value'] || ''"
+              :currentValue="selectedChannel['value'] || null"
               :label="channel.label"
               @change="handleChange('channels', channel)"
             />
@@ -337,12 +337,7 @@
       isEnabledButNotSelected(inputKey, value) {
         return (
           !this.isSelected(inputKey, value) &&
-          {
-            languages: this.enabledLanguageOptions,
-            channels: this.enabledChannelOptions,
-            accessibility_labels: this.enabledAccessibilityOptions,
-            grade_levels: this.enabledContentLevels,
-          }[inputKey].includes(value)
+          Object.values(this.activeSearchTerms[inputKey]).includes(value)
         );
       },
       accordionHeaderStyles(selected) {
@@ -354,14 +349,25 @@
       },
       handleChange(field, value) {
         const prevFieldValue = this.value[field];
-        if (value && this.isSelected(field, value)) {
-          delete prevFieldValue[value.value];
-          this.$emit('input', { ...this.value, [field]: prevFieldValue });
+        if (field === 'channels') {
+          // Channels are a radio button, so only when the user selects a new value
+          // will we emit the change
+          if (!prevFieldValue[value.value]) {
+            this.$emit('input', {
+              ...this.value,
+              [field]: { [value.value]: true },
+            });
+          }
         } else {
-          this.$emit('input', {
-            ...this.value,
-            [field]: { ...prevFieldValue, [value.value]: true },
-          });
+          if (value && this.isSelected(field, value)) {
+            delete prevFieldValue[value.value];
+            this.$emit('input', { ...this.value, [field]: prevFieldValue });
+          } else {
+            this.$emit('input', {
+              ...this.value,
+              [field]: { ...prevFieldValue, [value.value]: true },
+            });
+          }
         }
       },
       isCategoryActive(categoryValue) {

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -80,7 +80,7 @@
             v-for="lang in languageOptionsList"
             :key="'lang-' + lang.value"
             :checked="isSelected('languages', lang)"
-            :disabled="lang.disabled || isActiveButNotSelected('languages', lang)"
+            :disabled="lang.disabled"
             :label="lang.label"
             @change="handleChange('languages', lang)"
           />
@@ -108,7 +108,7 @@
             v-for="level in contentLevelOptions"
             :key="'level-' + level.value"
             :checked="isSelected('grade_levels', level)"
-            :disabled="level.disabled || isActiveButNotSelected('grade_levels', level)"
+            :disabled="level.disabled"
             :label="level.label"
             @change="handleChange('grade_levels', level)"
           />
@@ -163,7 +163,7 @@
             v-for="a11y in accessibilityOptionsList"
             :key="'a11y-' + a11y.value"
             :checked="isSelected('accessibility_labels', a11y)"
-            :disabled="a11y.disabled || isActiveButNotSelected('accessibility_labels', a11y)"
+            :disabled="a11y.disabled"
             :label="a11y.label"
             @change="handleChange('accessibility_labels', a11y)"
           />
@@ -188,7 +188,7 @@
             v-for="need in needsOptionsList"
             :key="'resource-need-' + need.value"
             :checked="isSelected('learner_needs', need)"
-            :disabled="need.disabled || isActiveButNotSelected('learner_needs', need)"
+            :disabled="need.disabled"
             :label="need.label"
             @change="handleChange('learner_needs', need)"
           />
@@ -407,17 +407,6 @@
       },
       isSelected(inputKey, value) {
         return this.value[inputKey][value.value] === true;
-      },
-      isActiveButNotSelected(inputKey, value) {
-        // When a filter is selected, the other filters are disabled if they are no longer
-        // applicable. Additionally, some filters are automatically selected because they're
-        // mutually inclusive with the user's selections.
-        // This basically just answers the question "is this filter active, but *not* because they
-        // directly selected it"
-        return (
-          !this.isSelected(inputKey, value) &&
-          Object.values(this.activeSearchTerms[inputKey]).includes(value)
-        );
       },
       accordionHeaderStyles(selected) {
         return {

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -337,24 +337,8 @@
         return this.activeCategories.some(k => k.includes(categoryValue));
       },
       categoryIcon(key) {
-        // 'language' icon is already in use and it doesn't follow the
-        // same naming pattern for category resources, so set separate
-        // case to return the correct icon
-        if (camelCase(key) === 'languageLearning') {
-          return 'language';
-        } else if (
-          camelCase(key) === 'technicalAndVocationalTraining' ||
-          camelCase(key) === 'professionalSkills'
-        ) {
-          // similarly, 'skills' icon is used for both of these resources
-          // and doesn't follow same pattern
-          return 'skillsResource';
-        } else if (camelCase(key) === 'foundationsLogicAndCriticalThinking') {
-          // naming mismatch
-          return 'logicCriticalThinkingResource';
-        } else {
-          return `${camelCase(key)}Resource`;
-        }
+        // TODO Add icons to KDS then use them
+        return 'categories';
       },
     },
     $trs: {

--- a/packages/kolibri-common/components/SearchFiltersPanel/ActivityButtonsGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/ActivityButtonsGroup.vue
@@ -4,28 +4,30 @@
     <h2 class="title">
       {{ $tr('activities') }}
     </h2>
-    <span
-      v-for="(key, activity) in availableLearningActivities"
-      :key="key"
-      alignment="center"
-    >
-      <KButton
-        appearance="flat-button"
-        :appearanceOverrides="
-          isKeyActive(key) ? { ...activityStyles, ...activityActiveStyles } : activityStyles
-        "
-        :disabled="availableActivities && !availableActivities[key] && !isKeyActive(key)"
-        @click="$emit('input', key)"
+    <div class="wrapper">
+      <span
+        v-for="(key, activity) in availableLearningActivities"
+        :key="key"
+        alignment="center"
       >
-        <KIcon
-          :icon="activityIcon(activity)"
-          class="activity-icon"
-        />
-        <p class="activity-button-text">
-          {{ coreString(camelCase(activity)) }}
-        </p>
-      </KButton>
-    </span>
+        <KButton
+          appearance="flat-button"
+          :appearanceOverrides="
+            isKeyActive(key) ? { ...activityStyles, ...activityActiveStyles } : activityStyles
+          "
+          :disabled="availableActivities && !availableActivities[key] && !isKeyActive(key)"
+          @click="$emit('input', key)"
+        >
+          <KIcon
+            :icon="activityIcon(activity)"
+            class="activity-icon"
+          />
+          <p class="activity-button-text">
+            {{ coreString(camelCase(activity)) }}
+          </p>
+        </KButton>
+      </span>
+    </div>
   </div>
 
 </template>
@@ -54,8 +56,8 @@
       activityStyles() {
         return {
           color: this.$themeTokens.text,
-          width: '50%',
-          height: '100px',
+          width: '120px',
+          height: '120px',
           border: '2px solid transparent',
           textTransform: 'capitalize',
           fontWeight: 'normal',
@@ -124,6 +126,11 @@
   .activity-button-text {
     margin: auto;
     margin-top: -12px;
+  }
+
+  .wrapper {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   }
 
 </style>

--- a/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
@@ -23,6 +23,7 @@
           <KIcon
             :icon="icon(key)"
             size="large"
+            :color="$themeTokens.primary"
             :style="{ marginLeft: '8px' }"
           />
           <h3>

--- a/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/index.vue
@@ -11,7 +11,6 @@
 
 <script>
 
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import CategorySearchOptions from './CategorySearchOptions';
 
@@ -20,7 +19,6 @@
     components: {
       CategorySearchOptions,
     },
-    mixins: [commonCoreStrings],
     setup() {
       const { windowIsLarge } = useKResponsiveWindow();
       return {
@@ -42,12 +40,6 @@
        */
       focusFirstEl() {
         this.$refs.searchOptions.$el.querySelector('.filter-list-title > h2 > a').focus();
-      },
-    },
-    $trs: {
-      title: {
-        message: 'Choose a category',
-        context: 'Title of the category selection window',
       },
     },
   };

--- a/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/index.vue
@@ -1,29 +1,10 @@
 <template>
 
-  <div>
-    <KModal
-      v-if="windowIsLarge"
-      appendToOverlay
-      :title="$tr('title')"
-      :cancelText="coreString('closeAction')"
-      size="large"
-      @cancel="$emit('cancel')"
-    >
-      <CategorySearchOptions
-        ref="searchOptions"
-        :selectedCategory="selectedCategory"
-        v-on="$listeners"
-      />
-    </KModal>
-    <div v-else>
-      <h2>{{ $tr('title') }}</h2>
-      <CategorySearchOptions
-        ref="searchOptions"
-        :selectedCategory="selectedCategory"
-        v-on="$listeners"
-      />
-    </div>
-  </div>
+  <CategorySearchOptions
+    ref="searchOptions"
+    :selectedCategory="selectedCategory"
+    v-on="$listeners"
+  />
 
 </template>
 

--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -25,18 +25,6 @@
       @change="val => handleChange('grade_levels', val)"
     />
     <KSelect
-      v-if="showChannels && channelOptionsList.length"
-      :options="channelOptionsList"
-      :disabled="!channelId && enabledChannelOptions.length < 2"
-      class="selector"
-      :clearable="!(!channelId && enabledChannelOptions.length < 2)"
-      :clearText="coreString('clearAction')"
-      :value="selectedChannel"
-      :label="coreString('channelLabel')"
-      :style="selectorStyle"
-      @change="val => handleChange('channels', val)"
-    />
-    <KSelect
       v-if="accessibilityOptionsList.length"
       :options="accessibilityOptionsList"
       :disabled="!accessId && enabledAccessibilityOptions.length < 2"
@@ -68,14 +56,12 @@
         availableGradeLevels,
         availableAccessibilityOptions,
         availableLanguages,
-        availableChannels,
         searchableLabels,
       } = injectBaseSearch();
       return {
         availableGradeLevels,
         availableAccessibilityOptions,
         availableLanguages,
-        availableChannels,
         searchableLabels,
       };
     },
@@ -87,10 +73,6 @@
           const inputKeys = ['channels', 'accessibility_labels', 'languages', 'grade_levels'];
           return inputKeys.every(k => Object.prototype.hasOwnProperty.call(value, k));
         },
-      },
-      showChannels: {
-        type: Boolean,
-        default: true,
       },
     },
     computed: {
@@ -151,16 +133,6 @@
       enabledContentLevels() {
         return this.contentLevelsList.filter(c => !c.disabled);
       },
-      channelOptionsList() {
-        return this.availableChannels.map(channel => ({
-          value: channel.id,
-          disabled: this.searchableLabels && !this.searchableLabels.channels.includes(channel.id),
-          label: channel.name,
-        }));
-      },
-      enabledChannelOptions() {
-        return this.channelOptionsList.filter(c => !c.disabled);
-      },
       langId() {
         return Object.keys(this.value.languages)[0];
       },
@@ -187,15 +159,6 @@
           return this.enabledContentLevels[0];
         }
         return this.contentLevelsList.find(o => o.value === this.levelId) || {};
-      },
-      channelId() {
-        return Object.keys(this.value.channels)[0];
-      },
-      selectedChannel() {
-        if (!this.channelId && this.enabledChannelOptions.length === 1) {
-          return this.enabledChannelOptions[0];
-        }
-        return this.channelOptionsList.find(o => o.value === this.channelId) || {};
       },
     },
     methods: {

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -132,56 +132,11 @@
             @input="handleActivity"
           />
 
-          <AccordionContainer style="margin-top: 1em">
-            <AccordionItem
-              :title="$tr('categoryLabel')"
-              :headerAppearanceOverrides="{
-                background: activeCategories.length
-                  ? selectedHighlightColor
-                  : $themePalette.grey.v_100,
-              }"
-            >
-              <template #content>
-                <KButton
-                  v-for="(category, key) in availableLibraryCategories"
-                  :key="'cat-' + key"
-                  appearance="flat-button"
-                  class="categoryButton"
-                  :style="{
-                    background: isCategoryActive(category.value) ? selectedHighlightColor : '',
-                  }"
-                  :text="coreString(category.value)"
-                  :disabled="
-                    availableRootCategories &&
-                      !availableRootCategories[category.value] &&
-                      !isCategoryActive(category.value)
-                  "
-                  @click="handleCategory(key)"
-                >
-                  <template #icon>
-                    <KIcon
-                      icon="categories"
-                      class="categoryIcon"
-                      :color="$themeTokens.primary"
-                    />
-                  </template>
-                  <template
-                    v-if="hasNestedCategories(key)"
-                    #iconAfter
-                  >
-                    <KIcon
-                      icon="chevronRight"
-                      class="categoryIconAfter"
-                    />
-                  </template>
-                </KButton>
-              </template>
-            </AccordionItem>
-          </AccordionContainer>
-
           <AccordionSelectGroup
             v-model="inputValue"
             :showChannels="showChannels"
+            :activeCategories="activeCategories"
+            :handleCategory="handleCategory"
             style="margin-top: 1em"
           />
         </div>
@@ -204,7 +159,8 @@
 
   //
   // Usage of injectBaseSearch() in this component requires ancestor's use of useBaseSearch
-  // Examples of it can be found in the following components (Note: useSearch extends useBaseSearch):
+  // Examples of it can be found in the following components
+  // (Note: useSearch extends useBaseSearch):
   // - kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
   //   in https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue#L238-L251
   // - kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -452,11 +408,6 @@
       searchByKeyword: {
         message: 'Search by keyword',
         context: 'Placeholder text in the search box, which is otherwise not labelled',
-      },
-      categoryLabel: {
-        message: 'Category',
-        context:
-          'When user can select the categories, this is the header for the categories section',
       },
       categories: {
         message: 'Categories',

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -418,15 +418,6 @@
     padding-bottom: 60px;
   }
 
-  /*
-  * Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=1417667
-  */
-  .side-panel::after {
-    display: block;
-    padding-bottom: 70px;
-    content: '';
-  }
-
   .side-panel-folder-link {
     margin-top: 12px;
     margin-bottom: 12px;

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -1,10 +1,7 @@
 <template>
 
-  <component
-    :is="windowIsLarge ? 'section' : 'SidePanelModal'"
-    alignment="left"
+  <section
     role="region"
-    :class="windowIsLarge ? 'side-panel' : ''"
     :closeButtonIconType="closeButtonIcon"
     :aria-label="filterAndSearchLabel$()"
     :ariaLabel="filterAndSearchLabel$()"
@@ -112,7 +109,7 @@
             </div>
           </div>
         </div>
-        <div v-if="accordion">
+        <div v-if="accordion && !currentCategory">
           <!-- search by keyword -->
           <h2 class="title">
             {{ $tr('keywords') }}
@@ -150,7 +147,7 @@
       @cancel="currentCategory = null"
       @input="selectCategory"
     />
-  </component>
+  </section>
 
 </template>
 
@@ -167,8 +164,6 @@
   //   in https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue#L366-L378
   //
 
-  import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
-  import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
   import { NoCategories } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
@@ -176,7 +171,6 @@
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import { injectBaseSearch } from 'kolibri-common/composables/useBaseSearch';
   import SearchBox from '../SearchBox';
-  import SidePanelModal from '../SidePanelModal';
   import ActivityButtonsGroup from './ActivityButtonsGroup';
   import CategorySearchModal from './CategorySearchModal';
   import SelectGroup from './SelectGroup';
@@ -189,9 +183,6 @@
       ActivityButtonsGroup,
       SelectGroup,
       CategorySearchModal,
-      SidePanelModal,
-      AccordionItem,
-      AccordionContainer,
       AccordionSelectGroup,
     },
     mixins: [commonCoreStrings],
@@ -425,18 +416,6 @@
 
   .drawer-panel {
     padding-bottom: 60px;
-  }
-
-  .side-panel {
-    @extend %dropshadow-2dp;
-
-    position: fixed;
-    top: 60px;
-    left: 0;
-    height: 100%;
-    padding: 24px 24px 0;
-    overflow-y: scroll;
-    font-size: 14px;
   }
 
   /*

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -139,14 +139,24 @@
         </div>
       </div>
     </div>
-    <CategorySearchModal
-      v-if="currentCategory"
-      ref="searchModal"
-      :class="windowIsLarge ? '' : 'drawer-panel'"
-      :selectedCategory="currentCategory"
+    <!-- When accordion mode is NOT activated, show as KModal, otherwise, just a div -->
+    <component
+      :is="accordion ? 'div' : 'KModal'"
+      v-if="windowIsLarge && currentCategory"
+      appendToOverlay
+      :title="$tr('chooseACategory')"
+      :cancelText="coreString('closeAction')"
+      size="large"
       @cancel="currentCategory = null"
-      @input="selectCategory"
-    />
+    >
+      <CategorySearchModal
+        v-if="currentCategory"
+        ref="searchModal"
+        :class="windowIsLarge ? '' : 'drawer-panel'"
+        :selectedCategory="currentCategory"
+        @input="selectCategory"
+      />
+    </component>
   </section>
 
 </template>
@@ -403,6 +413,10 @@
       categories: {
         message: 'Categories',
         context: 'Section header label in the Library page sidebar.',
+      },
+      chooseACategory: {
+        message: 'Choose a category',
+        context: 'Title of the category selection window',
       },
     },
   };

--- a/packages/kolibri-common/components/accordion/AccordionContainer.vue
+++ b/packages/kolibri-common/components/accordion/AccordionContainer.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <div class="accordion">
+  <div
+    class="accordion"
+    :style="{ border: `1px solid ${$themeTokens.fineLine}` }"
+  >
     <div
       v-if="hasHeaderSlot"
       class="header"
@@ -58,12 +61,6 @@
 
 
 <style lang="scss" scoped>
-
-  @import '~kolibri-design-system/lib/styles/definitions';
-
-  .accordion {
-    @extend %dropshadow-1dp;
-  }
 
   .header {
     padding: 10px;

--- a/packages/kolibri-common/components/accordion/AccordionItem.vue
+++ b/packages/kolibri-common/components/accordion/AccordionItem.vue
@@ -15,6 +15,7 @@
         :style="headerAppearanceOverrides"
         :aria-expanded="isExpanded"
         :aria-controls="contentId"
+        :disabled="disabled"
         @click.stop="toggle"
       >
         <div class="header-content">

--- a/packages/kolibri-common/components/accordion/AccordionItem.vue
+++ b/packages/kolibri-common/components/accordion/AccordionItem.vue
@@ -31,6 +31,7 @@
           </div>
           <div class="trailing-actions">
             <KIconButton
+              tabindex="-1"
               :icon="isExpanded ? 'chevronDown' : 'chevronRight'"
               @click.stop="toggle"
             />


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Updates `SearchFiltersPanel` to accommodate latest design changes which will be used in the quiz resource selection
- Adds a button to Quiz Resource selection where you can view the accordion-ized versions of the filters
- Only focuses on updating the appearance and minimal functionality - so the filters, when clicked, will be applied as expected, but they will not create search chips (however, #12745 will make this possible upon further development)

![image](https://github.com/user-attachments/assets/71b1a7a2-07bc-43cd-b6d1-ed9fb9b723b0)

### Follow-up tasks (which I can do here and/or make an issue for):

- [ ] Add category icons to KDS per [Figma](https://www.figma.com/design/lVJt5ukOrxS9qay0rXy7GC/0.18-Coach-updates?node-id=107-69711&node-type=frame&t=56DAMWlKVf0Y6ogU-0) - should be aligned to the keys used in the code if possible (ie, if the `key` used in Kolibri were the label for the icon that'd be helpful) 
- [ ] The `ActivityButtonsGroup` component could use an update that lets use modify how they flow on the screen. We could fit 3, maybe 4 per row in the side panel but they display only in two columns. _Perhaps some flex styles could do us well here to serve all use cases_  


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #12521 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

**Feature QA**
- Go to Quiz creation and click the "Search" button there
- See that the filters align to the design changes ([FIGMA](https://www.figma.com/design/lVJt5ukOrxS9qay0rXy7GC/0.18-Coach-updates?node-id=107-69711&node-type=frame&t=4Rm6tBWuQRpL9Xdv-0))

NOTE: This is largely design focused, so any functionality issues will be addressed when it is fully integrated into Coach

**Regression testing**
- Search and filters should work exactly as before all throughout Learn (ie, no accordions, just the same as it has been)


**a11y guidance, keyboard nav in particular**

_I have added `tabindex=-1` to the KIconButton for the chevron to the right on the accordion heading area, so you will go from one accordion to the next_

- See that your focus is trapped in the side panel modal
- See that focus works as expected when using the "Categories" buttons in particular because they open a KModal, which should also trap focus before taking it back to where it was before
- Opening/closing accordion sections works, `aria-expanded` should be set as expected
- Should be able to close the side panel w/ keyboard nav