### PR TITLE
Add learner_needs field to contentnode API

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -648,6 +648,7 @@ class BaseContentNodeMixin(object):
         "grade_levels",
         "resource_types",
         "accessibility_labels",
+        "learner_needs",
         "categories",
         "duration",
         "ancestors",
@@ -659,6 +660,7 @@ class BaseContentNodeMixin(object):
         "resource_types": lambda x: _split_text_field(x["resource_types"]),
         "accessibility_labels": lambda x: _split_text_field(x["accessibility_labels"]),
         "categories": lambda x: _split_text_field(x["categories"]),
+        "learner_needs": lambda x: _split_text_field(x["learner_needs"]),
     }
 
     def get_queryset(self):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -195,8 +195,9 @@ class RemoteMixin(object):
         return headers
 
     def _cache_etag(self, baseurl, headers):
-        cache_key = REMOTE_ETAG_CACHE_KEY.format(baseurl)
-        cache.set(cache_key, headers["Etag"], 3600)
+        if "Etag" in headers:
+            cache_key = REMOTE_ETAG_CACHE_KEY.format(baseurl)
+            cache.set(cache_key, headers["Etag"], 3600)
 
     def update_data(self, response_data, baseurl):
         return response_data
@@ -792,6 +793,11 @@ class InternalContentNodeMixin(BaseContentNodeMixin):
                 response_data["admin_imported"] = (
                     response_data["id"] in self.locally_admin_imported_ids
                 )
+                if "learner_needs" not in response_data:
+                    # We accidentally omitted learner_needs from previous versions
+                    # of the public API, so we add it back in here,
+                    # so that remote data and local data have consistent structure.
+                    response_data["learner_needs"] = []
                 if "children" in response_data:
                     response_data["children"] = self.update_data(
                         response_data["children"], baseurl

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -334,6 +334,9 @@ class ContentNodeAPIBase(object):
                 "learning_activities": expected.learning_activities.split(",")
                 if expected.learning_activities
                 else [],
+                "learner_needs": expected.learner_needs.split(",")
+                if expected.learner_needs
+                else [],
                 "grade_levels": expected.grade_levels.split(",")
                 if expected.grade_levels
                 else [],

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -320,6 +320,8 @@ class ContentNodeAPIBase(object):
                 thumbnail = f.get_storage_url()
                 if self.baseurl and thumbnail:
                     thumbnail += "?baseurl={}".format(self.baseurl)
+        files = sorted(files, key=lambda x: x["id"])
+        actual["files"] = sorted(actual["files"], key=lambda x: x["id"])
         self.assertEqual(
             actual,
             {


### PR DESCRIPTION
## Summary
* Adds learner_needs field to content node API
* Adds response regularization to ensure that older public APIs have their learner_needs field backfilled to `[]` to ensure a consistent data structure on the frontend
* Handle etag being missing from response headers as an edge case
* Update and add tests for this
* Flyby - fix flakey assertion for files by explicitly sorting.

## References
Fixes #12687
Fixes one of the flaky tests remaining in https://github.com/learningequality/kolibri/issues/8255

## Reviewer guidance
Does the learner_needs field properly appear in both internal and public API endpoints now? Do the test changes make sense.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
