### PR TITLE
Update mappings for theme updates for newly introduced tokens made

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.7",
-    "kolibri-design-system": "5.0.0-rc7",
+    "kolibri-design-system": "5.0.0-rc8",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",

--- a/kolibri/plugins/bloompub_viewer/assets/src/views/BloomPubRendererIndex.vue
+++ b/kolibri/plugins/bloompub_viewer/assets/src/views/BloomPubRendererIndex.vue
@@ -8,7 +8,7 @@
   >
     <div
       class="fullscreen-header"
-      :style="{ backgroundColor: $themePalette.grey.v_100 }"
+      :style="{ backgroundColor: $themePalette.grey.v_200 }"
     >
       <KButton
         :primary="false"
@@ -36,7 +36,7 @@
         ref="iframe"
         class="iframe"
         sandbox="allow-scripts allow-same-origin"
-        :style="{ backgroundColor: $themePalette.grey.v_100 }"
+        :style="{ backgroundColor: $themePalette.grey.v_200 }"
         frameBorder="0"
         :src="rooturl"
         allow="fullscreen"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -175,7 +175,7 @@
       boxStyle() {
         return {
           border: '1px solid',
-          borderColor: this.$themePalette.grey.v_100,
+          borderColor: this.$themePalette.grey.v_200,
           borderRadius: '4px',
           padding: '0px 16px',
           margin: '5px',

--- a/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
@@ -14,7 +14,7 @@
       <div class="default-folder-icon">
         <KIcon
           icon="topic"
-          :color="$themePalette.grey.v_600"
+          :color="$themePalette.grey.v_700"
         />
       </div>
     </template>
@@ -31,7 +31,7 @@
         />
         <p
           class="folder-header-text"
-          :style="{ color: $themePalette.grey.v_600 }"
+          :style="{ color: $themePalette.grey.v_700 }"
         >
           {{ coreString('folder') }}
         </p>
@@ -85,7 +85,7 @@
           height: '24px',
           width: '74px',
           margin: '0',
-          backgroundColor: this.$themePalette.grey.v_50,
+          backgroundColor: this.$themePalette.grey.v_100,
         };
       },
     },

--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -28,7 +28,7 @@
         <KIconButton
           :icon="isBookmarked ? 'bookmark' : 'bookmarkEmpty'"
           size="mini"
-          :color="$themePalette.grey.v_600"
+          :color="$themePalette.grey.v_700"
           :ariaLabel="coreString('savedFromBookmarks')"
           :tooltip="coreString('savedFromBookmarks')"
           @click.stop="isBookmarked = !isBookmarked"
@@ -37,7 +37,7 @@
         <KIconButton
           icon="infoOutline"
           size="mini"
-          :color="$themePalette.grey.v_600"
+          :color="$themePalette.grey.v_700"
           :ariaLabel="coreString('viewInformation')"
           :tooltip="coreString('viewInformation')"
           @click.stop="$emit('toggleInfo')"

--- a/packages/kolibri-common/components/accordion/AccordionContainer.vue
+++ b/packages/kolibri-common/components/accordion/AccordionContainer.vue
@@ -6,7 +6,7 @@
       class="header"
       :style="{
         borderColor: $themeTokens.fineLine,
-        backgroundColor: $themePalette.grey.v_50,
+        backgroundColor: $themePalette.grey.v_100,
         ...headerAppearanceOverrides,
       }"
     >

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.7",
-    "kolibri-design-system": "5.0.0-rc7",
+    "kolibri-design-system": "5.0.0-rc8",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
 
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
+  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
   dependencies:
     asap "^2.0.3"
@@ -3108,7 +3109,7 @@ arrify@^1.0.1:
 asap@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 ast-metadata-inferer@^0.8.0:
   version "0.8.0"
@@ -3833,7 +3834,7 @@ color-convert@^2.0.1:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
@@ -6495,9 +6496,9 @@ humanize-ms@^1.2.1:
     ms "^2.0.0"
 
 hyphenate-style-name@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
-  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
+  integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -6660,19 +6661,19 @@ intl-format-cache@^2.0.5:
 intl-messageformat-parser@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz#5906b7f953ab7470e0dc8549097b648b991892ff"
-  integrity sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8=
+  integrity sha512-2qnIxfkrrzKAXR9m+rUqWb2yzeRX78k1l7+MU4ji7i4TIUyAIOo3KGV4hPKElRNyD40AAoAQdw1XXs5umB/usA==
 
 intl-messageformat@1.3.0, intl-messageformat@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-1.3.0.tgz#f7d926aded7a3ab19b2dc601efd54e99a4bd4eae"
-  integrity sha1-99kmre16OrGbLcYB79VOmaS9Tq4=
+  integrity sha512-dtj6VJ0Ul/DFyAksbEtOzsslkfuEu7r/d/oi8XltZgDLH3aUzxNkcb6SbguhHTi1RyPGtdWsfx6Q7qJGUySpow==
   dependencies:
     intl-messageformat-parser "1.2.0"
 
 intl-relativeformat@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz#893dc7076fccd380cf091a2300c380fa57ace45b"
-  integrity sha1-iT3HB2/M04DPCRojAMOA+les5Fs=
+  integrity sha512-pDbaJb3lh9IFyeY/bLZucvwcQgiUY6iqJ+ltMLi7FxMxIwzjHZrlSnvQbH3D0gQj1e1N9vpngh1kXMdfEbhPpA==
   dependencies:
     intl-messageformat "1.3.0"
 
@@ -7088,7 +7089,7 @@ iso8601-duration@^2.1.2:
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 istanbul-lib-coverage@^3.0.0:
   version "3.0.0"
@@ -7769,10 +7770,10 @@ kolibri-constants@0.2.7:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.7.tgz#7441bff81c459e081eeb8125a741745a72a002d1"
   integrity sha512-gzAeXmFCFYxTlvQ4sPdyRdQzm0FTD/ydK8Q7zgqcnooFjwPHw+cov8xmy6OKn/eqF/87fxFAv54bdkmrghkIPQ==
 
-kolibri-design-system@5.0.0-rc7:
-  version "5.0.0-rc7"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc7.tgz#3a965b6a0ab9042f6e1ad754a6ebcdb5f1b89da6"
-  integrity sha512-30lp0aY7maWXX9nwVDTNM49ittwIQgSbViQNw9RS5DLEXLEyJc212pabIytEGidyxmhpVj4gUM/MdwyM606Mxg==
+kolibri-design-system@5.0.0-rc8:
+  version "5.0.0-rc8"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc8.tgz#c96c80544dcf3671ddf899ded30bbcd155ca8f43"
+  integrity sha512-dEsMA0N3itEKnB8CSQl+xfmSI+YKvuMU733Guq3mL8YlTb7s07BltHbGspmOQmIA4Mv6WfdiYh0Nx7zec/+0dQ==
   dependencies:
     "@vue/composition-api" "1.7.2"
     aphrodite "https://github.com/learningequality/aphrodite/"
@@ -10680,7 +10681,7 @@ stream-browserify@^2.0.1:
 string-hash@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Summary
* Finalizes token updates for newly added token references in develop that weren't in release-v0.17.x

## Reviewer guidance
Follows mapping here: https://github.com/learningequality/kolibri-design-system/issues/775

Only places updated are ones that were discovered using: `git diff release-v0.17.x | grep "v_" -B 30 -A 30` while on the `develop` branch.

grey v_800 values were ignored as they're mapped to themselves, and the red v_600 value had already been updated, but had to be tweaked in the merge conflict when merging up to develop, so appears in the diff.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
