### PR TITLE
Miscellaneous fixes for things flagged by automated code scan

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -138,12 +138,9 @@ class FreeSpaceView(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def list(self, request):
         path = request.query_params.get("path")
-        if path is None:
-            free = get_free_space()
-        elif path == "Content":
-            free = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
-        else:
-            free = get_free_space(path)
+        if path != "Content":
+            return HttpResponseBadRequest("Invalid path")
+        free = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
 
         return Response({"freespace": free})
 

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import uuid
 from collections import namedtuple
@@ -48,6 +47,7 @@ from kolibri.plugins.app.utils import GET_OS_USER
 from kolibri.plugins.app.utils import interface
 from kolibri.plugins.utils.test.helpers import plugin_disabled
 from kolibri.plugins.utils.test.helpers import plugin_enabled
+from kolibri.utils.conf import OPTIONS
 from kolibri.utils.tests.helpers import override_option
 
 
@@ -380,10 +380,10 @@ class FreeSpaceTestCase(APITestCase):
             diskusage_mock.return_value = diskusage_result(free=2)
 
             response = self.client.get(
-                reverse("kolibri:core:freespace"), {"path": "test"}
+                reverse("kolibri:core:freespace"), {"path": "Content"}
             )
 
-            diskusage_mock.assert_called_with(os.path.realpath("test"))
+            diskusage_mock.assert_called_with(OPTIONS["Paths"]["CONTENT_DIR"])
             self.assertEqual(response.data, {"freespace": 2})
 
 

--- a/kolibri/plugins/app/api.py
+++ b/kolibri/plugins/app/api.py
@@ -66,6 +66,9 @@ class InitializeAppView(APIView):
                 user = FacilityUser.objects.get_or_create_os_user(auth_token)
                 if user is not None:
                     login(request, user)
+                else:
+                    # If the user is not found, then we should not persist the auth_token
+                    auth_token = None
             except ValidationError as e:
                 logger.error(e)
         redirect_url = request.GET.get("next", "/")

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -291,6 +291,7 @@
       const loadingPdf = PDFJSLib.getDocument({
         url: this.defaultFile.storage_url,
         worker: this.worker,
+        isEvalSupported: false,
       });
       // pass callback to update loading bar
       loadingPdf.onProgress = loadingProgress => {

--- a/kolibri/plugins/user_auth/assets/src/views/getUrlParameter.js
+++ b/kolibri/plugins/user_auth/assets/src/views/getUrlParameter.js
@@ -1,7 +1,4 @@
-// https://davidwalsh.name/query-string-javascript
 export default function getUrlParameter(name) {
-  name = name.replace(/[[]/, '[').replace(/[\]]/, '\\]');
-  var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
-  var results = regex.exec(location.search);
-  return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get(name) || '';
 }

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -115,9 +115,9 @@ export default class SandboxEnvironment {
     document.body.appendChild(this.iframe);
     const baseUrl = startUrl.split('?')[0];
     this.mediator.sendMessage({ nameSpace, event: events.LOADING, data: true });
-    if (baseUrl.indexOf('.h5p') === baseUrl.length - 4) {
+    if (baseUrl.endsWith('.h5p')) {
       this.H5P.init(this.iframe, startUrl);
-    } else if ([baseUrl.length - 7, baseUrl.length - 9].includes(baseUrl.indexOf('.bloom'))) {
+    } else if (baseUrl.endsWith('bloompub') || baseUrl.endsWith('bloomd')) {
       this.Bloom.init(this.iframe, startUrl);
     } else {
       this.iframe.onload = () => {


### PR DESCRIPTION
## Summary
* Gets rid of custom function for JS query parameter parsing in favour of built in web API
* Use endswith checking for more robust filename extension checks now that we can use it in every browser we support
* Limits which file paths the freespace view can access based on the query parameter
* Set isEvalSupported to false for PDFJS usage to prevent arbitrary JS execution from a PDF
* Don't persist the auth_token sent to the initialize endpoint if it hasn't returned a valid user

## Reviewer guidance
The net result here should be minimal.

Should test redirect after login using the next parameter.
Make sure that H5P apps run properly.
Ensure that free space checking during file import is working as intended.
Make sure PDFs still render properly.
Check that autologin is functioning as intended in the Android app.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
