### PR TITLE
Reactivate PR Size labels

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -3,6 +3,23 @@ name: PR Labels
 on: [pull_request_target]
 
 jobs:
+  size-labels:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          xs_label: 'SIZE: very small'
+          xs_max_size: '10'
+          s_label: 'SIZE: small'
+          s_max_size: '100'
+          m_label: 'SIZE: medium'
+          m_max_size: '500'
+          l_label: 'SIZE: large'
+          l_max_size: '1000'
+          xl_label: 'SIZE: very large'
+          fail_if_xl: 'false'
+          files_to_ignore: 'yarn.lock'
   other-labels:
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Uses a new Github Action to reactivate PR size labels

https://github.com/CodelyTV/pr-size-labeler

## References
This was previously disabled with a different action that had begun to break here: https://github.com/learningequality/kolibri/commit/afde8740690bf47dc6cc2aa1648669b18fa4abf7 this attempts to reinstate it, while still using the identical previous labels.

## Reviewer guidance
Previously we had to fork a third party action to choose our own custom label names, this one allows us to specify the label names, so hopefully this will work as is.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
