### PR TITLE
Remove "Activity" tab from learner view

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -9,7 +9,7 @@
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
       >
-        <KPageContainer class="left-container">
+        <KPageContainer class="content-spacing left-container">
           <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
           <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
             <template #headers>
@@ -56,7 +56,7 @@
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
       >
-        <KPageContainer class="right-container">
+        <KPageContainer class="content-spacing right-container">
           <h2>{{ coachString('quizzesAssignedLabel') }} </h2>
           <CoreTable :emptyMessage="coachString('quizListEmptyState')">
             <template #headers>
@@ -260,6 +260,9 @@
   .right-container {
     width: 100%;
     height: 100%;
+  }
+  .content-spacing {
+    padding: 24px 24px 16px 24px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -8,8 +8,9 @@
       <KGridItem
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
+        :layout4="{ span: 2 }"
       >
-        <KPageContainer class="content-spacing left-container">
+        <KPageContainer class="content-spacing">
           <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
           <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
             <template #headers>
@@ -55,8 +56,9 @@
       <KGridItem
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
+        :layout4="{ span: 2 }"
       >
-        <KPageContainer class="content-spacing right-container">
+        <KPageContainer class="content-spacing">
           <h2>{{ coachString('quizzesAssignedLabel') }} </h2>
           <CoreTable :emptyMessage="coachString('quizListEmptyState')">
             <template #headers>
@@ -172,7 +174,7 @@
     mixins: [commonCoach, commonCoreStrings],
     data() {
       return {
-        limit: 10,
+        lessonLimit: 10,
         quizLimit:10,
       };
     },
@@ -188,7 +190,7 @@
       },
       lessonsTable() {
         const sorted = this._.orderBy(this.getLessons, ['date_created'], ['desc']);
-        const limitedResults = sorted.slice(0, this.limit);
+        const limitedResults = sorted.slice(0, this.lessonLimit);
         return limitedResults.map(lesson => {
           const tableRow = {
             status: this.getLessonStatusStringForLearner(lesson.id, this.learner.id),
@@ -226,12 +228,12 @@
         return this.classRoute(PageNames.REPORTS_LEARNER_REPORT_QUIZ_PAGE_ROOT, { quizId });
       },
       loadMoreLessonTable(){
-        if(this.limit > 20){
-          this.limit = this.getLessons.length;
+        if(this.lessonLimit > 20){
+          this.lessonLimit = this.getLessons.length;
           return;
         }
 
-        this.limit += 10;
+        this.lessonLimit += 10;
       },
       loadMoreQuizzes(){
         if(this.quizLimit > 20){
@@ -253,16 +255,10 @@
   table {
     min-width: 0;
   }
-  .left-container {
-    width: 100%;
-    height: 100%;
-  }
-  .right-container {
-    width: 100%;
-    height: 100%;
-  }
   .content-spacing {
     padding: 24px 24px 16px 24px;
+    width: 100%;
+    height: 100%;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -5,7 +5,10 @@
       <LearnerHeader />
     </KPageContainer>
     <KGrid >
-      <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
+      <KGridItem
+        :layout12="{ span: 6 }"
+        :layout8="{ span: 4 }"
+      >
         <KPageContainer class="left-container">
           <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
           <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
@@ -45,6 +48,53 @@
             :text="coreString('viewMoreAction')"
             appearance="raised-button"
             @click="loadMoreLessonTable()"
+          />
+        </KPageContainer>
+      </KGridItem>
+
+      <KGridItem
+        :layout12="{ span: 6 }"
+        :layout8="{ span: 4 }"
+      >
+        <KPageContainer class="right-container">
+          <h2>{{ coachString('quizzesAssignedLabel') }} </h2>
+          <CoreTable :emptyMessage="coachString('quizListEmptyState')">
+            <template #headers>
+              <th>{{ coachString('titleLabel') }}</th>
+              <th>{{ coreString('progressLabel') }}</th>
+              <th>{{ coreString('scoreLabel') }}</th>
+            </template>
+            <template #tbody>
+              <transition-group
+                tag="tbody"
+                name="list"
+              >
+                <tr
+                  v-for="tableRow in examsTable"
+                  :key="tableRow.id"
+                >
+                  <td>
+                    <KRouterLink
+                      :to="quizLink(tableRow.id)"
+                      :text="tableRow.title"
+                      icon="quiz"
+                    />
+                  </td>
+                  <td>
+                    <StatusSimple :status="tableRow.statusObj.status" />
+                  </td>
+                  <td>
+                      {{ tableRow.statusObj.score }}
+                  </td>
+                </tr>
+              </transition-group>
+            </template>
+          </CoreTable>
+          <KButton
+            v-if="showQuizViewMoreButton"
+            :text="coreString('viewMoreAction')"
+            appearance="raised-button"
+            @click="loadMoreQuizzes"
           />
         </KPageContainer>
       </KGridItem>
@@ -193,11 +243,11 @@
     min-width: 0;
   }
   .left-container {
-    width: 480px;
+    width: 100%;
     height: 100%;
   }
   .right-container {
-    width: 432px;
+    width: 100%;
     height: 100%;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -100,50 +100,6 @@
           />
         </KPageContainer>
       </KGridItem>
-      <KPageContainer class="right-container">
-        <KGrid>
-          <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
-            <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
-            <CoreTable
-              :class="{ print: $isPrint }"
-              :emptyMessage="coachString('quizListEmptyState')"
-            >
-              <template #headers>
-                <th>{{ coachString('titleLabel') }}</th>
-                <th>{{ coreString('progressLabel') }}</th>
-              </template>
-              <template #tbody>
-                <transition-group
-                  tag="tbody"
-                  name="list"
-                >
-                  <tr
-                    v-for="tableRow in examsTable"
-                    :key="tableRow.id"
-                  >
-                    <td>
-                      <KRouterLink
-                        :to="quizLink(tableRow.id)"
-                        :text="tableRow.title"
-                        icon="quiz"
-                      />
-                    </td>
-                    <td>
-                      <StatusSimple :status="tableRow.statusObj" />
-                    </td>
-                  </tr>
-                </transition-group>
-              </template>
-            </CoreTable>
-            <KButton
-              v-if="showQuizViewMoreButton"
-              :text="coreString('viewMoreAction')"
-              appearance="raised-button"
-              @click="loadMoreQuizzes"
-            />
-          </KGridItem>
-        </KGrid>
-      </KPageContainer>
     </KGrid>
   </CoachAppBarPage>
 
@@ -152,17 +108,10 @@
 
 <script>
 
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import commonCoach from '../common';
-  import CoachAppBarPage from '../CoachAppBarPage';
-  import { PageNames } from '../../constants';
-  import ReportsLearnerHeader from './ReportsLearnerHeader';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import { PageNames } from '../../../constants';
-  import { REPORTS_LEARNERS_TABS_ID, ReportsLearnersTabs } from '../../../constants/tabsConstants';
-  import { useCoachTabs } from '../../../composables/useCoachTabs';
   import LearnerHeader from './LearnerHeader';
 
   export default {
@@ -250,7 +199,7 @@
 
 <style lang="scss" scoped>
 
-  @import '../common/print-table';
+  
 
   table {
     min-width: 0;

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -180,9 +180,14 @@
       learner() {
         return this.learnerMap[this.$route.params.learnerId];
       },
+      getLessons(){
+        return this.lessons.filter(lesson => this.isAssignedLesson(lesson));
+      },
+      getExam(){
+        return this.exams.filter(exam => this.isAssignedQuiz(exam));
+      },
       lessonsTable() {
-        const filtered = this.lessons.filter(lesson => this.isAssignedLesson(lesson));
-        const sorted = this._.orderBy(filtered, ['date_created'], ['desc']);
+        const sorted = this._.orderBy(this.getLessons, ['date_created'], ['desc']);
         const limitedResults = sorted.slice(0, this.limit);
         return limitedResults.map(lesson => {
           const tableRow = {
@@ -193,12 +198,10 @@
         });
       },
       showViewMoreButton(){
-        const assignedlessons = this.lessons.filter(lesson => this.isAssignedLesson(lesson));
-        return (assignedlessons.length !== this.lessonsTable.length) || assignedlessons.length > 10;
+        return (this.getLessons.length !== this.lessonsTable.length) && this.getLessons.length > 10;
       },
       examsTable() {
-        const filtered = this.exams.filter(exam => this.isAssignedQuiz(exam));
-        const sorted = this._.orderBy(filtered, ['date_created'], ['desc']);
+        const sorted = this._.orderBy(this.getExam, ['date_created'], ['desc']);
         const limitedQuizResults = sorted.slice(0, this.quizLimit);
         return limitedQuizResults.map(exam => {
           const tableRow = {
@@ -209,8 +212,7 @@
         });
       },
       showQuizViewMoreButton(){
-        const quizzes = this.exams.filter(exam => this.isAssignedQuiz(exam));
-        return (quizzes.length !== this.examsTable.length) || quizzes.length > 10;
+        return (this.getExam.length !== this.examsTable.length) && this.getExam.length > 2;
       },
     },
     methods: {
@@ -224,9 +226,18 @@
         return this.classRoute(PageNames.REPORTS_LEARNER_REPORT_QUIZ_PAGE_ROOT, { quizId });
       },
       loadMoreLessonTable(){
+        if(this.limit > 20){
+          this.limit = this.getLessons.length;
+          return;
+        }
+
         this.limit += 10;
       },
       loadMoreQuizzes(){
+        if(this.quizLimit > 20){
+          this.quizLimit = this.getExam.length;
+          return;
+        }
         this.quizLimit += 10;
       }
     },

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -4,7 +4,7 @@
     <KPageContainer>
       <LearnerHeader />
     </KPageContainer>
-    <KGrid >
+    <KGrid>
       <KGridItem
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
@@ -59,7 +59,7 @@
         :layout4="{ span: 2 }"
       >
         <KPageContainer class="content-spacing">
-          <h2>{{ coachString('quizzesAssignedLabel') }} </h2>
+          <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
           <CoreTable :emptyMessage="coachString('quizListEmptyState')">
             <template #headers>
               <th>{{ coachString('titleLabel') }}</th>
@@ -124,17 +124,17 @@
     data() {
       return {
         lessonLimit: 10,
-        quizLimit:10,
+        quizLimit: 10,
       };
     },
     computed: {
       learner() {
         return this.learnerMap[this.$route.params.learnerId];
       },
-      getLessons(){
+      getLessons() {
         return this.lessons.filter(lesson => this.isAssignedLesson(lesson));
       },
-      getExam(){
+      getExam() {
         return this.exams.filter(exam => this.isAssignedQuiz(exam));
       },
       lessonsTable() {
@@ -148,8 +148,8 @@
           return tableRow;
         });
       },
-      showViewMoreButton(){
-        return (this.getLessons.length !== this.lessonsTable.length) && this.getLessons.length > 10;
+      showViewMoreButton() {
+        return this.getLessons.length !== this.lessonsTable.length && this.getLessons.length > 10;
       },
       examsTable() {
         const sorted = this._.orderBy(this.getExam, ['date_created'], ['desc']);
@@ -162,8 +162,8 @@
           return tableRow;
         });
       },
-      showQuizViewMoreButton(){
-        return (this.getExam.length !== this.examsTable.length) && this.getExam.length > 2;
+      showQuizViewMoreButton() {
+        return this.getExam.length !== this.examsTable.length && this.getExam.length > 2;
       },
     },
     methods: {
@@ -176,21 +176,21 @@
       quizLink(quizId) {
         return this.classRoute(PageNames.REPORTS_LEARNER_REPORT_QUIZ_PAGE_ROOT, { quizId });
       },
-      loadMoreLessonTable(){
-        if(this.lessonLimit > 20){
+      loadMoreLessonTable() {
+        if (this.lessonLimit > 20) {
           this.lessonLimit = this.getLessons.length;
           return;
         }
 
         this.lessonLimit += 10;
       },
-      loadMoreQuizzes(){
-        if(this.quizLimit > 20){
+      loadMoreQuizzes() {
+        if (this.quizLimit > 20) {
           this.quizLimit = this.getExam.length;
           return;
         }
         this.quizLimit += 10;
-      }
+      },
     },
   };
 
@@ -199,15 +199,14 @@
 
 <style lang="scss" scoped>
 
-  
-
   table {
     min-width: 0;
   }
+
   .content-spacing {
-    padding: 24px 24px 16px 24px;
     width: 100%;
     height: 100%;
+    padding: 24px 24px 16px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -84,7 +84,7 @@
                     <StatusSimple :status="tableRow.statusObj.status" />
                   </td>
                   <td>
-                      {{ tableRow.statusObj.score }}
+                    <Score :value="tableRow.statusObj.score" />
                   </td>
                 </tr>
               </transition-group>


### PR DESCRIPTION
## Summary
 
 This PR  Remove "Activity" tab from learner view
 
 #### The currently on develop 
 
![image](https://github.com/user-attachments/assets/a3348558-7842-4244-8d48-0fbf016b4018)

### After  the clean up .


  #### on this PR

https://github.com/user-attachments/assets/1837f2bf-8ea1-4798-ae97-209bf4958fc9

#### On figma 
![image](https://github.com/user-attachments/assets/5e8bbbe8-c058-49e8-b9bb-7f51d16a7bf8)



 
 

## References
Closes #12733

## Reviewer guidance

-  Confirm that Tabs are no longer in use and all related code is cleaned up.
-  Verify that` ActivityList` is no longer rendered on this page (but remains in` kolibri-common)`.
-  For both lessons and quizzes, only the first 10 items are displayed initially.
-  When there are more than 10 items, a "view more" button appears.
-  On clicking "view more," an additional 10 items are displayed.
- Ensure all spacing and layout match the Figma design
- Confirm that there are no regressions affecting existing functionality.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
