### PR TITLE
Consistent 400 Response for Invalid Input in Kolibri Public Content APIs

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -861,7 +861,7 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
 
     def retrieve(self, request, pk=None):
         if pk is None:
-            raise Http404
+            raise status.HTTP_400_BAD_REQUEST
         if self._should_proxy_request(request):
             if self.get_queryset().filter(admin_imported=True, pk=pk).exists():
                 # Used in the update method for remote request retrieval

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -5,7 +5,6 @@ from base64 import urlsafe_b64decode
 from collections import OrderedDict
 from functools import reduce
 from random import sample
-from uuid import UUID
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -861,13 +860,8 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
     pagination_class = OptionalContentNodePagination
 
     def retrieve(self, request, pk=None):
-
-        try:
-            UUID(pk)
-        except ValueError:
-            return Response(
-                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
-            )
+        if pk is None:
+            raise Http404
 
         if self._should_proxy_request(request):
             if self.get_queryset().filter(admin_imported=True, pk=pk).exists():

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -864,13 +864,6 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
         if pk is None:
             raise Http404
 
-        try:
-            UUID(pk)
-        except ValueError:
-            return Response(
-                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
-            )
-
         if self._should_proxy_request(request):
             if self.get_queryset().filter(admin_imported=True, pk=pk).exists():
                 # Used in the update method for remote request retrieval
@@ -1175,6 +1168,14 @@ class ContentNodeTreeViewset(BaseContentNodeTreeViewset, RemoteMixin):
     def retrieve(self, request, pk=None):
         if pk is None:
             raise Http404
+
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         if self._should_proxy_request(request):
             try:
                 queryset = self.get_tree_queryset(request, pk)

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -5,6 +5,7 @@ from base64 import urlsafe_b64decode
 from collections import OrderedDict
 from functools import reduce
 from random import sample
+from uuid import UUID
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -862,6 +863,13 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
     def retrieve(self, request, pk=None):
         if pk is None:
             raise Http404
+
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         if self._should_proxy_request(request):
             if self.get_queryset().filter(admin_imported=True, pk=pk).exists():

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -5,6 +5,7 @@ from base64 import urlsafe_b64decode
 from collections import OrderedDict
 from functools import reduce
 from random import sample
+from uuid import UUID
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -860,8 +861,14 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
     pagination_class = OptionalContentNodePagination
 
     def retrieve(self, request, pk=None):
-        if pk is None:
-            raise status.HTTP_400_BAD_REQUEST
+
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         if self._should_proxy_request(request):
             if self.get_queryset().filter(admin_imported=True, pk=pk).exists():
                 # Used in the update method for remote request retrieval

--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from django.db import connection
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 from rest_framework.viewsets import GenericViewSet
@@ -50,6 +51,8 @@ class ImportMetadataViewset(GenericViewSet):
         :param pk: id parent node
         :return: an object with keys for each content metadata table and a schema_version key
         """
+        if pk is None:
+            raise status.HTTP_400_BAD_REQUEST
 
         content_schema = request.query_params.get(
             "schema_version", self.default_content_schema

--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from django.db import connection
 from django.db.models import Q
+from django.http import Http404
 from django.http import HttpResponseBadRequest
 from rest_framework import status
 from rest_framework.response import Response
@@ -51,12 +52,16 @@ class ImportMetadataViewset(GenericViewSet):
         :param pk: id parent node
         :return: an object with keys for each content metadata table and a schema_version key
         """
-        try:
-            UUID(pk)
-        except ValueError:
-            return Response(
-                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
-            )
+        if pk is None:
+            raise Http404
+        else:
+            try:
+                UUID(pk)
+            except ValueError:
+                return Response(
+                    {"error": "Invalid UUID format."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         content_schema = request.query_params.get(
             "schema_version", self.default_content_schema

--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -51,8 +51,12 @@ class ImportMetadataViewset(GenericViewSet):
         :param pk: id parent node
         :return: an object with keys for each content metadata table and a schema_version key
         """
-        if pk is None:
-            raise status.HTTP_400_BAD_REQUEST
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         content_schema = request.query_params.get(
             "schema_version", self.default_content_schema

--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -2,8 +2,8 @@ from uuid import UUID
 
 from django.db import connection
 from django.db.models import Q
-from django.http import Http404
 from django.http import HttpResponseBadRequest
+from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
@@ -52,16 +52,13 @@ class ImportMetadataViewset(GenericViewSet):
         :param pk: id parent node
         :return: an object with keys for each content metadata table and a schema_version key
         """
-        if pk is None:
-            raise Http404
-        else:
-            try:
-                UUID(pk)
-            except ValueError:
-                return Response(
-                    {"error": "Invalid UUID format."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         content_schema = request.query_params.get(
             "schema_version", self.default_content_schema
@@ -84,7 +81,7 @@ class ImportMetadataViewset(GenericViewSet):
 
         # Get the model for the target node here - we do this so that we trigger a 404 immediately if the node
         # does not exist.
-        node = self.get_object()
+        node = get_object_or_404(models.ContentNode.objects.all(), pk=pk)
 
         nodes = node.get_ancestors(include_self=True)
 

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -513,7 +513,7 @@ class ContentNodeAPIBase(object):
                 kwargs={"pk": "this is not a UUID"},
             )
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -515,6 +515,15 @@ class ContentNodeAPIBase(object):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_contentnode_tree_bad_pk(self):
+        response = self.client.get(
+            reverse(
+                "kolibri:core:contentnode_tree-detail",
+                kwargs={"pk": "this is not UUID"},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]
         == "django.db.backends.postgresql",

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -513,7 +513,7 @@ class ContentNodeAPIBase(object):
                 kwargs={"pk": None},
             )
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     def test_contentnode_tree_bad_pk(self):
         response = self.client.get(
@@ -523,6 +523,7 @@ class ContentNodeAPIBase(object):
             )
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error"], "Invalid UUID format.")
 
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -506,6 +506,15 @@ class ContentNodeAPIBase(object):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_contentnode_tree_none_pk(self):
+        response = self.client.get(
+            reverse(
+                "kolibri:core:contentnode_tree-detail",
+                kwargs={"pk": None},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_contentnode_tree_bad_pk(self):
         response = self.client.get(
             reverse(
@@ -514,6 +523,7 @@ class ContentNodeAPIBase(object):
             )
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error"], "Invalid UUID format.")
 
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -513,17 +513,7 @@ class ContentNodeAPIBase(object):
                 kwargs={"pk": None},
             )
         )
-        self.assertEqual(response.status_code, 400)
-
-    def test_contentnode_tree_bad_pk(self):
-        response = self.client.get(
-            reverse(
-                "kolibri:core:contentnode_tree-detail",
-                kwargs={"pk": "this is not a UUID"},
-            )
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["error"], "Invalid UUID format.")
+        self.assertEqual(response.status_code, 404)
 
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -507,13 +507,8 @@ class ContentNodeAPIBase(object):
         self.assertEqual(response.status_code, 404)
 
     def test_contentnode_tree_none_pk(self):
-        response = self.client.get(
-            reverse(
-                "kolibri:core:contentnode_tree-detail",
-                kwargs={"pk": None},
-            )
-        )
-        self.assertEqual(response.status_code, 400)
+        response = self.client.get("/api/content/contentnode_tree/")
+        self.assertEqual(response.status_code, 404)
 
     def test_contentnode_tree_bad_pk(self):
         response = self.client.get(

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -95,6 +95,15 @@ class ImportMetadataTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_import_metadata_bad_pk(self):
+        response = self.client.get(
+            reverse(
+                "kolibri:core:importmetadata-detail",
+                kwargs={"pk": "this is not a UUID"},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_schema_version_just_right(self):
         response = self.client.get(
             reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.node.id})

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -102,7 +102,7 @@ class ImportMetadataTestCase(APITestCase):
                 kwargs={"pk": None},
             )
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     def test_import_metadata_bad_pk(self):
         response = self.client.get(

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -95,6 +95,15 @@ class ImportMetadataTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_import_metadata_none_pk(self):
+        response = self.client.get(
+            reverse(
+                "kolibri:core:importmetadata-detail",
+                kwargs={"pk": None},
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_import_metadata_bad_pk(self):
         response = self.client.get(
             reverse(
@@ -103,6 +112,7 @@ class ImportMetadataTestCase(APITestCase):
             )
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error"], "Invalid UUID format.")
 
     def test_schema_version_just_right(self):
         response = self.client.get(

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -102,7 +102,7 @@ class ImportMetadataTestCase(APITestCase):
                 kwargs={"pk": None},
             )
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
     def test_import_metadata_bad_pk(self):
         response = self.client.get(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pr is intended to be consistent for 400 response for retrieve function of [ContentNodeTreeViewset](https://github.com/learningequality/kolibri/blob/04f4a38a0dc2b3b31754ffbd0dc324a05af7a122/kolibri/core/content/api.py#L859) and [ImportMetadataViewset](https://github.com/learningequality/kolibri/blob/04f4a38a0dc2b3b31754ffbd0dc324a05af7a122/kolibri/core/content/public_api.py#L16) invalid input by returning a 404 response.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes: #12807

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
