### PR TITLE
Resolve issue with user not seeing updated practice quiz score on TopicsContentPage

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
@@ -17,7 +17,7 @@ export function setContentNodeProgress(progress) {
   // Avoid setting stale progress data - assume that progress increases monotonically
   if (
     !contentNodeProgressMap[progress.content_id] ||
-    progress.progress > contentNodeProgressMap[progress.content_id]
+    progress.progress >= contentNodeProgressMap[progress.content_id]
   ) {
     set(contentNodeProgressMap, progress.content_id, progress.progress);
     // this should have been conditional


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates the function `setContentNodeProgress()` if statement to use the greater than or equal to (>=) operator to allow the user to see the latest practicer quiz score after clicking the back button on the `ContentPage`.

Previously, if the `progress` value passed to `setContentNodeProgress()` equaled 1 and the progress in the `contentNodeProgressMap` also equaled 1, the function wouldn't update either the `contentNodeProgressMap` or the `contentNodeProgressMetaDataMap`, until the page was reloaded.


Before:

https://github.com/user-attachments/assets/d663cb0b-9cdb-4fdf-b411-2d792589918f

After:

https://github.com/user-attachments/assets/c2173d11-f019-43a7-8c25-9773b4054be6



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12663 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Import a practice quiz resource from Kolibri QA Channel > Exercises > Practice quizzes.
2. Navigate to the practice quizzes Topics Page and take a practice quiz.
3. Click the "Back" arrow on the TopicsContentPage.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
