### PR TITLE
Remove channel labels from non-public ContentNode API

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -828,9 +828,10 @@ class OptionalContentNodePagination(OptionalPagination):
     def paginate_queryset(self, queryset, request, view=None):
         # Record the queryset for use in returning available filters
         self.queryset = queryset
-        self.use_deprecated_channels_labels = request.query_params.get(
-            "use_deprecated_channels_labels", "false"
-        ).lower() == "true"
+        self.use_deprecated_channels_labels = (
+            request.query_params.get("use_deprecated_channels_labels", "false").lower()
+            == "true"
+        )
         return super(OptionalContentNodePagination, self).paginate_queryset(
             queryset, request, view=view
         )
@@ -877,6 +878,7 @@ class OptionalContentNodePagination(OptionalPagination):
             def paginate_queryset(self, queryset, request, view=None):
                 self.use_deprecated_channels_labels = True
                 return super().paginate_queryset(queryset, request, view)
+
 
 @method_decorator(remote_metadata_cache, name="dispatch")
 class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesViewset):

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -86,8 +86,10 @@ def _get_available_channels(base_queryset, include_labels=False):
 
     if include_labels:
         for channel in channels:
-            channel['labels'] = list(
-                ChannelMetadata.objects.filter(id=channel['id']).values_list('labels', flat=True)
+            channel["labels"] = list(
+                ChannelMetadata.objects.filter(id=channel["id"]).values_list(
+                    "labels", flat=True
+                )
             )
 
     return list(channels)

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -77,14 +77,20 @@ def _get_available_languages(base_queryset):
     return list(langs)
 
 
-def _get_available_channels(base_queryset):
+def _get_available_channels(base_queryset, include_labels=False):
     from kolibri.core.content.models import ChannelMetadata
 
-    return list(
-        ChannelMetadata.objects.filter(
-            id__in=base_queryset.values_list("channel_id", flat=True).distinct()
-        ).values("id", "name")
-    )
+    channels = ChannelMetadata.objects.filter(
+        id__in=base_queryset.values_list("channel_id", flat=True).distinct()
+    ).values("id", "name")
+
+    if include_labels:
+        for channel in channels:
+            channel['labels'] = list(
+                ChannelMetadata.objects.filter(id=channel['id']).values_list('labels', flat=True)
+            )
+
+    return list(channels)
 
 
 class SQLiteBitwiseORAggregate(Aggregate):


### PR DESCRIPTION
## Fixes
Closes #12842

## Summary

- Removed the channel labels from the non-public `ContentNodeViewset` API.
- Added a flag `use_deprecated_channels_labels` to the `OptionalContentNodePagination` class to handle the inclusion of channel labels.
- Ensured that the public API still provides the channel labels.
- Verified that older Kolibri versions can navigate and search the library remotely without issues.

## References
- Issue: Remove the channel labels from the non-public ContentNode API
- Related PR: Update SearchFiltersPanel for Coach

## Reviewer guidance
- Test the non-public `ContentNodeViewset` API to ensure that channel labels are no longer returned.
- Verify that the public API still provides the channel labels.
- Ensure that older Kolibri versions (0.17.x) can navigate and search the library remotely from Kolibri 0.18.x and filter by Channels.
- Check for any potential issues or regressions in the search functionality and filtering by channels.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [X] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
