### PR TITLE
Allow plugins to be enabled, disabled, and applied via env vars.

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -48,6 +48,24 @@ ENVIRONMENT_VARIABLES = {
             See the sd_notify(3) man page for more details.
         """,
     },
+    "KOLIBRI_PLUGIN_APPLY": {
+        "description": """
+            A comma-separated list of plugins to apply. If this variable is set,
+            only the specified plugins will be applied.
+        """,
+    },
+    "KOLIBRI_PLUGIN_ENABLE": {
+        "description": """
+            A comma-separated list of plugins to enable. If this variable is set,
+            the specified plugins will be enabled, overriding plugins disabled via the CLI.
+        """,
+    },
+    "KOLIBRI_PLUGIN_DISABLE": {
+        "description": """
+            A comma-separated list of plugins to disable. If this variable is set,
+            the specified plugins will be disabled, overriding plugins enabled via the CLI.
+        """,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
* Adds environment variables to allow applying, enabling, and disabling plugins via a comma separated list of plugin names.

## References
No actual issue for this, but has something that has come up a few times to make deployment for BCK easier, and also for enabling plugins for use in our Kolibri Apps.

## Reviewer guidance
Test out each of the new environment variables.

I also thought I saw an issue where the environment variable set enabled plugins got saved to the plugin configuration when a Kolibri upgrade occurred - but I wasn't able to replicate on further testing.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
