### PR TITLE
Use webpack's built in dynamic public path setting

### DIFF
--- a/kolibri/core/assets/src/index.js
+++ b/kolibri/core/assets/src/index.js
@@ -15,13 +15,6 @@ import coreModule from './state/modules/core';
 // are set correctly
 urls.setUp();
 
-// Shim window.location.origin for IE.
-if (!window.location.origin) {
-  window.location.origin = `${window.location.protocol}//${window.location.hostname}${
-    window.location.port ? `:${window.location.port}` : ''
-  }`;
-}
-
 // set up logging
 logging.setDefaultLevel(process.env.NODE_ENV === 'production' ? 2 : 0);
 

--- a/kolibri/core/assets/src/index.js
+++ b/kolibri/core/assets/src/index.js
@@ -14,11 +14,6 @@ import coreModule from './state/modules/core';
 // Do this before any async imports to ensure that public paths
 // are set correctly
 urls.setUp();
-if (process.env.NODE_ENV === 'production') {
-  /* eslint-disable no-undef */
-  __webpack_public_path__ = urls.static(`${__kolibriModuleName}/`);
-  /* eslint-enable */
-}
 
 // Shim window.location.origin for IE.
 if (!window.location.origin) {

--- a/packages/kolibri-module/src/index.js
+++ b/packages/kolibri-module/src/index.js
@@ -5,13 +5,6 @@
  */
 
 import coreApp from 'kolibri';
-import urls from 'kolibri/urls';
-
-if (process.env.NODE_ENV === 'production') {
-  /* eslint-disable no-undef */
-  __webpack_public_path__ = urls.static(`${__kolibriModuleName}/`);
-  /* eslint-enable */
-}
 
 export default class KolibriModule {
   /**

--- a/packages/kolibri-tools/lib/webpack.config.plugin.js
+++ b/packages/kolibri-tools/lib/webpack.config.plugin.js
@@ -117,7 +117,8 @@ module.exports = (
       // webpack properly handles that or not.
       chunkLoadingGlobal: 'webpackChunkwebpack__' + data.name.replace('.', ''),
       scriptType: 'text/javascript',
-      pathinfo: mode === 'production',
+      pathinfo: false,
+      publicPath: 'auto',
     },
     resolve: {
       alias,


### PR DESCRIPTION
## Summary
Webpack 5 introduced built in capability to set the webpack public path dynamically, to allow proper loading of code splitting, and non-inlined assets.
We couldn't use this, as it wasn't compatible with IE11, but since dropping support we can.
Removes an unused IE11 shim in the frontend also.

## References
Fixes #9062

## Reviewer guidance
Nothing should be different behaviour wise as a result of this. Best things to check are places where we have large assets that should be loaded separately, ensuring they are still loaded as intended.
