### PR TITLE
Use kolibri-image-pi repo for building raspberry pi image.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -59,3 +59,10 @@ jobs:
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
       ref: v0.1.4
+  zip:
+    name: Build Raspberry Pi Image
+    needs: deb
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.0.0
+    with:
+      deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
+      ref: v1.0.0

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -105,10 +105,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/pi-gen/.github/workflows/build_zip.yml@v0.16.1
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.0.0
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v0.16.1
+      ref: v1.0.0
   upload_zip:
     uses: ./.github/workflows/upload_github_release_asset.yml
     needs: zip


### PR DESCRIPTION
## Summary
* Switches our raspberry pi image building on release to use the kolibri-image-pi repo, which has been confirmed as working there: https://github.com/learningequality/kolibri-image-pi/pull/5#issuecomment-2488833554
* Adds raspberry pi image building to our PR asset builds, as the build time is now shorter than the APK.

## References
https://github.com/learningequality/kolibri-image-pi/pull/5#issuecomment-2488833554

## Reviewer guidance
Does the image build properly for the PR?
