### PR TITLE
Fix masterylog end timestamp issues

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -628,6 +628,9 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 else:
                     self._check_quiz_log_permissions(masterylog)
                 if update_fields:
+                    if end_timestamp:
+                        masterylog.end_timestamp = end_timestamp
+                        update_fields += ("end_timestamp",)
                     masterylog.save(
                         update_fields=update_fields + ("_morango_dirty_bit",)
                     )

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -2145,6 +2145,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentTestCase(
             mastery_criterion=mastery_model,
             summarylog=self.summary_log,
             start_timestamp=self.summary_log.start_timestamp,
+            end_timestamp=self.summary_log.start_timestamp,
             user=self.user,
             mastery_level=1,
         )
@@ -2175,6 +2176,9 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentTestCase(
         self.assertEqual(response.status_code, 200)
         self.mastery_log.refresh_from_db()
         self.assertEqual(self.mastery_log.time_spent, 5)
+        self.assertNotEqual(
+            self.mastery_log.end_timestamp, self.mastery_log.start_timestamp
+        )
 
     def test_update_assessment_session_create_attempt_in_lesson_succeeds(self):
         lesson = create_assigned_lesson_for_user(self.user)

--- a/kolibri/core/logger/test/test_upgrades.py
+++ b/kolibri/core/logger/test/test_upgrades.py
@@ -1,0 +1,109 @@
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.upgrade import fix_masterylog_end_timestamps
+
+
+class MasteryLogEndTimestampUpgradeTest(TestCase):
+    def setUp(self):
+        self.facility = Facility.objects.create()
+        self.user = FacilityUser.objects.create(
+            username="learner", facility=self.facility
+        )
+        now = timezone.now()
+
+        # Create base content summary log
+        self.summary_log = ContentSummaryLog.objects.create(
+            user=self.user,
+            content_id=uuid4().hex,
+            channel_id=uuid4().hex,
+            kind="exercise",
+            start_timestamp=now,
+            end_timestamp=now + timezone.timedelta(minutes=10),
+        )
+
+        # Case 1: MasteryLog with attempts
+        self.attempt_session = ContentSessionLog.objects.create(
+            user=self.user,
+            content_id=self.summary_log.content_id,
+            channel_id=self.summary_log.channel_id,
+            kind="exercise",
+            start_timestamp=now,
+            end_timestamp=now + timezone.timedelta(minutes=3),
+        )
+
+        self.attempt_mastery = MasteryLog.objects.create(
+            user=self.user,
+            summarylog=self.summary_log,
+            mastery_level=2,
+            start_timestamp=now,
+            end_timestamp=now,
+        )
+
+        AttemptLog.objects.create(
+            masterylog=self.attempt_mastery,
+            sessionlog=self.attempt_session,
+            start_timestamp=now,
+            end_timestamp=now - timezone.timedelta(minutes=3),
+            complete=True,
+            correct=1,
+        )
+
+        AttemptLog.objects.create(
+            masterylog=self.attempt_mastery,
+            sessionlog=self.attempt_session,
+            start_timestamp=now,
+            end_timestamp=now - timezone.timedelta(minutes=2),
+            complete=True,
+            correct=1,
+        )
+
+        self.last_attempt = AttemptLog.objects.create(
+            masterylog=self.attempt_mastery,
+            sessionlog=self.attempt_session,
+            start_timestamp=now,
+            end_timestamp=now + timezone.timedelta(minutes=3),
+            complete=True,
+            correct=1,
+        )
+
+        # Case 2: MasteryLog with only summary log
+        self.summary_session = ContentSessionLog.objects.create(
+            user=self.user,
+            content_id=self.summary_log.content_id,
+            channel_id=self.summary_log.channel_id,
+            kind="exercise",
+            start_timestamp=now,
+            end_timestamp=now,
+        )
+        self.summary_only_mastery = MasteryLog.objects.create(
+            user=self.user,
+            summarylog=self.summary_log,
+            mastery_level=3,
+            start_timestamp=now,
+            end_timestamp=now,
+        )
+
+        fix_masterylog_end_timestamps()
+
+    def test_attempt_logs_case(self):
+        """Test MasteryLog with attempt logs gets end_timestamp from last attempt"""
+        self.attempt_mastery.refresh_from_db()
+        self.assertEqual(
+            self.attempt_mastery.end_timestamp, self.last_attempt.end_timestamp
+        )
+
+    def test_summary_log_case(self):
+        """Test MasteryLog with only summary log gets end_timestamp from summary"""
+        self.summary_only_mastery.refresh_from_db()
+        self.assertEqual(
+            self.summary_only_mastery.end_timestamp, self.summary_log.end_timestamp
+        )

--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -1,12 +1,12 @@
 from importlib import import_module
 
 from django.apps import apps
-from semver import match
 from semver import VersionInfo
 
 import kolibri
 from kolibri.utils.version import get_version_and_operator_from_range
 from kolibri.utils.version import normalize_version_to_semver
+from kolibri.utils.version import version_matches_range
 
 
 CURRENT_VERSION = VersionInfo.parse(normalize_version_to_semver(kolibri.__version__))
@@ -110,10 +110,7 @@ def version_upgrade(old_version=None, new_version=None):
 def matches_version(version, version_range):
     if version_range is None or not version:
         return True
-    # For the purposes of upgrade comparison, treat dev versions as alphas
-    version = normalize_version_to_semver(version).replace("dev", "a")
-    version_range = "".join(get_version_and_operator_from_range(version_range))
-    return match(version, version_range)
+    return version_matches_range(version, version_range)
 
 
 def get_upgrades(app_configs=None):


### PR DESCRIPTION
## Summary
* Fixes bug and adds regression test to ensure the end_timestamp on masterylogs get properly updated after initialization
* Adds tests for and updates behaviour to ensure that our upgrade machinery can handle compound version ranges
* Adds upgrade function to remediate the masterylog end timestamp issues if the upgrade is from an affected Kolibri version
* Updates any masterlogs whose end timestamp is the same as the start timestamp, as would be the case for those affected by this bug
* Sets to the end timestamp of the most recent attempt (if any)
* Otherwise set to the end timestamp of the content summary log

## References
Fixes [#12855](https://github.com/learningequality/kolibri/issues/12855)

## Reviewer guidance
Are all three cases needed? Possible we could just check attempts and then content summary log.

…
