### PR TITLE
Fix the CLI --pythonpath parameter

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -389,7 +389,7 @@ def plugin():
     pass
 
 
-@plugin.command(help="Enable Kolibri plugins")
+@plugin.command(cls=KolibriCommand, help="Enable Kolibri plugins")
 @click.argument("plugin_names", nargs=-1)
 @click.option("-d", "--default-plugins", default=False, is_flag=True)
 def enable(plugin_names, default_plugins):
@@ -409,7 +409,7 @@ def enable(plugin_names, default_plugins):
         raise exception
 
 
-@plugin.command(help="Disable Kolibri plugins")
+@plugin.command(cls=KolibriCommand, help="Disable Kolibri plugins")
 @click.argument("plugin_names", nargs=-1)
 @click.option("-a", "--all-plugins", default=False, is_flag=True)
 def disable(plugin_names, all_plugins):
@@ -429,7 +429,9 @@ def disable(plugin_names, all_plugins):
         raise exception
 
 
-@plugin.command(help="Set Kolibri plugins to be enabled and disable all others")
+@plugin.command(
+    cls=KolibriCommand, help="Set Kolibri plugins to be enabled and disable all others"
+)
 @click.argument("plugin_names", nargs=-1)
 @click.pass_context
 def apply(ctx, plugin_names):
@@ -451,7 +453,7 @@ def apply(ctx, plugin_names):
         raise exception
 
 
-@plugin.command(help="List all available Kolibri plugins")
+@plugin.command(cls=KolibriCommand, help="List all available Kolibri plugins")
 def list():
     plugins = [plugin for plugin in iterate_plugins()]
     lang = "en"
@@ -513,7 +515,10 @@ def _get_env_vars():
                     yield _format_env_var(envvar, v)
 
 
-@configure.command(help="List all available environment variables to configure Kolibri")
+@configure.command(
+    cls=KolibriCommand,
+    help="List all available environment variables to configure Kolibri",
+)
 def list_env():
     click.echo_via_pager(_get_env_vars())
 

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -9,7 +9,6 @@ from diskcache.fanout import FanoutCache
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from django.core.management.base import handle_default_options
 from django.db.utils import DatabaseError
 
 import kolibri
@@ -110,14 +109,6 @@ def _migrate_databases():
 
     # load morango fixtures needed for certificate related operations
     call_command("loaddata", "scopedefinitions")
-
-
-class DefaultDjangoOptions(object):
-    __slots__ = ["settings", "pythonpath"]
-
-    def __init__(self, settings, pythonpath):
-        self.settings = settings
-        self.pythonpath = pythonpath
 
 
 def setup_logging(debug=False, debug_database=False):
@@ -291,6 +282,15 @@ def _upgrades_after_django_setup(updated, version):
             logging.error(e)
 
 
+def set_django_settings_and_python_path(django_settings, pythonpath):
+
+    if django_settings:
+        os.environ["DJANGO_SETTINGS_MODULE"] = django_settings
+
+    if pythonpath and pythonpath not in sys.path:
+        sys.path.insert(0, pythonpath)
+
+
 def initialize(  # noqa C901
     skip_update=False,
     settings=None,
@@ -307,9 +307,7 @@ def initialize(  # noqa C901
 
     setup_logging(debug=debug, debug_database=debug_database)
 
-    default_options = DefaultDjangoOptions(settings, pythonpath)
-
-    handle_default_options(default_options)
+    set_django_settings_and_python_path(settings, pythonpath)
 
     version = get_version()
 


### PR DESCRIPTION
## Summary
* Make setting django settings and pythonpath idempotent and reusable.
* Ensure we validate pythonpath option before settings option.
* Set python path for all CLI commands so that it can be used for plugins too.
* Cleans up deprecated methods

## References
Fixes #10296

## Reviewer guidance
Create a dummy plugin or settings file in a completely different folder. Pass the (can be relative) path to that folder using the the `--pythonpath` CLI option when invoking `kolibri shell` `kolibri plugin enable` or the like, and ensure that the settings file or plugin can take effect.
