### PR TITLE
Remove channels label fetching in useBaseSearch composable

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
@@ -51,7 +51,6 @@ describe(`useSearch`, () => {
       expect(get(searchTerms)).toEqual({
         accessibility_labels: {},
         categories: {},
-        channels: {},
         grade_levels: {},
         languages: {},
         learner_needs: {},
@@ -69,7 +68,6 @@ describe(`useSearch`, () => {
       expect(get(searchTerms)).toEqual({
         accessibility_labels: {},
         categories: {},
-        channels: {},
         grade_levels: {},
         languages: {},
         learner_needs: {},
@@ -82,7 +80,6 @@ describe(`useSearch`, () => {
         accessibility_labels: 'test1,test2',
         keywords: 'I love paris in the springtime!',
         categories: 'notatest,reallynotatest,absolutelynotatest',
-        channels: 'channelid1,channelid2,channelid3',
         grade_levels: 'lowerprimary,uppersecondary,adult',
         languages: 'ar-jk,en-pr,en-gb',
         learner_needs: 'internet,pencil,rolodex',
@@ -97,11 +94,6 @@ describe(`useSearch`, () => {
           notatest: true,
           reallynotatest: true,
           absolutelynotatest: true,
-        },
-        channels: {
-          channelid1: true,
-          channelid2: true,
-          channelid3: true,
         },
         grade_levels: {
           lowerprimary: true,
@@ -185,7 +177,6 @@ describe(`useSearch`, () => {
       'learning_activities',
       'categories',
       'learner_needs',
-      'channels',
       'accessibility_labels',
       'languages',
       'grade_levels',
@@ -250,7 +241,6 @@ describe(`useSearch`, () => {
       const { labels, more, search } = prep({}, ref({ tree_id: 1, lft: 10, rght: 20 }));
       const labelsSet = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({ labels: labelsSet }));
@@ -288,27 +278,6 @@ describe(`useSearch`, () => {
         getParams: { categories__isnull: true, max_results: 25, include_coach_content: false },
       });
     });
-    it('should ignore channels when descendant is set', () => {
-      const { search } = prep(
-        {
-          categories: `test1,test2`,
-          channels: 'test1',
-        },
-        ref({ tree_id: 1, lft: 10, rght: 20 }),
-      );
-      ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
-      search();
-      expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: {
-          categories: ['test1', 'test2'],
-          max_results: 25,
-          tree_id: 1,
-          lft__gt: 10,
-          rght__lt: 20,
-          include_coach_content: false,
-        },
-      });
-    });
     it('should set keywords when defined', () => {
       const { search } = prep({ keywords: `this is just a test` });
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
@@ -325,7 +294,6 @@ describe(`useSearch`, () => {
       const { labels, more, results, search } = prep({ categories: 'test1,test2' });
       const expectedLabels = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       const expectedMore = {
@@ -385,7 +353,6 @@ describe(`useSearch`, () => {
       });
       const expectedLabels = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       const expectedMore = {
@@ -443,14 +410,14 @@ describe(`useSearch`, () => {
     it('should not remove any other filters', () => {
       const { removeFilterTag, router } = prep({
         categories: 'test1,test2',
-        channels: 'channel1',
+        learning_activities: 'watch',
       });
       removeFilterTag({ value: 'test1', key: 'categories' });
       expect(router.push).toHaveBeenCalledWith({
         name,
         query: {
           categories: 'test2',
-          channels: 'channel1',
+          learning_activities: 'watch',
         },
       });
     });
@@ -459,7 +426,7 @@ describe(`useSearch`, () => {
     it('should remove all filters from the searchTerms', () => {
       const { clearSearch, router } = prep({
         categories: 'test1,test2',
-        channels: 'channel1',
+        learning_activities: 'watch',
         keywords: 'this',
       });
       clearSearch();

--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -70,7 +70,7 @@
         type: Object,
         required: true,
         validator(value) {
-          const inputKeys = ['channels', 'accessibility_labels', 'languages', 'grade_levels'];
+          const inputKeys = ['accessibility_labels', 'languages', 'grade_levels'];
           return inputKeys.every(k => Object.prototype.hasOwnProperty.call(value, k));
         },
       },

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -233,7 +233,6 @@
           const inputKeys = [
             'learning_activities',
             'learner_needs',
-            'channels',
             'accessibility_labels',
             'languages',
             'grade_levels',

--- a/packages/kolibri-common/composables/__mocks__/useBaseSearch.js
+++ b/packages/kolibri-common/composables/__mocks__/useBaseSearch.js
@@ -36,7 +36,6 @@ const MOCK_DEFAULTS = {
     learning_activities: {},
     categories: {},
     learner_needs: {},
-    channels: {},
     accessibility_labels: {},
     languages: {},
     grade_levels: {},

--- a/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
@@ -51,7 +51,6 @@ describe(`useBaseSearch`, () => {
       expect(get(searchTerms)).toEqual({
         accessibility_labels: {},
         categories: {},
-        channels: {},
         grade_levels: {},
         languages: {},
         learner_needs: {},
@@ -69,7 +68,6 @@ describe(`useBaseSearch`, () => {
       expect(get(searchTerms)).toEqual({
         accessibility_labels: {},
         categories: {},
-        channels: {},
         grade_levels: {},
         languages: {},
         learner_needs: {},
@@ -82,7 +80,6 @@ describe(`useBaseSearch`, () => {
         accessibility_labels: 'test1,test2',
         keywords: 'I love paris in the springtime!',
         categories: 'notatest,reallynotatest,absolutelynotatest',
-        channels: 'channelid1,channelid2,channelid3',
         grade_levels: 'lowerprimary,uppersecondary,adult',
         languages: 'ar-jk,en-pr,en-gb',
         learner_needs: 'internet,pencil,rolodex',
@@ -97,11 +94,6 @@ describe(`useBaseSearch`, () => {
           notatest: true,
           reallynotatest: true,
           absolutelynotatest: true,
-        },
-        channels: {
-          channelid1: true,
-          channelid2: true,
-          channelid3: true,
         },
         grade_levels: {
           lowerprimary: true,
@@ -185,7 +177,6 @@ describe(`useBaseSearch`, () => {
       'learning_activities',
       'categories',
       'learner_needs',
-      'channels',
       'accessibility_labels',
       'languages',
       'grade_levels',
@@ -250,7 +241,6 @@ describe(`useBaseSearch`, () => {
       const { labels, more, search } = prep({}, ref({ tree_id: 1, lft: 10, rght: 20 }));
       const labelsSet = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({ labels: labelsSet }));
@@ -288,27 +278,6 @@ describe(`useBaseSearch`, () => {
         getParams: { categories__isnull: true, max_results: 25, include_coach_content: false },
       });
     });
-    it('should ignore channels when descendant is set', () => {
-      const { search } = prep(
-        {
-          categories: `test1,test2`,
-          channels: 'test1',
-        },
-        ref({ tree_id: 1, lft: 10, rght: 20 }),
-      );
-      ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
-      search();
-      expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: {
-          categories: ['test1', 'test2'],
-          max_results: 25,
-          tree_id: 1,
-          lft__gt: 10,
-          rght__lt: 20,
-          include_coach_content: false,
-        },
-      });
-    });
     it('should set keywords when defined', () => {
       const { search } = prep({ keywords: `this is just a test` });
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
@@ -325,7 +294,6 @@ describe(`useBaseSearch`, () => {
       const { labels, more, results, search } = prep({ categories: 'test1,test2' });
       const expectedLabels = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       const expectedMore = {
@@ -385,7 +353,6 @@ describe(`useBaseSearch`, () => {
       });
       const expectedLabels = {
         available: ['labels'],
-        channels: [],
         languages: [],
       };
       const expectedMore = {
@@ -443,14 +410,14 @@ describe(`useBaseSearch`, () => {
     it('should not remove any other filters', () => {
       const { removeFilterTag, router } = prep({
         categories: 'test1,test2',
-        channels: 'channel1',
+        learning_activities: 'watch',
       });
       removeFilterTag({ value: 'test1', key: 'categories' });
       expect(router.push).toHaveBeenCalledWith({
         name,
         query: {
           categories: 'test2',
-          channels: 'channel1',
+          learning_activities: 'watch',
         },
       });
     });
@@ -459,7 +426,7 @@ describe(`useBaseSearch`, () => {
     it('should remove all filters from the searchTerms', () => {
       const { clearSearch, router } = prep({
         categories: 'test1,test2',
-        channels: 'channel1',
+        learning_activities: 'watch',
         keywords: 'this',
       });
       clearSearch();

--- a/packages/kolibri-common/composables/useBaseSearch.js
+++ b/packages/kolibri-common/composables/useBaseSearch.js
@@ -147,7 +147,6 @@ export const searchKeys = [
   'learning_activities',
   'categories',
   'learner_needs',
-  'channels',
   'accessibility_labels',
   'languages',
   'grade_levels',
@@ -226,7 +225,6 @@ export default function useBaseSearch({
     if (searchableLabels) {
       set(labels, {
         ...searchableLabels,
-        channels: searchableLabels.channels ? searchableLabels.channels.map(c => c.id) : [],
         languages: searchableLabels.languages ? searchableLabels.languages.map(l => l.id) : [],
       });
     }
@@ -374,7 +372,6 @@ export default function useBaseSearch({
           gradeLevelsList: _generateGradeLevelsList(labels.grade_levels || []),
           accessibilityOptionsList: _generateAccessibilityOptionsList(labels.accessibility_labels),
           languagesList: labels.languages || [],
-          channelsList: labels.channels || [],
         });
       })
       .catch(err => logging.error('Failed to fetch search labels from remote', err))
@@ -414,9 +411,6 @@ export default function useBaseSearch({
   const languagesList = computed(() => {
     return _getGlobalLabels('languagesList', []);
   });
-  const channelsList = computed(() => {
-    return _getGlobalLabels('channelsList', []);
-  });
 
   provide('availableLearningActivities', learningActivitiesShown);
   provide('availableLibraryCategories', libraryCategories);
@@ -424,7 +418,6 @@ export default function useBaseSearch({
   provide('availableGradeLevels', gradeLevelsList);
   provide('availableAccessibilityOptions', accessibilityOptionsList);
   provide('availableLanguages', languagesList);
-  provide('availableChannels', channelsList);
 
   // Provide an object of searchable labels
   // This is a manifest of all the labels that could still be selected and produce search results
@@ -461,7 +454,6 @@ export function injectBaseSearch() {
   const availableGradeLevels = inject('availableGradeLevels');
   const availableAccessibilityOptions = inject('availableAccessibilityOptions');
   const availableLanguages = inject('availableLanguages');
-  const availableChannels = inject('availableChannels');
   const searchableLabels = inject('searchableLabels');
   const activeSearchTerms = inject('activeSearchTerms');
   return {
@@ -471,7 +463,6 @@ export function injectBaseSearch() {
     availableGradeLevels,
     availableAccessibilityOptions,
     availableLanguages,
-    availableChannels,
     searchableLabels,
     activeSearchTerms,
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request supports the removal of the 'channels' label from `SearchFiltersPanel` and the corresponding label processing for the 'channels' option used in the `useBaseSearch` composable, in addition to updating the relevant tests.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #12841 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
--> 
Confirm that `useBaseSearch` no longer exposes `availableChannels` and doesn't handle anything related to the 'channels' label. `useBaseSearch` should still filter search results based on the channel the user is currently in.
