### PR TITLE
Update content request handling to only use reserved locations representing Studio

### DIFF
--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -34,6 +34,7 @@ from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.errors import NetworkError
+from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 
 
 _module = "kolibri.core.content.utils.content_request."
@@ -589,10 +590,19 @@ class PreferredDevicesTestCase(BaseTestCase):
         instance = PreferredDevices([netloc.instance_id])
         self.assertEqual(len(list(instance)), 0)
 
-    def test_one_peer__reserved__connection_status(self):
+    def test_no_peer__reserved__connection_status(self):
         netloc = self._create_network_location(
             location_type="reserved",
             connection_status=ConnectionStatus.ConnectionFailure,
+        )
+        instance = PreferredDevices([netloc.instance_id])
+        self.assertEqual(len(list(instance)), 0)
+
+    def test__peer__studio__reserved__connection_status(self):
+        netloc = self._create_network_location(
+            location_type="reserved",
+            connection_status=ConnectionStatus.ConnectionFailure,
+            instance_id=CENTRAL_CONTENT_BASE_INSTANCE_ID,
         )
         instance = PreferredDevices([netloc.instance_id])
         peers = list(instance)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -44,6 +44,7 @@ from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.connections import capture_connection_state
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
+from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.data import bytes_for_humans
@@ -267,8 +268,11 @@ class PreferredDevices(object):
                 )
             )
             return None
-        # ensure peer is available, unless reserved
-        if not peer.reserved and peer.connection_status != ConnectionStatus.Okay:
+        # ensure peer is available, unless it's Studio
+        if (
+            not instance_id == CENTRAL_CONTENT_BASE_INSTANCE_ID
+            and peer.connection_status != ConnectionStatus.Okay
+        ):
             logger.debug("Peer {} is not available".format(instance_id))
             return None
         # ensure version is applicable according to filter


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request addresses the content request peer device validation issue that allowed attempts to download content from KDP, which is now a reserved network location. 

The original code allowed KDP to bypass the connection status check due to its reserved status. The updated condition ensures that only the Studio network location (with the specific instance_id) bypasses the connection status check.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #12876 

