### PR TITLE
Use notify_team_new_comment workflow action from .github repo

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   contributor_issue_comment:
-    uses: rparadowski/.github/.github/workflows/notify_team_new_comment.yml@12567_issue
+    uses: learningequality/.github/.github/workflows/notify_team_new_comment.yml@main
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -6,30 +6,4 @@ on:
 
 jobs:
   contributor_issue_comment:
-    name: Contributor issue comment
-
-    if: >-
-      ${{
-        !github.event.issue.pull_request &&
-        github.event.comment.author_association != 'MEMBER' &&
-        github.event.comment.author_association != 'OWNER'
-      }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Escape title double quotes
-        id: escape_title
-        env:
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: echo "ISSUE_TITLE=${ISSUE_TITLE//\"/\\\"}" >> "$GITHUB_OUTPUT"
-
-      - name: Send message to Slack channel
-        env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
-            }
+    uses: rparadowski/.github/.github/workflows/notify_team_new_comment.yml@12567_issue

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   contributor_issue_comment:
     uses: rparadowski/.github/.github/workflows/notify_team_new_comment.yml@12567_issue
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
With https://github.com/learningequality/.github/pull/11
reusable action is added to .github repo. This PR makes use of it.

## References
Issue: https://github.com/learningequality/kolibri/issues/12567


## Reviewer guidance
Create Pull request similar to https://github.com/learningequality/test-actions/pull/53
Create issue and link it to PR
Change default repo branch to the branch you are changing in PR from (1.) due to https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment
Post comment in issue.
