### PR TITLE
Update repository information for all npm packages that will be published.

### DIFF
--- a/packages/browserslist-config-kolibri/package.json
+++ b/packages/browserslist-config-kolibri/package.json
@@ -3,7 +3,11 @@
   "version": "0.16.1-dev.1",
   "description": "Browsers list configuration for Kolibri",
   "main": "index.js",
-  "repository": "github.com/learningequality/kolibri",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/browserslist-config-kolibri"
+  },
   "author": "Learning Equality",
   "license": "MIT",
   "private": false

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -4,6 +4,11 @@
   "description": "Custom linting rules for kolibri",
   "author": "Learning Equality",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/eslint-plugin-kolibri"
+  },
   "dependencies": {
     "requireindex": "^1.1.0"
   },

--- a/packages/kolibri-app/package.json
+++ b/packages/kolibri-app/package.json
@@ -4,6 +4,11 @@
   "description": "The Kolibri app",
   "main": "src/index.js",
   "author": "Learning Equality",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-app"
+  },
   "license": "MIT",
   "dependencies": {
     "vuex-router-sync": "^5.0.0"

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -2,7 +2,11 @@
   "name": "kolibri-format",
   "version": "1.0.0",
   "description": "A module for formatting frontend code to Kolibri standards",
-  "repository": "github.com/learningequality/kolibri",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-format"
+  },
   "author": "Learning Equality",
   "license": "MIT",
   "private": false,

--- a/packages/kolibri-logging/package.json
+++ b/packages/kolibri-logging/package.json
@@ -4,6 +4,11 @@
   "description": "The Kolibri logging module",
   "main": "src/index.js",
   "author": "Learning Equality",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-logging"
+  },
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/kolibri-module/package.json
+++ b/packages/kolibri-module/package.json
@@ -4,5 +4,10 @@
   "description": "The Kolibri module",
   "main": "src/index.js",
   "author": "Learning Equality",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-module"
+  },
   "license": "MIT"
 }

--- a/packages/kolibri-plugin-data/package.json
+++ b/packages/kolibri-plugin-data/package.json
@@ -4,5 +4,10 @@
   "description": "The Kolibri plugin data module",
   "main": "src/index.js",
   "author": "Learning Equality",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-plugin-data"
+  },
   "license": "MIT"
 }

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -3,7 +3,11 @@
   "version": "0.16.1-dev.1",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
-  "repository": "github.com/learningequality/kolibri",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-tools"
+  },
   "author": "Learning Equality",
   "license": "MIT",
   "private": false,

--- a/packages/kolibri-viewer/package.json
+++ b/packages/kolibri-viewer/package.json
@@ -4,5 +4,10 @@
   "description": "The Kolibri viewer",
   "main": "src/index.js",
   "author": "Learning Equality",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri-viewer"
+  },
   "license": "MIT"
 }

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -2,7 +2,11 @@
   "name": "kolibri",
   "version": "0.18.0",
   "description": "The Kolibri core API",
-  "repository": "github.com/learningequality/kolibri",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learningequality/kolibri.git",
+    "directory": "packages/kolibri"
+  },
   "author": "Learning Equality",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
* Adds or updates "repository" key on all package.json manifests for every package that we currently plan to publish
* Adds the suggested "directory" key for monorepos

## References
This is a prerequisite for adding provenance to published npm packages: https://docs.npmjs.com/generating-provenance-statements#prerequisites

## Reviewer guidance
Are all the repository values correct? Are all the directory values correct for the package they're in?
