### PR TITLE
Create github action for automatically cleaning up test pypi.

### DIFF
--- a/.github/workflows/cleanup_test_pypi.yml
+++ b/.github/workflows/cleanup_test_pypi.yml
@@ -1,0 +1,25 @@
+name: Cleanup TestPyPi
+
+on:
+  workflow_call:
+    secrets:
+      TESTPYPI_API_TOKEN:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pypi-cleanup
+    - name: Cleanup TestPyPi
+      env:
+        PYPI_CLEANUP_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
+      run: pypi-cleanup --host https://test.pypi.org --package kolibri --leave-most-recent-only --username __token__

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -134,9 +134,15 @@ jobs:
     with:
       filename: ${{ needs.apk.outputs.apk-file-name }}
       release_id: ${{ github.event.release.id }}
+  test_pypi_cleanup:
+    name: Cleanup TestPyPi
+    needs: whl
+    uses: ./.github/workflows/cleanup_test_pypi.yml
+    secrets:
+      TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
   test_pypi_upload:
     name: Upload to TestPyPi
-    needs: whl
+    needs: [whl, test_pypi_cleanup]
     uses: ./.github/workflows/pypi_upload.yml
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}


### PR DESCRIPTION
## Summary
* Creates github action that uses the [cleanup-pypi package](https://pypi.org/project/pypi-cleanup/) to automatically cleanup all but the last release from test pypi
* Allows it to be run manually and as a reusable workflow
* Run it before uploading to test pypi in kolibri release workflow.

## Reviewer guidance

Cross reference closely with the documentation, run the command locally with the `--query-only` flag to ensure that it is only getting a listing of packages from test-pypi and _not_ from real pypi.