### PR TITLE
[DO NOT MERGE] Test latest KTable updates for regressions

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -144,24 +144,28 @@
             dataType: 'string',
             minWidth: '150px',
             width: '20%',
+            columnId: 'class',
           },
           {
             label: this.coreString('coachesLabel'),
             dataType: 'undefined',
             minWidth: '150px',
             width: '30%',
+            columnId: 'coaches',
           },
           {
             label: this.coreString('learnersLabel'),
             dataType: 'number',
             minWidth: '150px',
             width: '20%',
+            columnId: 'learners',
           },
           {
             label: this.coreString('userActionsColumnHeader'),
             dataType: 'undefined',
             minWidth: '150px',
             width: '30%',
+            columnId: 'actions',
           },
         ];
       },

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -68,7 +68,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "kolibri-constants": "0.2.8",
-    "kolibri-design-system": "5.0.0-rc10",
+    "kolibri-design-system": "https://github.com/shivam-daksh/kolibri-design-system#15d86e5a69492ac5c74b61be10b048e2443fbead",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "path-to-regexp": "1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7770,10 +7770,9 @@ kolibri-constants@0.2.8:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.8.tgz#34ad2e2b87cf132ebe8dbaa9b64dc4a7bf261f8d"
   integrity sha512-ycXeK+ePw7zkiNtf+nX/yF5BO52+onoYS2V3d9HZDIvx7X6CDJPtMcypkXrK9aZ0JbWAegRFMD/lAd8q21cf4Q==
 
-kolibri-design-system@5.0.0-rc10:
+"kolibri-design-system@https://github.com/shivam-daksh/kolibri-design-system#15d86e5a69492ac5c74b61be10b048e2443fbead":
   version "5.0.0-rc10"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc10.tgz#8c92a1b097878a2a8e2f67cda76771914f77b7b8"
-  integrity sha512-Dkk5D5PunIm+qPsIMmgo06rjA0BkPZOOpeABuPgZmtpXcFwhpAP07VrLs0LhvFBdSFri3aJDXj/kj7HskXLhWg==
+  resolved "https://github.com/shivam-daksh/kolibri-design-system#15d86e5a69492ac5c74b61be10b048e2443fbead"
   dependencies:
     "@vue/composition-api" "1.7.2"
     aphrodite "https://github.com/learningequality/aphrodite/"


### PR DESCRIPTION
There were larger internal refactors of `KTable` https://github.com/learningequality/kolibri-design-system/pull/804. Changes are not user-facing, however touch areas related to a11y.

@radinamatic would you please do full keyboard, screenreader and general a11 QA here for regressions?

Side note for reference, this also includes new features introduced in https://github.com/learningequality/kolibri-design-system/pull/824, however those do not touch areas currently used in Kolibri.