### PR TITLE
Using the new ariaLabelledBy prop in KSwitch

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -28,7 +28,7 @@
           <h3 id="toggle-lesson-visibility-label">Toggle lesson visibility</h3>
           <KSwitch
             name="toggle-lesson-visibility"
-            :aria-labelledby="'toggle-lesson-visibility-label'"
+            :ariaLabelledBy="'toggle-lesson-visibility-label'"
             label=""
             :checked="lesson.active"
             :value="lesson.active"

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -12,6 +12,7 @@
         }"
       >
         <KGridItem
+        id="toggle-lesson-visibility-label"
           class="status-label"
           :style="{ marginBottom: 0 }"
           :layout4="{ span: 3 }"
@@ -25,7 +26,6 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
-          <h3 id="toggle-lesson-visibility-label">Toggle lesson visibility</h3>
           <KSwitch
             name="toggle-lesson-visibility"
             :ariaLabelledBy="'toggle-lesson-visibility-label'"

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -12,7 +12,7 @@
         }"
       >
         <KGridItem
-        id="toggle-lesson-visibility-label"
+          id="toggle-lesson-visibility-label"
           class="status-label"
           :style="{ marginBottom: 0 }"
           :layout4="{ span: 3 }"

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -29,7 +29,6 @@
           <KSwitch
             name="toggle-lesson-visibility"
             :ariaLabelledBy="'toggle-lesson-visibility-label'"
-            label=""
             :checked="lesson.active"
             :value="lesson.active"
             @change="toggleModal(lesson)"

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -25,7 +25,7 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
-          <span id="toggle-lesson-visibility-label">Toggle lesson visibility</span>
+          <h3 id="toggle-lesson-visibility-label">Toggle lesson visibility</h3>
           <KSwitch
             name="toggle-lesson-visibility"
             :aria-labelledby="'toggle-lesson-visibility-label'"

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -25,8 +25,10 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
+          <span id="toggle-lesson-visibility-label">Toggle lesson visibility</span>
           <KSwitch
             name="toggle-lesson-visibility"
+            :aria-labelledby="'toggle-lesson-visibility-label'"
             label=""
             :checked="lesson.active"
             :value="lesson.active"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -87,7 +87,7 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 10 }"
         >
-          <span> {{ $tr('reportVisibleToLearnersLabel') }} </span>
+          <span id="toggle-quiz-visibility-label"> {{ $tr('reportVisibleToLearnersLabel') }} </span>
           <StatusElapsedTime
             v-if="exam.active"
             :date="examDateOpened"
@@ -100,7 +100,6 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
-          <h3 id="toggle-quiz-visibility-label">Toggle quiz visibility</h3>
           <KSwitch
             name="toggle-quiz-visibility"
             :ariaLabelledBy="'toggle-quiz-visibility-label'"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -103,7 +103,7 @@
           <h3 id="toggle-quiz-visibility-label">Toggle quiz visibility</h3>
           <KSwitch
             name="toggle-quiz-visibility"
-            :aria-labelledby="'toggle-quiz-visibility'"
+            :ariaLabelledBy="'toggle-quiz-visibility-label'"
             label=""
             style="display: inline"
             :checked="exam.active"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -104,7 +104,6 @@
           <KSwitch
             name="toggle-quiz-visibility"
             :ariaLabelledBy="'toggle-quiz-visibility-label'"
-            label=""
             style="display: inline"
             :checked="exam.active"
             :value="exam.active"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -100,7 +100,7 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
-          <span id="toggle-quiz-visibility-label">Toggle quiz visibility</span>
+          <h3 id="toggle-quiz-visibility-label">Toggle quiz visibility</h3>
           <KSwitch
             name="toggle-quiz-visibility"
             :aria-labelledby="'toggle-quiz-visibility'"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -100,8 +100,10 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 2 }"
         >
+          <span id="toggle-quiz-visibility-label">Toggle quiz visibility</span>
           <KSwitch
             name="toggle-quiz-visibility"
+            :aria-labelledby="'toggle-quiz-visibility'"
             label=""
             style="display: inline"
             :checked="exam.active"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -96,9 +96,9 @@
                         :style="{ display: 'inline-block', marginLeft: '6px' }"
                         :size="26"
                       />
-                      <span :id="`toggle-lesson-visibility-label-${lesson.id}`">
+                      <h3 :id="`toggle-lesson-visibility-label-${lesson.id}`">
                         Toggle visibility for lesson {{ lesson.name }}
-                      </span>
+                      </h3>
                       <KSwitch
                         v-else:
                         key="`switch-${lesson.id}`"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -47,7 +47,7 @@
             <th>{{ coreString('progressLabel') }}</th>
             <th>{{ $tr('size') }}</th>
             <th>{{ coachString('recipientsLabel') }}</th>
-            <th id="`toggle-lesson-visibility-label-${lesson.id}`">{{ coachString('lessonVisibleLabel') }}</th>
+            <th :id="`toggle-lesson-visibility-label-${lesson.id}`">{{ coachString('lessonVisibleLabel') }}</th>
           </template>
           <template #tbody>
             <transition-group
@@ -97,8 +97,8 @@
                         :size="26"
                       />
                       <KSwitch
-                        v-else:
-                        key="`switch-${lesson.id}`"
+                        v-else
+                        :key="`switch-${lesson.id}`"
                         name="toggle-lesson-visibility"
                         :ariaLabelledBy="`toggle-lesson-visibility-label-${lesson.id}`"
                         :checked="lesson.active"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -104,7 +104,6 @@
                         key="`switch-${lesson.id}`"
                         name="toggle-lesson-visibility"
                         :ariaLabelledBy="`toggle-lesson-visibility-label-${lesson.id}`"
-                        label=""
                         :checked="lesson.active"
                         :value="lesson.active"
                         @change="toggleModal(lesson)"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -47,7 +47,7 @@
             <th>{{ coreString('progressLabel') }}</th>
             <th>{{ $tr('size') }}</th>
             <th>{{ coachString('recipientsLabel') }}</th>
-            <th>{{ coachString('lessonVisibleLabel') }}</th>
+            <th id="`toggle-lesson-visibility-label-${lesson.id}`">{{ coachString('lessonVisibleLabel') }}</th>
           </template>
           <template #tbody>
             <transition-group
@@ -96,9 +96,6 @@
                         :style="{ display: 'inline-block', marginLeft: '6px' }"
                         :size="26"
                       />
-                      <h3 :id="`toggle-lesson-visibility-label-${lesson.id}`">
-                        Toggle visibility for lesson {{ lesson.name }}
-                      </h3>
                       <KSwitch
                         v-else:
                         key="`switch-${lesson.id}`"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -47,7 +47,7 @@
             <th>{{ coreString('progressLabel') }}</th>
             <th>{{ $tr('size') }}</th>
             <th>{{ coachString('recipientsLabel') }}</th>
-            <th :id="`toggle-lesson-visibility-label-${lesson.id}`">{{ coachString('lessonVisibleLabel') }}</th>
+            <th>{{ coachString('lessonVisibleLabel') }}</th>
           </template>
           <template #tbody>
             <transition-group
@@ -100,7 +100,6 @@
                         v-else
                         :key="`switch-${lesson.id}`"
                         name="toggle-lesson-visibility"
-                        :ariaLabelledBy="`toggle-lesson-visibility-label-${lesson.id}`"
                         :checked="lesson.active"
                         :value="lesson.active"
                         @change="toggleModal(lesson)"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -96,10 +96,14 @@
                         :style="{ display: 'inline-block', marginLeft: '6px' }"
                         :size="26"
                       />
+                      <span :id="`toggle-lesson-visibility-label-${lesson.id}`">
+                        Toggle visibility for lesson {{ lesson.name }}
+                      </span>
                       <KSwitch
-                        v-else
-                        :key="`switch-${lesson.id}`"
+                        v-else:
+                        key="`switch-${lesson.id}`"
                         name="toggle-lesson-visibility"
+                        :ariaLabelledBy="`toggle-lesson-visibility-label-${lesson.id}`"
                         label=""
                         :checked="lesson.active"
                         :value="lesson.active"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
1)There are many uses of Kswitch in kolibri's codebase. https://github.com/learningequality/kolibri-design-system/issues/806 
introduced a new feature named arialLabelledBy in KDS , using that feature , some of the Kswitchs' doesnt have a label set.

2) We should use the new ariaLabelledBy prop in KSwitch to point to the element that has the label corresponding to the switch component.

3)All KSwitch components should have a label, either set by the ariaLabelledBy or by the label prop

## References
https://github.com/learningequality/kolibri/issues/12743

Issue/https://github.com/learningequality/kolibri-design-system/issues/806
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility Improvements**
  - Enhanced screen reader support for lesson and quiz visibility toggle switches by explicitly associating each switch with its visible label.
  - Improved accessibility on lesson visibility controls in lesson lists by linking switches to their corresponding column headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->