### PR TITLE
Fix broken CSV export features in COACH tabs

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -13,6 +13,7 @@
         :to="classLearnersListRoute"
       />
       <KIconButton
+        v-if="!disablePrint"
         ref="printButton"
         icon="print"
         :aria-label="coachString('printReportAction')"
@@ -65,6 +66,10 @@
     },
     props: {
       disableExport: {
+        type: Boolean,
+        default: false,
+      },
+      disablePrint: {
         type: Boolean,
         default: false,
       },

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
@@ -232,7 +232,7 @@
       printLabel: {
         message: '{className} Learners',
         context:
-          "Title that displays on a printed copy of the 'Coach' > 'Quizzes' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
+          "Title that displays on a printed copy of the 'Learners' > 'Learner' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
@@ -8,7 +8,7 @@
           :text="$tr('back')"
         />
       </p>
-      <ReportsControls @export="exportCSV" />
+      <ReportsControls :disableExport="true" />
     </div>
     <h1>
       <KLabeledIcon
@@ -114,8 +114,6 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
   import ReportsControls from '../../common/ReportsControls';
-  import CSVExporter from '../../../csv/exporter';
-  import * as csvFields from '../../../csv/fields';
 
   export default {
     name: 'LearnerHeader',
@@ -176,52 +174,6 @@
         };
       },
     },
-    methods: {
-      exportCSV() {
-        let filteredExams = this.exams.filter(exam =>
-          this.getLearnersForExam(exam).includes(this.learner.id),
-        );
-
-        let filteredLessons = this.lessons.filter(lesson =>
-          this.getLearnersForLesson(lesson).includes(this.learner.id),
-        );
-
-        filteredLessons = filteredLessons.map(lesson => {
-          lesson.status = this.getLessonStatusStringForLearner(lesson.id, this.learner.id);
-          return lesson;
-        });
-
-        filteredExams = filteredExams.map(exam => {
-          exam.statusObj = this.getExamStatusObjForLearner(exam.id, this.learner.id);
-          return exam;
-        });
-
-        const LessonColumn = [...csvFields.title(), ...csvFields.learnerProgress()];
-
-        const ExamColumn = [
-          ...csvFields.title(),
-          ...csvFields.learnerProgress('statusObj.status'),
-          ...csvFields.score(),
-        ];
-
-        const LessonfileName = this.$tr('printLabel', { className: this.className });
-        const ExamfileName = this.$tr('printLabel', { className: this.className });
-
-        const LessonExporter = new CSVExporter(LessonColumn, LessonfileName);
-        LessonExporter.addNames({
-          learner: this.learner.name,
-          report: 'Lesson',
-        });
-        const ExamExporter = new CSVExporter(ExamColumn, ExamfileName);
-        ExamExporter.addNames({
-          learner: this.learner.name,
-          report: 'Quizzes',
-        });
-
-        LessonExporter.export(filteredLessons);
-        ExamExporter.export(filteredExams);
-      },
-    },
     $trs: {
       back: {
         message: 'All learners',
@@ -229,11 +181,6 @@
           "Link that takes user back to the list of learners on the 'Reports' tab, from the individual learner's information page.",
       },
       totalLessons: 'of {total}',
-      printLabel: {
-        message: '{className} Learners',
-        context:
-          "Title that displays on a printed copy of the 'Learners' > 'Learner' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
-      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
@@ -192,24 +192,34 @@
         });
 
         filteredExams = filteredExams.map(exam => {
-          exam.tally = this.getExamStatusObjForLearner(exam.id, this.learner.id);
+          exam.statusObj = this.getExamStatusObjForLearner(exam.id, this.learner.id);
           return exam;
         });
 
-        const columns = [
+        const LessonColumn = [...csvFields.title(), ...csvFields.learnerProgress()];
+
+        const ExamColumn = [
           ...csvFields.title(),
-          ...csvFields.learnerProgress(),
-          ...csvFields.avgScore(),
-          // ...csvFields.tally(),
+          ...csvFields.learnerProgress('statusObj.status'),
+          ...csvFields.score(),
         ];
 
-        const fileName = this.$tr('printLabel', { className: this.className });
-        const exporter = new CSVExporter(columns, fileName);
-        exporter.addNames({
-          LearnerTitle: 'Learner',
+        const LessonfileName = this.$tr('printLabel', { className: this.className });
+        const ExamfileName = this.$tr('printLabel', { className: this.className });
+
+        const LessonExporter = new CSVExporter(LessonColumn, LessonfileName);
+        LessonExporter.addNames({
           learner: this.learner.name,
+          report: 'Lesson',
         });
-        exporter.export([...filteredLessons, ...filteredExams]);
+        const ExamExporter = new CSVExporter(ExamColumn, ExamfileName);
+        ExamExporter.addNames({
+          learner: this.learner.name,
+          report: 'Quizzes',
+        });
+
+        LessonExporter.export(filteredLessons);
+        ExamExporter.export(filteredExams);
       },
     },
     $trs: {
@@ -220,7 +230,7 @@
       },
       totalLessons: 'of {total}',
       printLabel: {
-        message: '{className} Quizzes',
+        message: '{className} Learners',
         context:
           "Title that displays on a printed copy of the 'Coach' > 'Quizzes' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
       },

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -251,6 +251,8 @@
         }
         this.quizLimit += 10;
       },
+    },
+    $trs: {
       printLabel: {
         message: '{className} Learners',
         context:

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -11,7 +11,13 @@
         :layout4="{ span: 2 }"
       >
         <KPageContainer class="content-spacing">
-          <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
+          <div style="display: flex; justify-content: space-between">
+            <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
+            <ReportsControls
+              :disablePrint="true"
+              @export="exportCSVLessons"
+            />
+          </div>
           <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
             <template #headers>
               <th>{{ coachString('titleLabel') }}</th>
@@ -59,7 +65,13 @@
         :layout4="{ span: 2 }"
       >
         <KPageContainer class="content-spacing">
-          <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
+          <div style="display: flex; justify-content: space-between">
+            <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
+            <ReportsControls
+              :disablePrint="true"
+              @export="exportCSVQuizzes"
+            />
+          </div>
           <CoreTable :emptyMessage="coachString('quizListEmptyState')">
             <template #headers>
               <th>{{ coachString('titleLabel') }}</th>
@@ -112,6 +124,9 @@
   import commonCoach from '../../common';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import { PageNames } from '../../../constants';
+  import ReportsControls from '../../common/ReportsControls';
+  import CSVExporter from '../../../csv/exporter';
+  import * as csvFields from '../../../csv/fields';
   import LearnerHeader from './LearnerHeader';
 
   export default {
@@ -119,6 +134,7 @@
     components: {
       CoachAppBarPage,
       LearnerHeader,
+      ReportsControls,
     },
     mixins: [commonCoach, commonCoreStrings],
     data() {
@@ -176,6 +192,50 @@
       quizLink(quizId) {
         return this.classRoute(PageNames.REPORTS_LEARNER_REPORT_QUIZ_PAGE_ROOT, { quizId });
       },
+      exportCSVLessons() {
+        const filteredLessons = this.lessons
+          .filter(lesson => this.getLearnersForLesson(lesson).includes(this.learner.id))
+          .map(lesson => ({
+            ...lesson,
+            status: this.getLessonStatusStringForLearner(lesson.id, this.learner.id),
+          }));
+
+        const LessonColumn = [...csvFields.title(), ...csvFields.learnerProgress()];
+
+        const LessonfileName = this.$tr('printLabel', { className: this.className });
+
+        const LessonExporter = new CSVExporter(LessonColumn, LessonfileName);
+        LessonExporter.addNames({
+          learner: this.learner.name,
+          report: 'Lesson',
+        });
+
+        LessonExporter.export(filteredLessons);
+      },
+      exportCSVQuizzes() {
+        const filteredExams = this.exams
+          .filter(exam => this.getLearnersForExam(exam).includes(this.learner.id))
+          .map(exam => ({
+            ...exam,
+            statusObj: this.getExamStatusObjForLearner(exam.id, this.learner.id),
+          }));
+
+        const ExamColumn = [
+          ...csvFields.title(),
+          ...csvFields.learnerProgress('statusObj.status'),
+          ...csvFields.score(),
+        ];
+
+        const ExamfileName = this.$tr('printLabel', { className: this.className });
+
+        const ExamExporter = new CSVExporter(ExamColumn, ExamfileName);
+        ExamExporter.addNames({
+          learner: this.learner.name,
+          report: 'Quizzes',
+        });
+
+        ExamExporter.export(filteredExams);
+      },
       loadMoreLessonTable() {
         if (this.lessonLimit > 20) {
           this.lessonLimit = this.getLessons.length;
@@ -190,6 +250,11 @@
           return;
         }
         this.quizLimit += 10;
+      },
+      printLabel: {
+        message: '{className} Learners',
+        context:
+          "Title that displays on a printed copy of the 'Learners' > 'Learner' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnersRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnersRootPage.vue
@@ -67,7 +67,7 @@
   import sortBy from 'lodash/sortBy';
   import ElapsedTime from 'kolibri-common/components/ElapsedTime';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { ref } from '@vue/composition-api';
+  import { ref } from 'vue';
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import CSVExporter from '../../csv/exporter';

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnersRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnersRootPage.vue
@@ -7,9 +7,9 @@
       />
       <div class="filter">
         <KSelect
-          v-model="filterSelection"
+          v-model="recipientSelected"
           :label="coachString('recipientsLabel')"
-          :options="filterOptions"
+          :options="recipientsOptions"
           :inline="true"
         />
       </div>
@@ -67,6 +67,7 @@
   import sortBy from 'lodash/sortBy';
   import ElapsedTime from 'kolibri-common/components/ElapsedTime';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { ref } from '@vue/composition-api';
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import CSVExporter from '../../csv/exporter';
@@ -74,6 +75,7 @@
   import CoachHeader from '../common/CoachHeader';
   import ReportsControls from '../common/ReportsControls';
   import { PageNames } from '../../constants';
+  import { coachStrings } from '../common/commonCoachStrings';
 
   export default {
     name: 'LearnersRootPage',
@@ -84,22 +86,25 @@
       CoachHeader,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
+    setup() {
+      const { entireClassLabel$ } = coachStrings;
+
+      const recipientSelected = ref({
+        label: entireClassLabel$(),
+        value: entireClassLabel$(),
+      });
+
       return {
-        filterOptions: [
-          {
-            label: this.coreString('allLabel'),
-            value: this.coreString('allLabel'),
-          },
-        ],
-        filterSelection: { label: this.coreString('allLabel'), value: this.coreString('allLabel') },
+        entireClassLabel$,
+        recipientSelected,
         PageNames,
       };
     },
     computed: {
       table() {
         const sorted = sortBy(this.learners, ['name']);
-        return sorted.map(learner => {
+
+        let augmentedTable = sorted.map(learner => {
           const groupNames = this.getGroupNames(
             this._.map(
               this.groups.filter(group => group.member_ids.includes(learner.id)),
@@ -121,6 +126,37 @@
           Object.assign(augmentedObj, learner);
           return augmentedObj;
         });
+
+        const recipientsFilter = this.recipientSelected.value;
+
+        if (recipientsFilter !== this.entireClassLabel$()) {
+          augmentedTable = augmentedTable.filter(entry => {
+            return entry.groups.includes(recipientsFilter) || entry.id === recipientsFilter;
+          });
+        }
+
+        return augmentedTable;
+      },
+
+      recipientsOptions() {
+        const groupOptions = this.groups.map(group => ({
+          label: group.name,
+          value: group.name,
+        }));
+
+        const learnerOptions = this.learners.map(learner => ({
+          label: learner.name,
+          value: learner.id,
+        }));
+
+        return [
+          {
+            label: this.entireClassLabel$(),
+            value: this.entireClassLabel$(),
+          },
+          ...groupOptions,
+          ...learnerOptions,
+        ];
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -371,6 +371,7 @@
         'getExamStatusTally',
         'getLearnersForExam',
         'getRecipientNamesForExam',
+        'getGroupNames',
       ]),
       ...mapState('classSummary', { className: 'name' }),
       practiceQuizzesExist() {
@@ -446,13 +447,14 @@
               exam.groups.includes(recipientsFilter) || exam.learner_ids.includes(recipientsFilter),
           );
         }
-
         return selectedExams.map(quiz => {
           const learnersForQuiz = this.getLearnersForExam(quiz);
           quiz.tally = this.getExamStatusTally(quiz.id, learnersForQuiz);
           quiz.avgScore = this.getExamAvgScore(quiz.id, learnersForQuiz);
-          quiz.recipientNames = this.getRecipientNamesForExam(quiz);
           quiz.totalLearners = this.getLearnersForExam(quiz).length;
+          quiz.recipientNames = this.getRecipientNamesForExam(quiz);
+          quiz.hasAssignments = quiz.assignments.length > 0;
+          quiz.groupNames = this.getGroupNames(quiz.groups);
           return quiz;
         });
       },
@@ -526,9 +528,9 @@
       exportCSV() {
         const columns = [
           ...csvFields.title(),
+          ...csvFields.recipients(this.className),
           ...csvFields.avgScore(),
           ...csvFields.allLearners('totalLearners'),
-          ...csvFields.recipients(this.className),
           ...csvFields.tally(),
         ];
 

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -451,6 +451,7 @@
           const learnersForQuiz = this.getLearnersForExam(quiz);
           quiz.tally = this.getExamStatusTally(quiz.id, learnersForQuiz);
           quiz.avgScore = this.getExamAvgScore(quiz.id, learnersForQuiz);
+          quiz.recipientNames = this.getRecipientNamesForExam(quiz);
           return quiz;
         });
       },
@@ -524,9 +525,12 @@
       exportCSV() {
         const columns = [
           ...csvFields.title(),
+          ...csvFields.avgScore(),
+          ...csvFields.allLearners(),
           ...csvFields.recipients(this.className),
           ...csvFields.tally(),
         ];
+
         const fileName = this.$tr('printLabel', { className: this.className });
         new CSVExporter(columns, fileName).export(this.filteredExams);
       },
@@ -591,9 +595,9 @@
           'Descriptive text at the top of the table that displays the calculated file size of all quiz resources (i.e. 120 MB)',
       },
       printLabel: {
-        message: '{className} Lessons',
+        message: '{className} Quizzes',
         context:
-          "Title that displays on a printed copy of the 'Reports' > 'Lessons' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
+          "Title that displays on a printed copy of the 'Coach' > 'Quizzes' page. This shows if the user uses the 'Print' option by clicking on the printer icon.",
       },
       adminLink: {
         message: 'Import channels to your device',

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -452,6 +452,7 @@
           quiz.tally = this.getExamStatusTally(quiz.id, learnersForQuiz);
           quiz.avgScore = this.getExamAvgScore(quiz.id, learnersForQuiz);
           quiz.recipientNames = this.getRecipientNamesForExam(quiz);
+          quiz.totalLearners = this.getLearnersForExam(quiz).length;
           return quiz;
         });
       },
@@ -526,7 +527,7 @@
         const columns = [
           ...csvFields.title(),
           ...csvFields.avgScore(),
-          ...csvFields.allLearners(),
+          ...csvFields.allLearners('totalLearners'),
           ...csvFields.recipients(this.className),
           ...csvFields.tally(),
         ];


### PR DESCRIPTION
## Summary
- Fixes broken csv export feature in COACH -> Learners -> Learner. 
- Fix broken csv export in COACH -> Quizzes.
       - fix recipients column not working.
       - additional columns "Average Score" and "All Learners".
- Fix broken recipients filter in Coach -> Learners tab.

## References
closes #12734 #12714

## Reviewer guidance
- Test the export csv feature by navigating to COACH -> LEARNERS -> Learner.
                    - check that two different csv files are being downloaded, one for lessons and other for quizzes.
                    - check the content of the files to ensure csv is populating the correct data.
- Test the filter by recipients is working as expected in COACH -> LEARNERS tab.
- Test the export csv feature by navigating to COACH -> QUIZZES tab. 
                    - check if the recipients column is working as expected now.
                    - check if the newly added columns All learners and Average Score is working as expected