### PR TITLE
Standardizing Validator Functions for Object props

### DIFF
--- a/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
@@ -60,9 +60,20 @@
       device: {
         type: Object,
         required: true,
-        validator(val) {
-          return val.name && val.id && val.baseurl;
-        },
+        validator: objectValidator({
+          name: {
+            type: String,
+            required: true,
+          },
+          id: {
+            type: String,
+            required: true,
+          },
+          baseurl: {
+            type: String,
+            required: true,
+          },
+        }),
       },
       facility: {
         type: Object,

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -93,12 +93,16 @@
       notification: {
         type: Object,
         required: true,
-        validator(notification) {
-          return (
-            Object.values(NotificationEvents).includes(notification.event) &&
-            Object.values(NotificationObjects).includes(notification.object)
-          );
-        },
+        validator: objectValidator({
+          event: {
+            required: true,
+            validator: value => Object.values(NotificationEvents).includes(value),
+          },
+          object: {
+            required: true,
+            validator: value => Object.values(NotificationObjects).includes(value),
+          },
+        }),
       },
       lastQuery: {
         type: Object,

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -42,9 +42,18 @@
       group: {
         type: Object,
         required: true,
-        validator(group) {
-          return group.name && group.users;
-        },
+        validator: objectValidator({
+          name: {
+            type: String,
+            required: true,
+            validator: value => value !== null && value !== '',
+          },
+          users: {
+            type: Array,
+            required: true,
+            validator: value => Array.isArray(value) && value.length > 0,
+          },
+        }),
       },
     },
     computed: {

--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -83,10 +83,24 @@
       value: {
         type: Object,
         required: true,
-        validator(value) {
-          const inputKeys = ['channels', 'accessibility_labels', 'languages', 'grade_levels'];
-          return inputKeys.every(k => Object.prototype.hasOwnProperty.call(value, k));
-        },
+        validator: objectValidator({
+          channels: {
+            type: Array,
+            required: true,
+          },
+          accessibility_labels: {
+            type: Array,
+            required: true,
+          },
+          languages: {
+            type: Array,
+            required: true,
+          },
+          grade_levels: {
+            type: Array,
+            required: true,
+          },
+        }),
       },
       showChannels: {
         type: Boolean,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
This pull request focuses on standardizing the validation logic for Object-type props across several components in the Kolibri project by replacing ad-hoc validators with a reusable objectValidator utility. This improves consistency, documentation, and error reporting for these props.

…

## References
Related Issue: #8903 

…

## Reviewer guidance
Check each affected component (FacilityAdminCredentialsForm.vue, NotificationCard.vue, GroupRow.vue, and SelectGroup.vue) to ensure they correctly reject invalid Object props and accept valid ones.

…
