### PR TITLE
Fixes filters not displayed  on the  imported exercises from QA channel

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -21,95 +21,95 @@
       v-if="windowIsLarge || !currentCategory"
       :class="windowIsLarge ? '' : 'drawer-panel'"
     >
-        <div v-if="!accordion">
-          <!-- search by keyword -->
-          <h2 class="title">
-            {{ $tr('keywords') }}
+      <div v-if="!accordion">
+        <!-- search by keyword -->
+        <h2 class="title">
+          {{ $tr('keywords') }}
+        </h2>
+        <SearchBox
+          key="channel-search"
+          ref="searchBox"
+          :placeholder="coreString('findSomethingToLearn')"
+          :value="value.keywords || ''"
+          @change="val => $emit('input', { ...value, keywords: val })"
+        />
+        <div v-if="Object.keys(availableLibraryCategories).length">
+          <h2 class="section title">
+            {{ $tr('categories') }}
           </h2>
-          <SearchBox
-            key="channel-search"
-            ref="searchBox"
-            :placeholder="coreString('findSomethingToLearn')"
-            :value="value.keywords || ''"
-            @change="val => $emit('input', { ...value, keywords: val })"
-          />
-          <div v-if="Object.keys(availableLibraryCategories).length">
-            <h2 class="section title">
-              {{ $tr('categories') }}
-            </h2>
-            <!-- list of category metadata - clicking prompts a filter modal -->
-            <div
-              v-for="(category, key) in availableLibraryCategories"
-              :key="key"
-              span="4"
-              class="category-list-item"
-            >
-              <KButton
-                :text="coreString(category.value)"
-                appearance="flat-button"
-                :appearanceOverrides="
-                  isCategoryActive(category.value)
-                    ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
-                    : categoryListItemStyles
-                "
-                :disabled="
-                  availableRootCategories &&
-                    !availableRootCategories[category.value] &&
-                    !isCategoryActive(category.value)
-                "
-                :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
-                @click="handleCategory(key)"
-              />
-            </div>
-            <div
-              span="4"
-              class="category-list-item"
-            >
-              <KButton
-                :text="coreString('uncategorized')"
-                appearance="flat-button"
-                :appearanceOverrides="
-                  isCategoryActive('no_categories')
-                    ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
-                    : categoryListItemStyles
-                "
-                @click="noCategories"
-              />
-            </div>
-        </div>
-          <ActivityButtonsGroup
-            v-if="showActivities"
-            class="section"
-            @input="handleActivity"
-          />
-          <!-- Filter results by learning activity, displaying all options -->
-          <SelectGroup
-            v-model="inputValue"
-            :showChannels="showChannels"
-            class="section"
-          />
+          <!-- list of category metadata - clicking prompts a filter modal -->
           <div
-            v-if="Object.keys(availableResourcesNeeded).length"
-            class="section"
+            v-for="(category, key) in availableLibraryCategories"
+            :key="key"
+            span="4"
+            class="category-list-item"
           >
-            <h2 class="title">
-              {{ coreString('showResources') }}
-            </h2>
-            <div
-              v-for="(val, activity) in availableResourcesNeeded"
-              :key="activity"
-              span="4"
-              alignment="center"
-            >
-              <KCheckbox
-                :checked="value.learner_needs[val]"
-                :label="coreString(activity)"
-                :disabled="availableNeeds && !availableNeeds[val]"
-                @change="handleNeed(val)"
-              />
-            </div>
+            <KButton
+              :text="coreString(category.value)"
+              appearance="flat-button"
+              :appearanceOverrides="
+                isCategoryActive(category.value)
+                  ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
+                  : categoryListItemStyles
+              "
+              :disabled="
+                availableRootCategories &&
+                  !availableRootCategories[category.value] &&
+                  !isCategoryActive(category.value)
+              "
+              :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
+              @click="handleCategory(key)"
+            />
           </div>
-       
+          <div
+            span="4"
+            class="category-list-item"
+          >
+            <KButton
+              :text="coreString('uncategorized')"
+              appearance="flat-button"
+              :appearanceOverrides="
+                isCategoryActive('no_categories')
+                  ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
+                  : categoryListItemStyles
+              "
+              @click="noCategories"
+            />
+          </div>
+        </div>
+        <ActivityButtonsGroup
+          v-if="showActivities"
+          class="section"
+          @input="handleActivity"
+        />
+        <!-- Filter results by learning activity, displaying all options -->
+        <SelectGroup
+          v-model="inputValue"
+          :showChannels="showChannels"
+          class="section"
+        />
+        <div
+          v-if="Object.keys(availableResourcesNeeded).length"
+          class="section"
+        >
+          <h2 class="title">
+            {{ coreString('showResources') }}
+          </h2>
+          <div
+            v-for="(val, activity) in availableResourcesNeeded"
+            :key="activity"
+            span="4"
+            alignment="center"
+          >
+            <KCheckbox
+              :checked="value.learner_needs[val]"
+              :label="coreString(activity)"
+              :disabled="availableNeeds && !availableNeeds[val]"
+              @change="handleNeed(val)"
+            />
+          </div>
+        </div>
+
         <div v-if="accordion && !currentCategory">
           <!-- search by keyword -->
           <h2 class="title">

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -21,7 +21,6 @@
       v-if="windowIsLarge || !currentCategory"
       :class="windowIsLarge ? '' : 'drawer-panel'"
     >
-      <div v-if="Object.keys(availableLibraryCategories).length">
         <div v-if="!accordion">
           <!-- search by keyword -->
           <h2 class="title">
@@ -108,7 +107,7 @@
               />
             </div>
           </div>
-        </div>
+       
         <div v-if="accordion && !currentCategory">
           <!-- search by keyword -->
           <h2 class="title">

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -33,32 +33,34 @@
             :value="value.keywords || ''"
             @change="val => $emit('input', { ...value, keywords: val })"
           />
-          <h2 class="section title">
-            {{ $tr('categories') }}
-          </h2>
-          <!-- list of category metadata - clicking prompts a filter modal -->
-          <div
-            v-for="(category, key) in availableLibraryCategories"
-            :key="key"
-            span="4"
-            class="category-list-item"
-          >
-            <KButton
-              :text="coreString(category.value)"
-              appearance="flat-button"
-              :appearanceOverrides="
-                isCategoryActive(category.value)
-                  ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
-                  : categoryListItemStyles
-              "
-              :disabled="
-                availableRootCategories &&
-                  !availableRootCategories[category.value] &&
-                  !isCategoryActive(category.value)
-              "
-              :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
-              @click="handleCategory(key)"
-            />
+          <div v-if="Object.keys(availableLibraryCategories).length">
+            <h2 class="section title">
+              {{ $tr('categories') }}
+            </h2>
+            <!-- list of category metadata - clicking prompts a filter modal -->
+            <div
+              v-for="(category, key) in availableLibraryCategories"
+              :key="key"
+              span="4"
+              class="category-list-item"
+            >
+              <KButton
+                :text="coreString(category.value)"
+                appearance="flat-button"
+                :appearanceOverrides="
+                  isCategoryActive(category.value)
+                    ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
+                    : categoryListItemStyles
+                "
+                :disabled="
+                  availableRootCategories &&
+                    !availableRootCategories[category.value] &&
+                    !isCategoryActive(category.value)
+                "
+                :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
+                @click="handleCategory(key)"
+              />
+            </div>
           </div>
           <div
             span="4"

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -61,22 +61,22 @@
                 @click="handleCategory(key)"
               />
             </div>
-          </div>
-          <div
-            span="4"
-            class="category-list-item"
-          >
-            <KButton
-              :text="coreString('uncategorized')"
-              appearance="flat-button"
-              :appearanceOverrides="
-                isCategoryActive('no_categories')
-                  ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
-                  : categoryListItemStyles
-              "
-              @click="noCategories"
-            />
-          </div>
+            <div
+              span="4"
+              class="category-list-item"
+            >
+              <KButton
+                :text="coreString('uncategorized')"
+                appearance="flat-button"
+                :appearanceOverrides="
+                  isCategoryActive('no_categories')
+                    ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
+                    : categoryListItemStyles
+                "
+                @click="noCategories"
+              />
+            </div>
+        </div>
           <ActivityButtonsGroup
             v-if="showActivities"
             class="section"


### PR DESCRIPTION

## Summary
This PR  fixes filters  not displaying if exercise  is imported 



### Before 

https://github.com/user-attachments/assets/deed4ec9-6a4c-46a7-b1ad-f3576aa55b2d

#### After 

https://github.com/user-attachments/assets/368958ff-0a51-4576-ba69-d8d3b053ca95





## References

closes #12890

## Reviewer guidance

Import  the exercises from the QA Channel (nakav-mafak) and go to the Library page then the filter panel. 

