### PR TITLE
AppBar: Use appBarText for text/icon colors

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -11,7 +11,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 17, 4)
+VERSION = (0, 17, 5)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"

--- a/kolibri/core/assets/src/styles/themeConfig.js
+++ b/kolibri/core/assets/src/styles/themeConfig.js
@@ -2,6 +2,8 @@ import Vue from 'vue';
 
 const themeConfig = Vue.observable({
   appBar: {
+    background: null,
+    textColor: null,
     topLogo: {
       src: null,
       alt: null,

--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -1,4 +1,5 @@
 import logger from 'kolibri.lib.logging';
+import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
 import isObject from 'lodash/isObject';
 
 const logging = logger.getLogger(__filename);
@@ -48,11 +49,11 @@ export default {
     spec: {
       background: {
         type: String,
-        default: null,
+        default: themeTokens.appBar,
       },
       textColor: {
         type: String,
-        default: null,
+        default: themeTokens.text,
       },
       topLogo: {
         type: Object,

--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -49,11 +49,11 @@ export default {
     spec: {
       background: {
         type: String,
-        default: themeTokens.appBar,
+        default: themeTokens().appBar,
       },
       textColor: {
         type: String,
-        default: themeTokens.text,
+        default: themeTokens().text,
       },
       topLogo: {
         type: Object,

--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -42,6 +42,25 @@ const _imageSpec = {
 };
 
 export default {
+  appBar: {
+    type: Object,
+    default: null,
+    spec: {
+      background: {
+        type: String,
+        default: null,
+      },
+      textColor: {
+        type: String,
+        default: null,
+      },
+      topLogo: {
+        type: Object,
+        default: null,
+        spec: _imageSpec,
+      },
+    },
+  },
   brandColors: {
     type: Object,
     default: null,

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -55,7 +55,6 @@
           <slot name="sub-nav">
             <Navbar
               v-if="links.length > 0"
-              :textColor="themeConfig.appBar.textColor"
               :navigationLinks="links"
             />
           </slot>

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -2,7 +2,7 @@
 
   <div
     v-show="!$isPrint"
-    :style="{ backgroundColor: $themeTokens.appBar }"
+    :style="{ backgroundColor: $themeConfig.appBar.background }"
   >
     <header>
       <SkipNavigationLink />
@@ -10,11 +10,11 @@
       <UiToolbar
         :removeNavIcon="showAppNavView"
         type="clear"
-        :textColor="$themeTokens.appBarText || $themeTokens.text"
+        :textColor="$themeConfig.appBar.textColor"
         class="app-bar"
         :style="{
           height: topBarHeight + 'px',
-          color: $themeTokens.appBarText || $themeTokens.text,
+          color: $themeConfig.appBar.textColor,
         }"
         :raised="false"
         :removeBrandDivider="true"
@@ -29,7 +29,7 @@
         >
           <KIconButton
             icon="menu"
-            :color="$themeTokens.appBarText || $themeTokens.text"
+            :color="$themeConfig.appBar.textColor"
             :ariaLabel="$tr('openNav')"
             @click="$emit('toggleSideNav')"
           />
@@ -52,7 +52,7 @@
           <slot name="sub-nav">
             <Navbar
               v-if="links.length > 0"
-              :textColor="$themeTokens.appBarText || $themeTokens.text"
+              :textColor="$themeConfig.appBar.textColor"
               :navigationLinks="links"
             />
           </slot>
@@ -98,7 +98,7 @@
               <KIcon
                 icon="person"
                 :style="{
-                  fill: $themeTokens.appBarText || $themeTokens.text,
+                  fill: $themeConfig.appBar.textColor,
                   height: '24px',
                   width: '24px',
                   margin: '4px',

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -10,9 +10,12 @@
       <UiToolbar
         :removeNavIcon="showAppNavView"
         type="clear"
-        textColor="black"
+        :textColor="$themeTokens.appBarText || $themeTokens.text"
         class="app-bar"
-        :style="{ height: topBarHeight + 'px' }"
+        :style="{
+          height: topBarHeight + 'px',
+          color: $themeTokens.appBarText || $themeTokens.text,
+        }"
         :raised="false"
         :removeBrandDivider="true"
       >
@@ -26,7 +29,7 @@
         >
           <KIconButton
             icon="menu"
-            :color="$themeTokens.text"
+            :color="$themeTokens.appBarText || $themeTokens.text"
             :ariaLabel="$tr('openNav')"
             @click="$emit('toggleSideNav')"
           />
@@ -49,6 +52,7 @@
           <slot name="sub-nav">
             <Navbar
               v-if="links.length > 0"
+              :textColor="$themeTokens.appBarText || $themeTokens.text"
               :navigationLinks="links"
             />
           </slot>
@@ -94,7 +98,7 @@
               <KIcon
                 icon="person"
                 :style="{
-                  fill: $themeTokens.text,
+                  fill: $themeTokens.appBarText || $themeTokens.text,
                   height: '24px',
                   width: '24px',
                   margin: '4px',

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -2,7 +2,10 @@
 
   <div
     v-show="!$isPrint"
-    :style="{ backgroundColor: $themeConfig.appBar.background }"
+    :style="{
+      backgroundColor: themeConfig.appBar.background,
+      color: themeConfig.appBar.textColor,
+    }"
   >
     <header>
       <SkipNavigationLink />
@@ -10,11 +13,11 @@
       <UiToolbar
         :removeNavIcon="showAppNavView"
         type="clear"
-        :textColor="$themeConfig.appBar.textColor"
+        :textColor="themeConfig.appBar.textColor"
         class="app-bar"
         :style="{
           height: topBarHeight + 'px',
-          color: $themeConfig.appBar.textColor,
+          color: themeConfig.appBar.textColor,
         }"
         :raised="false"
         :removeBrandDivider="true"
@@ -29,7 +32,7 @@
         >
           <KIconButton
             icon="menu"
-            :color="$themeConfig.appBar.textColor"
+            :color="themeConfig.appBar.textColor"
             :ariaLabel="$tr('openNav')"
             @click="$emit('toggleSideNav')"
           />
@@ -52,7 +55,7 @@
           <slot name="sub-nav">
             <Navbar
               v-if="links.length > 0"
-              :textColor="$themeConfig.appBar.textColor"
+              :textColor="themeConfig.appBar.textColor"
               :navigationLinks="links"
             />
           </slot>
@@ -98,7 +101,7 @@
               <KIcon
                 icon="person"
                 :style="{
-                  fill: $themeConfig.appBar.textColor,
+                  fill: themeConfig.appBar.textColor,
                   height: '24px',
                   width: '24px',
                   margin: '4px',

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -57,11 +57,15 @@
         required: true,
         validator: validateLinkObject,
       },
+      textColor: {
+        type: String,
+        default: null,
+      },
     },
     computed: {
       tabStyles() {
         return {
-          color: this.$themeTokens.text,
+          color: this.textColor || this.$themeTokens.text,
           ':hover': {
             'background-color': this.$themeBrand.secondary.v_600,
           },
@@ -81,7 +85,7 @@
       activeClasses() {
         // return both fixed and dynamic classes
         return `router-link-active ${this.$computedClass({
-          color: this.$themeTokens.text,
+          color: this.textColor || this.$themeTokens.text,
         })}`;
       },
     },

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -29,6 +29,7 @@
 
   import { validateLinkObject } from 'kolibri.utils.validators';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import themeConfig from 'kolibri.themeConfig';
 
   /**
      Links for use inside the Navbar
@@ -38,6 +39,7 @@
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
       return {
+        themeConfig,
         windowIsSmall,
       };
     },
@@ -57,15 +59,11 @@
         required: true,
         validator: validateLinkObject,
       },
-      textColor: {
-        type: String,
-        default: null,
-      },
     },
     computed: {
       tabStyles() {
         return {
-          color: this.textColor || this.$themeTokens.text,
+          color: this.themeConfig.appBar.textColor,
           ':hover': {
             'background-color': this.$themeBrand.secondary.v_600,
           },
@@ -85,7 +83,7 @@
       activeClasses() {
         // return both fixed and dynamic classes
         return `router-link-active ${this.$computedClass({
-          color: this.textColor || this.$themeTokens.text,
+          color: this.themeConfig.appBar.textColor,
         })}`;
       },
     },

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -13,10 +13,11 @@
         ref="navLinks"
         :title="link.title"
         :link="link.link"
+        :textColor="textColor || $themeTokens.text"
       >
         <KIcon
           :icon="link.icon"
-          :color="$themeTokens.text"
+          :color="textColor || $themeTokens.text"
         />
       </NavbarLink>
     </ul>
@@ -27,7 +28,7 @@
       :ariaLabel="coreString('moreOptions')"
       icon="optionsHorizontal"
       appearance="flat-button"
-      :color="$themeTokens.text"
+      :color="textColor || $themeTokens.text"
       :primary="false"
       class="kiconbutton-style"
     >
@@ -80,6 +81,10 @@
         validator(values) {
           return values.every(value => value.link.name);
         },
+      },
+      textColor: {
+        type: String,
+        default: null,
       },
     },
     data() {

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -13,11 +13,10 @@
         ref="navLinks"
         :title="link.title"
         :link="link.link"
-        :textColor="textColor || $themeTokens.text"
       >
         <KIcon
           :icon="link.icon"
-          :color="textColor || $themeTokens.text"
+          :color="themeConfig.appBar.textColor"
         />
       </NavbarLink>
     </ul>
@@ -28,7 +27,7 @@
       :ariaLabel="coreString('moreOptions')"
       icon="optionsHorizontal"
       appearance="flat-button"
-      :color="textColor || $themeTokens.text"
+      :color="themeConfig.appBar.textColor"
       :primary="false"
       class="kiconbutton-style"
     >
@@ -52,6 +51,7 @@
   import isUndefined from 'lodash/isUndefined';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import themeConfig from 'kolibri.themeConfig';
   import NavbarLink from './NavbarLink';
   /**
    * Used for navigation between sub-pages of a top-level Kolibri section
@@ -68,6 +68,7 @@
         windowIsLarge,
         windowIsMedium,
         windowWidth,
+        themeConfig,
       };
     },
     props: {
@@ -81,10 +82,6 @@
         validator(values) {
           return values.every(value => value.link.name);
         },
-      },
-      textColor: {
-        type: String,
-        default: null,
       },
     },
     data() {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -196,7 +196,7 @@
               height: topBarHeight + 'px',
               width: `${width}`,
               paddingTop: windowIsSmall ? '4px' : '8px',
-              backgroundColor: $themeTokens.appBar,
+              backgroundColor: $themeConfig.appBar.background,
             }"
           >
             <KIconButton

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -204,7 +204,7 @@
               ref="closeButton"
               tabindex="0"
               icon="close"
-              :color="$themeTokens.text"
+              :color="themeConfig.appBar.textColor"
               class="side-nav-header-icon"
               :ariaLabel="$tr('closeNav')"
               size="large"
@@ -212,7 +212,7 @@
             />
             <span
               class="side-nav-header-name"
-              :style="{ color: $themeTokens.text }"
+              :style="{ color: themeConfig.appBar.textColor }"
             >{{ sideNavTitleText }}</span>
           </div>
         </FocusTrap>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -196,7 +196,8 @@
               height: topBarHeight + 'px',
               width: `${width}`,
               paddingTop: windowIsSmall ? '4px' : '8px',
-              backgroundColor: $themeConfig.appBar.background,
+              backgroundColor: themeConfig.appBar.background,
+              color: themeConfig.appBar.textColor,
             }"
           >
             <KIconButton


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- NavBar & NavbarLink now take & drill a `textColor` prop
- In AppBar, the new token `appBarText` is passed to `textColor`
- In AppBar, it is also used as the default color for icons, the page title, and the user's info

This is done to permit plugins to customize the text in the AppBar so that they can ensure proper contrast with their chosen `appBar` token's value, which is used as the background.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri-instant-schools-plugin/issues/205

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

#### QA

Are there any regressions in the default Kolibri bevhaior for the top yellow AppBar? Check each plugin and any sub-routes you can.

The fixes that this allows will be tested upon rebuilding the VF IS plugin w/ this patched on Kolibri.

#### Code

- Anything I'm missing where this should be used?
- I have a patch ready for KDSv4 as well that isn't _necessary for this to work_ but it would keep v4 updated w/ a default. I have included fallbacks for each place where `appBarText` is used so having them defined in KDS may not be necessary (cc @AlexVelezLl)
- I have tested this by including the `appBarText` key in the `tokenMapping` section of the theme definition in the Instant Schools plugin and w/ that build, all of the colors are shown as expected. Should this be part of the theme itself - or does adding to that mapping jive w/ the way we want to use the theme machinery?

