### PR TITLE
Fix coach quizzes blank page

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -269,7 +269,7 @@
       // TODO: refactor to a more robust check
       UserSyncStatusResource.fetchCollection({
         force: true,
-        getParams: { member_of: classId },
+        getParams: { member_of: classId.value },
       }).then(data => {
         if (data && data.length > 0) {
           learnOnlyDevicesExist.value = true;


### PR DESCRIPTION
## Summary

When navigating to coach > quizzes, there was a blank page:

![image](https://github.com/user-attachments/assets/9f92960c-affb-457d-8275-305b6fdd898e)

The error was because we were trying to stringify a circular object, because we forgot to unwrap the classId value when fetching UserSyncStatusResource in ExamsRootPage.

After:
![image](https://github.com/user-attachments/assets/e96f03f8-4fc6-4872-aad5-dcc1b773bcad)
