### PR TITLE
Fix Coach > Quizzes blank page after copying a quiz

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -90,6 +90,8 @@ export default {
       if (!assignment) {
         throw new Error('getLearnersForAssignment: invalid parameter(s)');
       }
+      assignment.assignments = assignment.assignments || [];
+      assignment.learner_ids = assignment.learner_ids || [];
       if (!assignment.assignments.length && !assignment.learner_ids.length) {
         return [];
       }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
After creating a copy of a quiz and clicking the **"All quizzes"** link, an empty page was displayed with the console error message: `TypeError: Cannot read properties of undefined (reading 'length')`. 

The error occurred because assignment.assignments or assignment.learner_ids within getLearnersForAssignment() was not guaranteed to be defined. 

The change in this pull request ensures that every assignment object passed into getLearnersForAssignment() has assignments and learner_ids set as empty arrays if there are no items.

https://github.com/user-attachments/assets/4b6290c2-8ca5-4814-9349-86aa812236db


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #12814 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to to Coach > Class home, make a copy of a quiz, and select the 'All Quizzes' link.
