### PR TITLE
Don't use 'auto' public paths to resolve resources.

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -123,6 +123,8 @@ class WebpackBundleHook(hooks.KolibriHook):
             if getattr(settings, "DEVELOPER_MODE", False):
                 try:
                     f["url"] = f["publicPath"]
+                    if f["url"].startswith("auto"):
+                        raise KeyError
                 except KeyError:
                     f["url"] = staticfiles_storage.url(relpath)
             else:


### PR DESCRIPTION
## Summary
* Fixes regression in the devserver from using auto public paths in production builds

