### PR TITLE
Remove non-extant TODO

### DIFF
--- a/packages/kolibri/components/pages/AppBarPage/internal/Navbar/NavbarLink.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/Navbar/NavbarLink.vue
@@ -124,12 +124,6 @@ Links for use inside the Navbar
     }
   }
 
-  // Getting this class to work correctly with our theme system is not currently
-  // possible. Some options:
-  //  1. Update vueAphrodite to handle nested classes (to handle .dimmable)
-  //  2. Wait for <router-link> to support scoped slots as described in
-  //     https://github.com/vuejs/rfcs/pull/34
-  //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
     font-weight: bold;
     border-bottom-style: solid;


### PR DESCRIPTION
## Summary
* Removes TODO that is no longer relevant - scoped slots are already being used, and things seem to be working in a way that is themed