### PR TITLE
Fix  'New quiz' button is visible in the print report 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -16,7 +16,7 @@
         ref="printButton"
         icon="print"
         :aria-label="coachString('printReportAction')"
-        @click.prevent="$print()"
+        @click.prevent="printPDF()"
       />
       <KTooltip
         reference="printButton"
@@ -99,6 +99,17 @@
           },
         };
         return route;
+      },
+    },
+    methods: {
+      printPDF() {
+        const quizButton = document.getElementsByClassName('quiz-group-button-div');
+        quizButton[0].style.display = 'none';
+        this.$print();
+
+        setTimeout(() => {
+          quizButton[0].style.display = 'block';
+        }, 500);
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -16,7 +16,7 @@
         ref="printButton"
         icon="print"
         :aria-label="coachString('printReportAction')"
-        @click.prevent="printPDF()"
+        @click.prevent="$emit('printToPDF')"
       />
       <KTooltip
         reference="printButton"
@@ -99,17 +99,6 @@
           },
         };
         return route;
-      },
-    },
-    methods: {
-      printPDF() {
-        const quizButton = document.getElementsByClassName('quiz-group-button-div');
-        quizButton[0].style.display = 'none';
-        this.$print();
-
-        setTimeout(() => {
-          quizButton[0].style.display = 'block';
-        }, 500);
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -16,7 +16,7 @@
         ref="printButton"
         icon="print"
         :aria-label="coachString('printReportAction')"
-        @click.prevent="$emit('printToPDF')"
+        @click.prevent="$print()"
       />
       <KTooltip
         reference="printButton"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -4,13 +4,14 @@
     <KPageContainer>
       <CoachHeader :title="coreString('lessonsLabel')">
         <template #actions>
-          <KRouterLink
-            id="new-lesson-button"
-            primary
-            appearance="raised-button"
-            :text="coachString('newLessonAction')"
-            :to="newLessonRoute"
-          />
+          <div class="lesson-button">
+            <KRouterLink
+              primary
+              appearance="raised-button"
+              :text="coachString('newLessonAction')"
+              :to="newLessonRoute"
+            />
+          </div>
         </template>
       </CoachHeader>
       <div>
@@ -20,10 +21,7 @@
         >
           {{ coachString('totalLessonsSize', { size: calcTotalSizeOfVisibleLessons }) }}
         </p>
-        <ReportsControls
-          @export="exportCSV"
-          @printToPDF="printToPDF"
-        >
+        <ReportsControls @export="exportCSV">
           <div :style="windowIsSmall ? { display: 'grid' } : {}">
             <KSelect
               v-model="filterSelection"
@@ -459,15 +457,6 @@
         const fileName = this.$tr('printLabel', { className: this.className });
         new CSVExporter(columns, fileName).export(this.sortedLessons);
       },
-      printToPDF() {
-        const lessonButton = document.getElementById('new-lesson-button');
-        lessonButton.style.display = 'none';
-
-        this.$print();
-        setTimeout(() => {
-          lessonButton.style.display = 'block';
-        }, 500);
-      },
       bytesForHumans,
     },
     $trs: {
@@ -511,6 +500,12 @@
   .total-size {
     padding: 0;
     margin-bottom: 16px;
+  }
+
+  @media print {
+    .lesson-button {
+      display: none;
+    }
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -5,6 +5,7 @@
       <CoachHeader :title="coreString('lessonsLabel')">
         <template #actions>
           <KRouterLink
+            id="new-lesson-button"
             primary
             appearance="raised-button"
             :text="coachString('newLessonAction')"
@@ -19,7 +20,10 @@
         >
           {{ coachString('totalLessonsSize', { size: calcTotalSizeOfVisibleLessons }) }}
         </p>
-        <ReportsControls @export="exportCSV">
+        <ReportsControls
+          @export="exportCSV"
+          @printToPDF="printToPDF"
+        >
           <div :style="windowIsSmall ? { display: 'grid' } : {}">
             <KSelect
               v-model="filterSelection"
@@ -454,6 +458,15 @@
         ];
         const fileName = this.$tr('printLabel', { className: this.className });
         new CSVExporter(columns, fileName).export(this.sortedLessons);
+      },
+      printToPDF() {
+        const lessonButton = document.getElementById('new-lesson-button');
+        lessonButton.style.display = 'none';
+
+        this.$print();
+        setTimeout(() => {
+          lessonButton.style.display = 'block';
+        }, 500);
       },
       bytesForHumans,
     },

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -31,7 +31,7 @@
         <template #actions>
           <KButton
             v-if="practiceQuizzesExist && !hasNoChannels"
-            id="new-quiz-button"
+            class="new-quiz-button"
             primary
             hasDropdown
             appearance="raised-button"
@@ -62,7 +62,6 @@
         <ReportsControls
           class="report-controls"
           @export="exportCSV"
-          @printToPDF="printToPDF"
         >
           <KSelect
             v-model="statusSelected"
@@ -573,15 +572,6 @@
           this.isLoading = false;
         });
       },
-      printToPDF() {
-        const quizButton = document.getElementById('new-quiz-button');
-        quizButton.style.display = 'none';
-
-        this.$print();
-        setTimeout(() => {
-          quizButton.style.display = 'block';
-        }, 500);
-      },
     },
     $trs: {
       noExams: {
@@ -659,6 +649,12 @@
 
   .banner-spacing {
     margin: 0 0 1em;
+  }
+
+  @media print {
+    .new-quiz-button {
+      display: none;
+    }
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -31,6 +31,7 @@
         <template #actions>
           <KButton
             v-if="practiceQuizzesExist && !hasNoChannels"
+            id="new-quiz-button"
             primary
             hasDropdown
             appearance="raised-button"
@@ -61,6 +62,7 @@
         <ReportsControls
           class="report-controls"
           @export="exportCSV"
+          @printToPDF="printToPDF"
         >
           <KSelect
             v-model="statusSelected"
@@ -570,6 +572,15 @@
           this.channels = data;
           this.isLoading = false;
         });
+      },
+      printToPDF() {
+        const quizButton = document.getElementById('new-quiz-button');
+        quizButton.style.display = 'none';
+
+        this.$print();
+        setTimeout(() => {
+          quizButton.style.display = 'block';
+        }, 500);
       },
     },
     $trs: {


### PR DESCRIPTION

## Summary
This  PR fixes  the  'New quiz' / New lesson button  being displayed  in  the 'Print  preview. 
### Before

![image](https://github.com/user-attachments/assets/522dd5b9-46d8-49f5-8a82-721e8d2a3288)

### After

<img width="475" alt="Screenshot 2024-12-13 at 21 36 34" src="https://github.com/user-attachments/assets/10950c9b-6e2d-4c0e-9141-0a737c7b3ca3" />

<img width="463" alt="Screenshot 2024-12-13 at 21 40 07" src="https://github.com/user-attachments/assets/0c59fe8c-d316-4b47-a8f5-7b071f3aca5f" />



## References
closes #12715

## Reviewer guidance

1. Import the QA channel (nakav-mafak) and create quizzes assigned to learners
2. Complete some of the quizzes and go to Coach > Plan
3. Click the 'Print report' icon