### PR TITLE
Fix snackbar errors in content import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/taskNotificationMixin.js
+++ b/kolibri/plugins/device/assets/src/views/taskNotificationMixin.js
@@ -25,15 +25,13 @@ const TaskSnackbarStrings = createTranslator('TaskSnackbarStrings', {
   },
 });
 
+const { createSnackbar } = useSnackbar();
+
 export default {
   data() {
     return {
       showSnackbarWhenTaskHasFinished: true,
     };
-  },
-  setup() {
-    const { createSnackbar } = useSnackbar();
-    return { createSnackbar };
   },
   computed: {
     watchedTaskId() {
@@ -65,16 +63,16 @@ export default {
       this.$router.push({ name: PageNames.MANAGE_TASKS });
     },
     createTaskFailedSnackbar() {
-      this.createSnackbar(TaskSnackbarStrings.$tr('taskFailed'));
+      createSnackbar(TaskSnackbarStrings.$tr('taskFailed'));
     },
     createTaskFinishedSnackbar() {
-      this.createSnackbar({
+      createSnackbar({
         text: TaskSnackbarStrings.$tr('taskFinished'),
         autoDismiss: true,
       });
     },
     createTaskStartedSnackbar() {
-      this.createSnackbar({
+      createSnackbar({
         text: TaskSnackbarStrings.$tr('taskStarted'),
         autoDismiss: true,
       });


### PR DESCRIPTION
## Summary
* Regression caused by Vue 2.7 upgrade
* Use the composable in module scope, as can't define setup on a mixin if the consuming component also defines setup.

## References
Follow up from https://github.com/learningequality/kolibri/pull/12933

## Reviewer guidance
Import content into Kolibri, confirm that snackbars are displayed, without errors, and that redirects happen properly
