### PR TITLE
Fixes: Library - Connection state's position when there are no libraries around #11442

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -36,7 +36,7 @@
         v-if="hasActiveClassesQuizzes"
         class="section"
         :quizzes="activeClassesQuizzes"
-        displayClassName
+         displayClassName
         recent
         data-test="recentQuizzes"
       />

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -36,7 +36,7 @@
         v-if="hasActiveClassesQuizzes"
         class="section"
         :quizzes="activeClassesQuizzes"
-         displayClassName
+        displayClassName
         recent
         data-test="recentQuizzes"
       />

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -4,7 +4,6 @@
     <KGrid
       gutter="0"
       class="grid"
-      style="margin-bottom: -25px"
     >
       <KGridItem
         :layout12="{ span: 6 }"
@@ -14,6 +13,7 @@
         <h1 :style="{ marginLeft: '-8px' }">
           {{ injectedtr('otherLibraries') }}
         </h1>
+      </KGridItem>
 
         <KGridItem
         :layout12="{ span:12}"
@@ -69,7 +69,6 @@
           </span>
         </div>
       </KGridItem>
-    </KGridItem>
 
     </KGrid>
 
@@ -242,8 +241,7 @@
 
     span {
       display: inline-flex;
-      vertical-align: bottom;
-      
+      vertical-align: bottom;     
     }
   }
 
@@ -261,9 +259,8 @@
   }
 
   .connection-status{
-    margin-bottom: 30px;
-    margin-top: -15px;
     margin-left: -8px;
+    margin-bottom: 10px;
   }
   
 

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -4,18 +4,24 @@
     <KGrid
       gutter="0"
       class="grid"
-      style="margin-bottom:-25px ;"
+      style="margin-bottom: -25px"
     >
       <KGridItem
-        :layout12="{ span: 6 }"
-        :layout8="{ span: 4 }"
-        :layout4="{ span: 4 }"
+        :layout12="{ span: 10 }"
+        :layout8="{ span: 6 }"
+        :layout4="{ span: 4}"
       >
         <h1 :style="{ marginLeft: '-8px' }">
           {{ injectedtr('otherLibraries') }}
         </h1>
-     
-        <div class="sync-status" >
+
+        <KGridItem
+        :layout12="{ span:8 }"
+        :layout8="{ span:5 }"
+        :layout4="{span:4 }"
+      class="connection-status">
+
+        <div class="sync-status">
           <span
             v-show="searchingOtherLibraries"
             data-test="searching"
@@ -32,6 +38,7 @@
           <span
             v-show="!searchingOtherLibraries && devicesWithChannelsExist"
             data-test="showing-all"
+            class="otherLib"
           >
             <span>
               <KIcon
@@ -39,7 +46,7 @@
                 icon="wifi"
                 class="wifi-svg"
               />
-            </span> 
+            </span>
             &nbsp;&nbsp;
             <span data-test="showing-all-label">{{ injectedtr('showingAllLibraries') }}</span>
             &nbsp;&nbsp;
@@ -51,24 +58,21 @@
               />
             </span>
           </span>
-          <div class="a" v-show="!searchingOtherLibraries && !devicesWithChannelsExist" >
           <span
-            
+            v-show="!searchingOtherLibraries && !devicesWithChannelsExist"
             data-test="no-other"
-            
-          > <div  >
-            <span >
-              <KIcon class="disco"  icon="disconnected" />
-            </span >
-          </div>
+            class="noOtherLib"
+          >
+            <span>
+              <KIcon icon="disconnected" />
+            </span>
             &nbsp;&nbsp;
-            <div class="b">
-            <span   data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
-          </div>
+            <span  data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
           </span>
         </div>
-        </div>
       </KGridItem>
+    </KGridItem>
+
     </KGrid>
 
     <h2
@@ -98,7 +102,7 @@
       class="other-libraries-grid"
     >
       <KGridItem
-        :layout12="{ span: 10 }"
+        :layout12="{ span: 6 }"
         :layout8="{ span: 6 }"
         :layout4="{ span: 2 }"
       >
@@ -236,37 +240,16 @@
 <style lang="scss" scoped>
 
 .sync-status {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: -20px;
-  margin-left: 0px;
-  padding-left: 10px;
-  margin-bottom: 25px;
-  min-width: 400px;
- 
-  .a {
-    display: flex; 
-    align-items: center; 
-    margin-top: -5px; 
-     margin-left: 100px; }
-    
-  .b {
-      margin-left: 500px;
-      padding-left: 00px;
-      min-width: 200px;
-    }
-    .disco {
-      margin-left: 1000px;    
-    }
+    display: flex;
+    justify-content: flex-end;
+    margin: 30px 0 0px;
 
-  span {
-    margin-bottom: 10px;
-    vertical-align: bottom;
-    margin-top: 10px;
-    display: inline-flex;
-    margin-left: -8px;
+    span {
+      display: inline-flex;
+      vertical-align: bottom;
+      
+    }
   }
-}
 
   .wifi-svg {
     top: 0;
@@ -275,90 +258,27 @@
 
   .grid {
     margin: 8px;
-    
   }
 
   .other-libraries-grid {
     margin-left: 0.75em;
   }
 
-@media screen  and (max-width: 600px)  {
-  .sync-status {
-  
-   max-width: 400px;
-   
-   .a {
-     margin-right: 13px;
-    }
-    .disco {
-      margin-right: -640px; 
-    }
-
-   
-
-   span {
-      margin-left: -191px;
-      word-wrap: break-word;
-
-      
-    }
-  }
-  .wifi-svg {
+  .connection-status{
+    margin-top: -15px;
+    margin-bottom:20px;
+    padding-top: 0px;
+    margin-left:  -8px;
+    margin-right: 250px;
     
-    margin-left: -213px;
   }
-}
-@media screen and (min-width: 600px) and (max-width:1100px)  {
-  .sync-status {
- 
-
-   .a {
-
-     margin-right: 13px;
-    }
-    .disco {
-      margin-right: -640px; 
-    }
-
-
-    span {
-      margin-left: -190px;
-   
-    }
+  .noOtherLib{
+    padding-right: 194px;
+    margin-top: -30px;
   }
-  .wifi-svg {
-   
-    margin-left: -160px;
-  }
-}
-
-@media screen and (min-width: 1100px)  {
-  .sync-status {
- 
-    span {
-      margin-left: -220px;
-      padding-left: -50px;
-      
-      
-    }
-    .a {
-
-     margin-right: 50px;
-    
-    }
-    .disco {
-      margin-right: -610px; 
-    
-    }
-
-    
-   
-  }
-  .wifi-svg {
-   
-    margin-left: -140px;
-  }
-  
-}
+  .otherLib{
+    margin-top: -30px;
+    margin-right: 170px;
+     }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -7,17 +7,17 @@
       style="margin-bottom: -25px"
     >
       <KGridItem
-        :layout12="{ span: 10 }"
-        :layout8="{ span: 6 }"
-        :layout4="{ span: 4}"
+        :layout12="{ span: 6 }"
+        :layout8="{ span: 4 }"
+        :layout4="{ span: 4 }"
       >
         <h1 :style="{ marginLeft: '-8px' }">
           {{ injectedtr('otherLibraries') }}
         </h1>
 
         <KGridItem
-        :layout12="{ span:8 }"
-        :layout8="{ span:5 }"
+        :layout12="{ span:12}"
+        :layout8="{ span:8}"
         :layout4="{span:4 }"
       class="connection-status">
 
@@ -38,7 +38,6 @@
           <span
             v-show="!searchingOtherLibraries && devicesWithChannelsExist"
             data-test="showing-all"
-            class="otherLib"
           >
             <span>
               <KIcon
@@ -61,7 +60,6 @@
           <span
             v-show="!searchingOtherLibraries && !devicesWithChannelsExist"
             data-test="no-other"
-            class="noOtherLib"
           >
             <span>
               <KIcon icon="disconnected" />
@@ -102,7 +100,7 @@
       class="other-libraries-grid"
     >
       <KGridItem
-        :layout12="{ span: 6 }"
+        :layout12="{ span: 10 }"
         :layout8="{ span: 6 }"
         :layout4="{ span: 2 }"
       >
@@ -241,8 +239,6 @@
 
 .sync-status {
     display: flex;
-    justify-content: flex-end;
-    margin: 30px 0 0px;
 
     span {
       display: inline-flex;
@@ -265,20 +261,10 @@
   }
 
   .connection-status{
+    margin-bottom: 30px;
     margin-top: -15px;
-    margin-bottom:20px;
-    padding-top: 0px;
-    margin-left:  -8px;
-    margin-right: 250px;
-    
+    margin-left: -8px;
   }
-  .noOtherLib{
-    padding-right: 194px;
-    margin-top: -30px;
-  }
-  .otherLib{
-    margin-top: -30px;
-    margin-right: 170px;
-     }
+  
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -15,12 +15,12 @@
         </h1>
       </KGridItem>
 
-        <KGridItem
-        :layout12="{ span:12}"
-        :layout8="{ span:8}"
-        :layout4="{span:4 }"
-      class="connection-status">
-
+      <KGridItem
+        :layout12="{ span: 12 }"
+        :layout8="{ span: 8 }"
+        :layout4="{ span: 4 }"
+        class="connection-status"
+      >
         <div class="sync-status">
           <span
             v-show="searchingOtherLibraries"
@@ -65,11 +65,10 @@
               <KIcon icon="disconnected" />
             </span>
             &nbsp;&nbsp;
-            <span  data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
+            <span data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
           </span>
         </div>
       </KGridItem>
-
     </KGrid>
 
     <h2
@@ -236,12 +235,12 @@
 
 <style lang="scss" scoped>
 
-.sync-status {
+  .sync-status {
     display: flex;
 
     span {
       display: inline-flex;
-      vertical-align: bottom;     
+      vertical-align: bottom;
     }
   }
 
@@ -258,10 +257,9 @@
     margin-left: 0.75em;
   }
 
-  .connection-status{
-    margin-left: -8px;
+  .connection-status {
     margin-bottom: 10px;
+    margin-left: -8px;
   }
-  
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -4,6 +4,7 @@
     <KGrid
       gutter="0"
       class="grid"
+      style="margin-bottom:-25px ;"
     >
       <KGridItem
         :layout12="{ span: 6 }"
@@ -13,13 +14,8 @@
         <h1 :style="{ marginLeft: '-8px' }">
           {{ injectedtr('otherLibraries') }}
         </h1>
-      </KGridItem>
-      <KGridItem
-        :layout12="{ span: 6 }"
-        :layout8="{ span: 4 }"
-        :layout4="{ span: 4 }"
-      >
-        <div class="sync-status">
+     
+        <div class="sync-status" >
           <span
             v-show="searchingOtherLibraries"
             data-test="searching"
@@ -43,7 +39,7 @@
                 icon="wifi"
                 class="wifi-svg"
               />
-            </span>
+            </span> 
             &nbsp;&nbsp;
             <span data-test="showing-all-label">{{ injectedtr('showingAllLibraries') }}</span>
             &nbsp;&nbsp;
@@ -55,16 +51,22 @@
               />
             </span>
           </span>
+          <div class="a" v-show="!searchingOtherLibraries && !devicesWithChannelsExist" >
           <span
-            v-show="!searchingOtherLibraries && !devicesWithChannelsExist"
+            
             data-test="no-other"
-          >
-            <span>
-              <KIcon icon="disconnected" />
-            </span>
+            
+          > <div  >
+            <span >
+              <KIcon class="disco"  icon="disconnected" />
+            </span >
+          </div>
             &nbsp;&nbsp;
-            <span data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
+            <div class="b">
+            <span   data-test="no-other-label">{{ injectedtr('noOtherLibraries') }}</span>
+          </div>
           </span>
+        </div>
         </div>
       </KGridItem>
     </KGrid>
@@ -233,16 +235,20 @@
 
 <style lang="scss" scoped>
 
-  .sync-status {
-    display: flex;
-    justify-content: flex-end;
-    margin: 30px 0 10px;
+.sync-status {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 30px;
+  margin-left: -300px;
+ 
+  span {
 
-    span {
-      display: inline-flex;
-      vertical-align: bottom;
-    }
+   
+    display: inline-block;
+    vertical-align: bottom;
+    margin-left: -8px;
   }
+}
 
   .wifi-svg {
     top: 0;
@@ -251,10 +257,149 @@
 
   .grid {
     margin: 8px;
+    
   }
 
   .other-libraries-grid {
     margin-left: 0.75em;
   }
+
+@media screen  and (max-width: 600px)  {
+  .sync-status {
+  display: flex;
+  justify-content: flex-end;
+  margin-top:-20px ;
+   margin-left: 0px;
+   padding-left: 10px;
+   margin-bottom: 25px;
+   min-width: 400px;
+   max-width: 400px;
+   
+   .a {
+    display: flex; // Use flex to align items if needed
+    align-items: center; // Center items vertically
+    margin-top: -5px; // Add some margin for spacing
+     margin-left: 100px; 
+     margin-right: 13px;
+    }
+    .disco {
+      margin-left: 1000px;
+      margin-right: -640px; // Space between icon and text
+    }
+
+    .b {
+      margin-left: 500px;
+      padding-left: 00px;
+      min-width: 200px;
+    }
+
+   span {
+      margin-left: -191px;
+      margin-bottom:10px ;
+      display: inline-flex;
+      word-wrap: break-word;
+
+      
+      vertical-align: bottom;
+      margin-top: 10px;
+    }
+  }
+  .wifi-svg {
+    top: 0;
+    transform: scale(1.5);
+    margin-left: -213px;
+  }
+}
+@media screen and (min-width: 600px) and (max-width:1100px)  {
+  .sync-status {
+  display: flex;
+  justify-content: flex-end;
+  margin-top:-20px ;
+   margin-left: 0px;
+   padding-left: 10px;
+   margin-bottom: 25px;
+   min-width: 400px;
+
+   .a {
+    display: flex; // Use flex to align items if needed
+    align-items: center; // Center items vertically
+    margin-top: -5px; // Add some margin for spacing
+     margin-left: 100px; 
+     margin-right: 13px;
+    }
+    .disco {
+      margin-left: 1000px;
+      margin-right: -640px; // Space between icon and text
+    }
+
+    .b {
+      margin-left: 500px;
+      padding-left: 00px;
+      min-width: 200px;
+    }
+
+    span {
+      margin-left: -190px;
+      margin-bottom:10px ;
+      display: inline-flex;
+      
+      
+      vertical-align: bottom;
+      margin-top: 10px;
+    }
+  }
+  .wifi-svg {
+    top: 0;
+    transform: scale(1.5);
+    margin-left: -160px;
+  }
+}
+
+@media screen and (min-width: 1100px)  {
+  .sync-status {
+  display: flex;
+  justify-content: flex-end;
+  margin-top:-20px ;
+   margin-left: 0px;
+   padding-left: 10px;
+   margin-bottom: 25px;
+   min-width: 400px;
+    span {
+      margin-left: -220px;
+      margin-bottom:10px ;
+      display: inline-flex;
+      padding-left: -50px;
+      
+      vertical-align: bottom;
+      margin-top: 10px;
+    }
+    .a {
+    display: flex; // Use flex to align items if needed
+    align-items: center; // Center items vertically
+    margin-top: -5px; // Add some margin for spacing
+     margin-left: 100px; 
+     margin-right: 50px;
+    
+    }
+    .disco {
+      margin-left: 1000px;
+      margin-right: -610px; // Space between icon and text
+    
+    }
+
+    
+    .b {
+      margin-left: 500px;
+      padding-left: 00px;
+      min-width: 200px;
+    }
+  }
+  .wifi-svg {
+    top: 0;
+    transform: scale(1.5);
+    margin-left: -140px;
+  }
+  
+}
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -238,14 +238,32 @@
 .sync-status {
   display: flex;
   justify-content: flex-end;
-  margin-top: 30px;
-  margin-left: -300px;
+  margin-top: -20px;
+  margin-left: 0px;
+  padding-left: 10px;
+  margin-bottom: 25px;
+  min-width: 400px;
  
-  span {
+  .a {
+    display: flex; 
+    align-items: center; 
+    margin-top: -5px; 
+     margin-left: 100px; }
+    
+  .b {
+      margin-left: 500px;
+      padding-left: 00px;
+      min-width: 200px;
+    }
+    .disco {
+      margin-left: 1000px;    
+    }
 
-   
-    display: inline-block;
+  span {
+    margin-bottom: 10px;
     vertical-align: bottom;
+    margin-top: 10px;
+    display: inline-flex;
     margin-left: -8px;
   }
 }
@@ -266,137 +284,78 @@
 
 @media screen  and (max-width: 600px)  {
   .sync-status {
-  display: flex;
-  justify-content: flex-end;
-  margin-top:-20px ;
-   margin-left: 0px;
-   padding-left: 10px;
-   margin-bottom: 25px;
-   min-width: 400px;
+  
    max-width: 400px;
    
    .a {
-    display: flex; // Use flex to align items if needed
-    align-items: center; // Center items vertically
-    margin-top: -5px; // Add some margin for spacing
-     margin-left: 100px; 
      margin-right: 13px;
     }
     .disco {
-      margin-left: 1000px;
-      margin-right: -640px; // Space between icon and text
+      margin-right: -640px; 
     }
 
-    .b {
-      margin-left: 500px;
-      padding-left: 00px;
-      min-width: 200px;
-    }
+   
 
    span {
       margin-left: -191px;
-      margin-bottom:10px ;
-      display: inline-flex;
       word-wrap: break-word;
 
       
-      vertical-align: bottom;
-      margin-top: 10px;
     }
   }
   .wifi-svg {
-    top: 0;
-    transform: scale(1.5);
+    
     margin-left: -213px;
   }
 }
 @media screen and (min-width: 600px) and (max-width:1100px)  {
   .sync-status {
-  display: flex;
-  justify-content: flex-end;
-  margin-top:-20px ;
-   margin-left: 0px;
-   padding-left: 10px;
-   margin-bottom: 25px;
-   min-width: 400px;
+ 
 
    .a {
-    display: flex; // Use flex to align items if needed
-    align-items: center; // Center items vertically
-    margin-top: -5px; // Add some margin for spacing
-     margin-left: 100px; 
+
      margin-right: 13px;
     }
     .disco {
-      margin-left: 1000px;
-      margin-right: -640px; // Space between icon and text
+      margin-right: -640px; 
     }
 
-    .b {
-      margin-left: 500px;
-      padding-left: 00px;
-      min-width: 200px;
-    }
 
     span {
       margin-left: -190px;
-      margin-bottom:10px ;
-      display: inline-flex;
-      
-      
-      vertical-align: bottom;
-      margin-top: 10px;
+   
     }
   }
   .wifi-svg {
-    top: 0;
-    transform: scale(1.5);
+   
     margin-left: -160px;
   }
 }
 
 @media screen and (min-width: 1100px)  {
   .sync-status {
-  display: flex;
-  justify-content: flex-end;
-  margin-top:-20px ;
-   margin-left: 0px;
-   padding-left: 10px;
-   margin-bottom: 25px;
-   min-width: 400px;
+ 
     span {
       margin-left: -220px;
-      margin-bottom:10px ;
-      display: inline-flex;
       padding-left: -50px;
       
-      vertical-align: bottom;
-      margin-top: 10px;
+      
     }
     .a {
-    display: flex; // Use flex to align items if needed
-    align-items: center; // Center items vertically
-    margin-top: -5px; // Add some margin for spacing
-     margin-left: 100px; 
+
      margin-right: 50px;
     
     }
     .disco {
-      margin-left: 1000px;
-      margin-right: -610px; // Space between icon and text
+      margin-right: -610px; 
     
     }
 
     
-    .b {
-      margin-left: 500px;
-      padding-left: 00px;
-      min-width: 200px;
-    }
+   
   }
   .wifi-svg {
-    top: 0;
-    transform: scale(1.5);
+   
     margin-left: -140px;
   }
   


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
So I created media queries for specific screen sizes to display the connection state position correctly. applied Padding and margins wherever necessary and created 3 DIVS a, b and disco because when state was offline position was changed again,by using these DIVS I was able to fix issue for both offline and online state.




## References

https://github.com/learningequality/kolibri/issues/11442#issue-1954449606







