### PR TITLE
Remove 'pull_request_review' event from the community contributions spreadsheet action

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,11 +1,5 @@
 name: Update community pull requests spreadsheet
-on:
-  pull_request_target:
-    types: [opened, reopened, edited, closed, synchronize, assigned, unassigned, review_requested, review_request_removed]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
-  issue_comment:
-    types: [created, edited, deleted]
+on: [pull_request_target, issue_comment]
 
 jobs:
   call-update-spreadsheet:


### PR DESCRIPTION

## Summary

- Remove `pull_request_review` event. When triggered by this event, secrets are not available. This fixes the action failures when a pull request is reviewed, such as [here](https://github.com/learningequality/kolibri/actions/runs/12324738866).
- Remove unnecessary nuanced event settings. Generally the spreadsheet date should get updated on all associated events.

## References

https://learningequality.slack.com/archives/CB37UM23A/p1733946399034929

## Reviewer guidance

I tested here https://github.com/learningequality/test-actions/pull/60
