### PR TITLE
Avoid displaying CoachClassListPage until after data is finished loading 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <CoachAppBarPage :appBarTitle="appBarTitle">
-    <KPageContainer>
+    <KPageContainer v-if="!dataLoading">
       <p>
         <KRouterLink
           v-if="userIsMultiFacilityAdmin"

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <CoachAppBarPage :appBarTitle="appBarTitle">
-    <KPageContainer v-if="!dataLoading">
+    <KPageContainer v-if="!dataLoading && classListPageEnabled">
       <p>
         <KRouterLink
           v-if="userIsMultiFacilityAdmin"
@@ -65,7 +65,7 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import find from 'lodash/find';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import urls from 'kolibri/urls';
@@ -93,6 +93,7 @@
     },
     computed: {
       ...mapState(['classList', 'dataLoading']),
+      ...mapGetters(['classListPageEnabled']),
       // Message that shows up when state.classList is empty
       emptyStateDetails() {
         if (this.isClassCoach) {


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request handles the brief flash of the `CoachClassListPage` when there's only a single class, after navigating from another plugin to a page in the Coach plugin. The page now renders and displays only after the data is fully loaded. This allows the redirection implemented in `classIdParamRequiredGuard()` to correctly display the `CoachClassListPage` only when necessary.

Correct behavior:

https://github.com/user-attachments/assets/903803ff-c272-4259-b998-d0b7a7c60f5a


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #12815 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to any coach page from another plugin. Inspecting the page, pressing the Network tab, and setting the network throttling to slow 4g or 3g would be helpful to see a slower transition.