### PR TITLE
Add quiz recipients selector as Side Panel

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
@@ -5,17 +5,8 @@
     v-else
     class="items-label"
   >
-    <span v-if="items.length === 1">
-      {{ items[0] }}
-    </span>
-    <span v-else-if="items.length === 2">
-      {{ $tr('twoItems', { item1: items[0], item2: items[1] }) }}
-    </span>
-    <span v-else-if="items.length === 3">
-      {{ $tr('threeItems', { item1: items[0], item2: items[1], item3: items[2] }) }}
-    </span>
-    <span v-else>
-      {{ $tr('manyItems', { item1: items[0], item2: items[1], count: items.length - 2 }) }}
+    <span>
+      {{ getTruncatedItemsString(items) }}
     </span>
   </div>
 
@@ -23,6 +14,8 @@
 
 
 <script>
+
+  import { getTruncatedItemsString } from './commonCoachStrings';
 
   export default {
     name: 'TruncatedItemList',
@@ -32,21 +25,8 @@
         required: true,
       },
     },
-    $trs: {
-      twoItems: {
-        message: '{item1}, {item2}',
-        context:
-          "DO NOT TRANSLATE\nCopy the source string.\n\nFor reference: 'item' will be replaced by the name of the coach(es) in the list of classes.",
-      },
-      threeItems: {
-        message: '{item1}, {item2}, {item3}',
-        context:
-          "DO NOT TRANSLATE\nCopy the source string.\n\nFor reference: 'item' will be replaced by the name of the coach(es) in the list of classes.",
-      },
-      manyItems: {
-        message: '{item1}, {item2}, and {count, number, integer} others',
-        context: "'item' will be replaced by the name of the coach(es) in the list of classes.",
-      },
+    methods: {
+      getTruncatedItemsString,
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -277,6 +277,15 @@
       iconName() {
         return this.assignmentIsQuiz ? 'quiz' : 'lesson';
       },
+      submitObject() {
+        return {
+          title: this.title,
+          description: this.description,
+          assignments: this.selectedCollectionIds,
+          active: this.activeIsSelected,
+          learner_ids: this.adHocLearners,
+        };
+      },
     },
     watch: {
       title() {
@@ -290,6 +299,13 @@
       },
       adHocLearners() {
         this.$emit('update', { learner_ids: this.adHocLearners });
+      },
+      submitObject() {
+        if (this.showServerError) {
+          this.$nextTick(() => {
+            this.validate(false);
+          });
+        }
       },
     },
     methods: {
@@ -314,13 +330,7 @@
 
         if (this.formIsValid) {
           this.formIsSubmitted = true;
-          this.$emit('submit', {
-            title: this.title,
-            description: this.description,
-            assignments: this.selectedCollectionIds,
-            active: this.activeIsSelected,
-            learner_ids: this.adHocLearners,
-          });
+          this.$emit('submit', this.submitObject);
         } else {
           this.formIsSubmitted = false;
         }
@@ -352,11 +362,14 @@
       /**
        * @public
        */
-      validate() {
+      validate(handleFailure = true) {
         let error = '';
+        this.showServerError = false;
         // Validate title
         if (this.title === '') {
-          this.handleSubmitTitleFailure();
+          if (handleFailure) {
+            this.handleSubmitTitleFailure();
+          }
           error = this.coreString('requiredFieldError');
         }
 
@@ -364,7 +377,9 @@
         const recipientsError = this.$refs.recipientsSelector?.validate();
         if (!error && recipientsError) {
           error = recipientsError;
-          this.$refs.recipientsSelector?.handleSubmitRecipientsFailure();
+          if (handleFailure) {
+            this.$refs.recipientsSelector?.handleSubmitRecipientsFailure();
+          }
         }
 
         if (error) {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -82,22 +82,25 @@
         <legend>
           {{ recipientsLabel$() }}
         </legend>
-        <RecipientSelector
-          v-if="false"
-          v-model="selectedCollectionIds"
-          :groups="groups"
-          :classId="classId"
-          :disabled="disabled || formIsSubmitted"
-          :initialAdHocLearners="adHocLearners"
-          @updateLearners="learners => (adHocLearners = learners)"
-        />
+
         <SidePanelRecipientsSelector
+          v-if="selectRecipientsWithSidePanel"
+          ref="recipientsSelector"
           v-model="selectedCollectionIds"
           :groups="groups"
           :classId="classId"
           :disabled="disabled || formIsSubmitted"
           :adHocLearners.sync="adHocLearners"
           :selectedCollectionIds.sync="selectedCollectionIds"
+        />
+        <RecipientSelector
+          v-else
+          v-model="selectedCollectionIds"
+          :groups="groups"
+          :classId="classId"
+          :disabled="disabled || formIsSubmitted"
+          :initialAdHocLearners="adHocLearners"
+          @updateLearners="learners => (adHocLearners = learners)"
         />
       </fieldset>
     </form>
@@ -195,6 +198,10 @@
       },
       // If set to true, all of the forms are disabled
       disabled: {
+        type: Boolean,
+        default: false,
+      },
+      selectRecipientsWithSidePanel: {
         type: Boolean,
         default: false,
       },
@@ -341,6 +348,25 @@
       handleSubmitSuccess() {
         this.showTitleError = false;
         this.showServerError = false;
+      },
+      /**
+       * @public
+       */
+      validate() {
+        let error = '';
+        // Validate title
+        if (this.title === '') {
+          this.handleSubmitTitleFailure();
+          error = this.coreString('requiredFieldError');
+        }
+
+        // Validate recipients
+        const recipientsError = this.$refs.recipientsSelector?.validate();
+        if (!error && recipientsError) {
+          error = recipientsError;
+          this.$refs.recipientsSelector?.handleSubmitRecipientsFailure();
+        }
+        return error;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -366,6 +366,11 @@
           error = recipientsError;
           this.$refs.recipientsSelector?.handleSubmitRecipientsFailure();
         }
+
+        if (error) {
+          this.showServerError = true;
+        }
+
         return error;
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -11,6 +11,10 @@
         {{ submitErrorMessage }}
       </UiAlert>
 
+      <!--
+        TODO: Refactor or rename this component, setting a title or a description
+        is not part of an "assignment" process (?)
+      -->
       <fieldset>
         <KGrid>
           <KGridItem
@@ -79,12 +83,21 @@
           {{ recipientsLabel$() }}
         </legend>
         <RecipientSelector
+          v-if="false"
           v-model="selectedCollectionIds"
           :groups="groups"
           :classId="classId"
           :disabled="disabled || formIsSubmitted"
           :initialAdHocLearners="adHocLearners"
           @updateLearners="learners => (adHocLearners = learners)"
+        />
+        <SidePanelRecipientsSelector
+          v-model="selectedCollectionIds"
+          :groups="groups"
+          :classId="classId"
+          :disabled="disabled || formIsSubmitted"
+          :adHocLearners.sync="adHocLearners"
+          :selectedCollectionIds.sync="selectedCollectionIds"
         />
       </fieldset>
     </form>
@@ -118,6 +131,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { coachStrings } from '../../common/commonCoachStrings';
   import RecipientSelector from './RecipientSelector';
+  import SidePanelRecipientsSelector from './SidePanelRecipientsSelector';
 
   export default {
     name: 'AssignmentDetailsModal',
@@ -125,6 +139,7 @@
       BottomAppBar,
       RecipientSelector,
       UiAlert,
+      SidePanelRecipientsSelector,
     },
     mixins: [commonCoreStrings],
     setup() {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
@@ -1,7 +1,7 @@
 <template>
 
   <PaginatedListContainer
-    :items="allLearners"
+    :items="sortedAllLearners"
     :filterPlaceholder="$tr('searchPlaceholder')"
     :itemsPerPage="itemsPerPage"
     :searchFieldBlock="searchFieldBlock"
@@ -136,6 +136,10 @@
           // Falls into the default vuex state.
           return this.learners;
         }
+      },
+      sortedAllLearners() {
+        const allLearners = [...this.allLearners];
+        return allLearners.sort((a, b) => a.name.localeCompare(b.name));
       },
       currentGroupMap() {
         return this.groupMapFromOtherClass || this.groupMap;

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
@@ -1,87 +1,62 @@
 <template>
 
-  <div>
-    <!-- Main checkbox -->
-    <KCheckbox
-      key="adHocLearners"
-      :checked="isVisible"
-      :disabled="disabled"
-      @change="$emit('togglevisibility', $event)"
-    >
-      <KLabeledIcon
-        icon="people"
-        :label="$tr('individualLearnersLabel')"
-      />
-    </KCheckbox>
-
-    <!-- Paginated list of learners -->
-    <div v-if="isVisible">
-      <div class="table-title">
-        {{ $tr('selectedIndividualLearnersLabel') }}
-      </div>
-      <div class="table-description">
-        {{ $tr('onlyShowingEnrolledLabel') }}
-      </div>
-
-      <PaginatedListContainer
-        :items="allLearners"
-        :filterPlaceholder="$tr('searchPlaceholder')"
-        :itemsPerPage="itemsPerPage"
-        @pageChanged="currentPageLearners = $event.items"
+  <PaginatedListContainer
+    :items="allLearners"
+    :filterPlaceholder="$tr('searchPlaceholder')"
+    :itemsPerPage="itemsPerPage"
+    @pageChanged="currentPageLearners = $event.items"
+  >
+    <template #default="{ items }">
+      <CoreTable
+        :selectable="true"
+        :emptyMessage="emptyMessage"
       >
-        <template #default="{ items }">
-          <CoreTable
-            :selectable="true"
-            :emptyMessage="emptyMessage"
-          >
-            <template #headers>
-              <th class="table-checkbox-header">
-                <KCheckbox
-                  key="selectAllOnPage"
-                  :label="$tr('selectAllLabel')"
-                  :checked="selectAllCheckboxProps.checked"
-                  :indeterminate="selectAllCheckboxProps.indeterminate"
-                  :disabled="selectAllCheckboxProps.disabled"
-                  @change="selectVisiblePage"
-                />
-              </th>
-              <th class="table-header">
-                {{ coreString('usernameLabel') }}
-              </th>
-              <th class="table-header">
-                {{ coachString('groupsLabel') }}
-              </th>
-            </template>
-
-            <template #tbody>
-              <tbody>
-                <tr
-                  v-for="learner in items"
-                  :key="learner.id"
-                >
-                  <td>
-                    <KCheckbox
-                      :key="`select-learner-${learner.id}`"
-                      :label="learner.name"
-                      :checked="learnerIsSelected(learner)"
-                      :disabled="learnerIsNotSelectable(learner)"
-                      @change="toggleLearner($event, learner)"
-                    />
-                  </td>
-                  <td class="table-data">
-                    {{ learner.username }}
-                  </td>
-                  <td class="table-data">
-                    {{ groupNamesForLearner(learner) }}
-                  </td>
-                </tr>
-              </tbody>
-            </template>
-          </CoreTable>
+        <template #headers>
+          <th class="table-checkbox-header">
+            <KCheckbox
+              key="selectAllOnPage"
+              :label="$tr('selectAllLabel')"
+              :checked="selectAllCheckboxProps.checked"
+              :indeterminate="selectAllCheckboxProps.indeterminate"
+              :disabled="selectAllCheckboxProps.disabled"
+              @change="selectVisiblePage"
+            />
+          </th>
+          <th class="table-header">
+            {{ coreString('usernameLabel') }}
+          </th>
+          <th class="table-header">
+            {{ coachString('groupsLabel') }}
+          </th>
         </template>
-      </PaginatedListContainer>
-    </div>
-  </div>
+
+        <template #tbody>
+          <tbody>
+            <tr
+              v-for="learner in items"
+              :key="learner.id"
+            >
+              <td>
+                <KCheckbox
+                  :key="`select-learner-${learner.id}`"
+                  :label="learner.name"
+                  :checked="learnerIsSelected(learner)"
+                  :disabled="learnerIsNotSelectable(learner)"
+                  @change="toggleLearner($event, learner)"
+                />
+              </td>
+              <td class="table-data">
+                {{ learner.username }}
+              </td>
+              <td class="table-data">
+                {{ groupNamesForLearner(learner) }}
+              </td>
+            </tr>
+          </tbody>
+        </template>
+      </CoreTable>
+    </template>
+  </PaginatedListContainer>
 
 </template>
 
@@ -98,8 +73,8 @@
   import forEach from 'lodash/forEach';
   import countBy from 'lodash/countBy';
   import every from 'lodash/every';
-  import ClassSummaryResource from '../../../apiResources/classSummary';
-  import commonCoachStrings from '../../common';
+  import ClassSummaryResource from '../../../../apiResources/classSummary';
+  import commonCoachStrings from '../../../common';
 
   const DEFAULT_ITEMS_PER_PAGE = 30;
 
@@ -115,11 +90,6 @@
       };
     },
     props: {
-      // If true, the main checkbox is checked and the list of learners is shown
-      isVisible: {
-        type: Boolean,
-        required: true,
-      },
       // Used to disable learner rows if already assigned via learner group
       selectedGroupIds: {
         type: Array,
@@ -180,7 +150,10 @@
       learnerIdsFromSelectedGroups() {
         // If a learner is part of a Learner Group that has already been selected
         // in RecipientSelector, then disable their row
-        return flatMap(this.selectedGroupIds, groupId => this.currentGroupMap[groupId].member_ids);
+        return flatMap(
+          this.selectedGroupIds,
+          groupId => this.currentGroupMap[groupId]?.member_ids || [],
+        );
       },
       selectAllCheckboxProps() {
         const currentCount = this.currentPageLearners.length;
@@ -277,24 +250,9 @@
       },
     },
     $trs: {
-      selectedIndividualLearnersLabel: {
-        message: 'Select individual learners',
-        context:
-          'A bolded header for the table where a Coach will select individual learners who will have access to a quiz.',
-      },
-      onlyShowingEnrolledLabel: {
-        message: 'Only showing learners that are enrolled in this class',
-        context:
-          "Shows beneath 'Select individual learners' explaining that the table only includes enrolled learners.",
-      },
       selectAllLabel: {
         message: 'Select all on page',
         context: 'A checkbox label that will select all visible rows in the table',
-      },
-      individualLearnersLabel: {
-        message: 'Individual learners',
-        context:
-          'A label for a checkbox that allows the Coach to assign the quiz to individual learners who may not be in a selected group.',
       },
       searchPlaceholder: {
         message: 'Search for a user…',

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
@@ -4,6 +4,7 @@
     :items="allLearners"
     :filterPlaceholder="$tr('searchPlaceholder')"
     :itemsPerPage="itemsPerPage"
+    :searchFieldBlock="searchFieldBlock"
     @pageChanged="currentPageLearners = $event.items"
   >
     <template #default="{ items }">
@@ -111,6 +112,10 @@
         type: String,
         required: false,
         default: null,
+      },
+      searchFieldBlock: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/index.vue
@@ -39,7 +39,6 @@
 <script>
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoachStrings from '../../../common';
   import IndividualLearnerSelectorTable from './IndividualLearnerSelectorTable';
 
@@ -47,13 +46,6 @@
     name: 'IndividualLearnerSelector',
     components: { IndividualLearnerSelectorTable },
     mixins: [commonCoreStrings, commonCoachStrings],
-    setup() {
-      const { noLearnersEnrolled$ } = enhancedQuizManagementStrings;
-
-      return {
-        noLearnersEnrolled$,
-      };
-    },
     props: {
       // If true, the main checkbox is checked and the list of learners is shown
       isVisible: {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/IndividualLearnerSelector/index.vue
@@ -1,0 +1,138 @@
+<template>
+
+  <div>
+    <!-- Main checkbox -->
+    <KCheckbox
+      key="adHocLearners"
+      :checked="isVisible"
+      :disabled="disabled"
+      @change="$emit('togglevisibility', $event)"
+    >
+      <KLabeledIcon
+        icon="people"
+        :label="coachString('individualLearnersLabel')"
+      />
+    </KCheckbox>
+
+    <!-- Paginated list of learners -->
+    <div v-if="isVisible">
+      <div class="table-title">
+        {{ $tr('selectedIndividualLearnersLabel') }}
+      </div>
+      <div class="table-description">
+        {{ coachString('onlyShowingEnrolledLabel') }}
+      </div>
+
+      <IndividualLearnerSelectorTable
+        :selectedGroupIds="selectedGroupIds"
+        :selectedLearnerIds="selectedLearnerIds"
+        :targetClassId="targetClassId"
+        :disabled="disabled"
+        @update:selectedLearnerIds="$emit('update:selectedLearnerIds', $event)"
+      />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import commonCoachStrings from '../../../common';
+  import IndividualLearnerSelectorTable from './IndividualLearnerSelectorTable';
+
+  export default {
+    name: 'IndividualLearnerSelector',
+    components: { IndividualLearnerSelectorTable },
+    mixins: [commonCoreStrings, commonCoachStrings],
+    setup() {
+      const { noLearnersEnrolled$ } = enhancedQuizManagementStrings;
+
+      return {
+        noLearnersEnrolled$,
+      };
+    },
+    props: {
+      // If true, the main checkbox is checked and the list of learners is shown
+      isVisible: {
+        type: Boolean,
+        required: true,
+      },
+      // Used to disable learner rows if already assigned via learner group
+      selectedGroupIds: {
+        type: Array,
+        required: true,
+      },
+      // List of selected learner IDs (must be .sync'd with parent form)
+      selectedLearnerIds: {
+        type: Array,
+        required: true,
+      },
+      // Disables the entire form
+      disabled: {
+        type: Boolean,
+        required: true,
+        default: false,
+      },
+      // Only given when not used in current class context
+      targetClassId: {
+        type: String,
+        required: false,
+        default: null,
+      },
+    },
+    $trs: {
+      selectedIndividualLearnersLabel: {
+        message: 'Select individual learners',
+        context:
+          'A bolded header for the table where a Coach will select individual learners who will have access to a quiz.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  fieldset {
+    padding: 0;
+    margin: 24px 0;
+    border: 0;
+  }
+
+  .table-title {
+    margin: 16px 0;
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  .table-header {
+    padding: 24px 0;
+  }
+
+  .table-checkbox-header {
+    padding: 8px;
+  }
+
+  .hidden-learners-tooltip {
+    padding: 0 8px;
+  }
+
+  .table-description {
+    margin-bottom: 8px;
+    font-size: 16px;
+  }
+
+  .table-data {
+    padding-top: 6px;
+    vertical-align: middle;
+  }
+
+  .filter-input {
+    margin-top: 16px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -179,7 +179,7 @@
     },
     $trs: {
       allUngroupedLearnres: {
-        message: 'All ungrouped Learners',
+        message: 'All ungrouped learners',
         context: 'Option to select all learners that are not in a group',
       },
       selectGroupsAndIndividualLearnersTitle: {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -18,7 +18,7 @@
           {{ coachString('groupsLabel') }}
         </h2>
         <KCheckbox
-          v-for="group in groups"
+          v-for="group in sortedGroups"
           :key="group.id"
           :checked="groupIsSelected(group)"
           :disabled="disabled"
@@ -119,6 +119,10 @@
     computed: {
       ...mapGetters('classSummary', ['learners']),
       ...mapState('classSummary', ['groupMap']),
+      sortedGroups() {
+        const groups = [...this.groups];
+        return groups.sort((a, b) => a.name.localeCompare(b.name));
+      },
       ungroupedLearnersIds() {
         return this.learners
           .filter(learner => {
@@ -175,7 +179,7 @@
     },
     $trs: {
       allUngroupedLearnres: {
-        message: 'All Ungrouped Learners',
+        message: 'All ungrouped Learners',
         context: 'Option to select all learners that are not in a group',
       },
       selectGroupsAndIndividualLearnersTitle: {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -8,7 +8,7 @@
     @shouldFocusFirstEl="focusFirstEl"
   >
     <template #header>
-      <h1>
+      <h1 class="side-panel-title">
         {{ $tr('selectGroupsAndIndividualLearnersTitle') }}
       </h1>
     </template>
@@ -26,21 +26,28 @@
           <KLabeledIcon
             :label="group.name"
             icon="group"
+            class="font-size-14"
           />
         </KCheckbox>
         <KCheckbox
-          :label="$tr('allUngroupedLearnres')"
           :checked="allUngroupedLearnresIsSelected"
           :disabled="disabled"
           @change="selectAllUngroupedLearners($event)"
-        />
+        >
+          <KLabeledIcon
+            :label="$tr('allUngroupedLearnres')"
+            icon="people"
+            class="font-size-14"
+          />
+        </KCheckbox>
       </section>
       <section>
         <h2>{{ coachString('individualLearnersLabel') }}</h2>
-        <div>
+        <div class="font-size-14">
           {{ coachString('onlyShowingEnrolledLabel') }}
         </div>
         <IndividualLearnerSelectorTable
+          searchFieldBlock
           :selectedGroupIds="workingSelectedGroupIds"
           :selectedLearnerIds.sync="workingAdHocLearners"
           :disabled="disabled"
@@ -187,6 +194,21 @@
     justify-content: flex-end;
     width: 100%;
     margin-bottom: 16px;
+  }
+
+  .side-panel-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  section h2 {
+    margin-top: 24px;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .font-size-14 {
+    font-size: 14px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -1,0 +1,139 @@
+<template>
+
+  <SidePanelModal
+    alignment="right"
+    sidePanelWidth="700px"
+    closeButtonIconType="close"
+    @closePanel="$emit('close')"
+  >
+    <template #header>
+      <h1>
+        {{ $tr('selectGroupsAndIndividualLearnersTitle') }}
+      </h1>
+    </template>
+    <div style="padding-top: 30px">
+      <!-- TODO: remove this div once SidePanelModal is fixed-->
+      <section>
+        <h2>{{ coachString('groupsLabel') }}</h2>
+        <KCheckbox
+          v-for="group in groups"
+          :key="group.id"
+          :checked="groupIsSelected(group)"
+          :disabled="disabled"
+          @change="toggleGroup($event, group)"
+        >
+          <KLabeledIcon
+            :label="group.name"
+            icon="group"
+          />
+        </KCheckbox>
+        <KCheckbox
+          :label="$tr('allUngroupedLearnres')"
+          :checked="allUngroupedLearnresIsSelected"
+          :disabled="disabled"
+          @change="selectAllUngroupedLearners($event)"
+        />
+      </section>
+      <section>
+        <h2>{{ coachString('individualLearnersLabel') }}</h2>
+        <div>
+          {{ coachString('onlyShowingEnrolledLabel') }}
+        </div>
+        <IndividualLearnerSelectorTable
+          :selectedGroupIds="selectedGroupIds"
+          :selectedLearnerIds="adHocLearners"
+          :disabled="disabled"
+          :targetClassId="classId"
+          @update:selectedLearnerIds="updateAdHocLearners"
+        />
+      </section>
+    </div>
+  </SidePanelModal>
+
+</template>
+
+
+<script>
+
+  import { mapGetters } from 'vuex';
+  import SidePanelModal from 'kolibri-common/components/SidePanelModal';
+  import { coachStringsMixin } from '../../../common/commonCoachStrings';
+  import IndividualLearnerSelectorTable from '../IndividualLearnerSelector/IndividualLearnerSelectorTable';
+
+  export default {
+    name: 'LearnersSelectorSidePanel',
+    components: {
+      SidePanelModal,
+      IndividualLearnerSelectorTable,
+    },
+    mixins: [coachStringsMixin],
+    props: {
+      groups: {
+        type: Array,
+        required: true,
+      },
+      adHocLearners: {
+        type: Array,
+        required: false,
+        default: () => [],
+      },
+      selectedGroupIds: {
+        type: Array,
+        required: true,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      classId: {
+        type: String,
+        required: true,
+      },
+    },
+    computed: {
+      ...mapGetters('classSummary', ['learners']),
+      ungroupedLearnersIds() {
+        return this.learners.filter(learner => !learner.group_id).map(learner => learner.id);
+      },
+      allUngroupedLearnresIsSelected() {
+        return this.adHocLearners.length === this.ungroupedLearnersIds.length;
+      },
+    },
+    methods: {
+      groupIsSelected({ id }) {
+        return this.selectedGroupIds.includes(id);
+      },
+      toggleGroup(isChecked, { id }) {
+        if (isChecked) {
+          this.$emit('update:selectedGroupIds', [...this.selectedGroupIds, id]);
+        } else {
+          this.$emit(
+            'update:selectedGroupIds',
+            this.selectedGroupIds.filter(groupId => groupId !== id),
+          );
+        }
+      },
+      updateAdHocLearners(learnerIds) {
+        this.$emit('update:adHocLearners', learnerIds);
+      },
+      selectAllUngroupedLearners(isChecked) {
+        if (isChecked) {
+          this.updateAdHocLearners(this.ungroupedLearnersIds);
+        } else {
+          this.updateAdHocLearners([]);
+        }
+      },
+    },
+    $trs: {
+      allUngroupedLearnres: {
+        message: 'All Ungrouped Learners',
+        context: 'Option to select all learners that are not in a group',
+      },
+      selectGroupsAndIndividualLearnersTitle: {
+        message: 'Select groups and individual learners',
+        context: 'Title for the side panel to select groups and individual learners',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -5,6 +5,7 @@
     sidePanelWidth="700px"
     closeButtonIconType="close"
     @closePanel="$emit('close')"
+    @shouldFocusFirstEl="focusFirstEl"
   >
     <template #header>
       <h1>
@@ -126,6 +127,11 @@
       },
     },
     methods: {
+      focusFirstEl() {
+        this.$nextTick(() => {
+          this.$el.querySelector('input').focus();
+        });
+      },
       groupIsSelected({ id }) {
         return this.workingSelectedGroupIds.includes(id);
       },

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -12,10 +12,11 @@
         {{ $tr('selectGroupsAndIndividualLearnersTitle') }}
       </h1>
     </template>
-    <div style="padding-top: 30px">
-      <!-- TODO: remove this div once SidePanelModal is fixed-->
+    <template #default>
       <section>
-        <h2>{{ coachString('groupsLabel') }}</h2>
+        <h2 class="mt-0">
+          {{ coachString('groupsLabel') }}
+        </h2>
         <KCheckbox
           v-for="group in groups"
           :key="group.id"
@@ -55,7 +56,7 @@
           @update:selectedLearnerIds="updateAdHocLearners"
         />
       </section>
-    </div>
+    </template>
     <template #bottomNavigation>
       <div class="bottom-nav-container">
         <KButton
@@ -189,11 +190,14 @@
 
 <style lang="scss" scoped>
 
+  .mt-0 {
+    margin-top: 0;
+  }
+
   .bottom-nav-container {
     display: flex;
     justify-content: flex-end;
     width: 100%;
-    margin-bottom: 16px;
   }
 
   .side-panel-title {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
@@ -14,6 +14,7 @@
         />
       </KRadioButton>
       <KRadioButton
+        v-if="learners.length > 0"
         ref="groupOrIndividualRadioButton"
         v-model="selectedRecipients"
         :buttonValue="ClassRecipients.GROUP_OR_INDIVIDUAL"
@@ -134,7 +135,7 @@
       };
     },
     computed: {
-      ...mapGetters('classSummary', ['getRecipientNamesForExam']),
+      ...mapGetters('classSummary', ['getRecipientNamesForExam', 'learners']),
       hasGroupOrIndividualRecipients() {
         return (
           this.selectedRecipients === ClassRecipients.GROUP_OR_INDIVIDUAL &&

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
@@ -163,10 +163,21 @@
     watch: {
       selectedRecipients(newVal) {
         if (newVal === ClassRecipients.ENTIRE_CLASS) {
+          // Backup data in case user selects group or individual again.
+          this.selectedGroupsBackedUp = this.selectedGroupIds;
+          this.adHocLearnersBackedUp = this.adHocLearners;
+
           this.selectedGroupIds = [this.classId];
           this.updateAdHocLearners([]);
         } else {
-          this.selectedGroupIds = this.selectedCollectionIds.filter(id => id !== this.classId);
+          if (this.adHocLearnersBackedUp) {
+            this.updateAdHocLearners(this.adHocLearnersBackedUp);
+          }
+          if (this.selectedGroupsBackedUp) {
+            this.selectedGroupIds = this.selectedGroupsBackedUp;
+          } else {
+            this.selectedGroupIds = this.selectedCollectionIds.filter(id => id !== this.classId);
+          }
         }
       },
       selectedGroupIds(newVal) {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
@@ -173,7 +173,11 @@
       },
     },
     mounted() {
-      this.selectedRecipients = ClassRecipients.ENTIRE_CLASS;
+      if (this.selectedCollectionIds.includes(this.classId)) {
+        this.selectedRecipients = ClassRecipients.ENTIRE_CLASS;
+      } else {
+        this.selectedRecipients = ClassRecipients.GROUP_OR_INDIVIDUAL;
+      }
     },
     methods: {
       updateAdHocLearners(newVal) {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
@@ -1,0 +1,142 @@
+<template>
+
+  <div>
+    <!-- Entire class -->
+    <KRadioButtonGroup>
+      <KRadioButton
+        v-model="selectedRecipients"
+        :buttonValue="Recipients.ENTIRE_CLASS"
+        :disabled="disabled"
+      >
+        <KLabeledIcon
+          :label="coachString('entireClassLabel')"
+          icon="classes"
+        />
+      </KRadioButton>
+      <KRadioButton
+        v-model="selectedRecipients"
+        :buttonValue="Recipients.GROUP_OR_INDIVIDUAL"
+        :disabled="disabled"
+      >
+        <div class="flex-center">
+          <KLabeledIcon
+            :label="coachString('groupsAndLearnersLabel')"
+            icon="people"
+            style="width: auto"
+          />
+          <KButton
+            v-if="selectedRecipients === Recipients.GROUP_OR_INDIVIDUAL"
+            appearance="basic-link"
+            :text="coreString('selectAction')"
+            @click="isLearnersSelectorOpen = true"
+          />
+        </div>
+      </KRadioButton>
+    </KRadioButtonGroup>
+
+    <LearnersSelectorSidePanel
+      v-if="isLearnersSelectorOpen"
+      :groups="groups"
+      :adHocLearners="adHocLearners"
+      :selectedGroupIds.sync="selectedGroupIds"
+      :disabled="disabled"
+      :classId="classId"
+      @close="isLearnersSelectorOpen = false"
+      @update:adHocLearners="updateAdHocLearners"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import every from 'lodash/every';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { coachStringsMixin } from '../../../common/commonCoachStrings';
+  import LearnersSelectorSidePanel from './LearnersSelectorSidePanel';
+
+  const Recipients = {
+    ENTIRE_CLASS: 'entire_class',
+    GROUP_OR_INDIVIDUAL: 'group_or_individual',
+  };
+
+  export default {
+    name: 'SidePanelRecipientsSelector',
+    components: { LearnersSelectorSidePanel },
+    mixins: [coachStringsMixin, commonCoreStrings],
+    props: {
+      // Needs to equal [classId] if entire class is selected
+      // Otherwise, [groupId_1, groupId_2] for individual Learner Groups
+      selectedCollectionIds: {
+        type: Array,
+        required: true,
+      },
+      // Array of objects, each with (group) 'id' and 'name'
+      groups: {
+        type: Array,
+        required: true,
+        validator(value) {
+          return every(value, val => val.name && val.id);
+        },
+      },
+      // For the 'Entire Class' option
+      classId: {
+        type: String,
+        required: true,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      adHocLearners: {
+        type: Array,
+        required: false,
+        default: () => [],
+      },
+    },
+    data() {
+      return {
+        Recipients,
+        selectedRecipients: null,
+        // Determines whether the group's checkbox is checked and affects which
+        // learners are selectable in IndividualLearnerSelector
+        selectedGroupIds: this.selectedCollectionIds.filter(id => id !== this.classId),
+        isLearnersSelectorOpen: false,
+      };
+    },
+    watch: {
+      selectedRecipients(newVal) {
+        if (newVal === Recipients.ENTIRE_CLASS) {
+          this.selectedGroupIds = [this.classId];
+          this.updateAdHocLearners([]);
+        } else {
+          this.selectedGroupIds = this.selectedCollectionIds.filter(id => id !== this.classId);
+        }
+      },
+      selectedGroupIds(newVal) {
+        this.$emit('update:selectedCollectionIds', newVal);
+      },
+    },
+    mounted() {
+      this.selectedRecipients = Recipients.ENTIRE_CLASS;
+    },
+    methods: {
+      updateAdHocLearners(newVal) {
+        this.$emit('update:adHocLearners', newVal);
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .flex-center {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -200,6 +200,16 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       'A group is a collection of learners created by a coach inside a class to help with differentiated learning. Quizzes and lessons can be assigned to individual groups as well as to the whole class.',
   },
+  individualLearnersLabel: {
+    message: 'Individual learners',
+    context:
+      'A label for a checkbox that allows the Coach to assign the quiz to individual learners who may not be in a selected group.',
+  },
+  onlyShowingEnrolledLabel: {
+    message: 'Only showing learners that are enrolled in this class',
+    context:
+      "Shows beneath 'Select individual learners' explaining that the table only includes enrolled learners.",
+  },
   helpNeededLabel: {
     message: 'Help needed',
     context:
@@ -634,6 +644,11 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     message: 'Manage lesson resources',
     context:
       "In the 'Manage lesson resources' coaches can add new/remove resource material to a lesson.",
+  },
+  groupsAndLearnersLabel: {
+    message: 'Groups and individual learners',
+    context:
+      'Label for the radio button that allows the coach to select groups or individual learners to assign a quiz to.',
   },
 });
 

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -671,6 +671,24 @@ const MissingContentStrings = createTranslator('MissingContentStrings', {
   },
 });
 
+// Strings for showing lists of items that can be truncated
+const truncatedItemsStrings = createTranslator('TruncatedItemsStrings', {
+  twoItems: {
+    message: '{item1}, {item2}',
+    context:
+      "DO NOT TRANSLATE\nCopy the source string.\n\nFor reference: 'item' will be replaced by the name of the coach(es) in the list of classes.",
+  },
+  threeItems: {
+    message: '{item1}, {item2}, {item3}',
+    context:
+      "DO NOT TRANSLATE\nCopy the source string.\n\nFor reference: 'item' will be replaced by the name of the coach(es) in the list of classes.",
+  },
+  manyItems: {
+    message: '{item1}, {item2}, and {count, number, integer} others',
+    context: "'item' will be replaced by the name of the coach(es) in the list of classes.",
+  },
+});
+
 function coachString(key, args) {
   return coachStrings.$tr(key, args);
 }
@@ -684,4 +702,28 @@ const coachStringsMixin = {
   },
 };
 
-export { coachString, coachStrings, coachStringsMixin };
+function getTruncatedItemsString(items) {
+  if (items.length <= 1) {
+    return items[0] || '';
+  }
+  if (items.length === 2) {
+    return truncatedItemsStrings.$tr('twoItems', {
+      item1: items[0],
+      item2: items[1],
+    });
+  }
+  if (items.length === 3) {
+    return truncatedItemsStrings.$tr('threeItems', {
+      item1: items[0],
+      item2: items[1],
+      item3: items[2],
+    });
+  }
+  return truncatedItemsStrings.$tr('manyItems', {
+    item1: items[0],
+    item2: items[1],
+    count: items.length - 2,
+  });
+}
+
+export { coachString, coachStrings, coachStringsMixin, getTruncatedItemsString };

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
@@ -19,6 +19,7 @@
         v-if="quizInitialized"
         ref="detailsModal"
         assignmentType="quiz"
+        :selectRecipientsWithSidePanel="true"
         :assignment="quiz"
         :classId="classId"
         :groups="groups"
@@ -334,6 +335,10 @@
         }
       },
       saveQuizAndRedirect(close = true) {
+        const errorText = this.$refs.detailsModal.validate();
+        if (errorText) {
+          return;
+        }
         this.saveQuiz()
           .then(exam => {
             this.$refs.detailsModal.handleSubmitSuccess();

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
@@ -26,26 +26,30 @@
     name: 'QuizOptionsDropdownMenu',
     mixins: [coachStringsMixin, commonCoreStrings],
     props: {
-      draft: {
-        type: Boolean,
-        default: false,
+      exam: {
+        type: Object,
+        required: false,
+        default: null,
       },
     },
     computed: {
       options() {
-        return [
-          {
-            label: this.draft
-              ? this.coreString('editAction')
-              : this.coreString('editDetailsAction'),
-            value: 'EDIT_DETAILS',
-          },
+        const options = [
           {
             label: this.$tr('copyQuizAction'),
             value: 'COPY',
           },
           { label: this.coreString('deleteAction'), value: 'DELETE' },
         ];
+        if (!this.exam?.archive) {
+          options.unshift({
+            label: this.exam?.draft
+              ? this.coreString('editAction')
+              : this.coreString('editDetailsAction'),
+            value: 'EDIT_DETAILS',
+          });
+        }
+        return options;
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -23,7 +23,7 @@
               style="margin-right: 8px"
             />
             <QuizOptionsDropdownMenu
-              :draft="exam && exam.draft"
+              :exam="exam"
               @select="setCurrentAction"
             />
           </template>

--- a/packages/kolibri-common/components/PaginatedListContainer.vue
+++ b/packages/kolibri-common/components/PaginatedListContainer.vue
@@ -2,16 +2,17 @@
 
   <div>
     <KGrid>
-      <KGridItem :layout12="{ span: 7 }">
+      <KGridItem :layout12="{ span: searchFieldBlock ? 12 : 7 }">
         <slot name="otherFilter"></slot>
       </KGridItem>
       <KGridItem
-        :layout12="{ span: 5, alignment: 'right' }"
+        :layout12="{ span: searchFieldBlock ? 12 : 5, alignment: 'right' }"
         class="text-filter"
       >
         <FilterTextbox
           v-model="filterInput"
           :placeholder="filterPlaceholder"
+          :style="{ width: searchFieldBlock ? '100%' : null }"
         />
       </KGridItem>
     </KGrid>
@@ -74,6 +75,10 @@
         type: Number,
         required: false,
         default: 30,
+      },
+      searchFieldBlock: {
+        type: Boolean,
+        required: false,
       },
     },
     data() {

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -88,8 +88,6 @@
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
         // @type {RefImpl<number>}
         windowBreakpoint,
-        fixedHeaderHeight: 0,
-        fixedBottombarHeight: 0,
         lastFocus: null,
       };
     },
@@ -181,11 +179,6 @@
     mounted() {
       const htmlTag = window.document.getElementsByTagName('html')[0];
       htmlTag.style['overflow-y'] = 'hidden';
-      // Gets the height of the fixed header - adds 40 to account for padding + 24 for closeButton
-      this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight;
-      if (this.$refs.fixedBottombar) {
-        this.fixedBottombarHeight = this.$refs.fixedBottombar.clientHeight;
-      }
       this.$nextTick(() => {
         this.$emit('shouldFocusFirstEl');
       });

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -77,7 +77,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "kolibri-constants": "0.2.8",
-    "kolibri-design-system": "5.0.0-rc11",
+    "kolibri-design-system": "5.0.0-rc12",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "path-to-regexp": "1.9.0",

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1550,10 +1550,6 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Your library',
     context: '',
   },
-  selectAction: {
-    message: 'Select',
-    context: '',
-  },
 });
 
 /**

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1550,6 +1550,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Your library',
     context: '',
   },
+  selectAction: {
+    message: 'Select',
+    context: '',
+  },
 });
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,10 +7791,10 @@ kolibri-constants@0.2.8:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.8.tgz#34ad2e2b87cf132ebe8dbaa9b64dc4a7bf261f8d"
   integrity sha512-ycXeK+ePw7zkiNtf+nX/yF5BO52+onoYS2V3d9HZDIvx7X6CDJPtMcypkXrK9aZ0JbWAegRFMD/lAd8q21cf4Q==
 
-kolibri-design-system@5.0.0-rc11:
-  version "5.0.0-rc11"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc11.tgz#433b31d25337255708cf1bc28b86e4d619962f98"
-  integrity sha512-g3mxd+Bd82al5Bf3zfO3tizItI/LeMVCUVXwifv8rtbukIa5aoWDwCTUJkdnEQCFSZR5WQ0k9mhieIAe47ebvQ==
+kolibri-design-system@5.0.0-rc12:
+  version "5.0.0-rc12"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc12.tgz#326fa3446dbf597c1cdd8b08e3a4b64cb5d6ea30"
+  integrity sha512-IDbt5ADUSkvG6LyR9tUwMZz26xVcRBk1PBYCTbjNK+dJeuATp92QhTSh87sWXxlSoYV7/1DURqLA3lCefsaQnA==
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "3.0.21"


### PR DESCRIPTION
## Summary
Add quiz recipients selector as Side Panel.

https://github.com/user-attachments/assets/5cb53b4b-1bc2-4535-a28a-47fcda180122


## References
Closes #12901.

…

## Reviewer guidance
* Create a new quiz and assign an entire class, groups or students.
* Edit a created quiz and assig an entire class, groups or students.
* Check error statuses.