### PR TITLE
Drop and recreate M2M field to avoid constraint errors.

### DIFF
--- a/kolibri/core/content/migrations/0039_channelmetadata_ordered_fields.py
+++ b/kolibri/core/content/migrations/0039_channelmetadata_ordered_fields.py
@@ -22,11 +22,16 @@ class Migration(migrations.Migration):
             name="included_grade_levels",
             field=models.TextField(blank=True, null=True),
         ),
-        sortedm2m.operations.AlterSortedManyToManyField(
+        migrations.RemoveField(
+            model_name="channelmetadata",
+            name="included_languages",
+        ),
+        migrations.AddField(
             model_name="channelmetadata",
             name="included_languages",
             field=sortedm2m.fields.SortedManyToManyField(
                 blank=True,
+                help_text=None,
                 related_name="channels",
                 to="content.Language",
                 verbose_name="languages",


### PR DESCRIPTION
## Summary
Didn't discover the issue with this migration until after I had merged. Running the migration locally caused constraint errors.
Deleting and recreating the through table from scratch seemed simplest.

## References
Follow up from #12880 

## Reviewer guidance
Can you run migrations locally?