### PR TITLE
Add required sanity check flags to ensure deletion of testpypi artifacts

### DIFF
--- a/.github/workflows/cleanup_test_pypi.yml
+++ b/.github/workflows/cleanup_test_pypi.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pypi-cleanup
+        pip install pypi-cleanup==0.1.8
     - name: Cleanup TestPyPi
       env:
         PYPI_CLEANUP_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
-      run: pypi-cleanup --host https://test.pypi.org --package kolibri --leave-most-recent-only --username __token__
+      run: pypi-cleanup --host https://test.pypi.org --package kolibri --leave-most-recent-only --username __token__ --yes --do-it


### PR DESCRIPTION
## Summary
* Adds the two required flags `--do-it` and `--yes` to make the pypi-cleanup command run a destructive operation
* Pins the pypi-cleanup library to a specific version to avoid accidents from API changes

## References
https://github.com/learningequality/kolibri/actions/runs/12150283948/job/33882727667

