### PR TITLE
Pin python version to 3.11 for node-gyp support.

### DIFF
--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -42,6 +42,8 @@ jobs:
         restore-keys: |
           ${{ runner.OS }}-node-
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         # Use a Python virtual environment to ensure


### PR DESCRIPTION
## Summary
* Pins Python version to 3.11 in our license check to allow node-gyp to work without additional dependencies.