### PR TITLE
Fix top navigation positioning when window is resized

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -621,7 +621,7 @@
   }
 
   .filter-button {
-    margin-top: 5px;
+    margin-top: 35px;
   }
 
   .main-grid {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -473,11 +473,9 @@
         }
       },
       gridOffset() {
-        const paddingTop =
-          !this.windowIsLarge && (this.isLocalLibraryEmpty || this.deviceId) ? '140px' : '110px';
         return this.isRtl
-          ? { paddingRight: `${this.sidePanelWidth + 24}px`, paddingTop }
-          : { paddingLeft: `${this.sidePanelWidth + 24}px`, paddingTop };
+          ? { paddingRight: `${this.sidePanelWidth + 24}px` }
+          : { paddingLeft: `${this.sidePanelWidth + 24}px` };
       },
       sidePanelWidth() {
         if (
@@ -623,11 +621,10 @@
   }
 
   .filter-button {
-    margin-top: 30px;
+    margin-top: 5px;
   }
 
   .main-grid {
-    padding-top: 110px;
     padding-right: 24px;
     padding-bottom: 96px;
   }

--- a/packages/kolibri/components/pages/AppBarPage/__tests__/app-bar-core-page.spec.js
+++ b/packages/kolibri/components/pages/AppBarPage/__tests__/app-bar-core-page.spec.js
@@ -35,8 +35,12 @@ describe('AppBarPage', () => {
     }));
   });
   describe('AppBar & optional sub-nav slot display', () => {
-    it('should render the AppBar component with the given title prop', () => {
-      const wrapper = createWrapper({ propsData: { title: 'Test Title' } });
+    it('should render the AppBar component with the given title prop', async () => {
+      const wrapper = createWrapper({ propsData: { title: 'Test Title', loading: false } });
+      // set AppBar data prop appBarWidth to 1800 so that the full title is displayed
+      const appBar = wrapper.findComponent({ name: 'AppBar' });
+      appBar.setData({ appBarWidth: 1800 });
+      await appBar.vm.$nextTick();
       expect(wrapper.findComponent({ name: 'AppBar' }).element).toHaveTextContent('Test Title');
     });
     it("should pass a given `subNav` slot content to the AppBar's `sub-nav` slot", () => {

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -71,10 +71,9 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { windowBreakpoint, windowIsSmall } = useKResponsiveWindow();
+      const { windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
       return {
-        windowBreakpoint,
         windowIsSmall,
         isAppContext,
       };
@@ -146,20 +145,17 @@
         return show;
       },
     },
-    watch: {
-      windowBreakpoint() {
-        //Update the the app bar height at every breakpoint
-        this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 0;
-      },
+    beforeUpdate() {
+      // Update appBarHeight after AppBar is rerendered and updated
+      this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 0;
     },
     mounted() {
-      this.$nextTick(() => {
-        this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 0;
-      });
       this.addScrollListener();
+      window.addEventListener('resize', this.handleWindowResize);
     },
-    beforeUnmount() {
+    beforeDestroy() {
       this.removeScrollListener();
+      window.removeEventListener('resize', this.handleWindowResize);
     },
     methods: {
       addScrollListener() {
@@ -189,6 +185,10 @@
           this.throttledHandleScroll.cancel();
           this.throttledHandleScroll = null;
         }
+      },
+      handleWindowResize() {
+        // Update the app bar height when window is resized
+        this.appBarHeight = this.$refs.appBar.$el.offsetHeight || 0;
       },
     },
   };

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -30,7 +30,7 @@
     <div
       id="main"
       class="main-wrapper"
-      :style="wrapperStyles"
+      :style="[wrapperStyles, paddingTop]"
     >
       <slot></slot>
     </div>
@@ -126,13 +126,16 @@
             backgroundColor: this.$themePalette.grey.v_100,
             paddingLeft: this.paddingLeftRight,
             paddingRight: this.paddingLeftRight,
-            paddingTop: this.appBarHeight + this.paddingTop + 'px',
             paddingBottom: '72px',
             marginTop: 0,
           };
       },
       paddingTop() {
-        return this.isAppContext ? 0 : 5;
+        const extraPadding = this.isAppContext ? 0 : 5;
+        const totalPadding = this.appBarHeight + extraPadding;
+        return {
+          paddingTop: `${totalPadding}px`,
+        };
       },
       paddingLeftRight() {
         return this.isAppContext || this.windowIsSmall ? '8px' : '32px';
@@ -147,7 +150,7 @@
     },
     beforeUpdate() {
       // Update appBarHeight after AppBar is rerendered and updated
-      this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 124;
+      this.handleWindowResize();
     },
     mounted() {
       this.addScrollListener();

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -101,7 +101,7 @@
     },
     data() {
       return {
-        appBarHeight: 0,
+        appBarHeight: 124,
         navShown: false,
         lastScrollTop: 0,
         hideAppBars: true,
@@ -132,7 +132,7 @@
           };
       },
       paddingTop() {
-        return this.isAppContext ? 0 : 4;
+        return this.isAppContext ? 0 : 5;
       },
       paddingLeftRight() {
         return this.isAppContext || this.windowIsSmall ? '8px' : '32px';
@@ -147,7 +147,7 @@
     },
     beforeUpdate() {
       // Update appBarHeight after AppBar is rerendered and updated
-      this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 0;
+      this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 124;
     },
     mounted() {
       this.addScrollListener();
@@ -188,7 +188,7 @@
       },
       handleWindowResize() {
         // Update the app bar height when window is resized
-        this.appBarHeight = this.$refs.appBar.$el.offsetHeight || 0;
+        this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 124;
       },
     },
   };

--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -58,6 +58,7 @@
               v-if="links.length > 0"
               :class="{ 'hide-navbar': !showTopNavBar }"
               :navigationLinks="links"
+              :title="title"
               @update-overflow-count="overflowCount = $event"
             />
           </slot>
@@ -127,6 +128,7 @@
         <Navbar
           v-if="links.length > 0"
           :navigationLinks="links"
+          :title="title"
         />
       </slot>
     </div>

--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -23,7 +23,11 @@
         :removeBrandDivider="true"
       >
         <KTextTruncator
-          :text="windowIsSmall ? truncateText(title, 20) : truncateText(title, 50)"
+          :text="
+            windowIsSmall
+              ? truncateText(title, smallScreensMaxTitleLength)
+              : truncateText(title, 50)
+          "
           :maxLines="1"
         />
         <template
@@ -209,6 +213,9 @@
         pointsDisplayed: false,
         breakpointLimit: 4,
         showTopNavBar: false,
+        // Limit for title length on small screens to hide
+        // overflow menu button at windowBreakpoint 3
+        smallScreensMaxTitleLength: 20,
       };
     },
     computed: {
@@ -221,12 +228,11 @@
       if (this.isLearner) {
         this.fetchPoints();
       }
-      window.addEventListener('click', this.handleWindowClick);
-      window.addEventListener('keydown', this.handlePopoverByKeyboard, true);
     },
     beforeUpdate() {
       // Essential for title updates after data finishes loading
-      this.breakpointLimit = this.title && this.title.length >= 20 ? 4 : 3;
+      this.breakpointLimit =
+        this.title && this.title.length >= this.smallScreensMaxTitleLength ? 4 : 3;
       this.showTopNavBar = this.windowBreakpoint > this.breakpointLimit;
     },
     beforeDestroy() {
@@ -235,6 +241,8 @@
       window.removeEventListener('resize', this.handleWindowResize);
     },
     mounted() {
+      window.addEventListener('click', this.handleWindowClick);
+      window.addEventListener('keydown', this.handlePopoverByKeyboard, true);
       window.addEventListener('resize', this.handleWindowResize);
     },
     methods: {

--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -56,7 +56,7 @@
           <slot name="sub-nav">
             <Navbar
               v-if="links.length > 0"
-              :class="{ 'hide-navbar': !showTopNavBar }"
+              :style="hiddenNavbarStyle"
               :navigationLinks="links"
               :title="title"
               @update-overflow-count="overflowCount = $event"
@@ -232,6 +232,19 @@
         const availableWidth = this.appBarWidth - offset;
         const maxChars = availableWidth > 0 ? Math.floor(availableWidth / averageCharWidth) : 1;
         return this.truncateText(this.title, maxChars);
+      },
+      hiddenNavbarStyle() {
+        if (this.showTopNavBar) {
+          return {};
+        }
+        // Hide top navbar, but keep it in the DOM for overflow calulations
+        const rightOffset = `${this.title.length * 10 + 250}px`;
+        return {
+          pointerEvents: 'none',
+          opacity: '0',
+          position: 'fixed',
+          right: rightOffset,
+        };
       },
     },
     created() {
@@ -419,17 +432,6 @@
     display: inline-block;
     margin-left: 8px;
     font-size: 14px;
-  }
-
-  // Hide top navbar, but keep it in the DOM for overflow calulations
-  .hide-navbar {
-    pointer-events: none;
-    opacity: 0;
-  }
-
-  /deep/ .hide-navbar.navbar-positioning {
-    display: grid;
-    visibility: hidden;
   }
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -127,6 +127,7 @@
       <slot name="sub-nav">
         <Navbar
           v-if="links.length > 0"
+          :class="{ 'sub-nav': !showTopNavBar }"
           :navigationLinks="links"
           :title="title"
         />
@@ -432,6 +433,10 @@
     display: inline-block;
     margin-left: 8px;
     font-size: 14px;
+  }
+
+  /deep/ .sub-nav .items {
+    margin-top: 0;
   }
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/internal/Navbar/__tests__/nav-bar.spec.js
+++ b/packages/kolibri/components/pages/AppBarPage/internal/Navbar/__tests__/nav-bar.spec.js
@@ -57,6 +57,7 @@ describe('Navbar', () => {
         const wrapper = makeWrapper(Navbar, {
           propsData: {
             navigationLinks: longerNavigationList,
+            title: 'Title',
           },
         });
         expect(wrapper.findComponent({ name: 'KIconButton' }).element).toBeFalsy();

--- a/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
@@ -114,12 +114,18 @@
         if (this.windowIsLarge) {
           return styles;
         }
-        styles.marginTop = 0;
         if (this.windowIsMedium) {
           return styles;
         }
+        styles.marginTop = 0;
         styles.maxHeight = '42px';
         return styles;
+      },
+    },
+    watch: {
+      // Whenever overflowMenuLinks changes, emit its new length
+      overflowMenuLinks(newValue) {
+        this.$emit('update-overflow-count', newValue.length);
       },
     },
     mounted() {

--- a/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
@@ -83,6 +83,10 @@
           return values.every(value => value.link.name);
         },
       },
+      title: {
+        type: String,
+        required: true,
+      },
     },
     data() {
       return { mounted: false };
@@ -92,7 +96,7 @@
         return this.navigationLinks.filter(l => !l.isHidden);
       },
       overflowMenuLinks() {
-        if (!this.mounted || isUndefined(this.windowWidth)) {
+        if (!this.mounted || isUndefined(this.windowWidth) || !this.title) {
           return [];
         }
         const containerTop = this.$refs.items.offsetTop;

--- a/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/Navbar/index.vue
@@ -121,7 +121,6 @@
         if (this.windowIsMedium) {
           return styles;
         }
-        styles.marginTop = 0;
         styles.maxHeight = '42px';
         return styles;
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request adjusts the positioning of the `NavBar` within `AppBar.vue` so that the tabs in the navigation move to the second line when the page shrinks and there isn't enough space. Only after that, on smaller screen sizes, is the overflow menu dropdown button displayed.

This issue is most apparent in the Coach plugin when the classroom title is very long, however this change does impact other Kolibri plugins.

To prevent the overflow menu dropdown button from appearing when the navigation is at the top position, the position of the Navbar is now determined by the number of `overflowMenuLinks` in the first Navbar component found in `AppBar.vue`. 

The top NavBar is hidden and the bottom NavBar is displayed if the length of `overflowMenuLinks` is greater than 0.

Before:

https://github.com/user-attachments/assets/002ea05b-8c02-44b2-99a1-2ebe5fb56ec6

After:

https://github.com/user-attachments/assets/8d613907-8ac9-4f4d-ac0c-92fcadb05ffc




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #12813 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Create a class with a long class name.
2. Navigate to Coach > Class home and resize the page to see the responsive design behavior
