### PR TITLE
Small tweaks to simplify publishing packages.

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -17,6 +17,7 @@ on:
             - 'kolibri-logging'
             - 'kolibri-module'
             - 'kolibri-plugin-data'
+            - 'kolibri-tools'
             - 'kolibri-viewer'
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     -   id: core-js-api
         name: Rebuild kolibri package
         description: Rebuilds kolibri package on changes to core js api
-        entry: yarn run build-kolibri-tools
+        entry: node ./packages/build_kolibri_package.js
         language: system
         files: ^packages/kolibri/.*\.(js|vue)$
 - repo: local

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",
     "lint-frontend:watch:format": "yarn run lint-frontend --monitor --write",
-    "build-kolibri-tools": "yarn workspace kolibri-tools run build-kolibri-tools",
     "migrate-core-api": "kolibri-tools migrate  '{kolibri*/**/assets,packages}/**/*.{js,vue}' --ignore '**/dist/**,**/node_modules/**,**/static/**'",
     "hashi-dev": "yarn workspace hashi run dev",
     "hashi-build": "yarn workspace hashi run build",

--- a/packages/browserslist-config-kolibri/package.json
+++ b/packages/browserslist-config-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserslist-config-kolibri",
-  "version": "0.16.1-dev.1",
+  "version": "0.18.0",
   "description": "Browsers list configuration for Kolibri",
   "main": "index.js",
   "repository": {

--- a/packages/build_kolibri_package.js
+++ b/packages/build_kolibri_package.js
@@ -1,0 +1,4 @@
+/* Build file for kolibri package */
+const { rebuildApiSpec } = require('kolibri-tools/lib/apiSpecExportTools');
+
+rebuildApiSpec();

--- a/packages/kolibri-tools/.gitignore
+++ b/packages/kolibri-tools/.gitignore
@@ -3,3 +3,5 @@
 dist/*
 # Ignore any copied version of language info
 lib/i18n/language_info.json
+# Ignore any packaged version of the tools
+*.tgz

--- a/packages/kolibri-tools/.npmignore
+++ b/packages/kolibri-tools/.npmignore
@@ -1,1 +1,3 @@
 build_kolibri_tools.js
+test/*
+*.tgz

--- a/packages/kolibri-tools/build_kolibri_tools.js
+++ b/packages/kolibri-tools/build_kolibri_tools.js
@@ -1,7 +1,6 @@
-/* Build file for kolibri-tools and kolibri */
+/* Build file for kolibri-tools */
 const fs = require('fs');
 const path = require('path');
-const { rebuildApiSpec } = require('./lib/apiSpecExportTools');
 
 // /*
 //  * Copy the kolibri language_info.json into the kolibri-tools package for use externally
@@ -16,5 +15,3 @@ fs.writeFileSync(
     encoding: 'utf-8',
   },
 );
-
-rebuildApiSpec();

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -15,7 +15,7 @@
     "kolibri-tools": "./lib/cli.js"
   },
   "scripts": {
-    "build-kolibri-tools": "node ./build_kolibri_tools.js"
+    "prepack": "node ./build_kolibri_tools.js"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
@@ -32,7 +32,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.2.1",
-    "browserslist-config-kolibri": "0.16.1-dev.1",
+    "browserslist-config-kolibri": "0.18.0",
     "chalk": "4.1.2",
     "check-node-version": "^4.2.1",
     "cli-table": "^0.3.11",


### PR DESCRIPTION
## Summary
* Separate out kolibri package build and kolibri-tools.
* Update versions for browserslist-config-kolibri and kolibri-tools.
* Add kolibri-tools to npm publish github action

## References
Needed for publishing of latest kolibri-tools

## Reviewer guidance
Are version updates correlated?
Can you run `npm pack` inside the `kolibri-tools` directory and it properly includes the language_info.json in the tar file?
Does the linting rule for rebuilding the kolibri package still work as expected?
