### PR TITLE
Refactor facilityconfig facility actions into composables

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -3,8 +3,6 @@ import pick from 'lodash/pick';
 import client from 'kolibri/client';
 import heartbeat from 'kolibri/heartbeat';
 import logger from 'kolibri-logging';
-import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
-import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import UserSyncStatusResource from 'kolibri-common/apiResources/UserSyncStatusResource';
 import { setServerTime } from 'kolibri/utils/serverClock';
 import urls from 'kolibri/urls';
@@ -161,42 +159,6 @@ const _setPageVisibility = debounce((store, visibility) => {
 
 export function setPageVisibility(store) {
   _setPageVisibility(store, document.visibilityState === 'visible');
-}
-
-export function getFacilities(store) {
-  return FacilityResource.fetchCollection({ force: true }).then(facilities => {
-    store.commit('CORE_SET_FACILITIES', [...facilities]);
-  });
-}
-
-export function getFacilityConfig(store, facilityId) {
-  const { userFacilityId, selectedFacility } = store.getters;
-  const facId = facilityId || userFacilityId;
-  if (!facId) {
-    // No facility Id, so nothing good is going to happen here.
-    // Redirect and let Kolibri sort it out.
-    return Promise.resolve(redirectBrowser());
-  }
-  let datasetPromise;
-  if (selectedFacility && typeof selectedFacility.dataset !== 'object') {
-    datasetPromise = Promise.resolve([selectedFacility.dataset]);
-  } else {
-    datasetPromise = FacilityDatasetResource.fetchCollection({
-      getParams: {
-        // fetchCollection for currentSession's facilityId if none was passed
-        facility_id: facId,
-      },
-    });
-  }
-
-  return datasetPromise.then(facilityConfig => {
-    let config = {};
-    const facility = facilityConfig[0];
-    if (facility) {
-      config = { ...facility };
-    }
-    store.commit('CORE_SET_FACILITY_CONFIG', config);
-  });
 }
 
 export function loading(store) {

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -1,14 +1,6 @@
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
 
-export function facilityConfig(state) {
-  return state.facilityConfig;
-}
-
-export function facilities(state) {
-  return state.facilities;
-}
-
 export function pageSessionId(state) {
   return state.pageSessionId;
 }

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -13,8 +13,6 @@ export default {
       notifications: [],
       allowRemoteAccess: plugin_data.allowRemoteAccess,
       // facility
-      facilityConfig: {},
-      facilities: [],
       pageVisible: true,
     };
   },

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -1,10 +1,4 @@
 export default {
-  CORE_SET_FACILITY_CONFIG(state, facilityConfig) {
-    state.facilityConfig = facilityConfig;
-  },
-  CORE_SET_FACILITIES(state, facilities) {
-    state.facilities = facilities;
-  },
   CORE_SET_PAGE_LOADING(state, value) {
     const update = { loading: value };
     if (value) {

--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -1,6 +1,5 @@
 import some from 'lodash/some';
 import { UserKinds } from 'kolibri/constants';
-import useFacilities from 'kolibri-common/composables/useFacilities';
 
 export const baseSessionState = {
   app_context: false,
@@ -45,11 +44,6 @@ export default {
     },
     isFacilityAdmin(state) {
       return state.kind.includes(UserKinds.ADMIN);
-    },
-    // An "Multi-Facility Admin" is a superuser for a device with 2+ facilities
-    userIsMultiFacilityAdmin(state, getters) {
-      const { facilities } = useFacilities();
-      return getters.isSuperuser && facilities.value.length > 1;
     },
     getUserPermissions(state) {
       const permissions = {};

--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -1,5 +1,6 @@
 import some from 'lodash/some';
 import { UserKinds } from 'kolibri/constants';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 export const baseSessionState = {
   app_context: false,
@@ -46,8 +47,9 @@ export default {
       return state.kind.includes(UserKinds.ADMIN);
     },
     // An "Multi-Facility Admin" is a superuser for a device with 2+ facilities
-    userIsMultiFacilityAdmin(state, getters, rootState) {
-      return getters.isSuperuser && rootState.core.facilities.length > 1;
+    userIsMultiFacilityAdmin(state, getters) {
+      const { facilities } = useFacilities();
+      return getters.isSuperuser && facilities.value.length > 1;
     },
     getUserPermissions(state) {
       const permissions = {};

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -5,7 +5,7 @@ import router from 'kolibri/router';
 import ChannelResource from 'kolibri-common/apiResources/ChannelResource';
 import KolibriApp from 'kolibri-app';
 import useSnackbar from 'kolibri/composables/useSnackbar';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from './constants';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -5,10 +5,13 @@ import router from 'kolibri/router';
 import ChannelResource from 'kolibri-common/apiResources/ChannelResource';
 import KolibriApp from 'kolibri-app';
 import useSnackbar from 'kolibri/composables/useSnackbar';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { PageNames } from './constants';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
 import HomeActivityPage from './views/home/HomeActivityPage';
+
+const { getFacilities } = useFacilities();
 
 function _channelListState(data) {
   return data.map(channel => ({
@@ -138,7 +141,7 @@ class CoachToolsModule extends KolibriApp {
       }
 
       if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
-        promises.push(this.store.dispatch('getFacilities').catch(() => {}));
+        promises.push(getFacilities().catch(() => {}));
       }
 
       if (promises.length > 0) {

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -11,7 +11,7 @@ import routes from './routes';
 import pluginModule from './modules/pluginModule';
 import HomeActivityPage from './views/home/HomeActivityPage';
 
-const { getFacilities } = useFacilities();
+const { getFacilities, facilities } = useFacilities();
 
 function _channelListState(data) {
   return data.map(channel => ({
@@ -140,7 +140,7 @@ class CoachToolsModule extends KolibriApp {
         promises.push(this.store.dispatch('initClassInfo', to.params.classId));
       }
 
-      if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
+      if (get(isSuperuser) && facilities.value.length === 0) {
         promises.push(getFacilities().catch(() => {}));
       }
 

--- a/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
+++ b/kolibri/plugins/coach/assets/src/composables/useCoreCoach.js
@@ -4,6 +4,7 @@ import { get } from '@vueuse/core';
 import { computed, getCurrentInstance } from 'vue';
 import { currentLanguage, isRtl } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { coachStrings } from '../views/common/commonCoachStrings';
 
 const logging = logger.getLogger(__filename);
@@ -17,14 +18,15 @@ export default function useCoreCoach(store) {
   const classId = computed(() => get(route).params.classId);
   const groups = computed(() => store.getters['classSummary/groups']);
   const { isSuperuser } = useUser();
+  const { facilities } = useFacilities();
 
   function getAppBarTitle() {
     let facilityName;
     // Using coachStrings.$tr() here because mixins are not applied
     // prior to props being processed.
     const { facility_id, name } = store.state.classSummary;
-    if (facility_id && store.state.core.facilities.length > 1 && get(isSuperuser)) {
-      const match = find(store.state.core.facilities, { id: facility_id }) || {};
+    if (facility_id && get(facilities).length > 1 && get(isSuperuser)) {
+      const match = find(get(facilities), { id: facility_id }) || {};
       facilityName = match.name;
     }
     if (facilityName && name) {

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -3,7 +3,7 @@ import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator'
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import useUser from 'kolibri/composables/useUser';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 // Place outside the function to keep the state
 const groupsAreLoading = ref(false);

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -3,9 +3,11 @@ import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator'
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import useUser from 'kolibri/composables/useUser';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 
 // Place outside the function to keep the state
 const groupsAreLoading = ref(false);
+const { getFacilities } = useFacilities();
 
 export function useGroups() {
   function setGroupsLoading(loading) {
@@ -16,7 +18,7 @@ export function useGroups() {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
       useUser().isSuperuser.value && store.state.core.facilities.length === 0
-        ? store.dispatch('getFacilities').catch(() => {})
+        ? getFacilities().catch(() => {})
         : Promise.resolve();
 
     await Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -7,7 +7,7 @@ import useFacilities from 'kolibri-common/composables/useFacilities';
 
 // Place outside the function to keep the state
 const groupsAreLoading = ref(false);
-const { getFacilities } = useFacilities();
+const { getFacilities, facilities } = useFacilities();
 
 export function useGroups() {
   function setGroupsLoading(loading) {
@@ -17,7 +17,7 @@ export function useGroups() {
   async function showGroupsPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      useUser().isSuperuser.value && store.state.core.facilities.length === 0
+      useUser().isSuperuser.value && facilities.value.length === 0
         ? getFacilities().catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -1,10 +1,12 @@
 import { ref } from 'vue';
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import useUser from 'kolibri/composables/useUser';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../constants';
 
 // Place outside the function to keep the state
 const lessonsAreLoading = ref(false);
+const { getFacilities } = useFacilities();
 
 export function useLessons() {
   function setLessonsLoading(loading) {
@@ -16,7 +18,7 @@ export function useLessons() {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
       useUser().isSuperuser.value && store.state.core.facilities.length === 0
-        ? store.dispatch('getFacilities').catch(() => {})
+        ? getFacilities().catch(() => {})
         : Promise.resolve();
 
     await Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import useUser from 'kolibri/composables/useUser';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../constants';
 
 // Place outside the function to keep the state

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -6,7 +6,7 @@ import { PageNames } from '../constants';
 
 // Place outside the function to keep the state
 const lessonsAreLoading = ref(false);
-const { getFacilities } = useFacilities();
+const { getFacilities, facilities } = useFacilities();
 
 export function useLessons() {
   function setLessonsLoading(loading) {
@@ -17,7 +17,7 @@ export function useLessons() {
   async function showLessonsRootPage(store, classId) {
     const initClassInfoPromise = store.dispatch('initClassInfo', classId);
     const getFacilitiesPromise =
-      useUser().isSuperuser.value && store.state.core.facilities.length === 0
+      useUser().isSuperuser.value && facilities.value.length === 0
         ? getFacilities().catch(() => {})
         : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -9,7 +9,7 @@ import { get } from '@vueuse/core';
 import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
 
-const { getFacilities } = useFacilities();
+const { getFacilities, facilities } = useFacilities();
 
 async function showResourceSelectionPage(store, params) {
   const {
@@ -25,7 +25,7 @@ async function showResourceSelectionPage(store, params) {
   const initClassInfoPromise = store.dispatch('initClassInfo', params.classId);
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    get(isSuperuser) && store.state.core.facilities.length === 0
+    get(isSuperuser) && get(facilities).length === 0
       ? getFacilities().catch(() => {})
       : Promise.resolve();
 
@@ -189,7 +189,7 @@ export async function showLessonResourceContentPreview(store, params) {
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    get(isSuperuser) && store.state.core.facilities.length === 0
+    get(isSuperuser) && get(facilities).length === 0
       ? getFacilities().catch(() => {})
       : Promise.resolve();
 
@@ -206,7 +206,7 @@ export async function showLessonSelectionContentPreview(store, params, query = {
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    get(isSuperuser) && store.state.core.facilities.length === 0
+    get(isSuperuser) && get(facilities).length === 0
       ? getFacilities().catch(() => {})
       : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -6,7 +6,10 @@ import { ContentNodeKinds } from 'kolibri/constants';
 import chunk from 'lodash/chunk';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
+
+const { getFacilities } = useFacilities();
 
 async function showResourceSelectionPage(store, params) {
   const {
@@ -23,7 +26,7 @@ async function showResourceSelectionPage(store, params) {
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
     get(isSuperuser) && store.state.core.facilities.length === 0
-      ? store.dispatch('getFacilities').catch(() => {})
+      ? getFacilities().catch(() => {})
       : Promise.resolve();
 
   await Promise.all([initClassInfoPromise, getFacilitiesPromise]);
@@ -187,7 +190,7 @@ export async function showLessonResourceContentPreview(store, params) {
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
     get(isSuperuser) && store.state.core.facilities.length === 0
-      ? store.dispatch('getFacilities').catch(() => {})
+      ? getFacilities().catch(() => {})
       : Promise.resolve();
 
   await Promise.all([initClassInfoPromise, getFacilitiesPromise]);
@@ -204,7 +207,7 @@ export async function showLessonSelectionContentPreview(store, params, query = {
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
     get(isSuperuser) && store.state.core.facilities.length === 0
-      ? store.dispatch('getFacilities').catch(() => {})
+      ? getFacilities().catch(() => {})
       : Promise.resolve();
 
   await Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -6,7 +6,7 @@ import { ContentNodeKinds } from 'kolibri/constants';
 import chunk from 'lodash/chunk';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
 
 const { getFacilities } = useFacilities();

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -1,7 +1,7 @@
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
 
 export async function setLessonSummaryState(store, params) {

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -5,7 +5,7 @@ import useFacilities from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
 
 export async function setLessonSummaryState(store, params) {
-  const { getFacilities } = useFacilities();
+  const { getFacilities, facilities } = useFacilities();
   const { classId, lessonId } = params;
   store.commit('lessonSummary/resources/RESET_STATE');
   store.commit('lessonSummary/SET_STATE', {
@@ -18,7 +18,7 @@ export async function setLessonSummaryState(store, params) {
   const initClassInfoPromise = store.dispatch('initClassInfo', classId);
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
-    get(isSuperuser) && store.state.core.facilities.length === 0
+    get(isSuperuser) && get(facilities).length === 0
       ? getFacilities().catch(() => {})
       : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -1,9 +1,11 @@
 import LearnerGroupResource from 'kolibri-common/apiResources/LearnerGroupResource';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { PageNames } from '../../constants';
 
 export async function setLessonSummaryState(store, params) {
+  const { getFacilities } = useFacilities();
   const { classId, lessonId } = params;
   store.commit('lessonSummary/resources/RESET_STATE');
   store.commit('lessonSummary/SET_STATE', {
@@ -17,7 +19,7 @@ export async function setLessonSummaryState(store, params) {
   const { isSuperuser } = useUser();
   const getFacilitiesPromise =
     get(isSuperuser) && store.state.core.facilities.length === 0
-      ? store.dispatch('getFacilities').catch(() => {})
+      ? getFacilities().catch(() => {})
       : Promise.resolve();
 
   await Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -2,6 +2,7 @@ import store from 'kolibri/store';
 import router from 'kolibri/router';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import AllFacilitiesPage from '../views/AllFacilitiesPage';
 import CoachClassListPage from '../views/CoachClassListPage';
 import ClassLearnersListPage from '../views/ClassLearnersListPage';
@@ -20,9 +21,11 @@ import groupsRoutes from './groupsRoutes';
 function showHomePage(toRoute) {
   const initClassInfoPromise = store.dispatch('initClassInfo', toRoute.params.classId);
   const { isSuperuser } = useUser();
+  const { getFacilities } = useFacilities();
+
   const getFacilitiesPromise =
     get(isSuperuser) && store.state.core.facilities.length === 0
-      ? store.dispatch('getFacilities').catch(() => {})
+      ? getFacilities().catch(() => {})
       : Promise.resolve();
 
   return Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -2,7 +2,7 @@ import store from 'kolibri/store';
 import router from 'kolibri/router';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import AllFacilitiesPage from '../views/AllFacilitiesPage';
 import CoachClassListPage from '../views/CoachClassListPage';
 import ClassLearnersListPage from '../views/ClassLearnersListPage';

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -127,8 +127,8 @@ export default [
     path: '/',
     // Redirect to AllFacilitiesPage if a superuser and device has > 1 facility
     beforeEnter(to, from, next) {
-      const { userIsMultiFacilityAdmin } = useUser();
-      if (get(userIsMultiFacilityAdmin)) {
+      const { userIsMultiFacilityAdmin } = useFacilities();
+      if (userIsMultiFacilityAdmin.value) {
         next({ name: 'AllFacilitiesPage', replace: true });
       } else {
         next({ name: 'CoachClassListPage', replace: true });

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -21,10 +21,10 @@ import groupsRoutes from './groupsRoutes';
 function showHomePage(toRoute) {
   const initClassInfoPromise = store.dispatch('initClassInfo', toRoute.params.classId);
   const { isSuperuser } = useUser();
-  const { getFacilities } = useFacilities();
+  const { getFacilities, facilities } = useFacilities();
 
   const getFacilitiesPromise =
-    get(isSuperuser) && store.state.core.facilities.length === 0
+    get(isSuperuser) && get(facilities).length === 0
       ? getFacilities().catch(() => {})
       : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -1,11 +1,12 @@
 import store from 'kolibri/store';
-import useUser from 'kolibri/composables/useUser';
-import { get } from '@vueuse/core';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 export function classIdParamRequiredGuard(toRoute, subtopicName, next) {
   if (!toRoute.params.classId) {
-    const { userIsMultiFacilityAdmin } = useUser();
-    const redirectPage = get(userIsMultiFacilityAdmin) ? 'AllFacilitiesPage' : 'CoachClassListPage';
+    const { userIsMultiFacilityAdmin } = useFacilities();
+    const redirectPage = userIsMultiFacilityAdmin.value
+      ? 'AllFacilitiesPage'
+      : 'CoachClassListPage';
 
     next({
       name: redirectPage,

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -54,8 +54,8 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const { facility_id, userIsMultiFacilityAdmin } = useUser();
-      const { facilities } = useFacilities();
+      const { facility_id } = useUser();
+      const { facilities, userIsMultiFacilityAdmin } = useFacilities();
       return { facility_id, userIsMultiFacilityAdmin, facilities };
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -42,6 +42,7 @@
   import CoreTable from 'kolibri/components/CoreTable';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import commonCoach from './common';
   import CoachAppBarPage from './CoachAppBarPage';
 
@@ -54,18 +55,14 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { facility_id, userIsMultiFacilityAdmin } = useUser();
-      return { facility_id, userIsMultiFacilityAdmin };
+      const { facilities } = useFacilities();
+      return { facility_id, userIsMultiFacilityAdmin, facilities };
     },
     props: {
       subtopicName: {
         type: String,
         required: false,
         default: null,
-      },
-    },
-    computed: {
-      facilities() {
-        return this.$store.state.core.facilities;
       },
     },
     beforeMount() {

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -82,8 +82,8 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin } = useUser();
-      const { facilities } = useFacilities();
+      const { isClassCoach, isFacilityCoach } = useUser();
+      const { facilities, userIsMultiFacilityAdmin } = useFacilities();
       return { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin, facilities };
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -70,6 +70,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import urls from 'kolibri/urls';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { PageNames } from '../constants';
   import CoachAppBarPage from './CoachAppBarPage';
   import commonCoach from './common';
@@ -82,7 +83,8 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin } = useUser();
-      return { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin };
+      const { facilities } = useFacilities();
+      return { isClassCoach, isFacilityCoach, userIsMultiFacilityAdmin, facilities };
     },
     props: {
       subtopicName: {
@@ -127,7 +129,7 @@
         const { facility_id } = this.$route.params;
 
         if (facility_id) {
-          const match = find(this.$store.state.core.facilities, { id: facility_id }) || {};
+          const match = find(this.facilities, { id: facility_id }) || {};
           facilityName = match.name;
         }
         if (facilityName) {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -62,7 +62,7 @@
   import { mapGetters } from 'vuex';
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ClassesPageNames } from '../../../../../../learn/assets/src/constants';
   import commonCoach from '../../common';
   import { LastPages } from '../../../constants/lastPagesConstants';
@@ -71,7 +71,7 @@
     name: 'OverviewBlock',
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const { userIsMultiFacilityAdmin } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
       return { userIsMultiFacilityAdmin };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -35,7 +35,7 @@
                   <td>
                     <KRouterLink
                       :to="
-                        classRoute(PageNames.LEARNER_LESSON_REPORT, {
+                        classRoute('ReportsLearnerReportLessonPage', {
                           lessonId: tableRow.id,
                         })
                       "

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -35,7 +35,7 @@
                   <td>
                     <KRouterLink
                       :to="
-                        classRoute('ReportsLearnerReportLessonPage', {
+                        classRoute(PageNames.LEARNER_LESSON_REPORT, {
                           lessonId: tableRow.id,
                         })
                       "

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
@@ -48,10 +48,10 @@
       },
     },
     created() {
-      const { getFacilities } = useFacilities();
+      const { getFacilities, facilities } = useFacilities();
       const initClassInfoPromise = this.$store.dispatch('initClassInfo', this.classId);
       const getFacilitiesPromise =
-        this.isSuperuser && this.$store.state.core.facilities.length === 0
+        this.isSuperuser && facilities.length === 0
           ? getFacilities().catch(() => {})
           : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
@@ -30,7 +30,7 @@
   import { ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import AssignmentDetailsModal from '../common/assignments/AssignmentDetailsModal';
   import commonCoach from '../common';
   import CoachImmersivePage from '../CoachImmersivePage';

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
@@ -51,7 +51,7 @@
       const { getFacilities, facilities } = useFacilities();
       const initClassInfoPromise = this.$store.dispatch('initClassInfo', this.classId);
       const getFacilitiesPromise =
-        this.isSuperuser && facilities.length === 0
+        this.isSuperuser && facilities.value.length === 0
           ? getFacilities().catch(() => {})
           : Promise.resolve();
 

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonCreationPage.vue
@@ -30,6 +30,7 @@
   import { ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import AssignmentDetailsModal from '../common/assignments/AssignmentDetailsModal';
   import commonCoach from '../common';
   import CoachImmersivePage from '../CoachImmersivePage';
@@ -47,10 +48,11 @@
       },
     },
     created() {
+      const { getFacilities } = useFacilities();
       const initClassInfoPromise = this.$store.dispatch('initClassInfo', this.classId);
       const getFacilitiesPromise =
         this.isSuperuser && this.$store.state.core.facilities.length === 0
-          ? this.$store.dispatch('getFacilities').catch(() => {})
+          ? getFacilities().catch(() => {})
           : Promise.resolve();
 
       Promise.all([initClassInfoPromise, getFacilitiesPromise]);

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
@@ -38,6 +38,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
   import CoachImmersivePage from '../../CoachImmersivePage';
   import AssignmentDetailsModal from '../../common/assignments/AssignmentDetailsModal';
@@ -96,13 +97,14 @@
       },
     },
     created() {
+      const { getFacilities } = useFacilities();
       const initClassInfoPromise = this.$store.dispatch(
         'initClassInfo',
         this.$route.params.classId,
       );
       const getFacilitiesPromise =
         this.isSuperuser && this.$store.state.core.facilities.length === 0
-          ? this.$store.dispatch('getFacilities').catch(() => {})
+          ? getFacilities().catch(() => {})
           : Promise.resolve();
 
       Promise.all([initClassInfoPromise, getFacilitiesPromise])

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
@@ -38,7 +38,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
   import CoachImmersivePage from '../../CoachImmersivePage';
   import AssignmentDetailsModal from '../../common/assignments/AssignmentDetailsModal';

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/index.vue
@@ -56,10 +56,12 @@
     setup() {
       const { createSnackbar } = useSnackbar();
       const { isSuperuser } = useUser();
-
+      const { getFacilities, facilities } = useFacilities();
       return {
         createSnackbar,
         isSuperuser,
+        getFacilities,
+        facilities,
       };
     },
     props: {
@@ -97,14 +99,13 @@
       },
     },
     created() {
-      const { getFacilities } = useFacilities();
       const initClassInfoPromise = this.$store.dispatch(
         'initClassInfo',
         this.$route.params.classId,
       );
       const getFacilitiesPromise =
-        this.isSuperuser && this.$store.state.core.facilities.length === 0
-          ? getFacilities().catch(() => {})
+        this.isSuperuser && this.facilities.length === 0
+          ? this.getFacilities().catch(() => {})
           : Promise.resolve();
 
       Promise.all([initClassInfoPromise, getFacilitiesPromise])

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -44,10 +44,10 @@ class DeviceManagementModule extends KolibriApp {
     }
   }
   ready() {
-    const { getFacilities } = useFacilities();
+    const { getFacilities, facilities } = useFacilities();
     // reset module states after leaving their respective page
     router.beforeEach((to, from, next) => {
-      if (this.store.state.core.facilities.length === 0) {
+      if (facilities.value.length === 0) {
         getFacilities().then(next, next);
       }
       next();

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -4,7 +4,7 @@ import router from 'kolibri/router';
 import { IsPinAuthenticated } from 'kolibri/constants';
 import useUser from 'kolibri/composables/useUser';
 import KolibriApp from 'kolibri-app';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import RootVue from './views/DeviceIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -4,6 +4,7 @@ import router from 'kolibri/router';
 import { IsPinAuthenticated } from 'kolibri/constants';
 import useUser from 'kolibri/composables/useUser';
 import KolibriApp from 'kolibri-app';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import RootVue from './views/DeviceIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
@@ -43,10 +44,11 @@ class DeviceManagementModule extends KolibriApp {
     }
   }
   ready() {
+    const { getFacilities } = useFacilities();
     // reset module states after leaving their respective page
     router.beforeEach((to, from, next) => {
       if (this.store.state.core.facilities.length === 0) {
-        this.store.dispatch('getFacilities').then(next, next);
+        getFacilities().then(next, next);
       }
       next();
     });

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -3,7 +3,7 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 /**
  * Serially fetches Permissions, then FacilityUser. If returned Promise rejects,

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -3,6 +3,7 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 
 /**
  * Serially fetches Permissions, then FacilityUser. If returned Promise rejects,
@@ -43,6 +44,7 @@ function fetchUserPermissions(userId) {
  * @returns Promise<void>
  */
 export function showUserPermissionsPage(store, userId) {
+  const { getFacilities } = useFacilities();
   const setUserPermissionsState = state => store.commit('userPermissions/SET_STATE', state);
   const stopLoading = () => store.dispatch('notLoading');
 
@@ -56,7 +58,7 @@ export function showUserPermissionsPage(store, userId) {
 
   const samePage = samePageCheckGenerator(store);
 
-  return Promise.all([fetchUserPermissions(userId), store.dispatch('getFacilities')])
+  return Promise.all([fetchUserPermissions(userId), getFacilities()])
     .then(([data]) => {
       if (samePage()) {
         setUserPermissionsState({ user: data.user, permissions: data.permissions });

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -3,6 +3,7 @@ import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyn
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { showDeviceInfoPage } from '../modules/deviceInfo/handlers';
 import { showManagePermissionsPage } from '../modules/managePermissions/handlers';
 import { showManageContentPage } from '../modules/manageContent/handlers';
@@ -47,8 +48,9 @@ const routes = [
     // fetch the facilities if redirecting from /welcome, since the WelcomeModal
     // needs it
     beforeEnter(to, from, next) {
+      const { getFacilities } = useFacilities();
       if (to.redirectedFrom === '/welcome') {
-        store.dispatch('getFacilities').then(next, next);
+        getFacilities().then(next, next);
       } else {
         next();
       }

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -3,7 +3,7 @@ import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyn
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { showDeviceInfoPage } from '../modules/deviceInfo/handlers';
 import { showManagePermissionsPage } from '../modules/managePermissions/handlers';
 import { showManageContentPage } from '../modules/manageContent/handlers';

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -30,6 +30,7 @@
   import urls from 'kolibri/urls';
   import useUser from 'kolibri/composables/useUser';
   import plugin_data from 'kolibri-plugin-data';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { PageNames } from '../constants';
 
   import PinAuthenticationModal from './PinAuthenticationModal';
@@ -43,9 +44,11 @@
     mixins: [commonCoreStrings],
     setup() {
       const { isUserLoggedIn, userFacilityId } = useUser();
+      const { facilities } = useFacilities();
       return {
         isUserLoggedIn,
         userFacilityId,
+        facilities,
       };
     },
     data() {
@@ -56,9 +59,6 @@
     },
     computed: {
       ...mapState(['authenticateWithPin', 'grantPluginAccess']),
-      facilities() {
-        return this.$store.state.core.facilities;
-      },
       isPinSet() {
         const dataset = this.currentFacility['dataset'] || {};
         const extraFields = dataset['extra_fields'] || {};

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -386,6 +386,7 @@
   import { checkCapability } from 'kolibri/utils/appCapabilities';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import commonDeviceStrings from '../commonDeviceStrings';
   import DeviceAppBarPage from '../DeviceAppBarPage';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
@@ -430,6 +431,7 @@
       const { windowIsSmall } = useKResponsiveWindow();
       const dataPlugins = ref(null);
       const { snackbarIsVisible, createSnackbar } = useSnackbar();
+      const { facilities } = useFacilities();
 
       fetchPlugins.then(() => {
         dataPlugins.value = plugins.value.map(plugin => ({ ...plugin }));
@@ -468,6 +470,7 @@
         windowIsSmall,
         snackbarIsVisible,
         createSnackbar,
+        facilities,
       };
     },
     data() {
@@ -516,9 +519,6 @@
       },
       pageTitle() {
         return this.deviceString('deviceManagementTitle');
-      },
-      facilities() {
-        return this.$store.getters.facilities;
       },
       isMultiFacilitySuperuser() {
         return this.isSuperuser && this.facilities.length > 1;

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -65,13 +65,13 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import PermissionsIcon from 'kolibri-common/components/labels/PermissionsIcon';
   import memoize from 'lodash/memoize';
   import { PermissionTypes } from 'kolibri/constants';
   import CoreTable from 'kolibri/components/CoreTable';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
 
   export default {
     name: 'UserGrid',
@@ -82,7 +82,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { currentUserId } = useUser();
-      return { currentUserId };
+      const { facilities } = useFacilities();
+      return { currentUserId, facilities };
     },
     props: {
       filterText: {
@@ -104,7 +105,6 @@
       },
     },
     computed: {
-      ...mapGetters(['facilities']),
       emptyMessage() {
         return this.$tr('noUsersMatching', { searchFilter: this.filterText });
       },

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
@@ -56,11 +56,11 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
-
+  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import PaginatedListContainer from 'kolibri-common/components/PaginatedListContainer';
   import { PermissionTypes, UserKinds } from 'kolibri/constants';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import DeviceAppBarPage from '../DeviceAppBarPage';
   import { deviceString } from '../commonDeviceStrings';
   import UserGrid from './UserGrid';
@@ -80,6 +80,10 @@
       UserGrid,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { facilities } = useFacilities();
+      return { facilities };
+    },
     data() {
       return {
         searchFilterText: '',
@@ -97,7 +101,6 @@
       ...mapState({
         query: state => state.query,
       }),
-      ...mapGetters(['facilities']),
       hasMultipleFacilities() {
         if (this.facilities) {
           return this.facilities.length > 1;

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -44,6 +44,7 @@
   import AddDeviceForm from 'kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/AddDeviceForm';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
@@ -69,10 +70,12 @@
     setup() {
       const { isUserLoggedIn } = useUser();
       const { createSnackbar } = useSnackbar();
+      const { facilities } = useFacilities();
 
       return {
         isUserLoggedIn,
         createSnackbar,
+        facilities,
       };
     },
     props: {
@@ -91,7 +94,7 @@
     },
     computed: {
       importedFacility() {
-        const [facility] = this.$store.state.core.facilities;
+        const [facility] = this.facilities;
         if (facility && window.sessionStorage.getItem(facilityImported) === 'true') {
           return facility;
         }

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -123,6 +123,7 @@
   import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { PageNames } from '../../constants';
 
   export default {
@@ -140,7 +141,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { currentUserId } = useUser();
-      return { currentUserId };
+      const { facilities } = useFacilities();
+      return { currentUserId, facilities };
     },
     data() {
       return {
@@ -151,7 +153,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isPageLoading', 'facilities']),
+      ...mapGetters(['isPageLoading']),
       ...mapState('userPermissions', ['user', 'permissions']),
       backRoute() {
         return { name: PageNames.MANAGE_PERMISSIONS_PAGE };

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -21,13 +21,15 @@
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
 
   export default {
     name: 'WelcomeModal',
     mixins: [commonCoreStrings],
     setup() {
       const { isLearnerOnlyImport } = useUser();
-      return { isLearnerOnlyImport };
+      const { facilities } = useFacilities();
+      return { isLearnerOnlyImport, facilities };
     },
     props: {
       importedFacility: {
@@ -44,8 +46,7 @@
       paragraphs() {
         if (this.isLearnerOnlyImport) {
           let facility = this.importedFacility;
-          if (this.$store.getters.facilities.length > 0 && facility === null)
-            facility = this.$store.getters.facilities[0];
+          if (this.facilities.length > 0 && facility === null) facility = this.facilities[0];
           const sndParagraph =
             facility === null
               ? this.$tr('learnOnlyDeviceWelcomeMessage2')

--- a/kolibri/plugins/facility/assets/src/app.js
+++ b/kolibri/plugins/facility/assets/src/app.js
@@ -3,7 +3,7 @@ import useUser from 'kolibri/composables/useUser';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import router from 'kolibri/router';
 import KolibriApp from 'kolibri-app';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import RootVue from './views/FacilityIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';

--- a/kolibri/plugins/facility/assets/src/app.js
+++ b/kolibri/plugins/facility/assets/src/app.js
@@ -3,6 +3,7 @@ import useUser from 'kolibri/composables/useUser';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import router from 'kolibri/router';
 import KolibriApp from 'kolibri-app';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import RootVue from './views/FacilityIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
@@ -19,13 +20,14 @@ class FacilityManagementModule extends KolibriApp {
   }
   ready() {
     const { isLearnerOnlyImport, isSuperuser } = useUser();
+    const { getFacilities } = useFacilities();
     router.beforeEach((to, from, next) => {
       if (get(isLearnerOnlyImport)) {
         redirectBrowser();
         return;
       }
       if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
-        this.store.dispatch('getFacilities').then(next, next);
+        getFacilities().then(next, next);
       } else {
         next();
       }

--- a/kolibri/plugins/facility/assets/src/app.js
+++ b/kolibri/plugins/facility/assets/src/app.js
@@ -20,13 +20,13 @@ class FacilityManagementModule extends KolibriApp {
   }
   ready() {
     const { isLearnerOnlyImport, isSuperuser } = useUser();
-    const { getFacilities } = useFacilities();
+    const { getFacilities, facilities } = useFacilities();
     router.beforeEach((to, from, next) => {
       if (get(isLearnerOnlyImport)) {
         redirectBrowser();
         return;
       }
-      if (get(isSuperuser) && this.store.state.core.facilities.length === 0) {
+      if (get(isSuperuser) && facilities.value.length === 0) {
         getFacilities().then(next, next);
       } else {
         next();

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -2,6 +2,7 @@ import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDataset
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 
 export function saveFacilityName(store, payload) {
   return FacilityResource.saveModel({
@@ -11,8 +12,9 @@ export function saveFacilityName(store, payload) {
     },
   }).then(
     facility => {
+      const { getFacilities } = useFacilities();
       // Refresh facility list to get new name
-      store.dispatch('getFacilities', null, { root: true });
+      getFacilities(null);
       store.commit('UPDATE_FACILITIES', {
         oldName: store.state.facilityName,
         newName: facility.name,

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -2,7 +2,7 @@ import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDataset
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 export function saveFacilityName(store, payload) {
   return FacilityResource.saveModel({

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -1,6 +1,7 @@
 import find from 'lodash/find';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { pageNameToModuleMap, PageNames } from '../constants';
 import classAssignMembers from './classAssignMembers';
 import classEditManagement from './classEditManagement';
@@ -48,8 +49,9 @@ export default {
       }
       return rootState.route.params.facility_id || get(userFacilityId);
     },
-    currentFacilityName(state, getters, rootState) {
-      const match = find(rootState.core.facilities, { id: getters.activeFacilityId });
+    currentFacilityName(state, getters) {
+      const { facilities } = useFacilities();
+      const match = find(facilities.value, { id: getters.activeFacilityId });
       return match ? match.name : '';
     },
     facilityPageLinks(state, getters) {

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -43,8 +43,9 @@ export default {
 
       // For multi-facility case, only use facility_id if in route because userFacilityId
       // fallback would always navigate to our default facility, not multi-facility landing page
-      const { userIsMultiFacilityAdmin, userFacilityId } = useUser();
-      if (get(userIsMultiFacilityAdmin)) {
+      const { userFacilityId } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
+      if (userIsMultiFacilityAdmin.value) {
         return rootState.route.params.facility_id;
       }
       return rootState.route.params.facility_id || get(userFacilityId);
@@ -58,8 +59,8 @@ export default {
       // Use this getter to get Link objects that have the optional 'facility_id'
       // parameter if we're in a multi-facility situation
       const params = {};
-      const { userIsMultiFacilityAdmin } = useUser();
-      if (get(userIsMultiFacilityAdmin)) {
+      const { userIsMultiFacilityAdmin } = useFacilities();
+      if (userIsMultiFacilityAdmin.value) {
         params.facility_id = getters.activeFacilityId;
       }
       return {

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
 import useFacilities from 'kolibri-common/composables/useFacilities';
@@ -49,11 +48,6 @@ export default {
         return rootState.route.params.facility_id;
       }
       return rootState.route.params.facility_id || get(userFacilityId);
-    },
-    currentFacilityName(state, getters) {
-      const { facilities } = useFacilities();
-      const match = find(facilities.value, { id: getters.activeFacilityId });
-      return match ? match.name : '';
     },
     facilityPageLinks(state, getters) {
       // Use this getter to get Link objects that have the optional 'facility_id'

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -7,6 +7,7 @@ import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditD
 import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import ClassEditPage from './views/ClassEditPage';
 import CoachClassAssignmentPage from './views/CoachClassAssignmentPage';
 import LearnerClassEnrollmentPage from './views/LearnerClassEnrollmentPage';
@@ -31,8 +32,8 @@ import { PageNames } from './constants';
 const logging = logger.getLogger(__filename);
 
 function facilityParamRequiredGuard(toRoute, subtopicName) {
-  const { userIsMultiFacilityAdmin } = useUser();
-  if (get(userIsMultiFacilityAdmin) && !toRoute.params.facility_id) {
+  const { userIsMultiFacilityAdmin } = useFacilities();
+  if (userIsMultiFacilityAdmin.value && !toRoute.params.facility_id) {
     router
       .replace({
         name: 'ALL_FACILITIES_PAGE',
@@ -158,8 +159,8 @@ export default [
     path: '/',
     // Redirect to AllFacilitiesPage if a superuser and device has > 1 facility
     beforeEnter(to, from, next) {
-      const { userIsMultiFacilityAdmin } = useUser();
-      if (get(userIsMultiFacilityAdmin)) {
+      const { userIsMultiFacilityAdmin } = useFacilities();
+      if (userIsMultiFacilityAdmin.value) {
         next(store.getters.facilityPageLinks.AllFacilitiesPage);
       } else {
         next(store.getters.facilityPageLinks.ManageClassPage);

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -44,7 +44,6 @@
   import CoreTable from 'kolibri/components/CoreTable';
   import cloneDeep from 'lodash/cloneDeep';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useUser from 'kolibri/composables/useUser';
   import useFacilities from 'kolibri-common/composables/useFacilities';
 
   export default {
@@ -60,8 +59,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { userIsMultiFacilityAdmin } = useUser();
-      const { facilities } = useFacilities();
+      const { facilities, userIsMultiFacilityAdmin } = useFacilities();
       return { userIsMultiFacilityAdmin, facilities };
     },
     props: {

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -45,6 +45,7 @@
   import cloneDeep from 'lodash/cloneDeep';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
 
   export default {
     name: 'AllFacilitiesPage',
@@ -60,7 +61,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { userIsMultiFacilityAdmin } = useUser();
-      return { userIsMultiFacilityAdmin };
+      const { facilities } = useFacilities();
+      return { userIsMultiFacilityAdmin, facilities };
     },
     props: {
       subtopicName: {
@@ -71,9 +73,6 @@
     },
     computed: {
       ...mapGetters(['facilityPageLinks']),
-      facilities() {
-        return this.$store.state.core.facilities;
-      },
     },
     beforeMount() {
       // Redirect to single-facility landing page if user/device isn't supposed

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -203,6 +203,7 @@
   import { now } from 'kolibri/utils/serverClock';
   import format from 'date-fns/format';
   import KDateRange from 'kolibri-design-system/lib/KDateRange';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { PageNames } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import GeneratedElapsedTime from './GeneratedElapsedTime';
@@ -231,7 +232,7 @@
     setup() {
       const { windowIsMedium, windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
-      const { userIsMultiFacilityAdmin } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
       return { windowIsMedium, windowIsSmall, isAppContext, userIsMultiFacilityAdmin };
     },
     data() {

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -14,14 +14,14 @@
   import { mapGetters } from 'vuex';
   import AppBarPage from 'kolibri/components/pages/AppBarPage';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
 
   export default {
     name: 'FacilityAppBarPage',
     components: { AppBarPage },
     mixins: [commonCoreStrings],
     setup() {
-      const { userIsMultiFacilityAdmin } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
       return { userIsMultiFacilityAdmin };
     },
     props: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -11,7 +11,6 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import AppBarPage from 'kolibri/components/pages/AppBarPage';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
@@ -21,8 +20,8 @@
     components: { AppBarPage },
     mixins: [commonCoreStrings],
     setup() {
-      const { userIsMultiFacilityAdmin } = useFacilities();
-      return { userIsMultiFacilityAdmin };
+      const { userIsMultiFacilityAdmin, currentFacilityName } = useFacilities();
+      return { userIsMultiFacilityAdmin, currentFacilityName };
     },
     props: {
       appBarTitle: {
@@ -31,7 +30,6 @@
       },
     },
     computed: {
-      ...mapGetters(['currentFacilityName']),
       /* Returns the given appBarTitle prop if given, otherwise will return
        the facility label appropriate to whether there are multiple facilities
        and the current user is the correct kind of admin */

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -238,6 +238,7 @@
   import BottomAppBar from 'kolibri/components/BottomAppBar';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
@@ -294,7 +295,8 @@
     setup() {
       const { createSnackbar } = useSnackbar();
       const { windowIsSmall } = useKResponsiveWindow();
-      const { isAppContext, isSuperuser, userIsMultiFacilityAdmin } = useUser();
+      const { isAppContext, isSuperuser } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
       return {
         createSnackbar,
         windowIsSmall,

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -102,7 +102,6 @@
 
   import { mapState, mapActions, mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useUser from 'kolibri/composables/useUser';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
@@ -125,8 +124,7 @@
     mixins: [commonCoreStrings],
     setup() {
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
-      const { userIsMultiFacilityAdmin } = useUser();
-      const { getFacilities } = useFacilities();
+      const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
       return {
         classToDelete,
         selectClassToDelete,

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -103,6 +103,7 @@
   import { mapState, mapActions, mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ClassCreateModal from './ClassCreateModal';
@@ -125,11 +126,13 @@
     setup() {
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { userIsMultiFacilityAdmin } = useUser();
+      const { getFacilities } = useFacilities();
       return {
         classToDelete,
         selectClassToDelete,
         clearClassToDelete,
         userIsMultiFacilityAdmin,
+        getFacilities,
       };
     },
     computed: {
@@ -190,7 +193,7 @@
       refreshCoreFacilities() {
         if (this.userIsMultiFacilityAdmin) {
           // Update the core facilities object to update classroom number
-          this.$store.dispatch('getFacilities');
+          this.getFacilities();
         }
       },
       // Duplicated in class-list-page

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -103,7 +103,7 @@
   import { mapState, mapActions, mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ClassCreateModal from './ClassCreateModal';

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -188,7 +188,7 @@
       };
     },
     computed: {
-      ...mapGetters(['activeFacilityId', 'facilityConfig']),
+      ...mapGetters(['activeFacilityId']),
       ...mapState('userManagement', ['facilityUsers']),
       showPasswordInput() {
         if (this.facilityConfig.learner_can_login_with_no_password) {

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -135,7 +135,7 @@
   import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import IdentifierTextbox from './IdentifierTextbox';
 
   const { NOT_SPECIFIED } = DemographicConstants;

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -159,9 +159,10 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { getFacilityConfig } = useFacilities();
+      const { getFacilityConfig, facilityConfig } = useFacilities();
       return {
         getFacilityConfig,
+        facilityConfig,
       };
     },
     data() {

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -124,7 +124,7 @@
 <script>
 
   import every from 'lodash/every';
-  import { mapState, mapGetters, mapActions } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import { UserKinds, ERROR_CONSTANTS, DemographicConstants } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import GenderSelect from 'kolibri-common/components/userAccounts/GenderSelect';
@@ -135,6 +135,7 @@
   import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import IdentifierTextbox from './IdentifierTextbox';
 
   const { NOT_SPECIFIED } = DemographicConstants;
@@ -157,6 +158,12 @@
       ExtraDemographics,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { getFacilityConfig } = useFacilities();
+      return {
+        getFacilityConfig,
+      };
+    },
     data() {
       return {
         fullName: '',
@@ -226,7 +233,6 @@
       });
     },
     methods: {
-      ...mapActions(['getFacilityConfig']),
       goToUserManagementPage(onComplete) {
         this.$router.push(this.$store.getters.facilityPageLinks.UserPage, onComplete);
       },

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -153,7 +153,7 @@
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import IdentifierTextbox from './IdentifierTextbox';
 
   export default {

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -139,7 +139,7 @@
   import pickBy from 'lodash/pickBy';
   import UserType from 'kolibri-common/utils/userType';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
-  import { mapActions, mapState, mapGetters } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import urls from 'kolibri/urls';
   import { UserKinds, ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
@@ -153,6 +153,7 @@
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import IdentifierTextbox from './IdentifierTextbox';
 
   export default {
@@ -176,10 +177,12 @@
     setup() {
       const { createSnackbar } = useSnackbar();
       const { currentUserId } = useUser();
+      const { getFacilityConfig } = useFacilities();
 
       return {
         createSnackbar,
         currentUserId,
+        getFacilityConfig,
       };
     },
     data() {
@@ -284,7 +287,6 @@
         });
     },
     methods: {
-      ...mapActions(['getFacilityConfig']),
       setKind(user) {
         this.kind = UserType(user);
         const coachOption = this.userTypeOptions[1];

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -139,7 +139,7 @@
   import pickBy from 'lodash/pickBy';
   import UserType from 'kolibri-common/utils/userType';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import urls from 'kolibri/urls';
   import { UserKinds, ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
@@ -177,12 +177,13 @@
     setup() {
       const { createSnackbar } = useSnackbar();
       const { currentUserId } = useUser();
-      const { getFacilityConfig } = useFacilities();
+      const { getFacilityConfig, facilityConfig } = useFacilities();
 
       return {
         createSnackbar,
         currentUserId,
         getFacilityConfig,
+        facilityConfig,
       };
     },
     data() {
@@ -206,7 +207,6 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig']),
       ...mapState('userManagement', ['facilityUsers']),
       formDisabled() {
         return this.status === 'BUSY';

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -120,6 +120,7 @@
   import cloneDeep from 'lodash/cloneDeep';
   import PaginatedListContainerWithBackend from 'kolibri-common/components/PaginatedListContainerWithBackend';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ResetUserPasswordModal from './ResetUserPasswordModal';
@@ -144,7 +145,8 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { currentUserId, isSuperuser, userIsMultiFacilityAdmin } = useUser();
+      const { currentUserId, isSuperuser } = useUser();
+      const { userIsMultiFacilityAdmin } = useFacilities();
       return {
         currentUserId,
         isSuperuser,

--- a/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import { Store } from 'vuex';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
+import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import FacilityAppBarPage from '../../src/views/FacilityAppBarPage';
 
 function makeWrapper({ propsData = {}, getters = {} }) {
@@ -18,10 +19,12 @@ function makeWrapper({ propsData = {}, getters = {} }) {
 jest.mock('kolibri/urls');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
 jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri-common/composables/useFacilities');
 
 describe('FacilityAppBarPage', function () {
   beforeEach(() => {
     useUser.mockImplementation(() => useUserMock());
+    useFacilities.mockImplementation(() => useFacilitiesMock());
   });
   beforeAll(() => {
     useKResponsiveWindow.mockImplementation(() => ({
@@ -40,7 +43,9 @@ describe('FacilityAppBarPage', function () {
     });
     describe('the user is an admin of multiple facilities, and a current facility name is defined', () => {
       it("should return the string 'Facility – ' with the current facility name", () => {
-        useUser.mockImplementation(() => useUserMock({ userIsMultiFacilityAdmin: true }));
+        useFacilities.mockImplementation(() =>
+          useFacilitiesMock({ userIsMultiFacilityAdmin: true }),
+        );
         const wrapper = makeWrapper({
           propsData: { appBarTitle: null },
           getters: {

--- a/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
@@ -44,13 +44,13 @@ describe('FacilityAppBarPage', function () {
     describe('the user is an admin of multiple facilities, and a current facility name is defined', () => {
       it("should return the string 'Facility – ' with the current facility name", () => {
         useFacilities.mockImplementation(() =>
-          useFacilitiesMock({ userIsMultiFacilityAdmin: true }),
+          useFacilitiesMock({
+            userIsMultiFacilityAdmin: true,
+            currentFacilityName: 'currentFacilityName',
+          }),
         );
         const wrapper = makeWrapper({
           propsData: { appBarTitle: null },
-          getters: {
-            currentFacilityName: 'currentFacilityName',
-          },
         });
         const expectedTitle = 'Facility – currentFacilityName';
         expect(wrapper.vm.title).toBe(expectedTitle);
@@ -59,12 +59,13 @@ describe('FacilityAppBarPage', function () {
   });
   describe('the user is not an admin of multiple facilities', () => {
     it('should return the value of appBarTitle prop when provided', () => {
-      useUser.mockImplementation(() => useUserMock({ userIsMultiFacilityAdmin: false }));
-      const wrapper = makeWrapper({
-        getters: {
+      useUser.mockImplementation(() =>
+        useUserMock({
+          userIsMultiFacilityAdmin: false,
           currentFacilityName: 'currentFacilityName',
-        },
-      });
+        }),
+      );
+      const wrapper = makeWrapper({});
       expect(wrapper.vm.title).toBe('Facility');
     });
   });

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -3,7 +3,6 @@ import { get } from '@vueuse/core';
 import useUser from 'kolibri/composables/useUser';
 import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
-import { getFacilityConfig } from '../../../../../core/assets/src/state/modules/core/actions';
 import signIn from './signIn';
 
 export default {
@@ -35,19 +34,22 @@ export default {
       }
     },
     setFacilityId(store, { facilityId }) {
+      const { getFacilityConfig } = useFacilities();
       store.commit('SET_FACILITY_ID', facilityId);
       return getFacilityConfig(facilityId);
     },
   },
   getters: {
     // Return the facility that was last selected or fallback to the default facility.
-    selectedFacility(state, getters) {
-      const selectedFacility = getters.facilities.find(f => f.id === state.facilityId);
+
+    selectedFacility(state) {
+      const { facilities } = useFacilities();
+      const selectedFacility = facilities.value.find(f => f.id === state.facilityId);
       if (selectedFacility) {
         return selectedFacility;
       } else {
         const { userFacilityId } = useUser();
-        return getters.facilities.find(f => f.id === get(userFacilityId)) || null;
+        return facilities.value.find(f => f.id === get(userFacilityId)) || null;
       }
     },
   },

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -44,12 +44,12 @@ export default {
 
     selectedFacility(state) {
       const { facilities } = useFacilities();
-      const selectedFacility = facilities.find(f => f.id === state.facilityId);
+      const selectedFacility = facilities.value.find(f => f.id === state.facilityId);
       if (selectedFacility) {
         return selectedFacility;
       } else {
         const { userFacilityId } = useUser();
-        return facilities.find(f => f.id === get(userFacilityId)) || null;
+        return facilities.value.find(f => f.id === get(userFacilityId)) || null;
       }
     },
   },

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -1,6 +1,7 @@
 import Lockr from 'lockr';
 import { get } from '@vueuse/core';
 import useUser from 'kolibri/composables/useUser';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
 import signIn from './signIn';
 
@@ -18,7 +19,8 @@ export default {
       store.commit('CORE_SET_ERROR', null);
     },
     setFacilitiesAndConfig(store) {
-      return store.dispatch('getFacilities').then(() => {
+      const { getFacilities } = useFacilities();
+      return getFacilities().then(() => {
         return store.dispatch('getFacilityConfig', store.getters.selectedFacility.id);
       });
     },

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -3,6 +3,7 @@ import { get } from '@vueuse/core';
 import useUser from 'kolibri/composables/useUser';
 import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
+import { getFacilityConfig } from '../../../../../core/assets/src/state/modules/core/actions';
 import signIn from './signIn';
 
 export default {
@@ -19,9 +20,9 @@ export default {
       store.commit('CORE_SET_ERROR', null);
     },
     setFacilitiesAndConfig(store) {
-      const { getFacilities } = useFacilities();
+      const { getFacilities, getFacilityConfig } = useFacilities();
       return getFacilities().then(() => {
-        return store.dispatch('getFacilityConfig', store.getters.selectedFacility.id);
+        return getFacilityConfig(store.getters.selectedFacility.id);
       });
     },
     resetModuleState(store, { toRoute, fromRoute }) {
@@ -35,7 +36,7 @@ export default {
     },
     setFacilityId(store, { facilityId }) {
       store.commit('SET_FACILITY_ID', facilityId);
-      return store.dispatch('getFacilityConfig', facilityId);
+      return getFacilityConfig(facilityId);
     },
   },
   getters: {

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -1,7 +1,7 @@
 import Lockr from 'lockr';
 import { get } from '@vueuse/core';
 import useUser from 'kolibri/composables/useUser';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
 import signIn from './signIn';
 

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -44,12 +44,12 @@ export default {
 
     selectedFacility(state) {
       const { facilities } = useFacilities();
-      const selectedFacility = facilities.value.find(f => f.id === state.facilityId);
+      const selectedFacility = facilities.find(f => f.id === state.facilityId);
       if (selectedFacility) {
         return selectedFacility;
       } else {
         const { userFacilityId } = useUser();
-        return facilities.value.find(f => f.id === get(userFacilityId)) || null;
+        return facilities.find(f => f.id === get(userFacilityId)) || null;
       }
     },
   },

--- a/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/pluginModule.js
@@ -1,6 +1,4 @@
 import Lockr from 'lockr';
-import { get } from '@vueuse/core';
-import useUser from 'kolibri/composables/useUser';
 import useFacilities from 'kolibri-common/composables/useFacilities';
 import { ComponentMap, pageNameToModuleMap } from '../constants';
 import signIn from './signIn';
@@ -18,10 +16,10 @@ export default {
       store.commit('CORE_SET_PAGE_LOADING', false);
       store.commit('CORE_SET_ERROR', null);
     },
-    setFacilitiesAndConfig(store) {
-      const { getFacilities, getFacilityConfig } = useFacilities();
+    setFacilitiesAndConfig() {
+      const { getFacilities, getFacilityConfig, selectedFacility } = useFacilities();
       return getFacilities().then(() => {
-        return getFacilityConfig(store.getters.selectedFacility.id);
+        return getFacilityConfig(selectedFacility.value.id);
       });
     },
     resetModuleState(store, { toRoute, fromRoute }) {
@@ -37,20 +35,6 @@ export default {
       const { getFacilityConfig } = useFacilities();
       store.commit('SET_FACILITY_ID', facilityId);
       return getFacilityConfig(facilityId);
-    },
-  },
-  getters: {
-    // Return the facility that was last selected or fallback to the default facility.
-
-    selectedFacility(state) {
-      const { facilities } = useFacilities();
-      const selectedFacility = facilities.value.find(f => f.id === state.facilityId);
-      if (selectedFacility) {
-        return selectedFacility;
-      } else {
-        const { userFacilityId } = useUser();
-        return facilities.value.find(f => f.id === get(userFacilityId)) || null;
-      }
     },
   },
   mutations: {

--- a/kolibri/plugins/user_auth/assets/src/modules/signIn/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signIn/handlers.js
@@ -4,6 +4,7 @@ import { createTranslator } from 'kolibri/utils/i18n';
 import useSnackbar from 'kolibri/composables/useSnackbar';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 
 const snackbarTranslator = createTranslator('UserPageSnackbars', {
   dismiss: {
@@ -19,6 +20,7 @@ const snackbarTranslator = createTranslator('UserPageSnackbars', {
 });
 
 export function showSignInPage(store) {
+  const { facilities } = useFacilities();
   if (Lockr.get(SIGNED_OUT_DUE_TO_INACTIVITY)) {
     const { createSnackbar, clearSnackbar } = useSnackbar();
     createSnackbar({
@@ -33,14 +35,14 @@ export function showSignInPage(store) {
     // Use selected id if available, otherwise get the default facility id from session
     const { userFacilityId } = useUser();
     let facilityId;
-    if (store.getters.facilities.length > 1) {
+    if (facilities.value.length > 1) {
       facilityId = store.state.facilityId || get(userFacilityId);
     } else {
       facilityId = get(userFacilityId);
     }
     store.commit('SET_FACILITY_ID', facilityId);
     store.commit('signIn/SET_STATE', {
-      hasMultipleFacilities: store.getters.facilities.length > 1,
+      hasMultipleFacilities: facilities.value.length > 1,
     });
   });
 }

--- a/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
@@ -1,5 +1,5 @@
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { ComponentMap } from '../../constants';
 
 export function showSignUpPage(store, fromRoute) {

--- a/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
@@ -1,17 +1,16 @@
-import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import useFacilities from 'kolibri-common/composables/useFacilities';
 import { ComponentMap } from '../../constants';
 
 export function showSignUpPage(store, fromRoute) {
-  const { setFacilities } = useFacilities();
+  const { getFacilities } = useFacilities();
 
   // Don't do anything if going between Sign Up steps
   if (fromRoute.name === ComponentMap.SIGN_UP) {
     return Promise.resolve();
   }
-  return FacilityResource.fetchCollection()
-    .then(facilities => {
-      setFacilities(facilities);
+
+  return getFacilities()
+    .then(() => {
       store.dispatch('reset');
     })
     .catch(error => store.dispatch('handleApiError', { error, reloadOnReconnect: true }));

--- a/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
@@ -1,14 +1,17 @@
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import { ComponentMap } from '../../constants';
 
 export function showSignUpPage(store, fromRoute) {
+  const { setFacilities } = useFacilities();
+
   // Don't do anything if going between Sign Up steps
   if (fromRoute.name === ComponentMap.SIGN_UP) {
     return Promise.resolve();
   }
   return FacilityResource.fetchCollection()
     .then(facilities => {
-      store.commit('CORE_SET_FACILITIES', facilities);
+      setFacilities(facilities);
       store.dispatch('reset');
     })
     .catch(error => store.dispatch('handleApiError', { error, reloadOnReconnect: true }));

--- a/kolibri/plugins/user_auth/assets/src/routes.js
+++ b/kolibri/plugins/user_auth/assets/src/routes.js
@@ -2,6 +2,7 @@ import { get } from '@vueuse/core';
 import useUser from 'kolibri/composables/useUser';
 import store from 'kolibri/store';
 import router from 'kolibri/router';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { showSignInPage } from './modules/signIn/handlers';
 import { showSignUpPage } from './modules/signUp/handlers';
 import { ComponentMap } from './constants';
@@ -11,6 +12,8 @@ import SignInPage from './views/SignInPage';
 import SignUpPage from './views/SignUpPage';
 import NewPasswordPage from './views/SignInPage/NewPasswordPage';
 
+const { facilities } = useFacilities();
+
 export default [
   {
     path: '/',
@@ -18,7 +21,7 @@ export default [
     beforeEnter(to, from, next) {
       // If Multiple Facilities but we've not stored a facilityId in localstorage
       // then we go to the AuthSelect route
-      if (store.getters.facilities.length > 1 && !store.state.facilityId) {
+      if (facilities.value.length > 1 && !store.state.facilityId) {
         next(router.getRoute(ComponentMap.AUTH_SELECT));
       } else {
         next(router.getRoute(ComponentMap.SIGN_IN));
@@ -31,7 +34,7 @@ export default [
     beforeEnter(to, from, next) {
       // If we're on multiple facility device, show auth_select when
       // there is no facilityId
-      if (store.getters.facilities.length > 1 && !store.state.facilityId) {
+      if (facilities.value.length > 1 && !store.state.facilityId) {
         // Go to FacilitySelect with whereToNext => SignUpPage
         const whereToNext = router.getRoute(ComponentMap.SIGN_IN);
         let query = {};
@@ -62,7 +65,7 @@ export default [
         return Promise.resolve();
       }
 
-      if (store.getters.facilities.length > 1 && !store.state.facilityId) {
+      if (facilities.value.length > 1 && !store.state.facilityId) {
         // Go to FacilitySelect with whereToNext => SignUpPage
         const whereToNext = router.getRoute(ComponentMap.SIGN_UP);
         const route = {

--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -179,7 +179,6 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import CoreLogo from 'kolibri/components/CoreLogo';
   import PrivacyInfoModal from 'kolibri/components/PrivacyInfoModal';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
@@ -187,6 +186,7 @@
   import loginComponents from 'kolibri-common/utils/loginComponents';
   import urls from 'kolibri/urls';
   import plugin_data from 'kolibri-plugin-data';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../constants';
   import LanguageSwitcherFooter from '../views/LanguageSwitcherFooter';
   import commonUserStrings from './commonUserStrings';
@@ -197,7 +197,8 @@
     components: { CoreLogo, LanguageSwitcherFooter, PrivacyInfoModal },
     mixins: [commonCoreStrings, commonUserStrings],
     setup() {
-      return { themeConfig };
+      const { facilityConfig } = useFacilities();
+      return { themeConfig, facilityConfig };
     },
     props: {
       hideCreateAccount: {
@@ -218,7 +219,6 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig']),
       backgroundImageStyle() {
         if (this.themeConfig.signIn.background) {
           const scrimOpacity = this.themeConfig.signIn.scrimOpacity;

--- a/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
@@ -70,6 +70,7 @@
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import partition from 'lodash/partition';
+  import { useFacilities } from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../constants';
   import AuthBase from './AuthBase';
   import commonUserStrings from './commonUserStrings';
@@ -116,13 +117,14 @@
     },
     methods: {
       setFacility(facilityId) {
+        const { getFacilityConfig } = useFacilities();
         const whereToNext = { ...this.whereToNext };
         if (this.$route.query.next) {
           whereToNext.query.next = this.$route.query.next;
         }
         // Save the selected facility, get its config, then move along to next route
         this.$store.dispatch('setFacilityId', { facilityId }).then(() => {
-          this.$store.dispatch('getFacilityConfig', facilityId).then(() => {
+          getFacilityConfig(facilityId).then(() => {
             this.$router.push(whereToNext);
           });
         });

--- a/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
@@ -70,7 +70,7 @@
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import partition from 'lodash/partition';
-  import { useFacilities } from 'kolibri-common/composables/useFacilities';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../constants';
   import AuthBase from './AuthBase';
   import commonUserStrings from './commonUserStrings';

--- a/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
@@ -79,8 +79,8 @@
     components: { AuthBase },
     mixins: [commonCoreStrings, commonUserStrings],
     setup() {
-      const { getFacilityConfig, facilities } = useFacilities();
-      return { getFacilityConfig, facilities };
+      const { getFacilityConfig, facilities, setFacilityId } = useFacilities();
+      return { getFacilityConfig, facilities, setFacilityId };
     },
     props: {
       // This component is interstitial and needs to know where to go when it's done
@@ -125,6 +125,7 @@
         }
         // Save the selected facility, get its config, then move along to next route
         this.$store.dispatch('setFacilityId', { facilityId }).then(() => {
+          this.setFacilityId(facilityId);
           this.getFacilityConfig(facilityId).then(() => {
             this.$router.push(whereToNext);
           });

--- a/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/FacilitySelect.vue
@@ -67,7 +67,6 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import partition from 'lodash/partition';
   import useFacilities from 'kolibri-common/composables/useFacilities';
@@ -79,6 +78,10 @@
     name: 'FacilitySelect',
     components: { AuthBase },
     mixins: [commonCoreStrings, commonUserStrings],
+    setup() {
+      const { getFacilityConfig, facilities } = useFacilities();
+      return { getFacilityConfig, facilities };
+    },
     props: {
       // This component is interstitial and needs to know where to go when it's done
       // The type is Object, but it needs to be one of the listed routes in the validator
@@ -91,7 +94,6 @@
       },
     },
     computed: {
-      ...mapGetters(['facilities']),
       backTo() {
         return this.$router.getRoute(ComponentMap.AUTH_SELECT);
       },
@@ -117,14 +119,13 @@
     },
     methods: {
       setFacility(facilityId) {
-        const { getFacilityConfig } = useFacilities();
         const whereToNext = { ...this.whereToNext };
         if (this.$route.query.next) {
           whereToNext.query.next = this.$route.query.next;
         }
         // Save the selected facility, get its config, then move along to next route
         this.$store.dispatch('setFacilityId', { facilityId }).then(() => {
-          getFacilityConfig(facilityId).then(() => {
+          this.getFacilityConfig(facilityId).then(() => {
             this.$router.push(whereToNext);
           });
         });

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/SignInHeading.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/SignInHeading.vue
@@ -32,12 +32,18 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import commonUserStrings from '../commonUserStrings';
 
   export default {
     name: 'SignInHeading',
     mixins: [commonUserStrings],
+    setup() {
+      const { selectedFacility } = useFacilities();
+      return {
+        selectedFacility,
+      };
+    },
     props: {
       showFacilityName: {
         type: Boolean,
@@ -51,9 +57,6 @@
         type: String,
         required: true,
       },
-    },
-    computed: {
-      ...mapGetters(['selectedFacility']),
     },
   };
 

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -158,7 +158,7 @@
 
 <script>
 
-  import { mapState, mapGetters, mapActions } from 'vuex';
+  import { mapState, mapActions } from 'vuex';
   import FacilityUsernameResource from 'kolibri-common/apiResources/FacilityUsernameResource';
   import get from 'lodash/get';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
@@ -167,6 +167,7 @@
   import UiAutocompleteSuggestion from 'kolibri-design-system/lib/keen/UiAutocompleteSuggestion';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import useUser from 'kolibri/composables/useUser';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../../constants';
   import getUrlParameter from '../getUrlParameter';
   import AuthBase from '../AuthBase';
@@ -193,7 +194,8 @@
     mixins: [commonCoreStrings, commonUserStrings],
     setup() {
       const { isAppContext } = useUser();
-      return { isAppContext };
+      const { selectedFacility } = useFacilities();
+      return { isAppContext, selectedFacility };
     },
     data() {
       return {
@@ -213,7 +215,6 @@
       };
     },
     computed: {
-      ...mapGetters(['selectedFacility']),
       ...mapState('signIn', ['hasMultipleFacilities']),
       backToFacilitySelectionRoute() {
         const facilityRoute = this.$router.getRoute(ComponentMap.FACILITY_SELECT);

--- a/kolibri/plugins/user_auth/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignUpPage.vue
@@ -109,7 +109,6 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import every from 'lodash/every';
   import { DemographicConstants, ERROR_CONSTANTS } from 'kolibri/constants';
   import GenderSelect from 'kolibri-common/components/userAccounts/GenderSelect';
@@ -123,6 +122,7 @@
   import client from 'kolibri/client';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../constants';
   import { SignUpResource } from '../apiResource';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
@@ -148,6 +148,13 @@
       PrivacyLinkAndModal,
     },
     mixins: [commonCoreStrings, commonUserStrings],
+    setup() {
+      const { selectedFacility, facilityConfig } = useFacilities();
+      return {
+        selectedFacility,
+        facilityConfig,
+      };
+    },
     data() {
       return {
         name: '',
@@ -164,7 +171,6 @@
       };
     },
     computed: {
-      ...mapGetters(['selectedFacility', 'facilityConfig']),
       atFirstStep() {
         return !this.$route.query.step || this.$route.query.step === 1;
       },

--- a/kolibri/plugins/user_auth/assets/test/views/auth-base.spec.js
+++ b/kolibri/plugins/user_auth/assets/test/views/auth-base.spec.js
@@ -2,8 +2,11 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import AuthBase from '../../src/views/AuthBase';
 import makeStore from '../makeStore';
+import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 
+jest.mock('kolibri-common/composables/useFacilities');
 jest.mock('kolibri/urls');
+
 const localVue = createLocalVue();
 localVue.use(VueRouter);
 const router = new VueRouter({
@@ -12,7 +15,12 @@ const router = new VueRouter({
 router.getRoute = jest.fn();
 
 const store = makeStore();
-store.state.core.facilityConfig = { learner_can_sign_up: true };
+
+useFacilities.mockImplementation(() =>
+  useFacilitiesMock({
+    facilityConfig: { learner_can_sign_up: true },
+  }),
+);
 
 function makeWrapper(allowAccess = true) {
   store.getters = { ...store.getters, allowAccess: allowAccess };

--- a/kolibri/plugins/user_auth/assets/test/views/sign-in-page.spec.js
+++ b/kolibri/plugins/user_auth/assets/test/views/sign-in-page.spec.js
@@ -1,17 +1,27 @@
 import { mount } from '@vue/test-utils';
+import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import SignInPage from '../../src/views/SignInPage';
 import makeStore from '../makeStore';
 
 jest.mock('kolibri/urls');
+jest.mock('kolibri-common/composables/useFacilities');
 
 function makeWrapper() {
   const store = makeStore();
   store.state.facilityId = '123';
-  store.state.core.facilities.push({
-    id: '123',
-    name: 'test facility',
-    dataset: {},
-  });
+  useFacilities.mockImplementation(() =>
+    useFacilitiesMock({
+      facilities: {
+        value: [
+          {
+            id: '123',
+            name: 'test facility',
+            dataset: {},
+          },
+        ],
+      },
+    }),
+  );
   return mount(SignInPage, {
     store,
   });

--- a/kolibri/plugins/user_auth/assets/test/views/sign-in-page.spec.js
+++ b/kolibri/plugins/user_auth/assets/test/views/sign-in-page.spec.js
@@ -9,6 +9,13 @@ jest.mock('kolibri-common/composables/useFacilities');
 function makeWrapper() {
   const store = makeStore();
   store.state.facilityId = '123';
+  const selectedFacility = {
+    id: 123,
+    name: 'test facility',
+    dataset: {
+      learner_can_login_with_no_password: false,
+    },
+  };
   useFacilities.mockImplementation(() =>
     useFacilitiesMock({
       facilities: {
@@ -20,6 +27,8 @@ function makeWrapper() {
           },
         ],
       },
+      facilityId: '123',
+      selectedFacility: selectedFacility,
     }),
   );
   return mount(SignInPage, {

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -2,6 +2,7 @@ import store from 'kolibri/store';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';
@@ -19,8 +20,9 @@ import UsernameExists from './views/ChangeFacility/UsernameExists';
 import MergeDifferentAccounts from './views/ChangeFacility/MergeDifferentAccounts';
 
 function preload(next) {
+  const { getFacilityConfig } = useFacilities();
   store.commit('CORE_SET_PAGE_LOADING', true);
-  store.dispatch('getFacilityConfig').then(() => {
+  getFacilityConfig().then(() => {
     store.commit('CORE_SET_PAGE_LOADING', false);
     next();
   });

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -2,7 +2,7 @@ import store from 'kolibri/store';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';

--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -74,7 +74,6 @@
   import every from 'lodash/every';
   import pickBy from 'lodash/pickBy';
   import redirectBrowser from 'kolibri/utils/redirectBrowser';
-  import { mapGetters } from 'vuex';
   import { ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import GenderSelect from 'kolibri-common/components/userAccounts/GenderSelect';
@@ -85,6 +84,7 @@
   import useUser from 'kolibri/composables/useUser';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { RoutesMap } from '../constants';
 
   export default {
@@ -104,7 +104,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { isLearnerOnlyImport, isLearner, currentUserId } = useUser();
-      return { isLearnerOnlyImport, isLearner, currentUserId };
+      const { facilityConfig } = useFacilities();
+      return { isLearnerOnlyImport, isLearner, currentUserId, facilityConfig };
     },
     data() {
       return {
@@ -121,7 +122,6 @@
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig']),
       formDisabled() {
         return this.status === 'BUSY';
       },

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -186,7 +186,6 @@
 
   import NotificationsRoot from 'kolibri/components/pages/NotificationsRoot';
   import AppBarPage from 'kolibri/components/pages/AppBarPage';
-  import { mapGetters } from 'vuex';
   import { ref } from 'vue';
   import find from 'lodash/find';
   import pickBy from 'lodash/pickBy';
@@ -198,6 +197,7 @@
   import GenderDisplayText from 'kolibri-common/components/userAccounts/GenderDisplayText';
   import BirthYearDisplayText from 'kolibri-common/components/userAccounts/BirthYearDisplayText';
   import useTotalProgress from 'kolibri/composables/useTotalProgress';
+  import useFacilities from 'kolibri-common/composables/useFacilities';
   import { RoutesMap } from '../../constants';
   import useCurrentUser from '../../composables/useCurrentUser';
   import useOnMyOwnSetup from '../../composables/useOnMyOwnSetup';
@@ -235,6 +235,8 @@
       } = useUser();
       const { onMyOwnSetup } = useOnMyOwnSetup();
       const { fetchPoints, totalPoints } = useTotalProgress();
+      const { facilityConfig } = useFacilities();
+
       return {
         currentUser,
         onMyOwnSetup,
@@ -249,10 +251,10 @@
         showPasswordModal,
         fetchPoints,
         totalPoints,
+        facilityConfig,
       };
     },
     computed: {
-      ...mapGetters(['facilityConfig']),
       profileEditRoute() {
         return this.$router.getRoute(RoutesMap.PROFILE_EDIT);
       },

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -235,7 +235,7 @@
       } = useUser();
       const { onMyOwnSetup } = useOnMyOwnSetup();
       const { fetchPoints, totalPoints } = useTotalProgress();
-      const { facilityConfig } = useFacilities();
+      const { facilityConfig, facilities } = useFacilities();
 
       return {
         currentUser,
@@ -252,6 +252,7 @@
         fetchPoints,
         totalPoints,
         facilityConfig,
+        facilities,
       };
     },
     computed: {
@@ -262,7 +263,7 @@
         return pickBy(this.getUserPermissions);
       },
       facilityName() {
-        const match = find(this.$store.getters.facilities, {
+        const match = find(this.facilities, {
           id: this.userFacilityId,
         });
         return match ? match.name : '';

--- a/kolibri/plugins/user_profile/assets/test/views/profile-page.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/profile-page.spec.js
@@ -9,12 +9,14 @@ import useOnMyOwnSetup, {
   // eslint-disable-next-line import/named
   useOnMyOwnSetupMock,
 } from '../../src/composables/useOnMyOwnSetup';
+import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 
 jest.mock('kolibri-common/apiResources/FacilityUserResource');
 jest.mock('../../src/composables/useOnMyOwnSetup');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/urls');
+jest.mock('kolibri-common/composables/useFacilities');
 
 FacilityUserResource.fetchModel = jest.fn().mockResolvedValue({});
 
@@ -26,6 +28,11 @@ router.getRoute = () => {};
 
 function makeWrapper() {
   const store = makeStore();
+  useFacilities.mockImplementation(() =>
+    useFacilitiesMock({
+      facilityConfig: { learner_can_edit_password: true },
+    }),
+  );
   return mount(ProfilePage, {
     store,
     localVue,

--- a/packages/kolibri-common/composables/__mocks__/useFacilities.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacilities.js
@@ -2,6 +2,7 @@ const MOCK_DEFAULTS = {
   facilityConfig: {},
   selectedFacility: {},
   facilities: [],
+  facilityId: '',
   userIsMultiFacilityAdmin: false,
   getFacilities: jest.fn(),
   getFacilityConfig: jest.fn(),

--- a/packages/kolibri-common/composables/__mocks__/useFacilities.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacilities.js
@@ -1,0 +1,17 @@
+const MOCK_DEFAULTS = {
+  facilityConfig: {},
+  facilities: [],
+  getFacilities: jest.fn(),
+  getFacilityConfig: jest.fn(),
+  setFacilityConfig: jest.fn(),
+  setFacilities: jest.fn(),
+};
+
+export function useFacilitiesMock(overrides = {}) {
+  return {
+    ...MOCK_DEFAULTS,
+    ...overrides,
+  };
+}
+
+export default jest.fn(() => useFacilitiesMock());

--- a/packages/kolibri-common/composables/__mocks__/useFacilities.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacilities.js
@@ -2,6 +2,7 @@ const MOCK_DEFAULTS = {
   facilityConfig: {},
   selectedFacility: {},
   facilities: [],
+  userIsMultiFacilityAdmin: false,
   getFacilities: jest.fn(),
   getFacilityConfig: jest.fn(),
   setFacilityConfig: jest.fn(),

--- a/packages/kolibri-common/composables/__mocks__/useFacilities.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacilities.js
@@ -1,5 +1,6 @@
 const MOCK_DEFAULTS = {
   facilityConfig: {},
+  selectedFacility: {},
   facilities: [],
   getFacilities: jest.fn(),
   getFacilityConfig: jest.fn(),

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -12,6 +12,7 @@ const _facilityId = ref(Lockr.get('facilityId') || null);
 
 export default function useFacilities() {
   const { userFacilityId, isSuperuser } = useUser();
+
   // const route = router.currentRoute;
   const selectedFacility = computed(() => {
     const facilityById = _facilities.value.find(f => f.id === _facilityId.value);
@@ -77,6 +78,10 @@ export default function useFacilities() {
     _facilities.value = facilities;
   }
 
+  function setFacilityId(facilityId) {
+    _facilityId.value = facilityId;
+  }
+
   return {
     facilities,
     facilityConfig,
@@ -87,5 +92,6 @@ export default function useFacilities() {
     selectedFacility,
     userIsMultiFacilityAdmin,
     currentFacilityName,
+    setFacilityId,
   };
 }

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -4,14 +4,15 @@ import useUser from 'kolibri/composables/useUser';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import Lockr from 'lockr';
+import store from 'kolibri/store';
 
 const _facilityConfig = ref({});
 const _facilities = ref([]);
 const _facilityId = ref(Lockr.get('facilityId') || null);
 
 export default function useFacilities() {
-  const { userFacilityId } = useUser();
-
+  const { userFacilityId, isSuperuser } = useUser();
+  // const route = router.currentRoute;
   const selectedFacility = computed(() => {
     const facilityById = _facilities.value.find(f => f.id === _facilityId.value);
     if (facilityById) {
@@ -24,8 +25,11 @@ export default function useFacilities() {
   const facilities = computed(() => _facilities.value);
   const facilityConfig = computed(() => _facilityConfig.value);
   const userIsMultiFacilityAdmin = computed(() => {
-    const { isSuperuser } = useUser();
     return isSuperuser.value && _facilities.value.length > 1;
+  });
+  const currentFacilityName = computed(() => {
+    const match = _facilities.value.find(f => f.id === store.getters.activeFacilityId);
+    return match ? match.name : '';
   });
 
   //actions
@@ -82,5 +86,6 @@ export default function useFacilities() {
     setFacilities,
     selectedFacility,
     userIsMultiFacilityAdmin,
+    currentFacilityName,
   };
 }

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -1,35 +1,33 @@
-import { reactive, computed } from 'vue';
+import { ref, computed } from 'vue';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import useUser from 'kolibri/composables/useUser';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import Lockr from 'lockr';
 
-const state = reactive({
-  facilityConfig: {},
-  facilities: [],
-  facilityId: Lockr.get('facilityId') || null,
-});
+const _facilityConfig = ref({});
+const _facilities = ref([]);
+const _facilityId = ref(Lockr.get('facilityId') || null);
 
 export default function useFacilities() {
   const { userFacilityId } = useUser();
 
   const selectedFacility = computed(() => {
-    const facilityById = facilities.value.find(f => f.id === state.facilityId);
+    const facilityById = _facilities.value.find(f => f.id === _facilityId.value);
     if (facilityById) {
       return facilityById;
     }
-    return facilities.value.find(f => f.id === userFacilityId.value) || null;
+    return _facilities.value.find(f => f.id === userFacilityId.value) || null;
   });
 
   //getters
-  const facilities = computed(() => state.facilities);
-  const facilityConfig = computed(() => state.facilityConfig);
+  const facilities = computed(() => _facilities.value);
+  const facilityConfig = computed(() => _facilityConfig.value);
 
   //actions
   async function getFacilities() {
     const facilities = await FacilityResource.fetchCollection({ force: true });
-    state.facilities = facilities;
+    _facilities.value = facilities;
   }
 
   async function getFacilityConfig(facilityId) {
@@ -62,12 +60,12 @@ export default function useFacilities() {
   }
 
   //mutations
-  function setFacilityConfig(state, facilityConfig) {
-    state.facilityConfig = facilityConfig;
+  function setFacilityConfig(facilityConfig) {
+    _facilityConfig.value = facilityConfig;
   }
 
-  function setFacilities(state, facilities) {
-    state.facilities = facilities;
+  function setFacilities(facilities) {
+    _facilities.value = facilities;
   }
 
   return {

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -1,0 +1,96 @@
+import { reactive, computed } from 'vue';
+import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
+import useUser from 'kolibri/composables/useUser';
+import redirectBrowser from 'kolibri/utils/redirectBrowser';
+import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
+import Lockr from 'lockr';
+
+const state = reactive({
+  error: '',
+  facilityConfig: {},
+  facilities: [],
+  facilityId: Lockr.get('facilityId') || null,
+});
+
+export function useFacilities() {
+  const { userFacilityId } = useUser();
+
+  const selectedFacility = computed(() => {
+    const facilityById = facilities.value.find(f => f.id === state.facilityId);
+    if (facilityById) {
+      return facilityById;
+    }
+    return facilities.value.find(f => f.id === userFacilityId.value) || null;
+  });
+
+  //getters
+  const facilities = computed(() => state.facilities);
+  const facilityConfig = computed(() => state.facilityConfig);
+
+  //actions
+  async function getFacilities() {
+    try {
+      const facilities = await FacilityResource.fetchCollection({ force: true });
+      state.facilities = facilities;
+    } catch (error) {
+      state.error = error.message;
+    }
+  }
+
+  async function getFacilityConfig(facilityId) {
+    const facId = facilityId || userFacilityId.value;
+
+    if (!facId) {
+      // No facility Id, so redirect and let Kolibri sort it out
+      return redirectBrowser();
+    }
+
+    let facilityConfig;
+
+    try {
+      if (selectedFacility.value && typeof selectedFacility.value.dataset !== 'object') {
+        facilityConfig = [selectedFacility.value.dataset];
+      } else {
+        facilityConfig = await FacilityDatasetResource.fetchCollection({
+          getParams: {
+            facility_id: facId,
+          },
+        });
+      }
+
+      let config = {};
+      const facility = facilityConfig[0];
+
+      if (facility) {
+        config = { ...facility };
+      }
+      setFacilityConfig(config);
+    } catch (error) {
+      setError(error.message);
+      throw error;
+    }
+  }
+
+  //mutations
+  function setFacilityConfig(state, facilityConfig) {
+    state.facilityConfig = facilityConfig;
+  }
+
+  function setFacilities(state, facilities) {
+    state.facilities = facilities;
+  }
+
+  function setError(state, error) {
+    state.error = error;
+  }
+
+  return {
+    facilities,
+    facilityConfig,
+    getFacilities,
+    getFacilityConfig,
+    setFacilityConfig,
+    setFacilities,
+    setError,
+  };
+}

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -23,10 +23,15 @@ export default function useFacilities() {
   //getters
   const facilities = computed(() => _facilities.value);
   const facilityConfig = computed(() => _facilityConfig.value);
+  const userIsMultiFacilityAdmin = computed(() => {
+    const { isSuperuser } = useUser();
+    return isSuperuser.value && _facilities.value.length > 1;
+  });
 
   //actions
   async function getFacilities() {
     const facilities = await FacilityResource.fetchCollection({ force: true });
+
     _facilities.value = facilities;
   }
 
@@ -76,5 +81,6 @@ export default function useFacilities() {
     setFacilityConfig,
     setFacilities,
     selectedFacility,
+    userIsMultiFacilityAdmin,
   };
 }

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -11,7 +11,7 @@ const state = reactive({
   facilityId: Lockr.get('facilityId') || null,
 });
 
-export function useFacilities() {
+export default function useFacilities() {
   const { userFacilityId } = useUser();
 
   const selectedFacility = computed(() => {
@@ -77,5 +77,6 @@ export function useFacilities() {
     getFacilityConfig,
     setFacilityConfig,
     setFacilities,
+    selectedFacility,
   };
 }

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -6,7 +6,6 @@ import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDataset
 import Lockr from 'lockr';
 
 const state = reactive({
-  error: '',
   facilityConfig: {},
   facilities: [],
   facilityId: Lockr.get('facilityId') || null,
@@ -29,12 +28,8 @@ export function useFacilities() {
 
   //actions
   async function getFacilities() {
-    try {
-      const facilities = await FacilityResource.fetchCollection({ force: true });
-      state.facilities = facilities;
-    } catch (error) {
-      state.error = error.message;
-    }
+    const facilities = await FacilityResource.fetchCollection({ force: true });
+    state.facilities = facilities;
   }
 
   async function getFacilityConfig(facilityId) {
@@ -47,28 +42,23 @@ export function useFacilities() {
 
     let facilityConfig;
 
-    try {
-      if (selectedFacility.value && typeof selectedFacility.value.dataset !== 'object') {
-        facilityConfig = [selectedFacility.value.dataset];
-      } else {
-        facilityConfig = await FacilityDatasetResource.fetchCollection({
-          getParams: {
-            facility_id: facId,
-          },
-        });
-      }
-
-      let config = {};
-      const facility = facilityConfig[0];
-
-      if (facility) {
-        config = { ...facility };
-      }
-      setFacilityConfig(config);
-    } catch (error) {
-      setError(error.message);
-      throw error;
+    if (selectedFacility.value && typeof selectedFacility.value.dataset !== 'object') {
+      facilityConfig = [selectedFacility.value.dataset];
+    } else {
+      facilityConfig = await FacilityDatasetResource.fetchCollection({
+        getParams: {
+          facility_id: facId,
+        },
+      });
     }
+
+    let config = {};
+    const facility = facilityConfig[0];
+
+    if (facility) {
+      config = { ...facility };
+    }
+    setFacilityConfig(config);
   }
 
   //mutations
@@ -80,10 +70,6 @@ export function useFacilities() {
     state.facilities = facilities;
   }
 
-  function setError(state, error) {
-    state.error = error;
-  }
-
   return {
     facilities,
     facilityConfig,
@@ -91,6 +77,5 @@ export function useFacilities() {
     getFacilityConfig,
     setFacilityConfig,
     setFacilities,
-    setError,
   };
 }

--- a/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
+++ b/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
@@ -18,7 +18,6 @@ import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator'
 import { createTranslator } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
 import useFacilities from 'kolibri-common/composables/useFacilities';
-import { getFacilities } from '../../../../kolibri/core/assets/src/state/modules/core/actions';
 
 const translator = createTranslator('UserPermissionToolbarTitles', {
   loading: 'Loading user permissions…',
@@ -65,7 +64,7 @@ function fetchUserPermissions(userId) {
  * @returns Promise<void>
  */
 export function showUserPermissionsPage(store, userId) {
-  const { getfacilities } = useFacilities();
+  const { getFacilities } = useFacilities();
 
   const setAppBarTitle = title => store.commit('coreBase/SET_APP_BAR_TITLE', title);
   const setUserPermissionsState = state => store.commit('userPermissions/SET_STATE', state);

--- a/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
+++ b/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
@@ -17,7 +17,7 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator';
 import { createTranslator } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
-import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import useFacilities from 'kolibri-common/composables/useFacilities';
 import { getFacilities } from '../../../../kolibri/core/assets/src/state/modules/core/actions';
 
 const translator = createTranslator('UserPermissionToolbarTitles', {

--- a/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
+++ b/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
@@ -17,6 +17,8 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator';
 import { createTranslator } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
+import { useFacilities } from 'kolibri-common/composables/useFacilities';
+import { getFacilities } from '../../../../kolibri/core/assets/src/state/modules/core/actions';
 
 const translator = createTranslator('UserPermissionToolbarTitles', {
   loading: 'Loading user permissions…',
@@ -63,6 +65,8 @@ function fetchUserPermissions(userId) {
  * @returns Promise<void>
  */
 export function showUserPermissionsPage(store, userId) {
+  const { getfacilities } = useFacilities();
+
   const setAppBarTitle = title => store.commit('coreBase/SET_APP_BAR_TITLE', title);
   const setUserPermissionsState = state => store.commit('userPermissions/SET_STATE', state);
   const stopLoading = () => store.commit('CORE_SET_PAGE_LOADING', false);
@@ -81,7 +85,7 @@ export function showUserPermissionsPage(store, userId) {
   const samePage = samePageCheckGenerator(store);
   let testThing = translator.$tr('invalidUserTitle');
 
-  return Promise.all([fetchUserPermissions(userId), store.dispatch('getFacilities')])
+  return Promise.all([fetchUserPermissions(userId), getFacilities()])
     .then(([data]) => {
       if (samePage()) {
         setAppBarTitle(data.user.full_name);

--- a/packages/kolibri/composables/__mocks__/useUser.js
+++ b/packages/kolibri/composables/__mocks__/useUser.js
@@ -58,7 +58,6 @@ const MOCK_DEFAULTS = {
   isFacilityCoach: false,
   isLearner: true,
   isFacilityAdmin: false,
-  userIsMultiFacilityAdmin: false,
   getUserPermissions: {},
   userFacilityId: undefined,
   getUserKind: UserKinds.ANONYMOUS,

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -15,7 +15,6 @@ export default function useUser() {
   const isFacilityCoach = computed(() => store.getters.isFacilityCoach);
   const isLearner = computed(() => store.getters.isLearner);
   const isFacilityAdmin = computed(() => store.getters.isFacilityAdmin);
-  const userIsMultiFacilityAdmin = computed(() => store.getters.userIsMultiFacilityAdmin);
   const getUserPermissions = computed(() => store.getters.getUserPermissions);
   const userFacilityId = computed(() => store.getters.userFacilityId);
   const getUserKind = computed(() => store.getters.getUserKind);
@@ -46,7 +45,6 @@ export default function useUser() {
     isFacilityCoach,
     isLearner,
     isFacilityAdmin,
-    userIsMultiFacilityAdmin,
     getUserPermissions,
     userFacilityId,
     getUserKind,


### PR DESCRIPTION
## Summary
This PR Migrates:
1. `getFacilities` and `getFacilityConfig` actions from the core module.
2. `facilityConfig` and `facilities` getters.
3. `facilities` and `facilityConfig `state.
4. `CORE_SET_FACILITY_CONFIG` and `CORE_SET_FACILITIES` mutations.
5. `userIsMultiFacilityAdmin` and `currentFacilityName` from different pluginModules.
Into the useFacilities composable.
6. `selectedFacilty` getter from user_auth module. 


## References
Closes #12708

## Reviewer guidance
This PR migrates quite a lot of functionality around facilities and configurations around it.
We would primarily want to test the following things:

1. SignIn Page with multiple facilities workflow works as expected.
2. SignUp Page with multiple Facilities works as expected.
3. All the Coach Pages with a multiple facility setup works as expected and UI is responsive and displaying correct facility name where required.
4. Device Pages where information about facility is required like edit section of user which displays there assigned facilities.
5. Facilities Page worflows work as expected with multi-facility setup. 
