### PR TITLE
Fix alignment of language buttons in setup flow

### DIFF
--- a/packages/kolibri/components/language-switcher/internal/SelectedLanguage.vue
+++ b/packages/kolibri/components/language-switcher/internal/SelectedLanguage.vue
@@ -49,6 +49,7 @@
   .px-8 {
     padding-right: 8px;
     padding-left: 8px;
+    padding-bottom: 4px;
   }
 
 </style>


### PR DESCRIPTION
# Summary 
Correct alignment of language buttons in the default language page
fix #12298 