### PR TITLE
fix construction of cookie using user supplied input #12808

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1046,16 +1046,22 @@ class SessionViewSet(viewsets.ViewSet):
 
         if isinstance(user, AnonymousUser):
             response = Response(session)
-            if not request.COOKIES.get("visitor_id"):
+            try:
+                existing_visitor_id = request.COOKIES.get("visitor_id")
+                if existing_visitor_id:
+                    UUID(existing_visitor_id, version=4)
+                    response.set_cookie(
+                        "visitor_id", existing_visitor_id, expires=visitor_cookie_expiry
+                    )
+                else:
+                    visitor_id = str(uuid4().hex)
+                    response.set_cookie(
+                        "visitor_id", visitor_id, expires=visitor_cookie_expiry
+                    )
+            except (ValueError, TypeError):
                 visitor_id = str(uuid4().hex)
                 response.set_cookie(
                     "visitor_id", visitor_id, expires=visitor_cookie_expiry
-                )
-            else:
-                response.set_cookie(
-                    "visitor_id",
-                    request.COOKIES.get("visitor_id"),
-                    expires=visitor_cookie_expiry,
                 )
             return response
         # Set last activity on session to the current time to prevent session timeout

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1049,11 +1049,11 @@ class SessionViewSet(viewsets.ViewSet):
             try:
                 visitor_id = request.COOKIES.get("visitor_id")
                 if visitor_id:
-                    UUID(visitor_id, version=4) 
+                    UUID(visitor_id, version=4)
                 else:
-                    raise ValueError  
+                    raise ValueError
             except (ValueError, TypeError):
-                visitor_id = uuid4().hex  
+                visitor_id = uuid4().hex
             response.set_cookie("visitor_id", visitor_id, expires=visitor_cookie_expiry)
             return response
         # Set last activity on session to the current time to prevent session timeout

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1047,22 +1047,14 @@ class SessionViewSet(viewsets.ViewSet):
         if isinstance(user, AnonymousUser):
             response = Response(session)
             try:
-                existing_visitor_id = request.COOKIES.get("visitor_id")
-                if existing_visitor_id:
-                    UUID(existing_visitor_id, version=4)
-                    response.set_cookie(
-                        "visitor_id", existing_visitor_id, expires=visitor_cookie_expiry
-                    )
+                visitor_id = request.COOKIES.get("visitor_id")
+                if visitor_id:
+                    UUID(visitor_id, version=4) 
                 else:
-                    visitor_id = str(uuid4().hex)
-                    response.set_cookie(
-                        "visitor_id", visitor_id, expires=visitor_cookie_expiry
-                    )
+                    raise ValueError  
             except (ValueError, TypeError):
-                visitor_id = str(uuid4().hex)
-                response.set_cookie(
-                    "visitor_id", visitor_id, expires=visitor_cookie_expiry
-                )
+                visitor_id = uuid4().hex  
+            response.set_cookie("visitor_id", visitor_id, expires=visitor_cookie_expiry)
             return response
         # Set last activity on session to the current time to prevent session timeout
         # Only do this for logged in users, as anonymous users cannot get logged out!

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1048,10 +1048,7 @@ class SessionViewSet(viewsets.ViewSet):
             response = Response(session)
             try:
                 visitor_id = request.COOKIES.get("visitor_id")
-                if visitor_id:
-                    UUID(visitor_id, version=4)
-                else:
-                    raise ValueError
+                visitor_id = UUID(visitor_id, version=4).hex
             except (ValueError, TypeError):
                 visitor_id = uuid4().hex
             response.set_cookie("visitor_id", visitor_id, expires=visitor_cookie_expiry)


### PR DESCRIPTION
## Summary
This PR addresses the code scanning alert in issue [#12808](https://github.com/learningequality/kolibri/issues/12808) by ensuring that the `visitor_id` cookie value is validated before use. 

The validation ensures:
- The `visitor_id` cookie is a valid hex UUID by attempting to parse it with `UUID(visitor_id, version=4)`.
- If the validation fails or the cookie does not exist, a new `visitor_id` is generated using `uuid4().hex`.
- The validated or newly generated `visitor_id` is then set in the response.

---