### PR TITLE
Fix import path error in kolibri-tools migrate core API functionality

### DIFF
--- a/packages/kolibri-tools/lib/apiTransform.js
+++ b/packages/kolibri-tools/lib/apiTransform.js
@@ -1,6 +1,6 @@
 const compiler = require('vue-template-compiler');
 const descriptorToString = require('vue-sfc-descriptor-to-string');
-const { lintSource } = require('kolibri-tools/lib/lint');
+const { lintSource } = require('kolibri-format');
 const logger = require('./logging');
 const importMap = require('./moduleMapping');
 

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": {
@@ -51,6 +51,7 @@
     "jest-serializer-vue": "^3.1.0",
     "launch-editor-middleware": "^2.9.1",
     "jscodeshift": "^17.1.2",
+    "kolibri-format": "^1.0.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^2.9.2",
     "node-sass": "9.0.0",


### PR DESCRIPTION
## Summary
* I broke the migrate command by not updating the import paths when I spun out kolibri-format into a separate package
* This fixes that (verified by running the migrate command)
* Adds a dependency of kolibri-tools on kolibri-format
* Bumps version of kolibri-tools so we can make a new release with this bug fix.

## References
Fixes regression introduced by #12847

## Reviewer guidance
Can you run `yarn run migrate-core-api` locally without errors? (disgregard any changed files, this is due to a comment issue I couldn't resolve)
