### PR TITLE
LearnerSummaryPage: Fix quiz/lesson report links

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/reports/LearnerQuizPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/reports/LearnerQuizPage.vue
@@ -1,7 +1,6 @@
 <template>
 
   <CoachImmersivePage
-    :appBarTitle="exam.title"
     icon="back"
     :primary="false"
     :route="toolbarRoute"

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -34,11 +34,7 @@
                 >
                   <td>
                     <KRouterLink
-                      :to="
-                        classRoute('ReportsLearnerReportLessonPage', {
-                          lessonId: tableRow.id,
-                        })
-                      "
+                      :to="lessonLink(tableRow.id)"
                       :text="tableRow.title"
                       icon="lesson"
                     />
@@ -190,7 +186,10 @@
         return this.getLearnersForExam(quiz).includes(this.learner.id);
       },
       quizLink(quizId) {
-        return this.classRoute(PageNames.REPORTS_LEARNER_REPORT_QUIZ_PAGE_ROOT, { quizId });
+        return this.classRoute(PageNames.QUIZ_LEARNER_REPORT, { quizId });
+      },
+      lessonLink(lessonId) {
+        return this.classRoute(PageNames.LESSON_LEARNER_REPORT, { lessonId });
       },
       exportCSVLessons() {
         const filteredLessons = this.lessons

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -186,7 +186,13 @@
         return this.getLearnersForExam(quiz).includes(this.learner.id);
       },
       quizLink(quizId) {
-        return this.classRoute(PageNames.QUIZ_LEARNER_REPORT, { quizId });
+        return this.classRoute(PageNames.QUIZ_LEARNER_REPORT, {
+          quizId,
+          learnerId: this.learner.id,
+          questionId: 0,
+          interactionIndex: 0,
+          tryIndex: 0,
+        });
       },
       lessonLink(lessonId) {
         return this.classRoute(PageNames.LESSON_LEARNER_REPORT, { lessonId });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

LessonSummaryPage was using the wrong page names when generating the links to the proper reports. This PR corrects them.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13027 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Click the links in `Coach -> Learners -> <Specific Learner Summary>` for Lessons and Quizzes, they should work.
