### PR TITLE
Quiz creation: Show correct answers for questions

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -94,6 +94,7 @@
                   :assessment="true"
                   :allowHints="false"
                   :interactive="false"
+                  :showCorrectAnswers="true"
                   @interaction="() => null"
                   @updateProgress="() => null"
                   @updateContentState="() => null"

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -94,7 +94,7 @@
                   :assessment="true"
                   :allowHints="false"
                   :interactive="false"
-                  :showCorrectAnswers="true"
+                  :showCorrectAnswer="true"
                   @interaction="() => null"
                   @updateProgress="() => null"
                   @updateContentState="() => null"

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/QuestionListPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/QuestionListPreview.vue
@@ -129,7 +129,7 @@
         :itemId="currentQuestion.question_id"
         :assessment="true"
         :allowHints="false"
-        :showCorrectAnswer="false"
+        :showCorrectAnswer="true"
         :interactive="false"
       />
       <p v-else>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ReplaceQuestions.vue
@@ -89,7 +89,7 @@
               :assessment="true"
               :allowHints="false"
               :interactive="false"
-              :showCorrectAnswers="true"
+              :showCorrectAnswer="true"
               @interaction="() => null"
               @updateProgress="() => null"
               @updateContentState="() => null"

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/ReplaceQuestions.vue
@@ -89,6 +89,7 @@
               :assessment="true"
               :allowHints="false"
               :interactive="false"
+              :showCorrectAnswers="true"
               @interaction="() => null"
               @updateProgress="() => null"
               @updateContentState="() => null"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Puts the `showCorrectAnswers=true` prop onto the ContentRenderer in QuestiosnAccordion. 

I also applied it in ReplaceQuestions, although that is liable to be removed.

Also, in the [QuestionListPreview](https://github.com/learningequality/kolibri/blob/b6f59fef14672a1fea614e9d038898498936f93e/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/QuestionListPreview.vue#L132) it is explicitly set to `false` (which I did, but I don't recall why) - but should I also flip that one?

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13025 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do you see correct answers in Quiz Creation after adding questions?
