### PR TITLE
Add a placeholder string when no resources are available/no channels on devices

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectionIndex.vue
@@ -44,6 +44,12 @@
           :text="searchLabel$()"
         />
       </div>
+      <p
+        v-if="channels.length === 0"
+        class="mt-24"
+      >
+        {{ noAvailableResources$() }}
+      </p>
       <KCardGrid layout="1-1-1">
         <AccessibleChannelCard
           v-for="channel of channels"
@@ -83,6 +89,7 @@
 
       const {
         selectFromChannels$,
+        noAvailableResources$,
         numberOfBookmarks$,
         bookmarksLabel$,
         selectFromBookmarks$,
@@ -98,6 +105,7 @@
         bookmarksCount,
         channels,
         selectFromChannels$,
+        noAvailableResources$,
         numberOfBookmarks$,
         bookmarksLabel$,
         selectFromBookmarks$,
@@ -154,6 +162,10 @@
 
   .mb-16 {
     margin-bottom: 16px;
+  }
+
+  .mt-24 {
+    margin-top: 24px;
   }
 
   .side-panel-subtitle {

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1049,6 +1049,12 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Select from channels',
     context: "Option on the 'Manage lesson resources' page.",
   },
+  noAvailableResources: {
+    message:
+      'There are no resources available. Please contact your administrator to import channels on this device.',
+    context:
+      'Message displayed when there are no resources available for the user to select or view.',
+  },
   selectFromBookmarks: {
     message: 'Select from bookmarks',
     context: "Option on the 'Manage lesson resources' page.",


### PR DESCRIPTION
## Summary
This adds a common string that can be used across Kolibri for situations where there are no channels imported on the device and therefore no resources that are available for the user - whether this is for viewing, or for selecting (i.e. lesson and quiz creation).

## References
Fixes #13021

<img width="1244" alt="Screenshot 2025-01-29 at 3 34 41 PM" src="https://github.com/user-attachments/assets/ecf41660-57da-4922-94e1-101c477d6bd9" />


## Reviewer guidance
1. Remove all channels from the device, and ensure that the string displays on the `/lessonstemp` path when opening the "manage resources" side panel. 
2. When their are channels, the channel cards should display correctly.
