### PR TITLE
Allow Studio URLs to be created as network locations

### DIFF
--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -108,6 +108,8 @@ class NetworkLocation(models.Model):
 
     def save(self, *args, **kwargs):
         self._set_fields_for_type()
+        if self.operating_system is None:
+            self.operating_system = ""
         return super(NetworkLocation, self).save(*args, **kwargs)
 
     def _set_fields_for_type(self):

--- a/kolibri/core/discovery/test/helpers.py
+++ b/kolibri/core/discovery/test/helpers.py
@@ -38,6 +38,24 @@ def mock_request(session, method, url, *args, **kwargs):
         raise exceptions.ConnectionError("Refusing connection to: {}".format(url))
 
 
+def mock_happy_no_os_request(happy_url, default_error=exceptions.RequestException):
+    def mock_request(session, method, url, *args, **kwargs):
+        response = mock.MagicMock()
+        response.__enter__.return_value = response
+        response.status_code = 200
+        response.raw._connection.sock.getpeername.return_value = (
+            "192.168.101.101",
+            123456,
+        )
+        info_copy = dict(info)
+        info_copy["operating_system"] = None
+        response.json.return_value = info_copy
+        response.url = url
+        return response
+
+    return mock_request
+
+
 def mock_happy_request(happy_url, default_error=exceptions.RequestException):
     def mock_request(session, method, url, *args, **kwargs):
         response = mock_response(200)

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -12,6 +12,7 @@ from rest_framework.test import APITestCase
 
 from .. import models
 from ..utils.network import connections
+from .helpers import mock_happy_no_os_request
 from .helpers import mock_request
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
@@ -201,6 +202,29 @@ class NetworkLocationAPITestCase(APITestCase):
             self.dynamic_location.id,
         ]
         self.assert_network_location_list(None, expected_ids)
+
+    def test_update_connection_status(self):
+        from django.db.utils import IntegrityError
+
+        with mock.patch.object(
+            requests.Session,
+            "request",
+            mock_happy_no_os_request("https://happyurl.qqq/"),
+        ):
+            self.login(self.superuser)
+            try:
+                self.client.post(
+                    reverse(
+                        "kolibri:core:networklocation-update-connection-status",
+                        args=[self.studio_non_reserved_location.id],
+                    ),
+                )
+            except IntegrityError as e:
+                self.fail(
+                    "NetworkLocation.operating_system has no default value set: {}".format(
+                        e
+                    )
+                )
 
 
 class PinnedDeviceAPITestCase(APITestCase):

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -55,6 +55,9 @@ class NetworkLocationAPITestCase(APITestCase):
             base_url=CENTRAL_CONTENT_BASE_URL,
             location_type=models.LocationTypes.Reserved,
         )
+        cls.studio_non_reserved_location = models.NetworkLocation.objects.create(
+            base_url=CENTRAL_CONTENT_BASE_URL,
+        )
         cls.dynamic_location = models.DynamicNetworkLocation.objects.create(
             id="a" * 32,
             base_url="http://dynamiclocation.qqq",

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -55,9 +55,6 @@ class NetworkLocationAPITestCase(APITestCase):
             base_url=CENTRAL_CONTENT_BASE_URL,
             location_type=models.LocationTypes.Reserved,
         )
-        cls.studio_non_reserved_location = models.NetworkLocation.objects.create(
-            base_url=CENTRAL_CONTENT_BASE_URL,
-        )
         cls.dynamic_location = models.DynamicNetworkLocation.objects.create(
             id="a" * 32,
             base_url="http://dynamiclocation.qqq",
@@ -209,6 +206,10 @@ class NetworkLocationAPITestCase(APITestCase):
     def test_update_connection_status(self):
         from django.db.utils import IntegrityError
 
+        studio_non_reserved_location = models.NetworkLocation.objects.create(
+            base_url=CENTRAL_CONTENT_BASE_URL,
+        )
+
         with mock.patch.object(
             requests.Session,
             "request",
@@ -219,7 +220,7 @@ class NetworkLocationAPITestCase(APITestCase):
                 self.client.post(
                     reverse(
                         "kolibri:core:networklocation-update-connection-status",
-                        args=[self.studio_non_reserved_location.id],
+                        args=[studio_non_reserved_location.id],
                     ),
                 )
             except IntegrityError as e:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Adds regression test that would trigger the same error preventing hotfixes/studio urls to be used as network locations
- Fixes the error by adding conditional to NetworkLocation#save that ensures operating_system is not None

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12912 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Add studio.learningequality.org to your list of locations to import content from
- Restart your server
- You should see that URL is **not** disabled, no errors.

Note that during startup, the connections are updated there as well, so when you restart the server, you should also see no IntegrityErrors.
