### PR TITLE
adds notice for quizzes  created pre-0.17.x 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -27,6 +27,16 @@
       </div>
     </div>
     <MissingResourceAlert v-if="resource.missing_resource" />
+    <UiAlert
+      v-if="isFromOldKolibiri && hideAlert"
+      type="warning"
+      class="old-kolibri-banner"
+      @dismiss="hideAlert = false"
+    >
+      <span>
+        {{ warningForQuizFromOldKolibri$() }}
+      </span>
+    </UiAlert>
   </KPageContainer>
 
 </template>
@@ -35,7 +45,9 @@
 <script>
 
   import { mapState } from 'vuex';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import BackLink from './BackLink';
 
   export default {
@@ -43,6 +55,13 @@
     components: {
       MissingResourceAlert,
       BackLink,
+      UiAlert,
+    },
+    setup() {
+      const { warningForQuizFromOldKolibri$ } = searchAndFilterStrings;
+      return {
+        warningForQuizFromOldKolibri$,
+      };
     },
     props: {
       backlink: {
@@ -61,6 +80,11 @@
         },
       },
     },
+    data() {
+      return {
+        hideAlert: true,
+      };
+    },
     computed: {
       ...mapState('classSummary', ['examMap', 'lessonMap']),
       exam() {
@@ -71,6 +95,18 @@
       },
       resource() {
         return this.examOrLesson === 'lesson' ? this.lesson : this.exam;
+      },
+      isActive() {
+        return this.exam.active;
+      },
+      isExamDraft() {
+        return this.exam.draft;
+      },
+      isOldDataModelVersion() {
+        return this.exam.data_model_version < 3;
+      },
+      isFromOldKolibiri() {
+        return this.isOldDataModelVersion && !this.isExamDraft && !this.isActive;
       },
     },
   };
@@ -99,6 +135,10 @@
 
   /deep/ .time-context {
     margin-bottom: 0;
+  }
+
+  .old-kolibri-banner {
+    margin-top: 0.5em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -102,11 +102,11 @@
       isExamDraft() {
         return this.exam.draft;
       },
-      isOldDataModelVersion() {
+      isExamOldVersion() {
         return this.exam.data_model_version < 3;
       },
       isFromOldKolibri() {
-        return this.isOldDataModelVersion && !this.isExamDraft && !this.isActive;
+        return this.isExamOldVersion && !this.isExamDraft && !this.isActive;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -28,10 +28,10 @@
     </div>
     <MissingResourceAlert v-if="resource.missing_resource" />
     <UiAlert
-      v-if="isFromOldKolibiri && hideAlert"
+      v-if="isFromOldKolibri && showAlert"
       type="warning"
       class="old-kolibri-banner"
-      @dismiss="hideAlert = false"
+      @dismiss="showAlert = false"
     >
       <span>
         {{ warningForQuizFromOldKolibri$() }}
@@ -82,7 +82,7 @@
     },
     data() {
       return {
-        hideAlert: true,
+        showAlert: true,
       };
     },
     computed: {
@@ -105,7 +105,7 @@
       isOldDataModelVersion() {
         return this.exam.data_model_version < 3;
       },
-      isFromOldKolibiri() {
+      isFromOldKolibri() {
         return this.isOldDataModelVersion && !this.isExamDraft && !this.isActive;
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
@@ -41,7 +41,7 @@
           },
           { label: this.coreString('deleteAction'), value: 'DELETE' },
         ];
-        if (!this.exam?.archive) {
+        if (!this.exam?.data_model_version > 2) {
           options.unshift({
             label: this.exam?.draft
               ? this.coreString('editAction')

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
@@ -33,6 +33,9 @@
       },
     },
     computed: {
+      isLatestExamVersion() {
+        return this.exam?.data_model_version >= 3;
+      },
       options() {
         const options = [
           {
@@ -41,7 +44,7 @@
           },
           { label: this.coreString('deleteAction'), value: 'DELETE' },
         ];
-        if (this.exam?.data_model_version > 2) {
+        if (this.isLatestExamVersion) {
           options.unshift({
             label: this.exam?.draft
               ? this.coreString('editAction')

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/QuizOptionsDropdownMenu.vue
@@ -41,7 +41,7 @@
           },
           { label: this.coreString('deleteAction'), value: 'DELETE' },
         ];
-        if (!this.exam?.data_model_version > 2) {
+        if (this.exam?.data_model_version > 2) {
           options.unshift({
             label: this.exam?.draft
               ? this.coreString('editAction')

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -57,6 +57,11 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     message: 'Open exercise',
     context: 'Button label to open the exercise a question belongs to',
   },
+  warningForQuizFromOldKolibri: {
+    message:
+      'This quiz was created using an older version of Kolibri and cannot be edited directly. Create a copy of it to edit the resources.',
+    context: 'Warning message for quizzes created in an older version of Kolibri.',
+  },
   removeResourceLabel: {
     message: 'Remove resource',
     context: 'Button label to remove a resource from the selected resources',


### PR DESCRIPTION
## Summary
In version 0.17, the `question_sources` field structure was updated, introducing the` DraftExam` and `Exam ` models. Quizzes created in versions ≥0.17.x start as `DraftExam `and convert to `Exam `. However, quizzes created prior to 0.17.x (without `DraftExam` ) may exist in an uneditable state if the user upgraded Kolibri without starting the quiz.  This PR 
 add notice for  legacy quiz created pre-0.17.x) should not be uneditable but should see 

`"This quiz was created using an older version of Kolibri and cannot be edited directly. Create a copy of it to edit the resources."
`
closes #12954
## References
#12954

## Reviewer guidance
 - Import any older version on quizzes created prior to 0.17.x  and try to edit if the quiz has not been started 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning alert banner to quiz and lesson details when viewing quizzes from older Kolibri versions, informing users that these cannot be edited directly.
- **Improvements**
  - Updated quiz options dropdown to only show the edit option for quizzes created with the latest version.
- **Localization**
  - Added a new warning message string for legacy quizzes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->