### PR TITLE
Only show attempts column in lesson reports for practice quizzes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/tables/ReportsLearnersTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/tables/ReportsLearnersTable.vue
@@ -7,7 +7,7 @@
       <th v-if="anyScore">
         {{ coreString('scoreLabel') }}
       </th>
-      <th v-if="anyTries">
+      <th v-if="showTries">
         {{ coachString('attemptsLabel') }}
       </th>
       <th v-if="anyTimeSpent">
@@ -78,7 +78,7 @@
               :diff="getDiff(tableRow)"
             />
           </td>
-          <td v-if="anyTries">
+          <td v-if="showTries">
             {{ tableRow.statusObj.tries }}
           </td>
           <td v-if="anyTimeSpent">
@@ -100,6 +100,7 @@
 
 <script>
 
+  import Modalities from 'kolibri-constants/Modalities';
   import isUndefined from 'lodash/isUndefined';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
@@ -141,9 +142,17 @@
       anyTimeSpent() {
         return this.entries.some(entry => !isUndefined(entry.statusObj.time_spent));
       },
+      // Presumes this is a Lesson report table as exerciseId is only present in lesson routes
+      showTries() {
+        return (
+          this.anyTries &&
+          this.contentMap[this.$route.params.exerciseId]?.options?.modality === Modalities.QUIZ
+        );
+      },
       anyTries() {
         return this.entries.some(entry => !isUndefined(entry.statusObj.tries));
       },
+      // Presumes this is a Lesson report table as quizId is only present in quiz routes
       exam() {
         return this.examMap[this.$route.params.quizId];
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Modifies the condition in the ReportsLearnersTable for showing the attempts column so that it only shows if the currently viewed piece of content is a practice quiz.

Only affects the case in which the report is viewing a particular piece of content _in a lesson_.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13011 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Make a lesson w/ a Practice Quiz in it (available in QA channel > exercises > practice quizzes)
- Also add a regular exercise (QA channel > exercises > KA Perseus)
- Make some attempts with a user
- Go to Coach > Class Lessons > (your lesson) > (the practice quiz) and you should see the attempts column
- View the non-practice quiz, you should not see the attempts column

Edge case: When you have a practice quiz but _no attempts_ then in this case there should be _no attempts column_.
