### PR TITLE
Fix missing facility_name in facility removal notification

### DIFF
--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -296,7 +296,7 @@
             ) {
               this.fetchFacilites();
               if (task.type === TaskTypes.DELETEFACILITY) {
-                this.showFacilityRemovedSnackbar(task.facility_name);
+                this.showFacilityRemovedSnackbar(task.extra_metadata.facility_name);
               }
               this.taskIdsToWatch = this.taskIdsToWatch.filter(x => x !== task.id);
             } else if (this.isSyncTask(task) && task.status === TaskStatuses.FAILED) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The facility_name was reported missing from the snackbar notification for facility removal, fixed with minor update.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #13048 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Create a facility
- Remove that facility
- Do you see the facility's name in the snackbar notification?
