### PR TITLE
Fix bugs in common CategorySearchModal

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -141,8 +141,8 @@
     </div>
     <!-- When accordion mode is NOT activated, show as KModal, otherwise, just a div -->
     <component
-      :is="accordion ? 'div' : 'KModal'"
-      v-if="windowIsLarge && currentCategory"
+      :is="accordion || !windowIsLarge ? 'div' : 'KModal'"
+      v-if="currentCategory"
       appendToOverlay
       :title="$tr('chooseACategory')"
       :cancelText="coreString('closeAction')"
@@ -150,7 +150,6 @@
       @cancel="currentCategory = null"
     >
       <CategorySearchModal
-        v-if="currentCategory"
         ref="searchModal"
         :class="windowIsLarge ? '' : 'drawer-panel'"
         :selectedCategory="currentCategory"


### PR DESCRIPTION

## Summary
Fixes CategorySearchModal not rendering  work properly in  windowIsSmall in Learn from the  side panel

### Before 


https://github.com/user-attachments/assets/684816f2-7cd9-4032-bbaf-775383bb6bb9



### After 


https://github.com/user-attachments/assets/5f8e63aa-2151-424a-92e5-5b991dd0daff



## References
#13033


## Reviewer guidance
Navigate to learn > filter and try filter with different screen size option 
