### PR TITLE
Fix missing device name in SelectDeviceForm

### DIFF
--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -138,13 +138,13 @@
 <script>
 
   import { computed } from 'vue';
-  import { useLocalStorage, get } from '@vueuse/core';
+  import { useLocalStorage } from '@vueuse/core';
   import find from 'lodash/find';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
   import pickBy from 'lodash/pickBy';
-  import { UnreachableConnectionStatuses } from './constants';
+  import { LocationTypes, UnreachableConnectionStatuses } from './constants';
   import useDeviceDeletion from './useDeviceDeletion.js';
   import {
     useDevicesWithFilter,
@@ -208,8 +208,12 @@
 
       const storageDeviceId = useLocalStorage('kolibri-lastSelectedNetworkLocationId', '');
 
-      const discoveredDevices = computed(() => get(devices).filter(d => d.dynamic));
-      const savedDevices = computed(() => get(devices).filter(d => !d.dynamic));
+      const discoveredDevices = computed(() =>
+        devices.value.filter(d => d.location_type === LocationTypes.DYNAMIC),
+      );
+      const savedDevices = computed(() =>
+        devices.value.filter(d => d.location_type !== LocationTypes.DYNAMIC),
+      );
 
       return {
         // useDevices

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -130,7 +130,6 @@
         @click="$emit('click_add_address')"
       />
     </div>
-    <span></span>
   </KModal>
 
 </template>

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -120,7 +120,7 @@
       </KFixedGrid>
     </template>
 
-    <KButtonGroup class="under-buttons">
+    <div class="under-buttons">
       <slot name="underbuttons"></slot>
       <KButton
         v-show="!newDeviceButtonDisabled && !formDisabled"
@@ -129,7 +129,8 @@
         appearance="basic-link"
         @click="$emit('click_add_address')"
       />
-    </KButtonGroup>
+    </div>
+    <span></span>
   </KModal>
 
 </template>
@@ -477,8 +478,10 @@
   }
 
   .under-buttons {
-    /* align button group with the form content */
-    margin-left: -8px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin: 8px 0 2px;
   }
 
 </style>

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import SelectDeviceForm from '../SelectDeviceForm';
 import { fetchDevices, updateConnectionStatus } from '../api';
-import { ConnectionStatus } from '../constants';
+import { ConnectionStatus, LocationTypes } from '../constants';
 
 jest.mock('../api.js', () => ({
   fetchDevices: jest.fn(),
@@ -51,8 +51,8 @@ const devices = [
   },
 ];
 
-const staticDevices = devices.map(a => ({ ...a, dynamic: false }));
-const dynamicDevices = devices.map(a => ({ ...a, dynamic: true }));
+const staticDevices = devices.map(a => ({ ...a, location_type: LocationTypes.STATIC }));
+const dynamicDevices = devices.map(a => ({ ...a, location_type: LocationTypes.DYNAMIC }));
 
 function makeWrapper() {
   const wrapper = shallowMount(SelectDeviceForm);

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/constants.js
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/constants.js
@@ -14,3 +14,12 @@ export const UnreachableConnectionStatuses = [
   ConnectionStatus.ConnectionFailure,
   ConnectionStatus.ResponseTimeout,
 ];
+
+export const LocationTypes = {
+  // reserved locations like Studio and KDP
+  RESERVED: 'reserved',
+  // static locations added by the user
+  STATIC: 'static',
+  // dynamic locations discovered by the Kolibri instance
+  DYNAMIC: 'dynamic',
+};

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/index.vue
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/index.vue
@@ -20,14 +20,7 @@
       @removed_address="handleRemovedAddress"
       @cancel="handleCancel"
       @submit="handleSelectAddressSubmit"
-    >
-      <template #underbuttons>
-        <KButton
-          :text="'heheh'"
-          appearance="basic-link"
-        />
-      </template>
-    </SelectDeviceForm>
+    />
   </div>
 
 </template>

--- a/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/index.vue
+++ b/packages/kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/index.vue
@@ -20,7 +20,14 @@
       @removed_address="handleRemovedAddress"
       @cancel="handleCancel"
       @submit="handleSelectAddressSubmit"
-    />
+    >
+      <template #underbuttons>
+        <KButton
+          :text="'heheh'"
+          appearance="basic-link"
+        />
+      </template>
+    </SelectDeviceForm>
   </div>
 
 </template>


### PR DESCRIPTION
## Summary

* In the `SelectDeviceForm` component we were still using the depecrated `device.dynamic`  property to determine if the devices were dynamic or not. This PR updates this to use the new field `location_type`.
* Fixed vertical scrollbar being shown although it was not needed.

## References
Closes #12896.

## Reviewer guidance
Follow instructions in #12896 and check that devices names are present in the modal.