### PR TITLE
Fix lesson resource selection issues

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -70,10 +70,6 @@
         <div class="side-panel-subtitle">
           {{ selectFromChannels$() }}
         </div>
-        <KButton
-          icon="filter"
-          :text="searchLabel$()"
-        />
       </div>
       <p
         v-if="channels.length === 0"

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectFromSearchResults.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectFromSearchResults.vue
@@ -33,6 +33,7 @@
       :selectedResources="selectedResources"
       :getTopicLink="getTopicLink"
       :getResourceLink="getResourceLink"
+      :unselectableResourceIds="unselectableResourceIds"
       @selectResources="$emit('selectResources', $event)"
       @deselectResources="$emit('deselectResources', $event)"
     />
@@ -145,6 +146,11 @@
       getResourceLink: {
         type: Function,
         required: true,
+      },
+      unselectableResourceIds: {
+        type: Array,
+        required: false,
+        default: null,
       },
     },
     computed: {


### PR DESCRIPTION
## Summary

* Removes duplicated Search button
* Disable checkboxes of already selected resources in search results
  
  ![image](https://github.com/user-attachments/assets/ea300f42-3d26-4f61-bb7c-b26bf46eade7)



## References
Closes #13074
Closes #13072

## Reviewer guidance

Follow instructions in #13074 and #13072
