### PR TITLE
Category search modal icon update

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -51,7 +51,7 @@
             </template>
           </KButton>
           <KButton
-            :text="coreString('uncategorized')"
+            :text="coreString('otherCategories')"
             class="category-button"
             :class="$computedClass({ ':hover': { background: selectedHighlightColor } })"
             :style="{
@@ -59,7 +59,15 @@
             }"
             appearance="flat-button"
             @click="noCategories"
-          />
+          >
+            <template #icon>
+              <KIcon
+                class="category-icon"
+                icon="optionsCircle"
+                :color="$themeTokens.primary"
+              />
+            </template>
+          </KButton>
         </template>
       </AccordionItem>
       <AccordionItem
@@ -330,9 +338,16 @@
         // Takes the dot separated category value and checks if it is active
         return this.activeCategories.some(k => k.includes(categoryValue));
       },
-      categoryIcon() {
-        // TODO Add icons to KDS then use them
-        return 'categories';
+      categoryIcon(category) {
+        if (category === 'WORK') {
+          return 'skillsResource';
+        } else if (category === 'FOUNDATIONS') {
+          return 'basicSkillsResource';
+        }
+        // for those with a clearer 1:1 match with the category and icon
+        else {
+          return camelCase(category) + 'Resource';
+        }
       },
     },
     $trs: {
@@ -401,6 +416,8 @@
     position: absolute;
     top: 50%;
     left: 0.5em;
+    width: 32px;
+    height: 32px;
     transform: translateY(-50%);
   }
 
@@ -415,8 +432,7 @@
     // Ensure the child KIcons' absolute positioning anchors to this button
     position: relative;
     width: 100%;
-    // 0.5em around except on the right where the category icon is
-    padding: 0 0.5em 0 2.25em;
+    padding: 0.25em 0.5em 0.25em 3.5em;
     font-weight: normal;
     text-align: left;
     // KButton text formatting overrides

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -879,6 +879,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context: 'A label to indicate that no category label has been applied to the resource.',
   },
 
+  otherCategories: {
+    message: 'Other',
+    context: 'A label to indicate that the resource belongs to a category not listed.',
+  },
+
   // Resources Needed Categories = {
   forBeginners: {
     message: 'For beginners',


### PR DESCRIPTION
## Summary


After:
<img width="690" alt="Screenshot 2025-02-18 at 1 22 11 PM" src="https://github.com/user-attachments/assets/51bd20ba-56bd-4412-9085-4bce420c30b4" />

- Upgrades KDS to v5
- Updates the icon in the category search filter accordion in Coach 
- Updates the text to match figma/adds "other [categories]" to common strings

## References
Fixes #13042 

## Reviewer guidance
Navigate to the lessonstemp path in coach and begin a search. All icons should display, and should match [the figma spec](https://www.figma.com/design/lVJt5ukOrxS9qay0rXy7GC/0.18-Coach-updates?node-id=107-37800&m=dev).
