### PR TITLE
Upgrade kds v5.0.0

### DIFF
--- a/packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js
+++ b/packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js
@@ -11,7 +11,7 @@ describe('GenderSelect', () => {
 
   test('renders correctly with label placeholder and options', async () => {
     renderComponent();
-
+    await fireEvent.click(screen.getByText('Gender'));
     expect(screen.getByText('Gender')).toBeInTheDocument();
     labelOptions.forEach(option => {
       expect(screen.getByText(option)).toBeInTheDocument();
@@ -20,6 +20,7 @@ describe('GenderSelect', () => {
 
   test("emits 'update:value' event when an option is selected", async () => {
     const { emitted } = renderComponent();
+    await fireEvent.click(screen.getByText('Gender'));
 
     const selectedOption = labelOptions[0];
     await fireEvent.click(screen.getByText(selectedOption));
@@ -31,7 +32,7 @@ describe('GenderSelect', () => {
 
   test("the value of 'update:value' event is changed when a different option is selected", async () => {
     const { emitted } = renderComponent();
-
+    await fireEvent.click(screen.getByText('Gender'));
     const selectedOption = labelOptions[0];
     await fireEvent.click(screen.getByText(selectedOption));
     const newSelectedOption = labelOptions[1];

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -77,7 +77,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "kolibri-constants": "0.2.8",
-    "kolibri-design-system": "5.0.0-rc12",
+    "kolibri-design-system": "5.0.0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "path-to-regexp": "1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,15 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+"aphrodite@git+https://github.com/learningequality/aphrodite.git":
+  version "2.2.3"
+  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
+  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
+  dependencies:
+    asap "^2.0.3"
+    inline-style-prefixer "^4.0.2"
+    string-hash "^1.1.3"
+
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
@@ -3056,6 +3065,11 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
   integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
+
+async@^1.3.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -5929,6 +5943,11 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob-to-regexp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.1.0.tgz#e0369d426578fd456d47dc23b09de05c1da9ea5d"
+  integrity sha512-zNKwUvfFs4IbHMLzBDl4v5YbFNs64e4yGkptl4DncCYwmhMQORQflvs7XsEv50+M5bJqbgjBqnV+zZ8vF490yQ==
+
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
@@ -7717,10 +7736,10 @@ kolibri-constants@0.2.8:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.8.tgz#34ad2e2b87cf132ebe8dbaa9b64dc4a7bf261f8d"
   integrity sha512-ycXeK+ePw7zkiNtf+nX/yF5BO52+onoYS2V3d9HZDIvx7X6CDJPtMcypkXrK9aZ0JbWAegRFMD/lAd8q21cf4Q==
 
-kolibri-design-system@5.0.0-rc12:
-  version "5.0.0-rc12"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0-rc12.tgz#326fa3446dbf597c1cdd8b08e3a4b64cb5d6ea30"
-  integrity sha512-IDbt5ADUSkvG6LyR9tUwMZz26xVcRBk1PBYCTbjNK+dJeuATp92QhTSh87sWXxlSoYV7/1DURqLA3lCefsaQnA==
+kolibri-design-system@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.0.0.tgz#6c4db1ab6581d77f10a12b996d7980f65fa443d7"
+  integrity sha512-NjkUi7kzwobYZ3kFnn8hG6kJGDJ+gEtPl0BIdF+6TOKv4+3GuH55g6kPGSvDC4xzH/Kr0dR+6JDYCJoQVwmjGQ==
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "3.0.21"
@@ -7730,6 +7749,7 @@ kolibri-design-system@5.0.0-rc12:
     frame-throttle "3.0.0"
     fuzzysearch "1.0.3"
     lodash "4.17.21"
+    node-glob "^1.2.0"
     popper.js "1.16.1"
     purecss "2.2.0"
     tippy.js "4.3.5"
@@ -8490,6 +8510,14 @@ node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-glob@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-glob/-/node-glob-1.2.0.tgz#5240ffedefc6d663ce8515e5796a4d47a750c0d5"
+  integrity sha512-c0R4Wab2SAlwdBr5ehPANnbLzxv5dBMUdEYy8ilqBDkqvEIf74JGhaLhCh/EuhgzPTXuEOUoqDnAKdODpHXMNg==
+  dependencies:
+    async "^1.3.0"
+    glob-to-regexp "^0.1.0"
 
 node-gyp@^8.4.1:
   version "8.4.1"


### PR DESCRIPTION
Per conversation in https://github.com/learningequality/kolibri/pull/13092, moving the KDS V5 upgrade to separate PR and addressing failing tests here for scope.
