### PR TITLE
Remove .js extension from configuration imports for better compatibility

### DIFF
--- a/packages/kolibri-format/index.js
+++ b/packages/kolibri-format/index.js
@@ -14,23 +14,23 @@ const hostProjectDir = process.cwd();
 
 let esLintConfig;
 try {
-  esLintConfig = require(`${hostProjectDir}/.eslintrc.js`);
+  esLintConfig = require(`${hostProjectDir}/.eslintrc`);
 } catch (e) {
-  esLintConfig = require('./.eslintrc.js');
+  esLintConfig = require('./.eslintrc');
 }
 
 let stylelintConfig;
 try {
-  stylelintConfig = require(`${hostProjectDir}/.stylelintrc.js`);
+  stylelintConfig = require(`${hostProjectDir}/.stylelintrc`);
 } catch (e) {
-  stylelintConfig = require('./.stylelintrc.js');
+  stylelintConfig = require('./.stylelintrc');
 }
 
 let prettierConfig;
 try {
-  prettierConfig = require(`${hostProjectDir}/.prettierrc.js`);
+  prettierConfig = require(`${hostProjectDir}/.prettierrc`);
 } catch (e) {
-  prettierConfig = require('./.prettierrc.js');
+  prettierConfig = require('./.prettierrc');
 }
 
 const logging = logger.getLogger('Kolibri Format');

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-format",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A module for formatting frontend code to Kolibri standards",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
The `.js` extensions in the configuration imports seemed to cause breakage when importing outside of yarn installations
Removes these to fix this issue.
Bumps kolibri-format version for release.
