### PR TITLE
Add unstarted quiz string to quiz reports for learners who haven't started a quiz

### DIFF
--- a/packages/kolibri-common/components/quizzes/QuizReport/index.vue
+++ b/packages/kolibri-common/components/quizzes/QuizReport/index.vue
@@ -84,6 +84,9 @@
         :hideStatus="true"
         :isSurvey="isSurvey"
       />
+      <div v-if="!answerState">
+        {{ coreString('quizNotStartedText') }}
+      </div>
     </template>
 
     <template

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -565,6 +565,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Important: please remember this account information. Write it down if needed.',
     context: 'Helper/information text to remind user to take note of their account information.',
   },
+  quizNotStartedText: {
+    message: 'Quiz not started',
+    context: 'Message displayed to indicate that a quiz has not been started by a learner.',
+  },
 
   // Learning Activities
   all: {


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates the coach’s display of quiz reports with the message: “Quiz not started” for learners that have not started a quiz to properly indicate that the quiz has not been started.

Before:
![UnstartedQuizBefore](https://github.com/user-attachments/assets/22cc1d66-907d-4ce6-b5cd-0458f7c009d4)

After:
![unstartedQuizAfter](https://github.com/user-attachments/assets/bf8a33ab-9d3e-47ff-8d3c-8ed7727b76e8)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13057 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
* Assign a quiz to a learner 
* Navigate to Coach > Learners, and open the assigned quiz that has not been started
