### PR TITLE
Fix "change learning facility" workflow bugs

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -55,10 +55,10 @@
     },
     computed: {
       targetFacility() {
-        return this.state.value.targetFacility;
+        return this.state.targetFacility;
       },
       role() {
-        return this.state.value.role;
+        return this.state.role;
       },
       isCreateAccountDisabled() {
         return !get(this.targetFacility, 'learner_can_sign_up');
@@ -85,7 +85,7 @@
       FacilityUserResource.fetchCollection({
         force: true,
         getParams: {
-          member_of: this.state.value.sourceFacility,
+          member_of: this.state.sourceFacility,
         },
       }).then(users => {
         if (Object.keys(users).length === 1) {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -38,6 +38,7 @@
       :autofocus="true"
       :invalid="isPasswordInvalid"
       :invalidText="$tr('incorrectPasswordError')"
+      :showInvalidText="true"
       :floatingLabel="false"
       @keydown.enter="handleContinue"
     />
@@ -78,7 +79,7 @@
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
-  import { computed, inject, ref, watch } from 'vue';
+  import { computed, inject, ref, watch, nextTick } from 'vue';
   import get from 'lodash/get';
   import remoteFacilityUserData from '../../../composables/useRemoteFacility';
   import commonProfileStrings from '../../commonProfileStrings';
@@ -99,6 +100,13 @@
 
       const isFormSubmitted = ref(false);
       const isPasswordInvalid = ref(false);
+
+      // temporary workaround for accessing template refs before 3.5
+      // after upgrade, we will be able to access via `useTemplateRef()`
+      // in the meantime, declare a ref with a name that matches the template ref attribute's value
+      // and return it (https://vuejs.org/guide/essentials/template-refs)
+      const passwordTextbox = ref(null);
+
       const usingAdminPasswordState = ref(false);
       const fullName = computed(() => get(state, 'value.fullname', ''));
       const username = computed(() => get(state, 'value.username', ''));
@@ -137,9 +145,14 @@
         return !get(state, 'value.targetFacility.learner_can_login_with_no_password', false);
       }
 
-      function focusOnInvalidField(component) {
-        if (showPasswordTextbox && isPasswordInvalid.value) {
-          component.$refs.passwordTextbox.focus();
+      function focusOnInvalidField() {
+        if (showPasswordTextbox() && isPasswordInvalid.value) {
+          // the template ref is null at first, so we have to wait
+          nextTick(() => {
+            if (passwordTextbox.value) {
+              passwordTextbox.value.focus();
+            }
+          });
         }
       }
 
@@ -158,7 +171,6 @@
 
       function handleContinue() {
         const facility = get(state, 'value.targetFacility', {});
-        const component = this;
         remoteFacilityUserData(
           facility.url,
           facility.id,
@@ -168,7 +180,7 @@
         ).then(user_info => {
           if (user_info === 'error') {
             isPasswordInvalid.value = true;
-            focusOnInvalidField(component);
+            focusOnInvalidField();
           } else {
             isPasswordInvalid.value = false;
             isFormSubmitted.value = true;
@@ -198,6 +210,7 @@
         mergeAccountUserInfo,
         mergeAccountUsingAdminAccount,
         showPasswordTextbox,
+        passwordTextbox,
         useAdminAccount,
         sendBack,
         handleContinue,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -76,7 +76,7 @@
 <script>
 
   import { useLocalStorage, useMemoize, computedAsync, get } from '@vueuse/core';
-  import { computed, ref, watch } from 'vue';
+  import { inject, computed, ref, watch } from 'vue';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
   import { NetworkLocationResource } from 'kolibri-common/apiResources/NetworkLocationResource';
@@ -196,6 +196,8 @@
         };
       });
 
+      const changeFacilityService = inject('changeFacilityService');
+
       watch(availableFacilities, availableFacilities => {
         if (
           !get(availableFacilities)
@@ -231,7 +233,7 @@
       }
 
       function to_continue() {
-        this.changeFacilityService.send({
+        changeFacilityService.send({
           type: 'CONTINUE',
         });
       }
@@ -249,9 +251,9 @@
         facilityDisabled,
         handleAddedAddress,
         to_continue,
+        changeFacilityService,
       };
     },
-    inject: ['changeFacilityService'],
 
     watch: {
       selectedFacilityId(newVal) {


### PR DESCRIPTION
## Summary
There were a few bugs in the change facility workflow, I think due to some lingering side effects of composition API updates and other tech debt 0.18 projects. This PR is mainly around syntax adjustment to account for that (the underlying logic is unchanged), and also makes use of an a prop in `KTextbox` to more clearly surface password errors to the user.

## References
Fixes #[13097](https://github.com/learningequality/kolibri/issues/13097)

## Reviewer guidance
1. Set up an account as an on-my-own user (User A) on your Kolibri (Kolibri 1)
2. Run a second kolibri (Kolibri 2)
3. on the User A profile, go to "change facility" and begin the workflow to create or merge accounts using a facility that exists on Kolibri 2
4. Try first with entering an incorrect password, and ensure the error message is highlighted, before proceeding 

You should be able to successfully create or merge accounts

https://github.com/user-attachments/assets/ebd89e5f-1a0c-4c3e-91fc-ba1ad106b50c


