### PR TITLE
Implement quiz resources selection switching mode

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -8,7 +8,7 @@
         class="channel-header"
       >
         <p>
-          {{ coreString('selectFromChannels') }}
+          {{ selectFromChannels$() }}
         </p>
         <ResourceActionButton
           :isSelected="isSelected"
@@ -103,6 +103,7 @@
 
   import { getCurrentInstance, onMounted, ref, computed } from 'vue';
   import { ContentNodeKinds } from 'kolibri/constants';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings.js';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings.js';
@@ -135,6 +136,7 @@
         props.contentId,
       );
       const { manageLessonResourcesTitle$ } = coachStrings;
+      const { selectFromChannels$ } = coreStrings;
       const {
         selectResourcesDescription$,
         selectPracticeQuizLabel$,
@@ -206,6 +208,7 @@
         clearSelectionNotice,
         saveSettings,
         saveSettingsAction$,
+        selectFromChannels$,
         chooseQuestionsManuallyLabel$,
       };
     },

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -52,6 +52,28 @@
         </KLabeledIcon>
       </h2>
 
+      <div
+        v-if="target === SelectionTarget.QUIZ"
+        class="update-settings-container"
+        :style="{
+          backgroundColor: $themePalette.grey.v_100,
+        }"
+      >
+        <KCheckbox
+          :checked="workingIsChoosingManually"
+          :label="chooseQuestionsManuallyLabel$()"
+          :description="clearSelectionNotice"
+          @change="$event => (workingIsChoosingManually = $event)"
+        />
+        <KButton
+          class="no-shink"
+          appearance="flat-button"
+          :text="saveSettingsAction$()"
+          :disabled="isSaveSettingsDisabled"
+          @click="saveSettings"
+        />
+      </div>
+
       <QuestionsAccordion
         v-if="isExercise"
         :questions="exerciseQuestions"
@@ -79,10 +101,11 @@
 
 <script>
 
-  import { getCurrentInstance, onMounted, ref } from 'vue';
+  import { getCurrentInstance, onMounted, ref, computed } from 'vue';
+  import { ContentNodeKinds } from 'kolibri/constants';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings.js';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
-  import { ContentNodeKinds } from 'kolibri/constants';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings.js';
   import { SelectionTarget } from '../../contants.js';
   import { coachStrings } from '../../../commonCoachStrings.js';
   import { PageNames } from '../../../../../constants/index.js';
@@ -112,8 +135,12 @@
         props.contentId,
       );
       const { manageLessonResourcesTitle$ } = coachStrings;
-      const { selectResourcesDescription$, selectPracticeQuizLabel$ } =
-        enhancedQuizManagementStrings;
+      const {
+        selectResourcesDescription$,
+        selectPracticeQuizLabel$,
+        chooseQuestionsManuallyLabel$,
+        clearSelectionNotice$,
+      } = enhancedQuizManagementStrings;
 
       const getTitle = () => {
         if (props.target === SelectionTarget.LESSON) {
@@ -139,11 +166,30 @@
         });
       };
 
+      const workingIsChoosingManually = ref(props.settings?.isChoosingManually);
+      const saveSettings = () => {
+        instance.proxy.$emit('update:settings', {
+          ...props.settings,
+          isChoosingManually: workingIsChoosingManually.value,
+        });
+      };
+      const isSaveSettingsDisabled = computed(() => {
+        return workingIsChoosingManually.value === props.settings?.isChoosingManually;
+      });
+      const clearSelectionNotice = computed(() => {
+        if (!props.selectedResources.length && !props.selectedQuestions.length) {
+          return null;
+        }
+        return clearSelectionNotice$();
+      });
+
       onMounted(() => {
         if (!props.contentId) {
           redirectBack();
         }
       });
+
+      const { saveSettingsAction$ } = searchAndFilterStrings;
 
       return {
         contentNode,
@@ -155,6 +201,12 @@
         // eslint-disable-next-line vue/no-unused-properties
         prevRoute,
         exerciseQuestions,
+        workingIsChoosingManually,
+        isSaveSettingsDisabled,
+        clearSelectionNotice,
+        saveSettings,
+        saveSettingsAction$,
+        chooseQuestionsManuallyLabel$,
       };
     },
     props: {
@@ -320,6 +372,18 @@
 
   .channel-header p {
     font-weight: 600;
+  }
+
+  .update-settings-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    margin-bottom: 24px;
+  }
+
+  .no-shink {
+    flex-shrink: 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -211,6 +211,20 @@
 
       const { selectPracticeQuiz } = route.value.query;
 
+      /**
+       * @type {Ref<QuizExercise[]>} - The uncommitted version of the section's resource_pool
+       */
+      const workingResourcePool = ref([]);
+
+      const resetSelection = () => {
+        workingResourcePool.value = [];
+        workingQuestions.value = [];
+      };
+      /**
+       * @type {Ref<QuizQuestions[]>}
+       */
+      const workingQuestions = ref([]);
+
       const getDefaultQuestionCount = maxQuestions => {
         return Math.min(10, maxQuestions);
       };
@@ -250,6 +264,8 @@
           } else {
             newSettings.questionCount = getDefaultQuestionCount(newSettings.maxQuestions);
           }
+
+          resetSelection();
         }
       });
 
@@ -265,16 +281,6 @@
       } = enhancedQuizManagementStrings;
 
       const { closeConfirmationTitle$, closeConfirmationMessage$ } = coachStrings;
-
-      /**
-       * @type {Ref<QuizExercise[]>} - The uncommitted version of the section's resource_pool
-       */
-      const workingResourcePool = ref([]);
-
-      /**
-       * @type {Ref<QuizQuestions[]>}
-       */
-      const workingQuestions = ref([]);
 
       /**
        * @param {QuizExercise[]} resources

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -23,6 +23,35 @@
       </div>
 
       <div
+        v-if="showManualSelectionNotice && $route.name !== PageNames.QUIZ_SELECT_RESOURCES_SETTINGS"
+        class="alert-warning d-flex-between"
+        :class="{
+          shadow: isScrolled,
+        }"
+        :style="{
+          padding: '8px 16px',
+          background: $themePalette.green.v_100,
+        }"
+      >
+        <div class="choosing-manually-label">
+          <KIcon
+            icon="correct"
+            class="correct-icon"
+          />
+          <span>
+            {{
+              settings.isChoosingManually ? manualSelectionOnNotice$() : manualSelectionOffNotice$()
+            }}
+          </span>
+        </div>
+        <KButton
+          appearance="flat-button"
+          :text="dismissAction$()"
+          @click="showManualSelectionNotice = false"
+        />
+      </div>
+
+      <div
         v-if="maximumContentSelectedWarning"
         class="alert-warning"
         :class="{
@@ -79,7 +108,7 @@
         <KButton
           v-if="continueAction"
           :disabled="continueAction.disabled"
-          :text="coreString('continueAction')"
+          :text="continueAction.text || coreString('continueAction')"
           @click="continueAction.handler"
         />
         <template v-else>
@@ -186,10 +215,12 @@
         return Math.min(10, maxQuestions);
       };
 
+      const showManualSelectionNotice = ref(false);
+
       const settings = ref({
         maxQuestions: null,
         questionCount: null,
-        isChoosingManually: false,
+        isChoosingManually: null,
         selectPracticeQuiz,
       });
       watch(
@@ -209,6 +240,11 @@
       watch(settings, (newSettings, oldSettings) => {
         // If isChoosingManually was toggled
         if (newSettings.isChoosingManually !== oldSettings.isChoosingManually) {
+          // If value was set for the first time, dont show the notice
+          if (oldSettings.isChoosingManually !== null) {
+            showManualSelectionNotice.value = true;
+          }
+
           if (newSettings.isChoosingManually) {
             newSettings.questionCount = newSettings.maxQuestions;
           } else {
@@ -224,6 +260,8 @@
         addNumberOfQuestions$,
         maximumResourcesSelectedWarning$,
         maximumQuestionsSelectedWarning$,
+        manualSelectionOnNotice$,
+        manualSelectionOffNotice$,
       } = enhancedQuizManagementStrings;
 
       const { closeConfirmationTitle$, closeConfirmationMessage$ } = coachStrings;
@@ -452,7 +490,8 @@
         return maximumResourcesSelectedWarning$();
       });
 
-      const { numberOfSelectedResources$, numberOfSelectedQuestions$ } = searchAndFilterStrings;
+      const { numberOfSelectedResources$, numberOfSelectedQuestions$, dismissAction$ } =
+        searchAndFilterStrings;
 
       return {
         title,
@@ -479,6 +518,7 @@
         unselectableResourceIds,
         unselectableQuestionItems,
         maximumContentSelectedWarning,
+        showManualSelectionNotice,
         addToWorkingResourcePool,
         removeFromWorkingResourcePool,
         addToWorkingQuestions,
@@ -496,6 +536,9 @@
         addQuestionsToSectionFromResources,
         workingResourcePool,
         workingQuestions,
+        dismissAction$,
+        manualSelectionOnNotice$,
+        manualSelectionOffNotice$,
         numberOfSelectedResources$,
         numberOfSelectedQuestions$,
       };
@@ -596,6 +639,17 @@
     font-size: 18px;
   }
 
+  .choosing-manually-label {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+
+    .correct-icon {
+      position: unset;
+      font-size: 20px;
+    }
+  }
+
   .bottom-nav-container {
     display: flex;
     gap: 16px;
@@ -622,6 +676,12 @@
     &.shadow {
       @extend %dropshadow-2dp;
     }
+  }
+
+  .d-flex-between {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -45,6 +45,7 @@
     <KCheckbox
       :checked="isChoosingManually"
       :label="chooseQuestionsManuallyLabel$()"
+      :description="clearSelectionNotice"
       @change="$event => (isChoosingManually = $event)"
     />
   </div>
@@ -81,6 +82,7 @@
         maxNumberOfQuestionsInfo$,
         maxNumberOfQuestions$,
         chooseQuestionsManuallyLabel$,
+        clearSelectionNotice$,
       } = enhancedQuizManagementStrings;
 
       const { activeSection, activeSectionIndex } = injectQuizCreation();
@@ -93,7 +95,7 @@
       props.setGoBack(null);
 
       const workingQuestionCount = ref(props.settings.questionCount);
-      const workingIsChoosingManually = ref(props.settings.isChoosingManually);
+      const workingIsChoosingManually = ref(Boolean(props.settings.isChoosingManually));
 
       const invalidSettings = computed(() => {
         if (workingIsChoosingManually.value) {
@@ -143,12 +145,19 @@
       });
 
       const questionCountIsEditable = computed(() => !workingIsChoosingManually.value);
+      const clearSelectionNotice = computed(() => {
+        if (!props.selectedResources.length && !props.selectedQuestions.length) {
+          return null;
+        }
+        return clearSelectionNotice$();
+      });
 
       return {
         // eslint-disable-next-line vue/no-unused-properties
         prevRoute,
         questionCount: workingQuestionCount,
         isChoosingManually: workingIsChoosingManually,
+        clearSelectionNotice,
         questionCountIsEditable,
         maxQuestions: computed(() => props.settings.maxQuestions),
         maxNumberOfQuestions$,
@@ -177,6 +186,14 @@
       isLanding: {
         type: Boolean,
         default: false,
+      },
+      selectedQuestions: {
+        type: Array,
+        required: true,
+      },
+      selectedResources: {
+        type: Array,
+        required: true,
       },
     },
     beforeRouteEnter(to, from, next) {

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -241,6 +241,14 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     context:
       'A warning message that appears when the user has already selected the maximum number of questions',
   },
+  manualSelectionOnNotice: {
+    message: 'Manual question selection is on',
+    context: 'A message that appears when the user has enabled the manual selection of questions',
+  },
+  manualSelectionOffNotice: {
+    message: 'Manual question selection is off',
+    context: 'A message that appears when the user has disabled the manual selection of questions',
+  },
 });
 
 const { sectionLabel$ } = enhancedQuizManagementStrings;

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -219,6 +219,10 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message: 'Choose questions manually',
     context: 'A label for a checkbox that allows the user to manually select questions',
   },
+  clearSelectionNotice: {
+    message: 'Changing this setting will clear your current selections',
+    context: 'A message that informs the user that changing a setting will remove their selections',
+  },
   selectUpToNResources: {
     message:
       'Select up to { count, number } { count, plural, one { resource } other { resources }}',

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -126,4 +126,12 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     context:
       'Indicates time spent by learner on a specific activity. Only translate minute/minutes.',
   },
+  dismissAction: {
+    message: 'Dismiss',
+    context: 'Button label to dismiss a notification',
+  },
+  saveSettingsAction: {
+    message: 'Save settings',
+    context: 'Button label to save resource selection settings',
+  },
 });


### PR DESCRIPTION
## Summary
* Implement quiz resources selection switching mode logic
* Add button to change the selection mode within the exercise preview
* Fixes missing coreString value in ResourcePreview


https://github.com/user-attachments/assets/2a3f9260-5b46-420b-a4d9-7942a325211a



## References
Closes #13105.

## Reviewer guidance

* With random selection mode, select resources to add to a quiz, then change the selection mode to manual
* With manual selection mode, select questions to add to a quiz, then change the selection mode to quiz
* Play combining different possibilities and using the questions settings page and the selection mode checkbox in the exercise preview.