### PR TITLE
Fixed Text Overflow in FireFox and added a scrollbar

### DIFF
--- a/packages/kolibri/components/CoreTable.vue
+++ b/packages/kolibri/components/CoreTable.vue
@@ -144,6 +144,14 @@
     text-align: left;
   }
 
+  /deep/ .core-table {
+    display: table;
+    width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+    table-layout: fixed;
+  }
+
   /deep/ th,
   /deep/ td {
     padding: 12px 8px;
@@ -152,8 +160,12 @@
   }
 
   /deep/ td {
+    display: inline-block;
     max-width: 300px;
+    padding-bottom: 4px;
     overflow-x: auto;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /deep/ .core-table-checkbox-col {


### PR DESCRIPTION
**Summary**
Adds horizontal scrolling to the table in [CoreTable.vue]  by setting a fixed table layout and removing inline-block styling on <td>, ensuring the table scrolls correctly in all browsers.
**Fixes** : #6475
