### PR TITLE
Fix "Invalid prop" error

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -204,7 +204,7 @@
         type: Object,
         required: true,
         validator(value) {
-          const inputKeys = ['channels', 'accessibility_labels', 'languages', 'grade_levels'];
+          const inputKeys = ['accessibility_labels', 'languages', 'grade_levels'];
           return inputKeys.every(k => Object.prototype.hasOwnProperty.call(value, k));
         },
       },


### PR DESCRIPTION
## Summary

Fixes `"Invalid prop: custom validator check failed for prop 'value'` error by removing what appears to be, as best as I can say, the obsolete `'channels'` object property that is not passed into and neither used in the component.

## References

Fixes https://github.com/learningequality/kolibri/issues/13058

## Reviewer guidance

Note there is `The computed property "PageNames" is already defined in data` warning in the browser console - will fix in another PR.

### QA
- Go to Coach -> Lesson -> Manage resources -> rewrite `/lessons` to `/lessonstemp` URL and in the "Manage lesson resources", click on the Search button (make sure you see the new experience)

![Screenshot from 2025-02-27 19-26-38](https://github.com/user-attachments/assets/4b31af7a-36b0-4290-8881-185747458ee8)

- Check that there is no "Invalid prop" error in the browser console
- There should be no regressions in the side panel

### Code

- `'channels'` is really not needed anywhere?

