### PR TITLE
Fix 'computed property already' defined on the lesson summary page in Coach

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -94,7 +94,6 @@
   import CoachAppBarPage from '../../CoachAppBarPage';
   import ReportsControls from '../../common/ReportsControls';
   import { REPORTS_LESSON_TABS_ID, ReportsLessonTabs } from '../../../constants/tabsConstants';
-  import { PageNames } from '../../../constants';
   import { showLessonSummaryPage } from '../../../modules/lessonSummary/handlers';
   import LessonResourcesTable from './tables/LessonResourcesTable';
   import LessonLearnersTable from './tables/LessonLearnersTable';
@@ -145,7 +144,6 @@
       const workingResourcesBackup = [...(this.$store.state.lessonSummary.workingResources || [])];
 
       return {
-        PageNames,
         currentAction: '',
         ReportsLessonTabs,
         workingResourcesBackup,
@@ -163,11 +161,11 @@
       },
       lessonSelectionRootPage() {
         if (this.isTemp) {
-          return this.classRoute(PageNames.LESSON_SELECT_RESOURCES, {
+          return this.classRoute(this.PageNames.LESSON_SELECT_RESOURCES, {
             lessonId: this.lessonId,
           });
         }
-        return this.classRoute(PageNames.LESSON_RESOURCE_SELECTION_ROOT, {
+        return this.classRoute(this.PageNames.LESSON_RESOURCE_SELECTION_ROOT, {
           lessonId: this.lessonId,
         });
       },
@@ -192,7 +190,7 @@
 
         tabsList.forEach(tab => {
           tab.to = this.classRoute(
-            this.group ? PageNames.GROUP_LESSON_SUMMARY : PageNames.LESSON_SUMMARY,
+            this.group ? this.PageNames.GROUP_LESSON_SUMMARY : this.PageNames.LESSON_SUMMARY,
             { tabId: tab.id },
           );
         });
@@ -240,7 +238,9 @@
             groups: this.getGroupNamesForLearner(learner.id),
             status: this.getLessonStatusStringForLearner(this.lessonId, learner.id),
             link: this.classRoute(
-              this.group ? PageNames.GROUP_LESSON_LEARNER : PageNames.LESSON_LEARNER_REPORT,
+              this.group
+                ? this.PageNames.GROUP_LESSON_LEARNER
+                : this.PageNames.LESSON_LEARNER_REPORT,
               { learnerId: learner.id },
             ),
           };
@@ -272,7 +272,7 @@
       handleSelectOption(action) {
         switch (action) {
           case 'EDIT_DETAILS':
-            return this.$router.push(this.$router.getRoute(PageNames.LESSON_EDIT_DETAILS));
+            return this.$router.push(this.$router.getRoute(this.PageNames.LESSON_EDIT_DETAILS));
           case 'PRINT_REPORT':
             return this.$print();
           case 'EXPORT':
@@ -291,13 +291,15 @@
           if (resource.kind === this.ContentNodeKinds.EXERCISE) {
             return this.classRoute(
               this.group
-                ? PageNames.GROUP_LESSON_EXERCISE_LEARNER_REPORT
-                : PageNames.LESSON_EXERCISE_LEARNERS_REPORT,
+                ? this.PageNames.GROUP_LESSON_EXERCISE_LEARNER_REPORT
+                : this.PageNames.LESSON_EXERCISE_LEARNERS_REPORT,
               { exerciseId: resource.content_id },
             );
           } else {
             return this.classRoute(
-              this.group ? PageNames.GROUPS_ROOT : PageNames.LESSON_RESOURCE_LEARNERS_REPORT,
+              this.group
+                ? this.PageNames.GROUPS_ROOT
+                : this.PageNames.LESSON_RESOURCE_LEARNERS_REPORT,
               { resourceId: resource.content_id },
             );
           }

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/index.vue
@@ -94,6 +94,7 @@
   import CoachAppBarPage from '../../CoachAppBarPage';
   import ReportsControls from '../../common/ReportsControls';
   import { REPORTS_LESSON_TABS_ID, ReportsLessonTabs } from '../../../constants/tabsConstants';
+  import { PageNames } from '../../../constants';
   import { showLessonSummaryPage } from '../../../modules/lessonSummary/handlers';
   import LessonResourcesTable from './tables/LessonResourcesTable';
   import LessonLearnersTable from './tables/LessonLearnersTable';
@@ -161,11 +162,11 @@
       },
       lessonSelectionRootPage() {
         if (this.isTemp) {
-          return this.classRoute(this.PageNames.LESSON_SELECT_RESOURCES, {
+          return this.classRoute(PageNames.LESSON_SELECT_RESOURCES, {
             lessonId: this.lessonId,
           });
         }
-        return this.classRoute(this.PageNames.LESSON_RESOURCE_SELECTION_ROOT, {
+        return this.classRoute(PageNames.LESSON_RESOURCE_SELECTION_ROOT, {
           lessonId: this.lessonId,
         });
       },
@@ -190,7 +191,7 @@
 
         tabsList.forEach(tab => {
           tab.to = this.classRoute(
-            this.group ? this.PageNames.GROUP_LESSON_SUMMARY : this.PageNames.LESSON_SUMMARY,
+            this.group ? PageNames.GROUP_LESSON_SUMMARY : PageNames.LESSON_SUMMARY,
             { tabId: tab.id },
           );
         });
@@ -238,9 +239,7 @@
             groups: this.getGroupNamesForLearner(learner.id),
             status: this.getLessonStatusStringForLearner(this.lessonId, learner.id),
             link: this.classRoute(
-              this.group
-                ? this.PageNames.GROUP_LESSON_LEARNER
-                : this.PageNames.LESSON_LEARNER_REPORT,
+              this.group ? PageNames.GROUP_LESSON_LEARNER : PageNames.LESSON_LEARNER_REPORT,
               { learnerId: learner.id },
             ),
           };
@@ -272,7 +271,7 @@
       handleSelectOption(action) {
         switch (action) {
           case 'EDIT_DETAILS':
-            return this.$router.push(this.$router.getRoute(this.PageNames.LESSON_EDIT_DETAILS));
+            return this.$router.push(this.$router.getRoute(PageNames.LESSON_EDIT_DETAILS));
           case 'PRINT_REPORT':
             return this.$print();
           case 'EXPORT':
@@ -291,15 +290,13 @@
           if (resource.kind === this.ContentNodeKinds.EXERCISE) {
             return this.classRoute(
               this.group
-                ? this.PageNames.GROUP_LESSON_EXERCISE_LEARNER_REPORT
-                : this.PageNames.LESSON_EXERCISE_LEARNERS_REPORT,
+                ? PageNames.GROUP_LESSON_EXERCISE_LEARNER_REPORT
+                : PageNames.LESSON_EXERCISE_LEARNERS_REPORT,
               { exerciseId: resource.content_id },
             );
           } else {
             return this.classRoute(
-              this.group
-                ? this.PageNames.GROUPS_ROOT
-                : this.PageNames.LESSON_RESOURCE_LEARNERS_REPORT,
+              this.group ? PageNames.GROUPS_ROOT : PageNames.LESSON_RESOURCE_LEARNERS_REPORT,
               { resourceId: resource.content_id },
             );
           }


### PR DESCRIPTION
## Summary

Fixes `The computed property "PageNames" is already defined in data.` on the lesson summary page in Coach (present on both `/lessons` and `/lessonstemp`)

![Screenshot from 2025-02-27 20-15-20](https://github.com/user-attachments/assets/7175f4fd-968c-4ca2-a09c-78c179d12090)

This happens because 'LessonSummaryPage' has 'PageNames' in its 'data' while at the same time importing 'commonCoach' mixin that contains 'PageNames' as computed.

Also adds 'this.' before 'PageNames' so there's no need for the global import.

## Reviewer guidance

- Go to Coach -> Lessons -> Select a lesson
- On the lesson summary page, there should be no regressions or console errors