### PR TITLE
Remove unnecessary icon. Leave kgrid element for spacing.

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -53,10 +53,7 @@
               :layout8="{ span: 1, alignment: 'left' }"
               :layout12="{ span: 1, alignment: 'left' }"
             >
-              <KIcon
-                icon="circleCheckmark"
-                :class="windowIsSmall ? 'style-icon' : 'checkmark-style-icon'"
-              />
+              <br >
             </KGridItem>
             <KGridItem
               :layout4="{ span: 3 }"


### PR DESCRIPTION
## Summary
* Removes the icon next to the report visibility dropdown
* Leaves a `<br >` element in the `<KGrid>` component to maintain adequate spacing between the text box and the dropdown.

## References
Fixes https://www.notion.so/learningequality/The-icon-next-to-the-report-visibility-drop-down-seems-kind-of-random-1a7f45d6ef9680e083f3e51fa20c10e9?pvs=4 in #13127 

## Reviewer guidance
Before:
![Screenshot from 2025-02-28 08-44-00](https://github.com/user-attachments/assets/72ace999-2bc3-4fe9-8680-1122487bbef2)

After:
![Screenshot from 2025-02-28 08-47-32](https://github.com/user-attachments/assets/275c31a7-a875-47a9-840b-8e2914b01245)

