### PR TITLE
remove unused style; apply 95vw max width to users table in Facility

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -1,9 +1,7 @@
 <template>
 
   <AppBarPage :title="title">
-    <div style="max-width: 1000px; margin: 0 auto">
-      <slot></slot>
-    </div>
+    <slot></slot>
   </AppBarPage>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <AppBarPage :title="title">
+  <AppBarPage
+    :title="title"
+    :appearanceOverrides="appearanceOverrides"
+  >
     <slot></slot>
   </AppBarPage>
 
@@ -25,6 +28,11 @@
       appBarTitle: {
         type: String,
         default: null,
+      },
+      appearanceOverrides: {
+        type: Object,
+        default: null,
+        required: false,
       },
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <FacilityAppBarPage>
+  <FacilityAppBarPage :appearanceOverrides="{ maxWidth: '95vw', width: '100%', margin: 'auto' }">
     <KPageContainer>
       <p>
         <KRouterLink
@@ -493,11 +493,6 @@
 
   .user-roster {
     overflow-x: auto;
-  }
-
-  /deep/ .main-wrapper {
-    max-width: 95vw !important;
-    margin: 0 auto;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -495,4 +495,9 @@
     overflow-x: auto;
   }
 
+  /deep/ .main-wrapper {
+    max-width: 95vw !important;
+    margin: 0 auto;
+  }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Addresses issue noted in recent bug hunt by @rtibbles regarding the users table's width (or lack thereof).

There's so much screen available - so why would we limit the big table of data to the same width we use for settings forms and such?

The changes here remove an unused wrapper div that duplicated widths enforced elsewhere.

Then using a deep style we target our own `main-wrapper` style to override the page width specifically for the Users table without affecting the other Facility pages.

[Screencast_20250228_091120.webm](https://github.com/user-attachments/assets/7990def1-36a8-4da6-b09b-21af75aed915)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#13127 lists the issue & links to the relevant Notion 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Try users table on various screen sizes. Does it look okay?
- Check all other pages in Facility and see that they don't have any regressions.
