### PR TITLE
0.18 Bugs squashing

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -62,7 +62,7 @@
         <KCheckbox
           :checked="workingIsChoosingManually"
           :label="chooseQuestionsManuallyLabel$()"
-          :description="clearSelectionNotice"
+          :description="clearSelectionNotice$()"
           @change="$event => (workingIsChoosingManually = $event)"
         />
         <KButton
@@ -178,12 +178,6 @@
       const isSaveSettingsDisabled = computed(() => {
         return workingIsChoosingManually.value === props.settings?.isChoosingManually;
       });
-      const clearSelectionNotice = computed(() => {
-        if (!props.selectedResources.length && !props.selectedQuestions.length) {
-          return null;
-        }
-        return clearSelectionNotice$();
-      });
 
       onMounted(() => {
         if (!props.contentId) {
@@ -205,7 +199,7 @@
         exerciseQuestions,
         workingIsChoosingManually,
         isSaveSettingsDisabled,
-        clearSelectionNotice,
+        clearSelectionNotice$,
         saveSettings,
         saveSettingsAction$,
         selectFromChannels$,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -45,7 +45,7 @@
     <KCheckbox
       :checked="isChoosingManually"
       :label="chooseQuestionsManuallyLabel$()"
-      :description="clearSelectionNotice"
+      :description="clearSelectionNotice$()"
       @change="$event => (isChoosingManually = $event)"
     />
   </div>
@@ -145,19 +145,13 @@
       });
 
       const questionCountIsEditable = computed(() => !workingIsChoosingManually.value);
-      const clearSelectionNotice = computed(() => {
-        if (!props.selectedResources.length && !props.selectedQuestions.length) {
-          return null;
-        }
-        return clearSelectionNotice$();
-      });
 
       return {
         // eslint-disable-next-line vue/no-unused-properties
         prevRoute,
         questionCount: workingQuestionCount,
         isChoosingManually: workingIsChoosingManually,
-        clearSelectionNotice,
+        clearSelectionNotice$,
         questionCountIsEditable,
         maxQuestions: computed(() => props.settings.maxQuestions),
         maxNumberOfQuestions$,
@@ -186,14 +180,6 @@
       isLanding: {
         type: Boolean,
         default: false,
-      },
-      selectedQuestions: {
-        type: Array,
-        required: true,
-      },
-      selectedResources: {
-        type: Array,
-        required: true,
       },
     },
     beforeRouteEnter(to, from, next) {

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -150,15 +150,16 @@
     },
     beforeUpdate() {
       // Update appBarHeight after AppBar is rerendered and updated
-      this.handleWindowResize();
+      this.updateAppBarHeight();
     },
     mounted() {
+      this.updateAppBarHeight();
       this.addScrollListener();
-      window.addEventListener('resize', this.handleWindowResize);
+      window.addEventListener('resize', this.updateAppBarHeight);
     },
     beforeDestroy() {
       this.removeScrollListener();
-      window.removeEventListener('resize', this.handleWindowResize);
+      window.removeEventListener('resize', this.updateAppBarHeight);
     },
     methods: {
       addScrollListener() {
@@ -189,7 +190,7 @@
           this.throttledHandleScroll = null;
         }
       },
-      handleWindowResize() {
+      updateAppBarHeight() {
         // Update the app bar height when window is resized
         this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 124;
       },


### PR DESCRIPTION
## Summary

* Update appbar height on appbar mount: Fix for 
[Update spacing between navbar and container on the "learner's" subpage in coach](https://www.notion.so/learningequality/Learner-s-subpage-in-coach-has-inconsistent-spacing-between-navbar-and-container-when-compared-to-t-1a7f45d6ef968014a3e7dc7cbe3fd63e?pvs=4)
* Always show "Changing this setting will clear your current selections" in "Choose questions manually" in questions settings. Fix for: [Add additional string for "choose questions manually" UI](https://www.notion.so/learningequality/This-string-is-missing-from-the-Choose-questions-manually-box-in-the-resource-page-for-quizzes-1a7f45d6ef96809a9c89c7148d624c9c?pvs=4)

## References
Addresses part of #13127.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…
