### PR TITLE
Visual fixes on the 'Create new lesson' page

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -80,9 +80,9 @@
             </KGridItem>
           </template>
           <KGridItem
-            :layout4="{ span: 3 }"
-            :layout8="{ span: 7 }"
-            :layout12="{ span: 11 }"
+            :layout4="{ span: 4 }"
+            :layout8="{ span: 8 }"
+            :layout12="{ span: 12 }"
           >
             <KTextbox
               v-if="showDescriptionField"

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -43,6 +43,7 @@
               :invalidText="titleIsInvalidText"
               :showInvalidText="titleIsInvalid"
               :disabled="disabled || formIsSubmitted"
+              :style="{ marginLeft: windowIsLarge ? '-1em' : 0 }"
               @input="showTitleError = false"
               @keydown.enter="submitData"
             />
@@ -173,7 +174,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { windowIsSmall } = useKResponsiveWindow();
+      const { windowIsSmall, windowIsLarge } = useKResponsiveWindow();
       const {
         recipientsLabel$,
         descriptionLabel$,
@@ -190,6 +191,7 @@
       } = coachStrings;
       return {
         windowIsSmall,
+        windowIsLarge,
         recipientsLabel$,
         descriptionLabel$,
         titleLabel$,
@@ -460,7 +462,6 @@
   /deep/ .textbox {
     width: 100% !important;
     max-width: 100%;
-    margin-left: -1em;
   }
 
   /deep/ .ui-select-feedback {

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -79,10 +79,18 @@
               />
             </KGridItem>
           </template>
+          <!--Align with the title input-->
           <KGridItem
-            :layout4="{ span: 4 }"
-            :layout8="{ span: 8 }"
-            :layout12="{ span: 12 }"
+            :layout4="{ span: 1 }"
+            :layout8="{ span: 1 }"
+            :layout12="{ span: 1 }"
+          >
+            <div></div>
+          </KGridItem>
+          <KGridItem
+            :layout4="{ span: 3 }"
+            :layout8="{ span: 7 }"
+            :layout12="{ span: 11 }"
           >
             <KTextbox
               v-if="showDescriptionField"
@@ -91,6 +99,7 @@
               :maxlength="200"
               :disabled="disabled || formIsSubmitted"
               :textArea="true"
+              :style="{ marginLeft: windowIsLarge ? '-1em' : 0 }"
             />
           </KGridItem>
         </KGrid>


### PR DESCRIPTION
## Summary

Fixes width and spacing of inputs on the Create new lesson page. See commit messages.

| Before | After |
| ---------- | ------- |
| ![Screenshot from 2025-02-28 18-22-51](https://github.com/user-attachments/assets/49002eee-7d38-4101-a849-23809685bc87) | ![Screenshot from 2025-02-28 18-22-39](https://github.com/user-attachments/assets/fab1d5c2-e6db-416b-be90-9a40de205e7a) |
![Screenshot from 2025-02-28 18-23-12](https://github.com/user-attachments/assets/d0c8bb01-3e4e-45b6-88c8-8d837794cd10) | ![Screenshot from 2025-02-28 18-23-21](https://github.com/user-attachments/assets/1742d413-73cc-4eee-ae01-0b6f46af87aa) |

## References

Sub-task of https://github.com/learningequality/kolibri/issues/13127

## Reviewer guidance

- Go to "Create new lesson" page in Coach
- Observe on various screen sizes