### PR TITLE
Add side panel title margins for consistency and spacing

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -41,7 +41,7 @@
         :topicsLink="topicsLink"
       />
 
-      <h2>
+      <h2 class="resource-title">
         <KLabeledIcon :label="contentNode.kind">
           <template #icon>
             <LearningActivityIcon :kind="learningActivities" />
@@ -387,6 +387,10 @@
 
   .no-shink {
     flex-shrink: 0;
+  }
+
+  .resource-title {
+    margin: 25px 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromTopicTree.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromTopicTree.vue
@@ -331,6 +331,7 @@
   }
 
   .side-panel-subtitle {
+    margin: 16px 0;
     font-size: 16px;
     font-weight: 600;
   }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request adds top and bottom margins to the `selectFromChannels` string when selecting resources for lessons and to the resource title when manually selecting questions to add to a quiz section.

| Before | After |
| ---------- | ------- |
![Screenshot 2025-02-28 at 11 04 01 AM](https://github.com/user-attachments/assets/5b130c78-2dd2-4e2c-9e60-e8f264577be2)  | ![Screenshot 2025-02-28 at 11 06 01 AM](https://github.com/user-attachments/assets/73fe1b91-55fd-453d-afac-cd9aef7ef808)  |
  |   |

https://github.com/user-attachments/assets/27123023-d8ef-42e5-b946-a1b38dca1a72

https://github.com/user-attachments/assets/a0f64b4e-38db-44d9-8bbe-37d8be04fbe0

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes `Adjust padding for consistency on resource preview subpage` and `Add a bit of extra margin around resource titles` within #13127 
