### PR TITLE
fixes workskills string not being  available in the commoncorestrings

### DIFF
--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1585,6 +1585,7 @@ const nonconformingKeys = {
   FOUNDATIONS: 'basicSkills',
   foundations: 'basicSkills',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
+  WORK_SKILLS: 'allLevelsWorkSkills',
 };
 
 /**


### PR DESCRIPTION

## Summary
Fixes mismatch of work skills string reference on search chips.


## References
#13127



## Reviewer guidance
Go to lesson using lessontemp
Click to search a resource and under levels select All levels --work skill 
Observe the searchips
