### PR TITLE
Add blob: to CSP_SCRIPT_SRC to allow perseus graphie rendering.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -450,8 +450,12 @@ CSP_DEFAULT_SRC = ("'self'", "data:", "blob:") + tuple(
     conf.OPTIONS["Deployment"]["CSP_HOST_SOURCES"]
 )
 
-# Use a stricter script source policy to prevent blob: and data: from being used
-CSP_SCRIPT_SRC = ("'self'",) + tuple(conf.OPTIONS["Deployment"]["CSP_HOST_SOURCES"])
+# Use a stricter script source policy to prevent data: from being used
+# we still allow blob: as a source for scripts, as this is used for
+# processing graphie scripts in Perseus.
+CSP_SCRIPT_SRC = ("'self'", "blob:") + tuple(
+    conf.OPTIONS["Deployment"]["CSP_HOST_SOURCES"]
+)
 
 # Allow inline styles, as we rely on them heavily in our templates
 # and the Aphrodite CSS in JS library generates inline styles


### PR DESCRIPTION
## Summary
* Adds 'blob:' as an allowed source for script execution, as Perseus' graphie framework involves loading some JSONP and executing it to render data into an SVG
* We load this from a blob: file, having parsed everything in the frontend from the perseus archive file
* So we need to allow scripts to execute from a blob: src
* This seems OK, as blobs can't come 'preloaded' into a page, whereas data URIs (which we still exclude) could.

## References
Fixes #12936

## Reviewer guidance
I have checked about 10 different exercises in the QA channel and seen no issues - as well as the same exercise in KA Fulfulde and KA French.
