### PR TITLE
Fix H5P resources not showing completion when all questions answered correctly

### DIFF
--- a/packages/hashi/src/H5P/H5PRunner.js
+++ b/packages/hashi/src/H5P/H5PRunner.js
@@ -27,7 +27,7 @@ for (const doNotLogVerb of doNotLogVerbs) {
 }
 // These verbs are reported too much by H5P leading to spammy responses,
 // so we debounce logging of these responses.
-const debounceVerbs = ['answered', 'interacted'];
+const debounceVerbs = ['interacted'];
 // Time in seconds to debounce by.
 const debounceDelay = 5;
 // Max time that debounce should delay by.
@@ -341,7 +341,7 @@ export default class H5PRunner {
         } else if (debouncedHandlers[statement.verb.id]) {
           debouncedHandlers[statement.verb.id](statement);
         } else {
-          contentWindow.xAPI.sendStatement(event.data.statement, true).catch(err => {
+          contentWindow.xAPI.sendStatement(statement, true).catch(err => {
             // eslint-disable-next-line no-console
             console.error('Statement: ', statement, 'gave the following error: ', err);
           });

--- a/packages/hashi/src/xAPI/xAPIInterface.js
+++ b/packages/hashi/src/xAPI/xAPIInterface.js
@@ -69,16 +69,22 @@ export default class xAPI extends BaseShim {
    * be calculated.
    */
   __calculateProgress() {
-    const successStatement = find(
+    const possibleSuccessStatement = find(
       this.data[STATEMENT],
       s =>
         !s.error &&
         (s.verb.id === XAPIVerbMap.mastered ||
           s.verb.id === XAPIVerbMap.passed ||
-          s.verb.id === XAPIVerbMap.completed),
+          s.verb.id === XAPIVerbMap.completed ||
+          s.verb.id === XAPIVerbMap.answered),
     );
-    if (successStatement) {
-      return 1;
+    if (possibleSuccessStatement) {
+      if (possibleSuccessStatement.verb.id !== XAPIVerbMap.answered) {
+        return 1;
+      }
+      if (possibleSuccessStatement?.result?.completion) {
+        return 1;
+      }
     }
     // If there has been any interaction return some progress, otherwise null.
     return Object.keys(this.data[STATEMENT] || {}).length ? 0.01 : null;


### PR DESCRIPTION
## Summary
* It seems like newer H5P resources make more use of the `answered` event which we were not previously handling for triggering completion
* We remove the debounce from the answered to ensure quick processing of completion
* Add handling in the progress calculation for xAPI for the answered event - checking if it has `result.completion` set to true.

## References
Fixes [#13010](https://github.com/learningequality/kolibri/issues/13010)

## Reviewer guidance
I don't think we've seen this in the QA channel, as I think older H5P resources didn't use this specific event. I will share the  channel_id on slack for testing this.
