### PR TITLE
Fix view learn device regression

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -52,7 +52,7 @@
         <template #tbody>
           <tbody>
             <tr
-              v-for="learner in learnersWithLearnOnlyDevices"
+              v-for="learner in learnerMap"
               :key="learner.id"
             >
               <td>
@@ -122,12 +122,6 @@
       ...mapState('classSummary', ['learnerMap']),
       className() {
         return this.$store.state.classSummary.name;
-      },
-      learnersWithLearnOnlyDevices() {
-        const lods = Object.fromEntries(
-          Object.entries(this.learnerMap).filter(([key]) => key in this.classSyncStatusList),
-        );
-        return lods;
       },
       syncStatusOptions() {
         const options = [];

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -125,7 +125,7 @@
       },
       learnersWithLearnOnlyDevices() {
         const lods = Object.fromEntries(
-          Object.entries(this.learnerMap).filter(([key]) => key in this.classSyncStatusList)
+          Object.entries(this.learnerMap).filter(([key]) => key in this.classSyncStatusList),
         );
         return lods;
       },

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -52,7 +52,7 @@
         <template #tbody>
           <tbody>
             <tr
-              v-for="learner in learnerMap"
+              v-for="learner in learnersWithLearnOnlyDevices"
               :key="learner.id"
             >
               <td>
@@ -122,6 +122,12 @@
       ...mapState('classSummary', ['learnerMap']),
       className() {
         return this.$store.state.classSummary.name;
+      },
+      learnersWithLearnOnlyDevices() {
+        const lods = Object.fromEntries(
+          Object.entries(this.learnerMap).filter(([key]) => key in this.classSyncStatusList)
+        );
+        return lods;
       },
       syncStatusOptions() {
         const options = [];

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -133,6 +133,9 @@
           return;
         }
         this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
+          if (!data || !Array.isArray(data)) {
+            return;
+          }
           this.userSet = new Set(data.map(item => item.user));
           setTimeout(() => {
             this.pollClassListSyncStatuses();

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -120,26 +120,15 @@
       },
     },
     created() {
-      this.isPolling = true;
-      this.pollClassListSyncStatuses();
-    },
-    beforeDestroy() {
-      this.isPolling = false;
+      this.fetchClassListSyncStatus();
     },
     methods: {
       ...mapActions(['fetchUserSyncStatus']),
-      pollClassListSyncStatuses() {
-        if (!this.isPolling) {
-          return;
-        }
+      fetchClassListSyncStatus() {
         this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
-          if (!data || !Array.isArray(data)) {
-            return;
+          if (Array.isArray(data)) {
+            this.userSet = new Set(data.map(item => item.user));
           }
-          this.userSet = new Set(data.map(item => item.user));
-          setTimeout(() => {
-            this.pollClassListSyncStatuses();
-          }, '10000');
         });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -8,7 +8,7 @@
     <div class="report-controls-buttons">
       <KRouterLink
         v-if="isMainReport"
-        :text="$tr('viewLearners')"
+        :text="coachString('viewLearners')"
         appearance="basic-link"
         :to="classLearnersListRoute"
       />
@@ -76,7 +76,7 @@
     },
     data() {
       return {
-        userSet: new Set(),
+        userList: [],
       };
     },
     computed: {
@@ -87,7 +87,7 @@
       },
       filteredLearnMap() {
         return Object.fromEntries(
-          Object.entries(this.learnerMap || {}).filter(([key]) => this.userSet.has(key)),
+          Object.entries(this.learnerMap || {}).filter(([key]) => this.userList.includes(key)),
         );
       },
       isMainReport() {
@@ -127,16 +127,9 @@
       fetchClassListSyncStatus() {
         this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
           if (Array.isArray(data)) {
-            this.userSet = new Set(data.map(item => item.user));
+            this.userList = data.map(item => item.user);
           }
         });
-      },
-    },
-    $trs: {
-      viewLearners: {
-        message: 'View learner devices',
-        context:
-          "Option in the Reports > Quizzes section which allows coach to view a list of the learners' devices.\n\nLearner devices are ones that have Kolibri features for learners, but not those for coaches and admins.",
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -49,6 +49,7 @@
 
   import pickBy from 'lodash/pickBy';
   import useUser from 'kolibri/composables/useUser';
+  import { mapState } from 'vuex';
   import commonCoach from '../common';
   import { ClassesPageNames } from '../../../../../learn/assets/src/constants';
   import { LastPages } from '../../constants/lastPagesConstants';
@@ -75,18 +76,22 @@
       },
     },
     computed: {
+      ...mapState('classSummary', ['learnerMap']),
       exportDisabled() {
         // Always disable in app mode until we add the ability to download files.
         return this.isAppContext || this.disableExport;
       },
       isMainReport() {
-        return [
-          PageNames.LEARNERS_ROOT,
-          PageNames.LESSONS_ROOT,
-          PageNames.EXAMS_ROOT,
-          PageNames.EXAM_SUMMARY,
-          PageNames.LESSON_SUMMARY,
-        ].includes(this.$route.name);
+        return (
+          [
+            PageNames.LEARNERS_ROOT,
+            PageNames.LESSONS_ROOT,
+            PageNames.LESSONS_ROOT_BETTER,
+            PageNames.EXAMS_ROOT,
+            PageNames.EXAM_SUMMARY,
+            PageNames.LESSON_SUMMARY,
+          ].includes(this.$route.name) && Object.keys(this.learnerMap).length > 0
+        );
       },
       classLearnersListRoute() {
         const { query } = this.$route;

--- a/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/ReportsControls.vue
@@ -125,13 +125,13 @@
         this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
           const userSet = new Set(data.map(item => item.user));
           this.filteredLearnMap.value = Object.fromEntries(
-            Object.entries(this.learnerMap).filter(([key]) => userSet.has(key))
+            Object.entries(this.learnerMap).filter(([key]) => userSet.has(key)),
           );
         });
         if (this.isPolling) {
           setTimeout(() => {
             this.pollClassListSyncStatuses();
-          }, "10000");
+          }, '10000');
         }
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -58,6 +58,10 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       'Option to view all elements that make up a class. For example, all quizzes or all lessons.',
   },
+  viewLearners: {
+    message: 'View learner devices',
+    context: 'View a list of learners in a class.',
+  },
 
   // labels, phrases, titles, headers...
   activityLabel: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -120,7 +120,7 @@
         context: 'Refers to the learner or learners who are in a class.',
       },
       viewLearners: {
-        message: 'View learners',
+        message: 'View learner devices',
         context: 'Button which allows coach to view a list of learners in a class.',
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -41,9 +41,9 @@
         </template>
         <template #value>
           {{ $formatNumber(learnerNames.length) }}
-          <template v-if="learnerNames.length > 0">
+          <template v-if="Object.keys(filteredLearnMap).length > 0">
             <KRouterLink
-              :text="$tr('viewLearners')"
+              :text="coachString('viewLearners')"
               appearance="basic-link"
               :to="classLearnersListRoute"
               style="margin-left: 24px"
@@ -59,10 +59,11 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import { ref } from 'vue';
   import { ClassesPageNames } from '../../../../../../learn/assets/src/constants';
   import commonCoach from '../../common';
   import { LastPages } from '../../../constants/lastPagesConstants';
@@ -72,12 +73,18 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { userIsMultiFacilityAdmin } = useFacilities();
-      return { userIsMultiFacilityAdmin };
+      const userList = ref([]);
+      return { userIsMultiFacilityAdmin, userList };
     },
     computed: {
       ...mapGetters(['classListPageEnabled']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
+      },
+      filteredLearnMap() {
+        return Object.fromEntries(
+          Object.entries(this.learnerMap || {}).filter(([key]) => this.userList.includes(key)),
+        );
       },
       learnerNames() {
         return this.learners.map(learner => learner.name);
@@ -106,6 +113,19 @@
         return route;
       },
     },
+    created() {
+      this.fetchClassListSyncStatus();
+    },
+    methods: {
+      ...mapActions(['fetchUserSyncStatus']),
+      fetchClassListSyncStatus() {
+        this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
+          if (Array.isArray(data)) {
+            this.userList = data.map(item => item.user);
+          }
+        });
+      },
+    },
     $trs: {
       allClassesLabel: {
         message: 'All classes',
@@ -118,10 +138,6 @@
       learner: {
         message: '{count, plural, one {Learner} other {Learners}}',
         context: 'Refers to the learner or learners who are in a class.',
-      },
-      viewLearners: {
-        message: 'View learner devices',
-        context: 'Button which allows coach to view a list of learners in a class.',
       },
     },
   };


### PR DESCRIPTION
## Summary
- Only show "View learner devices"  link when a learner with LOD setup actually exists.
- Only show learners that are using devices with LOD in ClassLearnersListPage.


https://github.com/user-attachments/assets/b16e8c3e-f36e-41bc-bf37-4b5b36362c41


## References
closes #12947


## Reviewer guidance
- Create a facility, users, and class where there is a coach and learner(s) but the learners are NOT on LODs
- Go to the exams page
Observe that in the main exam page, and when clicking into a specific exam, see that the "View learner devices" link (and link to that page) is absent.
- Not setup the learner on LOD. Observe that "View learner devices"  link is present and only shows the learners which are present on the lod. 
