### PR TITLE
Add warning banner for "insufficient resources" 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -210,7 +210,7 @@
     },
     data() {
       return {
-        inputMaxQuestions: 18,
+        inputMaxQuestions: 25,
       };
     },
     beforeRouteEnter(to, from, next) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -2,10 +2,10 @@
 
   <div>
     <div class="mb-20">
-      {{ maxNumberOfQuestionsInfo$({ count: maxQuestions }) }}
+      {{ maxNumberOfQuestionsInfo$({ count: settings.maxQuestions }) }}
     </div>
     <UiAlert
-      v-if="showAlert && addableQuestionCount < maxQuestions"
+      v-if="showAlert && addableQuestionCount < settings.maxQuestions"
       type="warning"
       @dismiss="showAlert = false"
     >

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -43,7 +43,7 @@
           <KIconButton
             icon="plus"
             aria-hidden="true"
-            :disabled="questionCount >= inputMaxQuestions || !questionCountIsEditable"
+            :disabled="questionCount >= maxQuestions || !questionCountIsEditable"
             @click="questionCount += 1"
           />
         </div>
@@ -173,7 +173,11 @@
         isChoosingManually: workingIsChoosingManually,
         clearSelectionNotice$,
         questionCountIsEditable,
-        maxQuestions: computed(() => props.settings.maxQuestions),
+        maxQuestions: computed(() =>
+          addableQuestionCount.value > props.settings.maxQuestions
+            ? props.settings.maxQuestions
+            : addableQuestionCount.value,
+        ),
         maxNumberOfQuestions$,
         numberOfQuestionsLabel$,
         maxNumberOfQuestionsInfo$,
@@ -207,11 +211,6 @@
         type: Object,
         required: true,
       },
-    },
-    data() {
-      return {
-        inputMaxQuestions: 25,
-      };
     },
     beforeRouteEnter(to, from, next) {
       next(vm => {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -4,6 +4,12 @@
     <div class="mb-20">
       {{ maxNumberOfQuestionsInfo$({ count: maxQuestions }) }}
     </div>
+    <UiAlert
+      v-if="addableQuestionCount < 25"
+      type="warning"
+    >
+      {{ insufficientResources$({ count: addableQuestionCount }) }}
+    </UiAlert>
     <div class="number-question">
       <div>
         <KTextbox
@@ -62,6 +68,8 @@
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../../constants';
   import { injectQuizCreation } from '../../../../../../composables/useQuizCreation';
 
@@ -71,10 +79,20 @@
 
   export default {
     name: 'SelectFromBookmarks',
-    components: {},
+    components: {
+      UiAlert,
+    },
     setup(props) {
       const prevRoute = ref(null);
       const instance = getCurrentInstance();
+
+      const { data: channels } = props.channelsFetch;
+
+      const addableQuestionCount = computed(() => {
+        return channels.value.reduce((total, currentObject) => {
+          return total + currentObject.num_assessments;
+        }, 0);
+      });
 
       const {
         questionsSettingsLabel$,
@@ -85,6 +103,8 @@
         clearSelectionNotice$,
       } = enhancedQuizManagementStrings;
 
+
+      const { insufficientResources$ } = searchAndFilterStrings;
       const { activeSection, activeSectionIndex } = injectQuizCreation();
 
       props.setTitle(
@@ -158,6 +178,8 @@
         numberOfQuestionsLabel$,
         maxNumberOfQuestionsInfo$,
         chooseQuestionsManuallyLabel$,
+        insufficientResources$,
+        addableQuestionCount,
       };
     },
     props: {
@@ -180,6 +202,10 @@
       isLanding: {
         type: Boolean,
         default: false,
+      },
+      channelsFetch: {
+        type: Object,
+        required: true,
       },
     },
     beforeRouteEnter(to, from, next) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -5,7 +5,7 @@
       {{ maxNumberOfQuestionsInfo$({ count: maxQuestions }) }}
     </div>
     <UiAlert
-      v-if="showAlert && addableQuestionCount < 25"
+      v-if="showAlert && addableQuestionCount < maxQuestions"
       type="warning"
       @dismiss="showAlert = false"
     >
@@ -43,7 +43,7 @@
           <KIconButton
             icon="plus"
             aria-hidden="true"
-            :disabled="questionCount >= maxQuestions || !questionCountIsEditable"
+            :disabled="questionCount >= inputMaxQuestions || !questionCountIsEditable"
             @click="questionCount += 1"
           />
         </div>
@@ -207,6 +207,11 @@
         type: Object,
         required: true,
       },
+    },
+    data() {
+      return {
+        inputMaxQuestions: 18,
+      };
     },
     beforeRouteEnter(to, from, next) {
       next(vm => {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -69,7 +69,6 @@
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../../constants';
   import { injectQuizCreation } from '../../../../../../composables/useQuizCreation';
 
@@ -103,8 +102,7 @@
         clearSelectionNotice$,
       } = enhancedQuizManagementStrings;
 
-
-      const { insufficientResources$ } = searchAndFilterStrings;
+      const { insufficientResources$, saveSettingsAction$ } = searchAndFilterStrings;
       const { activeSection, activeSectionIndex } = injectQuizCreation();
 
       props.setTitle(
@@ -143,7 +141,6 @@
         });
       };
 
-      const { saveSettingsAction$ } = searchAndFilterStrings;
       const { continueAction$ } = coreStrings;
       const continueText = props.isLanding ? continueAction$() : saveSettingsAction$();
 

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -5,8 +5,9 @@
       {{ maxNumberOfQuestionsInfo$({ count: maxQuestions }) }}
     </div>
     <UiAlert
-      v-if="addableQuestionCount < 25"
+      v-if="showAlert && addableQuestionCount < 25"
       type="warning"
+      @dismiss="showAlert = false"
     >
       {{ insufficientResources$({ count: addableQuestionCount }) }}
     </UiAlert>
@@ -83,6 +84,7 @@
     },
     setup(props) {
       const prevRoute = ref(null);
+      const showAlert = ref(true);
       const instance = getCurrentInstance();
 
       const { data: channels } = props.channelsFetch;
@@ -166,6 +168,7 @@
       return {
         // eslint-disable-next-line vue/no-unused-properties
         prevRoute,
+        showAlert,
         questionCount: workingQuestionCount,
         isChoosingManually: workingIsChoosingManually,
         clearSelectionNotice$,

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -138,6 +138,6 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     message:
       'There are currently only {count, number} questions across all practice resources in your library. To create a larger quiz, consider adding more resources to your library.',
     context:
-      'Message to indicate that the resources are not not sufficient for the user to create a quiz.',
+      'Message to indicate that the resources are not sufficient for the user to create a quiz.',
   },
 });

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -136,7 +136,7 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
   },
   insufficientResources: {
     message:
-      'There are currently only 18 questions across all practice resources in your library. To create a larger quiz, consider adding more resources to your library.',
+      'There are currently only {count, number} questions across all practice resources in your library. To create a larger quiz, consider adding more resources to your library.',
     context: 'Message to indicate that the license is not sufficient for the user.',
   },
 });

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -134,4 +134,9 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     message: 'Save settings',
     context: 'Button label to save resource selection settings',
   },
+  insufficientResources: {
+    message:
+      'There are currently only 18 questions across all practice resources in your library. To create a larger quiz, consider adding more resources to your library.',
+    context: 'Message to indicate that the license is not sufficient for the user.',
+  },
 });

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -137,6 +137,7 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
   insufficientResources: {
     message:
       'There are currently only {count, number} questions across all practice resources in your library. To create a larger quiz, consider adding more resources to your library.',
-    context: 'Message to indicate that the license is not sufficient for the user.',
+    context:
+      'Message to indicate that the resources are not not sufficient for the user to create a quiz.',
   },
 });


### PR DESCRIPTION
## Summary
This update introduces a banner to alert coaches when they do not have enough available resources to create a quiz

## References
#13109


## Reviewer guidance

- Delete some exercise  from the QA channel to about 2 or 3
- Go to coach >quiz>create  new quiz. 
- Add number of questions to be 25 or any number but your resource is less.

