### PR TITLE
Fix regression with category icons overlapping text

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -40,15 +40,11 @@
                 :color="$themeTokens.primary"
               />
             </template>
-            <template
+            <KIcon
               v-if="category.nested"
-              #iconAfter
-            >
-              <KIcon
-                icon="chevronRight"
-                class="category-icon-after"
-              />
-            </template>
+              icon="chevronRight"
+              class="category-icon-after"
+            />
           </KButton>
           <KButton
             :text="coreString('otherCategories')"
@@ -412,31 +408,30 @@
     margin-bottom: 1em;
   }
 
+  .category-button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 0.25em 0.5em;
+    font-weight: normal;
+    text-align: left;
+    text-transform: none;
+  }
+
   .category-icon {
-    position: absolute;
-    top: 50%;
-    left: 0.5em;
-    width: 32px;
-    height: 32px;
-    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    margin-right: 1em;
   }
 
   .category-icon-after {
     position: absolute;
-    top: 50%;
+    top: 0.75em;
     right: 0.5em;
-    transform: translateY(-50%);
-  }
-
-  .category-button {
-    // Ensure the child KIcons' absolute positioning anchors to this button
-    position: relative;
-    width: 100%;
-    padding: 0.25em 0.5em 0.25em 3.5em;
-    font-weight: normal;
-    text-align: left;
-    // KButton text formatting overrides
-    text-transform: unset;
+    width: 20px;
+    height: 20px;
+    margin-left: 0.5em;
   }
 
   .category-button:not(:last-child) {


### PR DESCRIPTION
## Summary
With updates to `Kbutton` there was a problem with the original fix when it got merged in.

## References
Fixes one of the items in https://github.com/learningequality/kolibri/issues/13127, "[Fix category icons in search modal](https://www.notion.so/learningequality/Wonky-icon-spacing-in-lesson-content-search-1a7f45d6ef9680ed8c33c230c4b04437?pvs=4)"

After:
<img width="694" alt="Screenshot 2025-03-05 at 8 51 07 AM" src="https://github.com/user-attachments/assets/add0478e-5692-4b70-9287-e04bb8133a67" />

## Reviewer guidance
Confirm that the icon spacing and layout works across screen sizes

