### PR TITLE
Implement task polling composable

### DIFF
--- a/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
@@ -193,7 +193,7 @@
       BottomAppBar,
     },
     mixins: [commonCoreStrings],
-    setup () {
+    setup() {
       const { tasks } = useTaskPooling('facility_task');
       return { tasks };
     },
@@ -294,10 +294,10 @@
           : this.device.device_name;
       },
       currentTask() {
-        return  this.filteredTasks.length ? this.filteredTasks[0] : null;
+        return this.filteredTasks.length ? this.filteredTasks[0] : null;
       },
       currentTaskRunning() {
-        return  this.currentTask?.status === TaskStatuses.RUNNING;
+        return this.currentTask?.status === TaskStatuses.RUNNING;
       },
       timeRequired() {
         return this.selectedItem.value > oneHour;
@@ -437,8 +437,7 @@
             const hours = enqueueAt.getHours();
             const minutes = enqueueAt.getMinutes();
             this.selectedItem =
-              this.selectArray.find(item => item.value === this.currentTask.repeat_interval) ||
-              {};
+              this.selectArray.find(item => item.value === this.currentTask.repeat_interval) || {};
             this.selectedDay = this.getDays.find(item => item.value === day) || {};
             for (const time of this.SyncTime) {
               // Because there can be some drift in the task scheduling process,

--- a/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
@@ -159,7 +159,7 @@
   import { now } from 'kolibri/utils/serverClock';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { TaskStatuses, TaskTypes } from 'kolibri-common/utils/syncTaskUtils';
-  import useTaskPooling from '../../composables/useTaskPooling';
+  import useTaskPolling from '../../composables/useTaskPolling';
   import { KDP_ID, oneHour, oneDay, oneWeek, twoWeeks, oneMonth } from './constants';
   import { kdpNameTranslator } from './i18n';
 
@@ -197,7 +197,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { tasks } = useTaskPooling('facility_task');
+      const { tasks } = useTaskPolling('facility_task');
       return { tasks };
     },
     props: {

--- a/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
@@ -31,6 +31,7 @@
                 :style="selectorStyle"
                 :options="selectArray"
                 :label="$tr('frequency')"
+                @select="handleUserInput"
               />
             </KGridItem>
           </KGrid>
@@ -43,6 +44,7 @@
                 :style="selectorStyle"
                 :options="getDays"
                 :label="$tr('day')"
+                @select="handleUserInput"
               />
             </KGridItem>
           </KGrid>
@@ -55,6 +57,7 @@
                 :style="selectorStyle"
                 :options="SyncTime"
                 :label="$tr('time')"
+                @select="handleUserInput"
               />
             </KGridItem>
           </KGrid>
@@ -78,7 +81,7 @@
             <KCheckbox
               :checked="retryFlag"
               :disabled="currentTaskRunning"
-              @change="retryFlag = !retryFlag"
+              @change="handleRetryCheckboxChange"
             >
               {{ $tr('checkboxLabel') }}
             </KCheckbox>
@@ -222,9 +225,9 @@
         device: null,
         now: null,
         selectedItem: {},
-        // tasks: [],
         selectedDay: {},
         selectedTime: {},
+        userHasEdited: false,
       };
     },
     computed: {
@@ -321,7 +324,7 @@
     },
     watch: {
       currentTask() {
-        if (this.currentTask) {
+        if (this.currentTask && !this.userHasEdited) {
           const enqueueAt = new Date(Date.parse(this.currentTask.scheduled_datetime));
           const day = enqueueAt.getDay();
           const hours = enqueueAt.getHours();
@@ -438,12 +441,8 @@
           })
           .catch(() => {
             this.createTaskFailedSnackbar();
-            // if (this.currentTask) {
-            //   this.fetchSyncTasks();
-            // }
           });
       },
-
       goBack() {
         this.$router.push(this.goBackRoute);
       },
@@ -460,6 +459,13 @@
         NetworkLocationResource.fetchModel({ id: this.deviceId }).then(device => {
           this.device = device;
         });
+      },
+      handleUserInput() {
+        this.userHasEdited = true;
+      },
+      handleRetryCheckboxChange() {
+        this.retryFlag = !this.retryFlag;
+        this.handleUserInput();
       },
     },
     $trs: {

--- a/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
@@ -277,7 +277,7 @@
       filteredTasks() {
         return this.tasks.filter(
           task =>
-            (this.isKdp || task.extra_metadata.device_id === this.device.id) &&
+            (this.isKdp || task.extra_metadata.device_id === this.device?.id) &&
             task.facility_id === this.facilityId &&
             task.type === this.taskType &&
             // Only show tasks that are repeating indefinitely

--- a/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
@@ -117,7 +117,6 @@
   import { computed } from 'vue';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import CoreTable from 'kolibri/components/CoreTable';
-  import TaskResource from 'kolibri/apiResources/TaskResource';
   import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
@@ -127,6 +126,7 @@
     useDevicesWithFilter,
   } from 'kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/useDevices';
   import { TaskTypes } from 'kolibri-common/utils/syncTaskUtils';
+  import useTaskPolling from '../../composables/useTaskPolling';
   import { KDP_ID, oneHour, oneDay, oneWeek, twoWeeks, oneMonth } from './constants';
   import { kdpNameTranslator } from './i18n';
 
@@ -141,6 +141,7 @@
     mixins: [commonCoreStrings, commonSyncElements],
     setup(props) {
       const deviceFilter = useDeviceFacilityFilter({ id: props.facilityId });
+      const { tasks } = useTaskPolling('facility_task');
       const { devices } = useDevicesWithFilter(
         {
           subset_of_users_device: false,
@@ -165,6 +166,7 @@
       });
       return {
         devicesById,
+        tasks,
       };
     },
     props: {
@@ -185,10 +187,17 @@
       return {
         deviceModal: false,
         facility: null,
-        facilitySyncTasks: [],
       };
     },
     computed: {
+      facilitySyncTasks() {
+        return this.tasks.filter(
+          t =>
+            t.facility_id === this.facilityId &&
+            t.repeat === null &&
+            (t.type === TaskTypes.SYNCDATAPORTAL || t.type === TaskTypes.SYNCPEERFULL),
+        );
+      },
       scheduledTasks() {
         return this.facilitySyncTasks.map(task => {
           const deviceName = this.devicesById[this.getDeviceId(task)]
@@ -208,28 +217,12 @@
       },
     },
     beforeMount() {
-      this.pollFacilityTasks();
       this.fetchFacility();
     },
     methods: {
       fetchFacility() {
         FacilityResource.fetchModel({ id: this.facilityId, force: true }).then(facility => {
           this.facility = { ...facility };
-        });
-      },
-      pollFacilityTasks() {
-        TaskResource.list({ queue: 'facility_task' }).then(tasks => {
-          this.facilitySyncTasks = tasks.filter(
-            t =>
-              t.facility_id === this.facilityId &&
-              t.repeat === null &&
-              (t.type === TaskTypes.SYNCDATAPORTAL || t.type === TaskTypes.SYNCPEERFULL),
-          );
-          if (this.isPolling) {
-            setTimeout(() => {
-              return this.pollFacilityTasks();
-            }, 2000);
-          }
         });
       },
       closeModal() {

--- a/packages/kolibri-common/composables/useTaskPolling.js
+++ b/packages/kolibri-common/composables/useTaskPolling.js
@@ -7,11 +7,10 @@ const taskPollers = new Map();
 
 const logging = logger.getLogger(__filename);
 
-export default function useTaskPooling(queueName) {
+export default function useTaskPolling(queueName) {
   if (!taskPollers.has(queueName)) {
     const consumers = ref(0);
     const tasks = ref([]);
-
     const { pause, resume, isActive } = useTimeoutPoll(
       async () => {
         try {

--- a/packages/kolibri-common/composables/useTaskPooling.js
+++ b/packages/kolibri-common/composables/useTaskPooling.js
@@ -30,9 +30,9 @@ export default function useTaskPooling(queueName) {
   const poller = taskPollers.get(queueName);
   poller.consumers.value++;
 
-  console.log("Current number of consuemrs for the queue ", queueName, poller.consumers.value);
+  console.log('Current number of consuemrs for the queue ', queueName, poller.consumers.value);
   //log the current value of taskPollers map
-  console.log("Current value of taskPollers map", taskPollers);
+  console.log('Current value of taskPollers map', taskPollers);
 
   onMounted(() => {
     if (!poller.isActive) {

--- a/packages/kolibri-common/composables/useTaskPooling.js
+++ b/packages/kolibri-common/composables/useTaskPooling.js
@@ -21,18 +21,12 @@ export default function useTaskPooling(queueName) {
       { immediate: true },
     );
 
-    //TO DECIDE if the key should be uniquely
-    // identified by the queueName,
-    // queueName + fetchTaskFunction or queueName + fetchTaskFunction + interval
     taskPollers.set(queueName, { consumers, tasks, pause, resume, isActive });
   }
 
   const poller = taskPollers.get(queueName);
   poller.consumers.value++;
 
-  console.log('Current number of consuemrs for the queue ', queueName, poller.consumers.value);
-  //log the current value of taskPollers map
-  console.log('Current value of taskPollers map', taskPollers);
 
   onMounted(() => {
     if (!poller.isActive) {

--- a/packages/kolibri-common/composables/useTaskPooling.js
+++ b/packages/kolibri-common/composables/useTaskPooling.js
@@ -1,0 +1,51 @@
+import { ref, onMounted, onUnmounted } from 'vue';
+import { useTimeoutPoll } from '@vueuse/core';
+
+const taskPollers = new Map();
+
+export function useTaskPooling(queueName, fetchTaskFunction, interval = 5000){
+   if(!taskPollers.has(queueName)){
+    const consumers = ref(0);
+    const tasks = ref([]);
+
+    const {pause, resume, isActive} = useTimeoutPoll(async () => {
+         try{
+            tasks.value = await fetchTaskFunction();
+         }
+          catch(e){
+              console.error(e);
+          }
+    }, interval, { immediate: true });
+
+    //TO DECIDE if the key should be uniquely
+    // identified by the queueName,
+    // queueName + fetchTaskFunction or queueName + fetchTaskFunction + interval
+    taskPollers.set(queueName, { consumers, tasks, pause, resume, isActive });
+
+  }
+
+  const poller = taskPollers.get(queueName);
+  poller.consumers.value++;
+
+  onMounted(() => {
+    if (!poller.isActive) {
+      poller.resume();
+    }
+  });
+
+  onUnmounted(() => {
+    poller.consumers.value--;
+    if (poller.consumers.value === 0) {
+      poller.pause();
+      taskPollers.delete(queueName);
+    }
+  });
+
+   return { tasks: poller.tasks };
+
+}
+
+
+
+
+

--- a/packages/kolibri-common/composables/useTaskPooling.js
+++ b/packages/kolibri-common/composables/useTaskPooling.js
@@ -3,25 +3,27 @@ import { useTimeoutPoll } from '@vueuse/core';
 
 const taskPollers = new Map();
 
-export function useTaskPooling(queueName, fetchTaskFunction, interval = 5000){
-   if(!taskPollers.has(queueName)){
+export function useTaskPooling(queueName, fetchTaskFunction, interval = 5000) {
+  if (!taskPollers.has(queueName)) {
     const consumers = ref(0);
     const tasks = ref([]);
 
-    const {pause, resume, isActive} = useTimeoutPoll(async () => {
-         try{
-            tasks.value = await fetchTaskFunction();
-         }
-          catch(e){
-              console.error(e);
-          }
-    }, interval, { immediate: true });
+    const { pause, resume, isActive } = useTimeoutPoll(
+      async () => {
+        try {
+          tasks.value = await fetchTaskFunction();
+        } catch (e) {
+          console.error(e);
+        }
+      },
+      interval,
+      { immediate: true },
+    );
 
     //TO DECIDE if the key should be uniquely
     // identified by the queueName,
     // queueName + fetchTaskFunction or queueName + fetchTaskFunction + interval
     taskPollers.set(queueName, { consumers, tasks, pause, resume, isActive });
-
   }
 
   const poller = taskPollers.get(queueName);
@@ -41,11 +43,5 @@ export function useTaskPooling(queueName, fetchTaskFunction, interval = 5000){
     }
   });
 
-   return { tasks: poller.tasks };
-
+  return { tasks: poller.tasks };
 }
-
-
-
-
-


### PR DESCRIPTION
## Summary
* Implement task polling composable
* Use the composable in the EditDeviceSyncSchedule component, fixing a bug that caused multiple setIntervals to poll the same queue at the same time.

**Before:**


https://github.com/user-attachments/assets/8ffcd7c0-4bd4-4e6e-b000-162b1835f66b

**After:**


https://github.com/user-attachments/assets/489adf1f-b8ce-4c73-9f85-158b7c6f22b0




## References
Closes #13093

## Reviewer guidance
* Go to Device > facilities > [facility] > manage sync facilities
* Add new / edit sync schedule and set hourly frequency
* While the sync task is running (the edit schedule inputs are disabled) keep the edit sync schedule modal open for some time
* While you are in the edit sync schedule modal, open your network tab and check that requests behave normally and that they dont increment over time.
