### PR TITLE
Fix incorrect validator.

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -73,15 +73,15 @@
         validator(value) {
           return validateObject(value, {
             accessibility_labels: {
-              type: Array,
+              type: Object,
               required: true,
             },
             languages: {
-              type: Array,
+              type: Object,
               required: true,
             },
             grade_levels: {
-              type: Array,
+              type: Object,
               required: true,
             },
           });


### PR DESCRIPTION
## Summary
* Fixes regression introduced by https://github.com/learningequality/kolibri/pull/13015

## Reviewer guidance
Navigate to the learn page - ensure that big red validator errors do not appear in the console.