### PR TITLE
Reintroduce paddingTop when we are in an immersive modal view

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -473,9 +473,10 @@
         }
       },
       gridOffset() {
+        const paddingTop = this.deviceId ? (this.windowIsLarge ? '64px' : '32px') : null;
         return this.isRtl
-          ? { paddingRight: `${this.sidePanelWidth + 24}px` }
-          : { paddingLeft: `${this.sidePanelWidth + 24}px` };
+          ? { paddingRight: `${this.sidePanelWidth + 24}px`, paddingTop }
+          : { paddingLeft: `${this.sidePanelWidth + 24}px`, paddingTop };
       },
       sidePanelWidth() {
         if (


### PR DESCRIPTION
## Summary
* Reintroduces paddingTop to the main grid of the LibraryPage in the case when we are in an immersive modal (as determined by the deviceId being defined)

## References
Fixes small regression from #13007 

## Reviewer guidance

### Desktop
| Before | After |
-----------|---------|
| ![Screenshot from 2025-03-06 07-34-02](https://github.com/user-attachments/assets/241db72d-6e65-4019-a6ad-c9d27c3c8e83) | ![Screenshot from 2025-03-06 07-32-47](https://github.com/user-attachments/assets/9ce0b005-b965-4e00-b99e-687abb82379f) |

### Mobile
| Before | After |
-----------|---------|
| ![Screenshot from 2025-03-06 07-33-48](https://github.com/user-attachments/assets/4ccd3f22-b840-45e2-942b-03aaa6f16a4d) | ![Screenshot from 2025-03-06 07-33-22](https://github.com/user-attachments/assets/64ed030d-beeb-46c7-8a30-e2cc4d135358) |

