### PR TITLE
Ensure quiz report visibility is updated correctly after a quiz has been closed

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -417,9 +417,9 @@
         }
       },
       reportVisibilityStatus() {
-        return this.exam.instant_report_visibility
-          ? this.coachString('afterLearnerSubmitsQuizLabel')
-          : this.coachString('afterCoachEndsQuizLabel');
+        return this.exam.instant_report_visibility === false
+          ? this.coachString('afterCoachEndsQuizLabel')
+          : this.coachString('afterLearnerSubmitsQuizLabel');
       },
       layout12Label() {
         return { span: this.$isPrint ? 3 : 12 };

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -99,8 +99,8 @@
       },
       reportVisible() {
         const quiz = this.activeClassesQuizzes.find(q => q.id === this.exam.id) || this.exam;
-        // Show report if quiz is closed or if instant_report_visibility is true
-        return quiz.archive || quiz.instant_report_visibility;
+        // Show report if instant_report_visibility is true or null, or if quiz is closed
+        return quiz.instant_report_visibility !== false || quiz.archive;
       },
       showQuizReportComingSoonModal() {
         return !this.reportVisible && !this.loading;

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -33,7 +33,7 @@
         </p>
       </div>
     </KPageContainer>
-    <div v-else>
+    <div v-else-if="showQuizReportComingSoonModal">
       <KModal
         :title="$tr('quizReportComingSoon')"
         :submitText="coreString('closeAction')"
@@ -101,6 +101,9 @@
         const quiz = this.activeClassesQuizzes.find(q => q.id === this.exam.id) || this.exam;
         // Show report if quiz is closed or if instant_report_visibility is true
         return quiz.archive || quiz.instant_report_visibility;
+      },
+      showQuizReportComingSoonModal() {
+        return !this.reportVisible && !this.loading;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -57,6 +57,7 @@
   import useUser from 'kolibri/composables/useUser';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { PageNames, ClassesPageNames } from '../constants';
+  import useLearnerResources from '../composables/useLearnerResources';
 
   export default {
     name: 'LearnExamReportViewer',
@@ -72,7 +73,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { full_name, user_id } = useUser();
-      return { userName: full_name, userId: user_id };
+      const { activeClassesQuizzes } = useLearnerResources();
+      return { userName: full_name, userId: user_id, activeClassesQuizzes };
     },
     computed: {
       ...mapState('examReportViewer', [
@@ -96,8 +98,9 @@
         };
       },
       reportVisible() {
+        const quiz = this.activeClassesQuizzes.find(q => q.id === this.exam.id) || this.exam;
         // Show report if quiz is closed or if instant_report_visibility is true
-        return this.exam.archive || this.exam.instant_report_visibility;
+        return quiz.archive || quiz.instant_report_visibility;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
@@ -86,8 +86,9 @@
         return '';
       },
       reportVisible() {
-        // Show report if quiz is closed or instant_report_visibility is true
-        return this.quiz.archive || this.quiz.instant_report_visibility;
+        const { instant_report_visibility, archive } = this.quiz;
+        // Show report if instant_report_visibility is true or null, if the quiz is closed
+        return instant_report_visibility !== false || archive;
       },
     },
     $trs: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request adds `UseLearnerResources` to `LearnExamReportViewer` to retrieve the most up-to-date active quiz fields so that when the quiz card updates on the homepage to reflect an available report, the learner can view the quiz report as intended.

This pull request also ensures that the modal informing the user that the quiz report is unavailable does not appear prematurely while the quiz report is loading.

Before:

https://github.com/user-attachments/assets/31cb5892-367b-4b85-ad18-1d5c230a87b7

After:

https://github.com/user-attachments/assets/7c760ed5-4790-4699-8582-56093a493992

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13111 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Assign a quiz to a learner with the quiz report visibility selection “After coach ends the quiz”.
2. In a separate browser, signed into the learner account, complete the quiz, then leave the homepage with the view of the assigned quizzes displayed open.
3. In the browser that the coach is signed into, close the quiz.
4. Once the learner’s quiz card updates to reflect that the quiz report can be viewed, click the quiz card. The quiz report should be shown.
