### PR TITLE
Fix change facility workflow

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { coreStoreFactory } from 'kolibri/store';
 import { shallowMount, mount } from '@vue/test-utils';
 import ChooseAdmin from '../index.vue';
@@ -14,12 +15,10 @@ function makeWrapper({ userId, sourceFacilityUsers } = {}) {
       changeFacilityService: {
         send: sendMachineEvent,
       },
-      state: {
-        value: {
-          userId,
-          sourceFacilityUsers,
-        },
-      },
+      state: computed(() => ({
+        userId,
+        sourceFacilityUsers,
+      })),
     },
   });
 }

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { shallowMount, mount } from '@vue/test-utils';
 import ConfirmAccountUsername from '../index.vue';
 
@@ -8,9 +9,7 @@ function makeWrapper({ targetFacility } = {}) {
       changeFacilityService: {
         send: sendMachineEvent,
       },
-      state: {
-        targetFacility,
-      },
+      state: computed(() => ({ targetFacility })),
     },
   });
 }

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
@@ -9,9 +9,7 @@ function makeWrapper({ targetFacility } = {}) {
         send: sendMachineEvent,
       },
       state: {
-        value: {
-          targetFacility,
-        },
+        targetFacility,
       },
     },
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/index.vue
@@ -50,13 +50,13 @@
     inject: ['changeFacilityService', 'state'],
     computed: {
       targetFacility() {
-        return get(this.state, 'value.targetFacility');
+        return get(this.state, 'targetFacility');
       },
       username() {
-        return get(this.state, 'value.username');
+        return get(this.state, 'username');
       },
       usernameExists() {
-        return get(this.state, 'value.accountExists');
+        return get(this.state, 'accountExists');
       },
       isCreateAccountButtonDisabled() {
         return !get(this.targetFacility, 'learner_can_sign_up');

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -55,10 +55,10 @@
     },
     computed: {
       targetFacility() {
-        return this.state.value.targetFacility;
+        return this.state.targetFacility;
       },
       role() {
-        return this.state.value.role;
+        return this.state.role;
       },
       isCreateAccountDisabled() {
         return !get(this.targetFacility, 'learner_can_sign_up');
@@ -85,7 +85,7 @@
       FacilityUserResource.fetchCollection({
         force: true,
         getParams: {
-          member_of: this.state.value.sourceFacility,
+          member_of: this.state.sourceFacility,
         },
       }).then(users => {
         if (Object.keys(users).length === 1) {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
@@ -15,9 +16,9 @@ function makeWrapper({ targetFacility } = {}) {
       changeFacilityService: {
         send: sendMachineEvent,
       },
-      state: {
+      state: computed(() => ({
         targetFacility,
-      },
+      })),
     },
     localVue,
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -16,9 +16,7 @@ function makeWrapper({ targetFacility } = {}) {
         send: sendMachineEvent,
       },
       state: {
-        value: {
-          targetFacility,
-        },
+        targetFacility,
       },
     },
     localVue,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -96,11 +96,11 @@
       description() {
         return this.$tr('description', {
           fullName: get(this.session, 'full_name', ''),
-          targetFacility: get(this.state, 'value.targetFacility.name', ''),
+          targetFacility: get(this.state, 'targetFacility.name', ''),
         });
       },
       showPasswordTextbox() {
-        return !get(this.state, 'value.targetFacility.learner_can_login_with_no_password', false);
+        return !get(this.state, 'targetFacility.learner_can_login_with_no_password', false);
       },
       isFormValid() {
         return this.isUsernameValid && (!this.showPasswordTextbox || this.isPasswordValid);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreatePassword.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreatePassword.vue
@@ -79,7 +79,7 @@
       description() {
         return this.$tr('description', {
           username: get(this.session, 'username', ''),
-          targetFacility: get(this.state, 'value.targetFacility.name', ''),
+          targetFacility: get(this.state, 'targetFacility.name', ''),
         });
       },
     },
@@ -96,7 +96,7 @@
         this.changeFacilityService.send({
           type: 'CONTINUE',
           value: {
-            username: get(this.state, 'value.targetAccount.username', ''),
+            username: get(this.state, 'targetAccount.username', ''),
             password: this.formData.password,
           },
         });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
@@ -12,11 +12,9 @@ function makeWrapper({ targetFacility, targetAccount, username } = {}) {
         send: sendMachineEvent,
       },
       state: {
-        value: {
-          targetFacility,
-          targetAccount,
-          username,
-        },
+        targetFacility,
+        targetAccount,
+        username,
       },
     },
     localVue,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import { FacilityUserGender } from 'kolibri/constants';
 import ConfirmAccountDetails from '../ConfirmAccountDetails';
@@ -11,11 +12,11 @@ function makeWrapper({ targetFacility, targetAccount, username } = {}) {
       changeFacilityService: {
         send: sendMachineEvent,
       },
-      state: {
+      state: computed(() => ({
         targetFacility,
         targetAccount,
         username,
-      },
+      })),
     },
     localVue,
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
@@ -15,12 +15,10 @@ function makeWrapper({ targetFacility, targetAccount, fullname, username } = {})
         state: { value: 'requireAccountCreds' },
       },
       state: {
-        value: {
-          targetFacility,
-          targetAccount,
-          fullname,
-          username,
-        },
+        targetFacility,
+        targetAccount,
+        fullname,
+        username,
       },
     },
     localVue,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import MergeAccountDialog from '../index.vue';
 
@@ -14,12 +15,12 @@ function makeWrapper({ targetFacility, targetAccount, fullname, username } = {})
         send: sendMachineEvent,
         state: { value: 'requireAccountCreds' },
       },
-      state: {
+      state: computed(() => ({
         targetFacility,
         targetAccount,
         fullname,
         username,
-      },
+      })),
     },
     localVue,
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -78,7 +78,7 @@
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
-  import { computed, inject, ref, watch } from 'vue';
+  import { computed, getCurrentInstance, inject, ref, watch } from 'vue';
   import get from 'lodash/get';
   import remoteFacilityUserData from '../../../composables/useRemoteFacility';
   import commonProfileStrings from '../../commonProfileStrings';
@@ -156,9 +156,9 @@
         });
       }
 
+      const component = getCurrentInstance().proxy;
       function handleContinue() {
         const facility = get(state, 'value.targetFacility', {});
-        const component = this;
         remoteFacilityUserData(
           facility.url,
           facility.id,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeDifferentAccounts/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeDifferentAccounts/__tests__/index.spec.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import MergeDifferentAccounts from '../index.vue';
 import * as useRemoteFacility from '../../../../composables/useRemoteFacility';
@@ -17,14 +18,12 @@ function makeWrapper({ targetFacility, targetAccount, fullname, username } = {})
         send: sendMachineEvent,
         state: { value: 'requireAccountCreds' },
       },
-      state: {
-        value: {
-          targetFacility,
-          targetAccount,
-          fullname,
-          username,
-        },
-      },
+      state: computed(() => ({
+        targetFacility,
+        targetAccount,
+        fullname,
+        username,
+      })),
     },
     localVue,
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -63,7 +63,7 @@
             :primary="true"
             :text="coreString('continueAction')"
             :disabled="selectedFacilityId === ''"
-            @click="to_continue"
+            @click="toContinue"
           />
         </KButtonGroup>
       </slot>
@@ -76,7 +76,7 @@
 <script>
 
   import { useLocalStorage, useMemoize, computedAsync, get } from '@vueuse/core';
-  import { computed, ref, watch } from 'vue';
+  import { computed, ref, watch, inject } from 'vue';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
   import { NetworkLocationResource } from 'kolibri-common/apiResources/NetworkLocationResource';
@@ -230,8 +230,9 @@
         }
       }
 
-      function to_continue() {
-        this.changeFacilityService.send({
+      const changeFacilityService = inject('changeFacilityService');
+      function toContinue() {
+        changeFacilityService.send({
           type: 'CONTINUE',
         });
       }
@@ -248,7 +249,7 @@
         showAddAddressModal,
         facilityDisabled,
         handleAddedAddress,
-        to_continue,
+        toContinue,
       };
     },
     inject: ['changeFacilityService'],


### PR DESCRIPTION
## Summary

After the vue upgrade to vue 2.7, [this `state` computed property](https://github.com/AlexVelezLl/kolibri/blob/abcf8f619e5e18c3660bd5394cc1618949687814/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue#L54) that was the context of the state machine provided by the `ChangeFacility` index component had a change: When we refer to this injected property from the setup method, we need to access it through the `.value` property, but when we access it through the options api we dont need the `.value` property anymore. This basically caused the entire change facility workflow to break.

In the course of that refactor I somehow fixed the underlying issue that was causing #12762 (that wasnt initially caused by the vue upgrade since it was reported before that).


https://github.com/user-attachments/assets/ab8e22c0-fdf6-4e4f-9d51-d383814b737d



## References
Closes #12762

## Reviewer guidance

1. Go through the 'On my own' setup flow.
2. Go to Profile > Change > Merge accounts
3. Go through the different paths for merging accounts
4. Check that the user is properly redirected after the account was merged.

###  Note

* I have manually checked all references to the `state` injected prop in the whole ChangeFacility folder, and validated that all references to it inside the `setup` method was being referenced with the `.value` property, and all the references outside the `setup` method was being referenced without the `.value` property. But a double check never hurts :)