### PR TITLE
No redirect resource preview

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/ResourceActionButton.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/ResourceActionButton.vue
@@ -6,7 +6,7 @@
       class="mr-16"
     >
       <KIcon icon="onDevice" />
-      {{ addedIndicator$() }}
+      {{ selectedIndicator$() }}
     </span>
 
     <KButton
@@ -18,7 +18,7 @@
     />
     <KButton
       v-else
-      :text="addText$()"
+      :text="selectResource$()"
       :primary="false"
       :disabled="isActionDisabled"
       @click="$emit('addResource')"
@@ -37,12 +37,12 @@
     name: 'ResourceActionButton',
     setup() {
       const { removeAction$ } = coreStrings;
-      const { addText$, addedIndicator$ } = searchAndFilterStrings;
+      const { selectResource$, selectedIndicator$ } = searchAndFilterStrings;
 
       return {
-        addText$,
+        selectResource$,
         removeAction$,
-        addedIndicator$,
+        selectedIndicator$,
       };
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -193,7 +193,6 @@
         questions,
         loading,
         SelectionTarget,
-        redirectBack,
         // eslint-disable-next-line vue/no-unused-properties
         prevRoute,
         exerciseQuestions,
@@ -323,11 +322,9 @@
     },
     methods: {
       handleAddResource() {
-        this.redirectBack();
         this.$emit('selectResources', [this.contentNode]);
       },
       handleRemoveResource() {
-        this.redirectBack();
         this.$emit('deselectResources', [this.contentNode]);
       },
       topicsLink(topicId) {

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -153,8 +153,6 @@
         }
         return selectResourcesDescription$({ sectionTitle: props.sectionTitle });
       };
-      props.setTitle(getTitle());
-      props.setGoBack(null);
 
       const redirectBack = () => {
         if (prevRoute.value?.name) {
@@ -167,6 +165,9 @@
               : PageNames.QUIZ_SELECT_RESOURCES_INDEX,
         });
       };
+
+      props.setTitle(getTitle());
+      props.setGoBack(redirectBack);
 
       const workingIsChoosingManually = ref(props.settings?.isChoosingManually);
       const saveSettings = () => {

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -98,8 +98,8 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     message: 'Choose a category',
     context: 'Label for a selector component to choose a category',
   },
-  addText: {
-    message: 'Add',
+  selectResource: {
+    message: 'Select resource',
     context: 'Button for adding a resource',
   },
 
@@ -113,9 +113,10 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     context:
       "Refers to the type of license the learning resource has. For example, 'CC BY-NC' meaning 'Creative Commons: attribution, non-commercial'.",
   },
-  addedIndicator: {
-    message: 'Added',
-    context: 'Notification that can refer to when resources are added to a lesson, for example.',
+  selectedIndicator: {
+    message: 'Selected',
+    context:
+      'Notification that can refer to when resources are selected to add to a lesson, for example.',
   },
   notAvailableLabel: {
     message: 'Not available',


### PR DESCRIPTION
## Summary
Implements some suggestions from the bug bash which was to not automatically redirect after adding a resource from the resource preview. 

I've also updated the language so it's clearer that it's a "select" (parallel to the checkmark, not saving to the lesson) and added a back button for navigation out. (instead of the redirect)

## References
Bug bash document
- [feedback 1
](https://www.notion.so/learningequality/As-a-user-I-would-expect-that-we-have-a-back-button-in-the-resource-preview-page-and-use-that-back--1a7f45d6ef9680b5a2acf0b1e1ec52ec?pvs=4)
- [feedback 2](https://www.notion.so/learningequality/When-adding-a-resource-to-a-lesson-from-the-resource-preview-page-I-think-the-re-rerouting-out-of--1a7f45d6ef9680d18cc5e3f509882609?pvs=4)


After:

https://github.com/user-attachments/assets/fc120a11-3aca-489b-9cce-5db3491297a8


## Reviewer guidance
Preview and add resources, navigating in and out of the resource preview page. Does the experience feel "better"? And does the text more accurately describe what's happening?
