### PR TITLE
Update question settings back navigation

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -92,7 +92,13 @@
           sectionTitle: displaySectionTitle(activeSection.value, activeSectionIndex.value),
         }),
       );
-      props.setGoBack(null);
+      const redirectBack = props.isLanding
+        ? null
+        : () => {
+          instance.proxy.$router.go(-1);
+        };
+
+      props.setGoBack(redirectBack);
 
       const workingQuestionCount = ref(props.settings.questionCount);
       const workingIsChoosingManually = ref(Boolean(props.settings.isChoosingManually));


### PR DESCRIPTION
## Summary
Adds a back button to the question settings page, for any situation where it is not the "landing" page, meaning it is not the first page the user sees in the side panel. 

## References
[Bug bash feedback](https://www.notion.so/learningequality/Kolibri-bug-hunt-v0-18-0-alpha2-Product-Team-1a7f45d6ef9680be9d34cf02231e56f8) from Jessica

After:

https://github.com/user-attachments/assets/3792fde3-c741-4a74-b1ae-349606731c43


## Reviewer guidance
1. Add new questions to a quiz - you should see at first the questions settings page, and not have a back button. 
2. In any other scenario when you open the questions settings (from the "settings" button) - such as navigating up and down the topics tree - you should see the back button, which should return you to where you just were. (i.e. function identically to the back button on the browser)
