### PR TITLE
Add task restarting to failed content management tasks.

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -91,10 +91,16 @@
       </p>
     </div>
 
-    <div
+    <KButtonGroup
       class="buttons"
       :class="{ 'button-lift': taskIsRunning }"
     >
+      <KButton
+        v-if="taskIsFailed"
+        :text="coreString('retryAction')"
+        appearance="flat-button"
+        @click="$emit('restart')"
+      />
       <KButton
         v-if="taskIsCancellable || taskIsClearable"
         :disabled="taskIsCanceling"
@@ -102,7 +108,7 @@
         appearance="flat-button"
         @click="handleClick"
       />
-    </div>
+    </KButtonGroup>
   </div>
 
 </template>
@@ -480,6 +486,8 @@
   }
 
   .buttons {
+    display: flex;
+
     .task-panel-sm & {
       align-self: flex-end;
     }

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
@@ -22,11 +22,15 @@ exports[`TaskPanel renders correctly when it is a canceled DISKCONTENTEXPORT tas
       Started by 'Tester'
     </p>
   </div>
-  <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
-      <!---->
-      <!----> <span class="link-text">Clear</span>
-      <!---->
-      <!----></button></div>
+  <div class="buttons button-group"><span class="button-group-item"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
+    <!---->
+    <!----> <span class="link-text">Retry</span>
+    <!---->
+    <!----></button></span><span class="button-group-item"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
+    <!---->
+    <!----> <span class="link-text">Clear</span>
+    <!---->
+    <!----></button></span></div>
 </div>
 `;
 
@@ -52,10 +56,14 @@ exports[`TaskPanel renders correctly when it is a canceled DISKEXPORT task (bulk
       Started by 'Tester'
     </p>
   </div>
-  <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
-      <!---->
-      <!----> <span class="link-text">Clear</span>
-      <!---->
-      <!----></button></div>
+  <div class="buttons button-group"><span class="button-group-item"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
+    <!---->
+    <!----> <span class="link-text">Retry</span>
+    <!---->
+    <!----></button></span><span class="button-group-item"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_1y0ur7h"><span class="icon-container"></span>
+    <!---->
+    <!----> <span class="link-text">Clear</span>
+    <!---->
+    <!----></button></span></div>
 </div>
 `;

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -52,6 +52,7 @@
           :style="{ borderBottomColor: $themePalette.grey.v_300 }"
           @clickclear="handleClickClear(task)"
           @clickcancel="handleClickCancel(task)"
+          @restart="restartTask(task)"
           @update-title="updateAppBarTitle"
         />
       </transition-group>
@@ -210,6 +211,9 @@
       },
       handleClickCancel(task) {
         TaskResource.cancel(task.id);
+      },
+      restartTask(task) {
+        TaskResource.restart(task.id);
       },
       handleClickClearAll() {
         TaskResource.clearAll();


### PR DESCRIPTION
## Summary
* Fixes a long standing issue where failed content management tasks could not be restarted

## References
Fixes the most important extant element of this issue: https://github.com/learningequality/kolibri/issues/7930

## Reviewer guidance
Can you restart a failed task? (failed either because it was cancelled or there was an error)?

[Screencast from 03-07-2025 02:14:54 PM.webm](https://github.com/user-attachments/assets/0003d694-c8f1-4ff5-ba12-d791399359de)

