### PR TITLE
Add Swipe Gesture Support for Side Navigation in Kolibri

### DIFF
--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -3,6 +3,8 @@
   <!-- TODO useScrollPosition to set scrollPosition...
     here or in router, but somewhere -->
   <div class="main">
+    <div v-if="windowIsSmall" ref="swipeZone" :class="{ 'rtl-swipe-zone': isRtl.value }" class="swipe-zone"></div>
+
     <ScrollingHeader :scrollPosition="0">
       <transition mode="out-in">
         <AppBar
@@ -61,6 +63,8 @@
   import ScrollingHeader from '../ScrollingHeader';
   import AppBar from './internal/AppBar';
   import SideNav from './internal/SideNav';
+  import { ref,getCurrentInstance} from 'vue';
+  import { useSwipe } from '@vueuse/core';
 
   export default {
     name: 'AppBarPage',
@@ -71,11 +75,29 @@
     },
     mixins: [commonCoreStrings],
     setup() {
+      const instance = getCurrentInstance();
+      const isRtl =ref(instance?.proxy.isRtl);
+      const swipeZone = ref(null);
+      const navShown = ref(false);
+      useSwipe(swipeZone, {
+        onSwipeEnd: (e, direction) => {
+          if (direction === 'right' && !navShown.value && !isRtl.value) {
+            navShown.value = true;
+          }
+          else if (direction === 'left' && !navShown.value && isRtl.value) {
+            navShown.value = true;
+          }
+        },
+      });
       const { windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
       return {
         windowIsSmall,
         isAppContext,
+        swipeZone,
+        navShown,
+        isRtl,
+
       };
     },
     props: {
@@ -102,7 +124,6 @@
     data() {
       return {
         appBarHeight: 124,
-        navShown: false,
         lastScrollTop: 0,
         hideAppBars: true,
         throttledHandleScroll: null,
@@ -220,6 +241,22 @@
     z-index: 12;
     height: 48px;
     background-color: white;
+  }
+
+  .swipe-zone {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 5;
+    width: 30px;
+    opacity: 0;
+    background: red;
+  }
+
+  .rtl-swipe-zone {
+    right: 0;
+    left: auto;
   }
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -3,7 +3,11 @@
   <!-- TODO useScrollPosition to set scrollPosition...
     here or in router, but somewhere -->
   <div class="main">
-    <div v-if="windowIsSmall" ref="swipeZone" class="swipe-zone"></div>
+    <div
+      v-if="windowIsSmall"
+      ref="swipeZone"
+      class="swipe-zone"
+    ></div>
 
     <ScrollingHeader :scrollPosition="0">
       <transition mode="out-in">
@@ -60,11 +64,11 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
   import useUser from 'kolibri/composables/useUser';
+  import { ref, getCurrentInstance } from 'vue';
+  import { useSwipe } from '@vueuse/core';
   import ScrollingHeader from '../ScrollingHeader';
   import AppBar from './internal/AppBar';
   import SideNav from './internal/SideNav';
-  import { ref,getCurrentInstance} from 'vue';
-  import { useSwipe } from '@vueuse/core';
 
   export default {
     name: 'AppBarPage',
@@ -76,15 +80,14 @@
     mixins: [commonCoreStrings],
     setup() {
       const instance = getCurrentInstance();
-      const isRtl =ref(instance?.proxy.isRtl);
+      const isRtl = ref(instance?.proxy.isRtl);
       const swipeZone = ref(null);
       const navShown = ref(false);
       useSwipe(swipeZone, {
         onSwipeEnd: (e, direction) => {
           if (direction === 'right' && !navShown.value && !isRtl.value) {
             navShown.value = true;
-          }
-          else if (direction === 'left' && !navShown.value && isRtl.value) {
+          } else if (direction === 'left' && !navShown.value && isRtl.value) {
             navShown.value = true;
           }
         },
@@ -97,7 +100,6 @@
         swipeZone,
         navShown,
         isRtl,
-
       };
     },
     props: {
@@ -250,10 +252,8 @@
     left: 0;
     z-index: 5;
     width: 30px;
-    opacity: 0;
     background: red;
+    opacity: 0;
   }
-
- 
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -3,7 +3,7 @@
   <!-- TODO useScrollPosition to set scrollPosition...
     here or in router, but somewhere -->
   <div class="main">
-    <div v-if="windowIsSmall" ref="swipeZone" :class="{ 'rtl-swipe-zone': isRtl.value }" class="swipe-zone"></div>
+    <div v-if="windowIsSmall" ref="swipeZone" class="swipe-zone"></div>
 
     <ScrollingHeader :scrollPosition="0">
       <transition mode="out-in">
@@ -254,9 +254,6 @@
     background: red;
   }
 
-  .rtl-swipe-zone {
-    right: 0;
-    left: auto;
-  }
+ 
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -99,7 +99,6 @@
         isAppContext,
         swipeZone,
         navShown,
-        isRtl,
       };
     },
     props: {

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -273,7 +273,7 @@
   import SideNavDivider from './SideNavDivider';
   import BottomNavigationBar from './BottomNavigationBar';
   import { useSwipe } from '@vueuse/core';
-  import {ref,onMounted,getCurrentInstance} from 'vue'
+  import {ref,getCurrentInstance} from 'vue'
 
   // Explicit ordered list of roles for nav item sorting
   const navItemRoleOrder = [

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -267,13 +267,13 @@
   import useNav from 'kolibri/composables/useNav';
   import useUser from 'kolibri/composables/useUser';
   import useUserSyncStatus from 'kolibri/composables/useUserSyncStatus';
+  import { useSwipe } from '@vueuse/core';
+  import { ref, getCurrentInstance } from 'vue';
   import SyncStatusDisplay from '../../../SyncStatusDisplay';
   import LearnOnlyDeviceNotice from './LearnOnlyDeviceNotice';
   import TotalPoints from './TotalPoints';
   import SideNavDivider from './SideNavDivider';
   import BottomNavigationBar from './BottomNavigationBar';
-  import { useSwipe } from '@vueuse/core';
-  import {ref,getCurrentInstance} from 'vue'
 
   // Explicit ordered list of roles for nav item sorting
   const navItemRoleOrder = [
@@ -311,8 +311,7 @@
         onSwipeEnd: (e, direction) => {
           if (direction === 'left' && !isRtl) {
             emit('toggleSideNav');
-          }
-          else if (direction === 'right' && isRtl) {
+          } else if (direction === 'right' && isRtl) {
             emit('toggleSideNav');
           }
         },
@@ -349,7 +348,6 @@
         userLastSynced: lastSynced,
         navItems,
         sideNavInside,
-
       };
     },
     props: {

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -9,6 +9,7 @@
     <transition :name="showAppNavView ? 'bottom-nav' : 'side-nav'">
       <div
         v-show="navShown"
+        ref="sideNavInside"
         class="side-nav"
         :class="showAppNavView ? 'bottom-offset' : ''"
         :style="{
@@ -271,6 +272,8 @@
   import TotalPoints from './TotalPoints';
   import SideNavDivider from './SideNavDivider';
   import BottomNavigationBar from './BottomNavigationBar';
+  import { useSwipe } from '@vueuse/core';
+  import {ref,onMounted,getCurrentInstance} from 'vue'
 
   // Explicit ordered list of roles for nav item sorting
   const navItemRoleOrder = [
@@ -298,7 +301,22 @@
       BottomNavigationBar,
     },
     mixins: [commonCoreStrings],
-    setup() {
+    setup(props, { emit }) {
+      const instance = getCurrentInstance();
+      const isRtl = instance?.proxy.isRtl;
+
+      const sideNavInside = ref(null);
+      useSwipe(sideNavInside, {
+        threshold: 100,
+        onSwipeEnd: (e, direction) => {
+          if (direction === 'left' && !isRtl) {
+            emit('toggleSideNav');
+          }
+          else if (direction === 'right' && isRtl) {
+            emit('toggleSideNav');
+          }
+        },
+      });
       const { windowIsSmall, windowIsLarge } = useKResponsiveWindow();
       const {
         canManageContent,
@@ -330,6 +348,8 @@
         userSyncStatus: status,
         userLastSynced: lastSynced,
         navItems,
+        sideNavInside,
+
       };
     },
     props: {


### PR DESCRIPTION

## Summary

This PR introduces swipe gesture support for toggling the side navigation menu, enhancing the mobile user experience. The feature leverages useSwipe from @vueuse/core, ensuring seamless navigation for touch-screen devices. The implementation is non-intrusive and retains the existing navigation methods.Here is small GIF representing the change ![swip compress](https://github.com/user-attachments/assets/5e88bf4a-e82c-4ecb-b83d-8d2477362ce2)



## References
ISSUE: swipe from left to open side nav on mobile #6899

Summary of changes:
1)Added swipe-to-open functionality for the side navigation menu.
2)Integrated useSwipe from @vueuse/core to manage swipe detection.
3)Implemented swipe gestures in two key components:
Main Wrapper: Swipe right to open the side navigation.
Side Navigation: Swipe left to close the navigation.
4) Provided RTL support using isRTL.





## Reviewer guidance

Reviewers can test these changes by using kolibri app mode.

Q Is width for swipe zone fine or it needs some refinements?
