### PR TITLE
Fix infinite load more

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
+++ b/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
@@ -153,13 +153,13 @@ export default function useResourceSelection({
       topic.value = newTopic;
     }
     if (topicTree?.annotator) {
-      const annotatedResults = await topicTree.annotator(topic.value.children.results);
+      const annotatedResults = await topicTree.annotator(newTopic.children.results);
       return {
-        ...topic.value.children,
+        ...newTopic.children,
         results: annotatedResults,
       };
     }
-    return topic.value.children;
+    return newTopic.children;
   };
 
   const treeFetch = useFetch({


### PR DESCRIPTION
## Summary

* Fix infinite load more in lessons/quizzes resource selection
  * In the fetch tree resources, we were incorrectly setting the results of the last topic data if we were loading more resources from the tree fetch


https://github.com/user-attachments/assets/347f9dd2-65d1-4bab-8f87-131f74463228




## References
Closes #13173.

## Reviewer guidance
1. Go to coach > lessons > manage resources
2. Load any folder whose resource list is paginated.
3. Check that there are no regressions neither browsing the resources in the resources tree nor inside folders that appear in search results
