### PR TITLE
Fix: Show search & setting buttons at channel level in quiz resource selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -7,24 +7,32 @@
       :settings="settings"
       @searchClick="onSearchClick"
     />
+    <!-- flexDirection is set to row-reverse to align the search button to the right
+         when we have no bookmarks and thus, no selectFromBookmarks$ string -->
+    <div
+      v-if="target === SelectionTarget.LESSON"
+      class="subheader"
+      :style="{
+        flexDirection: bookmarksCount > 0 ? 'row' : 'row-reverse',
+      }"
+    >
+      <div
+        v-if="bookmarksCount > 0"
+        class="side-panel-subtitle"
+      >
+        {{ selectFromBookmarks$() }}
+      </div>
+      <KButton
+        icon="filter"
+        :text="searchLabel$()"
+        @click="onSearchClick"
+      />
+    </div>
+
     <div
       v-if="bookmarksCount > 0"
       class="mb-24"
     >
-      <div
-        v-if="target === SelectionTarget.LESSON"
-        class="subheader"
-      >
-        <div class="side-panel-subtitle">
-          {{ selectFromBookmarks$() }}
-        </div>
-        <KButton
-          icon="filter"
-          :text="searchLabel$()"
-          @click="onSearchClick"
-        />
-      </div>
-
       <div
         v-if="target === SelectionTarget.QUIZ && settings.selectPracticeQuiz"
         class="d-flex-end mb-24"

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -1,6 +1,12 @@
 <template>
 
   <div>
+    <QuizResourceSelectionHeader
+      v-if="target === SelectionTarget.QUIZ && !settings.selectPracticeQuiz"
+      class="mb-24"
+      :settings="settings"
+      @searchClick="onSearchClick"
+    />
     <div
       v-if="bookmarksCount > 0"
       class="mb-24"
@@ -19,12 +25,6 @@
         />
       </div>
 
-      <QuizResourceSelectionHeader
-        v-if="target === SelectionTarget.QUIZ && !settings.selectPracticeQuiz"
-        class="mb-24"
-        :settings="settings"
-        @searchClick="onSearchClick"
-      />
       <div
         v-if="target === SelectionTarget.QUIZ && settings.selectPracticeQuiz"
         class="d-flex-end mb-24"

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -30,20 +30,20 @@
     </div>
 
     <div
+      v-if="target === SelectionTarget.QUIZ && settings.selectPracticeQuiz"
+      class="d-flex-end mb-24"
+    >
+      <KButton
+        icon="filter"
+        :text="searchLabel$()"
+        @click="onSearchClick"
+      />
+    </div>
+
+    <div
       v-if="bookmarksCount > 0"
       class="mb-24"
     >
-      <div
-        v-if="target === SelectionTarget.QUIZ && settings.selectPracticeQuiz"
-        class="d-flex-end mb-24"
-      >
-        <KButton
-          icon="filter"
-          :text="searchLabel$()"
-          @click="onSearchClick"
-        />
-      </div>
-
       <KCardGrid
         layout="1-1-1"
         :layoutOverride="gridLayoutOverrides"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Uses `QuizResourceSelectionHeader` on the resource selection side panel's index (aka channels listing page) to display the filters & search buttons. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13144 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

You should see Settings & Search filters at the top of the page listing the channels. They should work as expected.
