### PR TITLE
Update content cache key after metadata update.

### DIFF
--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -358,3 +358,4 @@ def ordered_metadata_in_channels():
         calculate_ordered_categories(channel)
         calculate_ordered_grade_levels(channel)
         calculate_included_languages(channel)
+    ContentCacheKey.update_cache_key()


### PR DESCRIPTION
## Summary
* Need to update the content cache key after adding new annotated metadata on channels

## References
Another commit spun out from https://github.com/learningequality/kolibri/pull/12892

## Reviewer guidance
This should have no effect except to invalidate the content cache on upgrade to ensure content API requests are not cached.