### PR TITLE
Update obsolete email in the developer documentation

### DIFF
--- a/docs/contributing/ways_to_contribute.rst
+++ b/docs/contributing/ways_to_contribute.rst
@@ -12,7 +12,7 @@ Talk to us
 
 * Get product support in our `Community Forums <http://community.learningequality.org/>`__.
 * Get development contributions support in `Kolibri GitHub Discussions <https://github.com/learningequality/kolibri/discussions>`__.
-* Email us at info@learningequality.org
+* Email us at contributors@learningequality.org
 
 Translate
 ---------


### PR DESCRIPTION
## Summary

Changes info@ to contributors@ on _contributing/ways_to_contribute_.