### PR TITLE
Makes sync schedule update/edit string available

### DIFF
--- a/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule.vue
@@ -437,7 +437,12 @@
         promise
           .then(() => {
             this.goBack();
-            this.showSnackbarNotification('syncAdded');
+            if (this.currentTask) {
+              // the sync schedule has already been created and we are editing it
+              this.showSnackbarNotification('syncUpdated');
+            } else {
+              this.showSnackbarNotification('syncAdded');
+            }
           })
           .catch(() => {
             this.createTaskFailedSnackbar();

--- a/packages/kolibri/uiText/notificationStrings.js
+++ b/packages/kolibri/uiText/notificationStrings.js
@@ -131,6 +131,10 @@ export default createTranslator('NotificationStrings', {
     message: 'Sync schedule added',
     context: 'Snackbar message for adding the sync schedule',
   },
+  syncUpdated: {
+    message: 'Sync schedule updated',
+    context: 'Snackbar message for updating the sync schedule',
+  },
   deviceRemove: {
     message: 'Device removed',
     context: 'Snackbar message when a device is removed from the sync schedule',


### PR DESCRIPTION
## Summary
Add the string required for [10753](https://github.com/learningequality/kolibri/issues/10753). Will update draft PR to include snackbar after task composable fix is merged

## References
Fixes https://github.com/learningequality/kolibri/issues/10753

https://github.com/user-attachments/assets/58d2a7dd-a334-4e6b-b723-1bb2f52b95ff


## Reviewer guidance
Add, create, and delete a sync schedule. The proper snackbar should display for each.
