### PR TITLE
Skip initClassInfo request for quiz and lesson resource selection side panel subpages

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -117,6 +117,7 @@ class CoachToolsModule extends KolibriApp {
         to.name &&
         [
           PageNames.EXAMS_ROOT,
+          PageNames.EXAM_CREATION_ROOT,
           PageNames.LESSONS_ROOT,
           PageNames.LESSON_CREATION_ROOT,
           PageNames.LESSON_SUMMARY,
@@ -126,6 +127,25 @@ class CoachToolsModule extends KolibriApp {
           PageNames.GROUP_ENROLL,
           PageNames.GROUPS_ROOT,
           PageNames.HOME_PAGE,
+          PageNames.LESSON_SELECT_RESOURCES,
+          PageNames.LESSON_SELECT_RESOURCES_PREVIEW_SELECTION,
+          PageNames.LESSON_SELECT_RESOURCES_PREVIEW_RESOURCE,
+          PageNames.LESSON_SELECT_RESOURCES_INDEX,
+          PageNames.LESSON_SELECT_RESOURCES_SEARCH,
+          PageNames.LESSON_SELECT_RESOURCES_SEARCH_RESULTS,
+          PageNames.LESSON_SELECT_RESOURCES_BOOKMARKS,
+          PageNames.LESSON_SELECT_RESOURCES_TOPIC_TREE,
+          PageNames.QUIZ_SELECT_RESOURCES,
+          PageNames.QUIZ_SELECT_RESOURCES_INDEX,
+          PageNames.QUIZ_SELECT_RESOURCES_BOOKMARKS,
+          PageNames.QUIZ_SELECT_RESOURCES_TOPIC_TREE,
+          PageNames.QUIZ_PREVIEW_SELECTED_RESOURCES,
+          PageNames.QUIZ_PREVIEW_SELECTED_QUESTIONS,
+          PageNames.QUIZ_SELECT_RESOURCES_SETTINGS,
+          PageNames.QUIZ_SELECT_RESOURCES_SEARCH,
+          PageNames.QUIZ_SELECT_RESOURCES_SEARCH_RESULTS,
+          PageNames.QUIZ_PREVIEW_RESOURCE,
+          PageNames.QUIZ_SELECT_RESOURCES_LANDING_SETTINGS,
           HomeActivityPage.name,
         ].includes(to.name)
       ) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
@@ -116,7 +116,7 @@
   import get from 'lodash/get';
   import { ERROR_CONSTANTS } from 'kolibri/constants';
   import CatchErrors from 'kolibri/utils/CatchErrors';
-  import { ref } from 'vue';
+  import { ref, getCurrentInstance } from 'vue';
   import pickBy from 'lodash/pickBy';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
@@ -140,9 +140,10 @@
     },
     mixins: [commonCoreStrings],
     setup() {
+      const store = getCurrentInstance().proxy.$store;
       const closeConfirmationToRoute = ref(null);
       const { createSnackbar } = useSnackbar();
-      const { classId, groups } = useCoreCoach();
+      const { classId, initClassInfo, groups } = useCoreCoach();
       const {
         quizHasChanged,
         quiz,
@@ -154,6 +155,8 @@
       } = useQuizCreation();
       const showError = ref(false);
       const quizInitialized = ref(false);
+
+      initClassInfo().then(() => store.dispatch('notLoading'));
 
       const {
         saveAndClose$,


### PR DESCRIPTION
## Summary
* Skip initClassInfo request for quiz and lesson resource selection side panel subpages
* This will make that the navigation flow in the side panel is smoother (most noticeable when you simulate a slow network)


Before:

https://github.com/user-attachments/assets/85fe4b6f-9a43-43bf-97b8-b2ff6c9706b0

After:

https://github.com/user-attachments/assets/828edb0f-8c04-4b9c-8d82-0f701cb30ae9


## Reviewer guidance
Go through the quiz and lessons resource selection workflows, notice that the flow is smoother in slow networks, refresh the pages while on the side panel, and check that nothing breaks when you close the side panel.