### PR TITLE
Migrate core logic of deletecontent and exportcontent to a util function

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -3,93 +3,16 @@ import os
 
 from django.core.management.base import CommandError
 from django.db.models import Sum
-from le_utils.constants import content_kinds
 
 from kolibri.core.content.models import ChannelMetadata
-from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
-from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
-from kolibri.core.content.utils.annotation import reannotate_all_channels
-from kolibri.core.content.utils.annotation import set_content_invisible
-from kolibri.core.content.utils.content_request import propagate_contentnode_removal
-from kolibri.core.content.utils.importability_annotation import clear_channel_stats
+from kolibri.core.content.utils.content_delete import delete_metadata
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.lock import db_lock
 
 logger = logging.getLogger(__name__)
-
-
-def delete_metadata(
-    channel,
-    node_ids,
-    exclude_node_ids,
-    force_delete,
-    ignore_admin_flags,
-    update_content_requests,
-):
-    # Only delete all metadata if we are not doing selective deletion
-    delete_all_metadata = not (node_ids or exclude_node_ids)
-
-    resources_before = set(
-        ContentNode.objects.filter(channel_id=channel.id, available=True)
-        .exclude(kind=content_kinds.TOPIC)
-        .values_list("id", flat=True)
-    )
-
-    # If we have been passed node ids do not do a full deletion pass
-    set_content_invisible(
-        channel.id, node_ids, exclude_node_ids, not ignore_admin_flags
-    )
-    # If everything has been made invisible, delete all the metadata
-    delete_all_metadata = delete_all_metadata or not channel.root.available
-
-    resources_after = set(
-        ContentNode.objects.filter(channel_id=channel.id, available=True)
-        .exclude(kind=content_kinds.TOPIC)
-        .values_list("id", flat=True)
-    )
-
-    removed_resources = resources_before.difference(resources_after)
-
-    total_resource_number = len(removed_resources)
-
-    if force_delete:
-        # Do this before we delete all the metadata, as otherwise we lose
-        # track of which local files were associated with the channel we
-        # just deleted.
-
-        unused_files = (
-            LocalFile.objects.filter(
-                available=True,
-                files__contentnode__channel_id=channel.id,
-                files__contentnode__available=False,
-            )
-            .distinct()
-            .values("id", "file_size", "extension")
-        )
-
-        with db_lock():
-            removed_resources.update(propagate_forced_localfile_removal(unused_files))
-        # Separate these operations as running the SQLAlchemy code in the latter
-        # seems to cause the Django ORM interactions in the former to roll back
-        # Not quite sure what is causing it, but presumably due to transaction
-        # scopes.
-        reannotate_all_channels()
-
-    if delete_all_metadata:
-        logger.info("Deleting all channel metadata")
-        with db_lock():
-            channel.delete_content_tree_and_files()
-
-    if update_content_requests and removed_resources:
-        propagate_contentnode_removal(list(removed_resources))
-
-    # Clear any previously set channel availability stats for this channel
-    clear_channel_stats(channel.id)
-
-    return total_resource_number, delete_all_metadata
 
 
 class Command(AsyncCommand):

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -1,18 +1,10 @@
 import logging
-import os
 
 from django.core.management.base import CommandError
 
 from ...utils import paths
-from kolibri.core.content.errors import InvalidStorageFilenameError
-from kolibri.core.content.models import ChannelMetadata
-from kolibri.core.content.utils.content_manifest import ContentManifest
-from kolibri.core.content.utils.import_export_content import get_content_nodes_data
-from kolibri.core.content.utils.import_export_content import get_import_export_nodes
-from kolibri.core.content.utils.paths import get_content_file_name
+from kolibri.core.content.utils.content_export import export_content
 from kolibri.core.tasks.management.commands.base import AsyncCommand
-from kolibri.core.tasks.utils import get_current_job
-from kolibri.utils import file_transfer as transfer
 
 logger = logging.getLogger(__name__)
 
@@ -67,97 +59,19 @@ class Command(AsyncCommand):
             help="Generate only the manifest.json file",
         )
 
-    def update_job_metadata(self, total_bytes_to_transfer, total_resource_count):
-        job = get_current_job()
-        if job:
-            job.extra_metadata["file_size"] = total_bytes_to_transfer
-            job.extra_metadata["total_resources"] = total_resource_count
-            job.save_meta()
-
     def handle_async(self, *args, **options):
         if paths.using_remote_storage():
             raise CommandError("Cannot export files when using remote file storage")
         channel_id = options["channel_id"]
-        data_dir = os.path.realpath(options["destination"])
+        destination = options["destination"]
         node_ids = options["node_ids"]
         exclude_node_ids = options["exclude_node_ids"]
+        manifest_only = options["manifest_only"]
 
-        channel_metadata = ChannelMetadata.objects.get(id=channel_id)
-
-        nodes_queries_list = get_import_export_nodes(
-            channel_id, node_ids, exclude_node_ids, available=True
+        export_content(
+            channel_id,
+            destination,
+            manifest_only=manifest_only,
+            node_ids=node_ids,
+            exclude_node_ids=exclude_node_ids,
         )
-
-        (total_resource_count, files, total_bytes_to_transfer) = get_content_nodes_data(
-            channel_id, nodes_queries_list, available=True
-        )
-
-        self.update_job_metadata(total_bytes_to_transfer, total_resource_count)
-
-        # dont copy files if we are only exporting the manifest
-        if not options["manifest_only"]:
-            self.copy_content_files(
-                channel_id, data_dir, files, total_bytes_to_transfer
-            )
-
-        # Reraise any cancellation
-        self.check_for_cancel()
-
-        logger.info(
-            "Exporting manifest for channel id {} to {}".format(channel_id, data_dir)
-        )
-
-        manifest_path = os.path.join(data_dir, "content", "manifest.json")
-        content_manifest = ContentManifest()
-        content_manifest.read(manifest_path)
-        content_manifest.add_content_nodes(
-            channel_id, channel_metadata.version, nodes_queries_list
-        )
-        content_manifest.write(manifest_path)
-
-    def copy_content_files(self, channel_id, data_dir, files, total_bytes_to_transfer):
-        logger.info(
-            "Exporting content for channel id {} to {}".format(channel_id, data_dir)
-        )
-        with self.start_progress(
-            total=total_bytes_to_transfer
-        ) as overall_progress_update:
-            for f in files:
-                if self.is_cancelled():
-                    break
-                self.export_file(f, data_dir, overall_progress_update)
-
-    def export_file(self, f, data_dir, overall_progress_update):
-        filename = get_content_file_name(f)
-        try:
-            srcpath = paths.get_content_storage_file_path(filename)
-            dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
-        except InvalidStorageFilenameError:
-            # If any files have an invalid storage file name, don't export them.
-            overall_progress_update(f["file_size"])
-            return
-
-        # if the file already exists, add its size to our overall progress, and skip
-        if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
-            overall_progress_update(f["file_size"])
-            return
-        copy = transfer.FileCopy(srcpath, dest, cancel_check=self.is_cancelled)
-        with copy, self.start_progress(
-            total=copy.transfer_size
-        ) as file_cp_progress_update:
-
-            def progress_update(length):
-                self.exported_size = self.exported_size + length
-                overall_progress_update(length)
-                file_cp_progress_update(length)
-
-            try:
-                copy.run(progress_update=progress_update)
-            except transfer.TransferCanceled:
-                job = get_current_job()
-                if job:
-                    job.extra_metadata["file_size"] = self.exported_size
-                    job.extra_metadata["total_resources"] = 0
-                    job.save_meta()
-                return
-        return dest

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -16,6 +16,7 @@ from kolibri.core.content.utils.channel_transfer import export_channel
 from kolibri.core.content.utils.channel_transfer import transfer_channel
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.channels import read_channel_metadata_from_db_file
+from kolibri.core.content.utils.content_delete import delete_content
 from kolibri.core.content.utils.content_request import incomplete_removals_queryset
 from kolibri.core.content.utils.content_request import process_content_removal_requests
 from kolibri.core.content.utils.content_request import process_content_requests
@@ -505,13 +506,7 @@ def deletechannel(
     """
     Delete a channel and all its associated content from the server.
     """
-    call_command(
-        "deletecontent",
-        channel_id,
-        node_ids=node_ids,
-        exclude_node_ids=exclude_node_ids,
-        force_delete=force_delete,
-    )
+    delete_content(channel_id, node_ids, exclude_node_ids, force_delete)
 
 
 @register_task(

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ValidationError
-from django.core.management import call_command
 from django.db.models import Q
 from rest_framework import serializers
 
@@ -17,6 +16,7 @@ from kolibri.core.content.utils.channel_transfer import transfer_channel
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.channels import read_channel_metadata_from_db_file
 from kolibri.core.content.utils.content_delete import delete_content
+from kolibri.core.content.utils.content_export import export_content
 from kolibri.core.content.utils.content_request import incomplete_removals_queryset
 from kolibri.core.content.utils.content_request import process_content_removal_requests
 from kolibri.core.content.utils.content_request import process_content_requests
@@ -467,8 +467,7 @@ def diskexport(
 
     export_channel(channel_id, drive.datafolder)
 
-    call_command(
-        "exportcontent",
+    export_content(
         channel_id,
         drive.datafolder,
         node_ids=node_ids,

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -184,7 +184,7 @@ class DeleteContentTestCase(TransactionTestCase):
         except ContentNode.DoesNotExist:
             self.fail("Content node has been deleted")
 
-    @patch("kolibri.core.content.management.commands.deletecontent.clear_channel_stats")
+    @patch("kolibri.core.content.utils.content_delete.clear_channel_stats")
     def test_deleting_channel_clears_stats_cache(self, channel_stats_clear_mock):
         self.assertFalse(channel_stats_clear_mock.called)
         self._call_delete_command(node_ids=self._get_node_ids())

--- a/kolibri/core/content/utils/channel_transfer.py
+++ b/kolibri/core/content/utils/channel_transfer.py
@@ -23,6 +23,7 @@ class DummyJob:
         # same default values as in the Job contructor
         self.progress = 0
         self.total_progress = 0
+        self.extra_metadata = {}
 
     def is_cancelled(self):
         return False
@@ -31,6 +32,12 @@ class DummyJob:
         pass
 
     def update_progress(self, bytes_transferred, extra_data=None):
+        pass
+
+    def update_metadata(self, **kwargs):
+        pass
+
+    def save_meta(self):
         pass
 
 

--- a/kolibri/core/content/utils/content_delete.py
+++ b/kolibri/core/content/utils/content_delete.py
@@ -1,0 +1,86 @@
+import logging
+
+from le_utils.constants import content_kinds
+
+from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import LocalFile
+from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
+from kolibri.core.content.utils.annotation import reannotate_all_channels
+from kolibri.core.content.utils.annotation import set_content_invisible
+from kolibri.core.content.utils.content_request import propagate_contentnode_removal
+from kolibri.core.content.utils.importability_annotation import clear_channel_stats
+from kolibri.core.utils.lock import db_lock
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_metadata(
+    channel,
+    node_ids,
+    exclude_node_ids,
+    force_delete,
+    ignore_admin_flags,
+    update_content_requests,
+):
+    # Only delete all metadata if we are not doing selective deletion
+    delete_all_metadata = not (node_ids or exclude_node_ids)
+
+    resources_before = set(
+        ContentNode.objects.filter(channel_id=channel.id, available=True)
+        .exclude(kind=content_kinds.TOPIC)
+        .values_list("id", flat=True)
+    )
+
+    # If we have been passed node ids do not do a full deletion pass
+    set_content_invisible(
+        channel.id, node_ids, exclude_node_ids, not ignore_admin_flags
+    )
+    # If everything has been made invisible, delete all the metadata
+    delete_all_metadata = delete_all_metadata or not channel.root.available
+
+    resources_after = set(
+        ContentNode.objects.filter(channel_id=channel.id, available=True)
+        .exclude(kind=content_kinds.TOPIC)
+        .values_list("id", flat=True)
+    )
+
+    removed_resources = resources_before.difference(resources_after)
+
+    total_resource_number = len(removed_resources)
+
+    if force_delete:
+        # Do this before we delete all the metadata, as otherwise we lose
+        # track of which local files were associated with the channel we
+        # just deleted.
+
+        unused_files = (
+            LocalFile.objects.filter(
+                available=True,
+                files__contentnode__channel_id=channel.id,
+                files__contentnode__available=False,
+            )
+            .distinct()
+            .values("id", "file_size", "extension")
+        )
+
+        with db_lock():
+            removed_resources.update(propagate_forced_localfile_removal(unused_files))
+        # Separate these operations as running the SQLAlchemy code in the latter
+        # seems to cause the Django ORM interactions in the former to roll back
+        # Not quite sure what is causing it, but presumably due to transaction
+        # scopes.
+        reannotate_all_channels()
+
+    if delete_all_metadata:
+        logger.info("Deleting all channel metadata")
+        with db_lock():
+            channel.delete_content_tree_and_files()
+
+    if update_content_requests and removed_resources:
+        propagate_contentnode_removal(list(removed_resources))
+
+    # Clear any previously set channel availability stats for this channel
+    clear_channel_stats(channel.id)
+
+    return total_resource_number, delete_all_metadata

--- a/kolibri/core/content/utils/content_delete.py
+++ b/kolibri/core/content/utils/content_delete.py
@@ -10,7 +10,6 @@ from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import reannotate_all_channels
 from kolibri.core.content.utils.annotation import set_content_invisible
-from kolibri.core.content.utils.channel_transfer import DummyJob
 from kolibri.core.content.utils.channel_transfer import get_job
 from kolibri.core.content.utils.content_request import propagate_contentnode_removal
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
@@ -118,11 +117,9 @@ def delete_content(
     # Get the number of files that are being deleted
     unused_files_count = unused_files.count()
     deleted_bytes = unused_files.aggregate(size=Sum("file_size"))["size"] or 0
-    # check job is not instance of DummyJob
-    if not isinstance(job, DummyJob):
-        job.extra_metadata["file_size"] = deleted_bytes
-        job.extra_metadata["total_resources"] = total_resource_number
-        job.save_meta()
+    job.extra_metadata["file_size"] = deleted_bytes
+    job.extra_metadata["total_resources"] = total_resource_number
+    job.save_meta()
     additional_progress = sum((1, bool(delete_all_metadata)))
     target_progress = unused_files_count + additional_progress
     current_progress = 0

--- a/kolibri/core/content/utils/content_export.py
+++ b/kolibri/core/content/utils/content_export.py
@@ -1,0 +1,88 @@
+import logging
+import os
+
+from kolibri.core.content.errors import InvalidStorageFilenameError
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.utils import paths
+from kolibri.core.content.utils.channel_transfer import get_job
+from kolibri.core.content.utils.content_manifest import ContentManifest
+from kolibri.core.content.utils.import_export_content import get_content_nodes_data
+from kolibri.core.content.utils.import_export_content import get_import_export_nodes
+from kolibri.core.content.utils.paths import get_content_file_name
+from kolibri.utils import file_transfer as transfer
+
+logger = logging.getLogger(__name__)
+
+
+def export_content(
+    channel_id, destination, manifest_only=False, node_ids=None, exclude_node_ids=None
+):
+    job = get_job()
+    data_dir = os.path.realpath(destination)
+    channel_metadata = ChannelMetadata.objects.get(id=channel_id)
+
+    nodes_queries_list = get_import_export_nodes(
+        channel_id, node_ids, exclude_node_ids, available=True
+    )
+    (total_resource_count, files, total_bytes_to_transfer) = get_content_nodes_data(
+        channel_id, nodes_queries_list, available=True
+    )
+    # update job meta data
+    job.extra_metadata["file_size"] = total_bytes_to_transfer
+    job.extra_metadata["total_resources"] = total_resource_count
+    job.save_meta()
+    # dont copy files if we are only exporting the manifest
+    if not manifest_only:
+        copy_content_files(channel_id, data_dir, files, total_bytes_to_transfer)
+    # Reraise any cancellation
+    job.check_for_cancel()
+    logger.info(
+        "Exporting manifest for channel id {} to {}".format(channel_id, data_dir)
+    )
+    manifest_path = os.path.join(data_dir, "content", "manifest.json")
+    content_manifest = ContentManifest()
+    content_manifest.read(manifest_path)
+    content_manifest.add_content_nodes(
+        channel_id, channel_metadata.version, nodes_queries_list
+    )
+    content_manifest.write(manifest_path)
+
+
+def copy_content_files(channel_id, data_dir, files, total_bytes_to_transfer):
+    job = get_job()
+    logger.info(
+        "Exporting content for channel id {} to {}".format(channel_id, data_dir)
+    )
+    for f in files:
+        if job.is_cancelled():
+            break
+        export_file(f, data_dir, total_bytes_to_transfer)
+
+
+def export_file(f, data_dir, total_bytes_to_transfer):
+    job = get_job()
+    filename = get_content_file_name(f)
+    try:
+        srcpath = paths.get_content_storage_file_path(filename)
+        dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
+    except InvalidStorageFilenameError:
+        # If any files have an invalid storage file name, don't export them.
+        job.update_progress(job.progress + f["file_size"], total_bytes_to_transfer)
+        return
+    # if the file already exists, add its size to our overall progress, and skip
+    if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
+        job.update_progress(job.progress + f["file_size"], total_bytes_to_transfer)
+        return
+    with transfer.FileCopy(srcpath, dest, cancel_check=job.is_cancelled) as copy:
+
+        def progress_update(length):
+            job.update_progress(job.progress + length, total_bytes_to_transfer)
+
+        try:
+            copy.run(progress_update=progress_update)
+        except transfer.TransferCanceled:
+            job.extra_metadata["file_size"] = job.progress
+            job.extra_metadata["total_resources"] = 0
+            job.save_meta()
+            return
+        return dest


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This refactors the exportcontent and exportcontent commands and its related tasks

- Moved the exportcontent core logic to export_content util function
- Updated the diskexport task to use export_content instead of calling exportcontent command
- Moved the deletecontent core logic to delete_content util function
- Updated deletechannel task to user delete_content


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13209 
Fixes #13208 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Try soft delete and force delete a content
- Export a channel contents to a file
