### PR TITLE
SetupWizard: Fix import facility superuser password

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
@@ -10,6 +10,7 @@
     :uniqueUsernameValidator="uniqueUsernameValidator"
     :selectedUser="selectedImportedUser"
     :noBackAction="true"
+    @passwordChanged="p => (password = p)"
     @submit="handleClickNext"
   >
     <template #aboveform>

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -205,6 +205,9 @@
       },
     },
     watch: {
+      password(newPass) {
+        this.$emit('passwordChanged', newPass);
+      },
       selectedUser(user) {
         // user will be null unless an existing user is selected
         if (user) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -258,7 +258,12 @@
           this.focusOnInvalidField();
           return;
         } else {
-          this.$emit('submit');
+          const payload = {
+            password: this.password,
+            username: this.username,
+            full_name: this.fullName,
+          };
+          this.$emit('submit', payload);
 
           if (!this.doNotContinue) {
             this.wizardService.send({


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In UserCredentialsForm we were just emitting a `submit` event with no data, which I found meant that of the internals of SelectSuperAdminAccountForm were thought to be doing some things they weren't w/ the password data.

Also fixes some refs to the password textbox.

----

#### Weirdness Note

- I spent a while trying to figure out why the page refreshes when the password is invalid but couldn't work it out. I don't think this is a bug that _needs_ to be fixed here, but I can make a follow-up

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13103 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

_You must import from a device that has multiiple facilities on it. The reported bug does not replicate unless the device you import from has multiple facilities_

**1**
- Import a facility via the Full device import flow in Setup
- After import, see that when you put a password in for the admin you used to authorize the import, there are no errors and you are redirected as expect.

**2**
- Import a facility the same way again
- After import, see that you can successfully create a new superuser

**3**
- Regression test On My Own flow

