### PR TITLE
fix conditional for channels in useCoachMetatdataTags

### DIFF
--- a/packages/kolibri-common/composables/useCoachMetadataTags.js
+++ b/packages/kolibri-common/composables/useCoachMetadataTags.js
@@ -21,7 +21,7 @@ export function useCoachMetadataTags(contentNode) {
   // With no kind, we know it is a CHANNEL.
   // Channel API response is shaped a little differently than Topics and Resources
   // so we make sure we have the right shape.
-  if (!contentNode.kind) {
+  if (!contentNode.kind || contentNode.kind === ContentNodeKinds.CHANNEL) {
     contentNode.lang = { lang_name: contentNode.lang_name, id: contentNode.lang_code };
     // The grade_levels and categories fields are stored as
     // comma-separated strings in the database


### PR DESCRIPTION
## Summary
* Ensures that channels can render in quizzes as well as lessons

## References
Cherry-pick from https://github.com/learningequality/kolibri/pull/13198

## Reviewer guidance

Ensure channels show up in the Quiz resource selection side panel
![Screenshot from 2025-03-13 15-44-36](https://github.com/user-attachments/assets/1b7e7d7b-73eb-4677-a32b-339dcd1c1670)

