### PR TITLE
LessonResourceSelection: Add margin to bottom controls when isAppContext & touch device

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -54,7 +54,12 @@
       v-if="$route.name !== PageNames.LESSON_SELECT_RESOURCES_SEARCH"
       #bottomNavigation
     >
-      <div class="bottom-nav-container">
+      <div
+        class="bottom-nav-container"
+        :style="{
+          marginBottom: isAppContextAndTouchDevice ? '56px' : '0px',
+        }"
+      >
         <KButtonGroup>
           <KRouterLink
             v-if="
@@ -103,6 +108,8 @@
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import bytesForHumans from 'kolibri/uiText/bytesForHumans';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { isTouchDevice } from 'kolibri/utils/browserInfo';
+  import useUser from 'kolibri/composables/useUser';
   import { PageNames } from '../../../../../constants';
   import { coachStrings } from '../../../../common/commonCoachStrings';
   import { SelectionTarget } from '../../../../common/resourceSelection/contants';
@@ -170,8 +177,13 @@
         deselectResources($evt);
         sendPoliteMessage(numberOfSelectedResources$({ count: selectedResources?.value.length }));
       }
+      const { isAppContext } = useUser();
+      const isAppContextAndTouchDevice = computed(() => {
+        return isAppContext.value && isTouchDevice;
+      });
 
       return {
+        isAppContextAndTouchDevice,
         defaultTitle,
         subpageLoading,
         selectedResources,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Ensures Save & Finish is visible on Android by adding padding when isAppContext and isTouchDevice (aka, when the BottomNavigationBar is present).

From the commit message:

> In Quiz this is not necessary because QuizCreation is in its own immersive page when the user is selecting resources, so the BottomNavigationBar is not present. However, in Lessons, the base Lesson page is not an immersive page, so the app-mode-specific menu is still visible, causing the side panel's bottom controls to be hidden behind the menu. Rather than fiddling w/ z-indexes or trying to conditionally hide that menu, this just puts the Save & Finish button in a visible place

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13172 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

In the app context, can you see Save & Finish in lesson resource selection? Can you view all resources in the cards list during:

- Channel resource navigation
- Bookmarks
- Search results (incl View More btn)

Additionally, does it look correct in _not_ app context?
