### PR TITLE
Fix glitch in completed quiz report sections displaying incorrect values

### DIFF
--- a/packages/kolibri-common/components/quizzes/QuizReport/AttemptLogList.vue
+++ b/packages/kolibri-common/components/quizzes/QuizReport/AttemptLogList.vue
@@ -134,9 +134,9 @@
                   "
                 >
                   <AttemptLogItem
-                    v-if="attemptLogsForCurrentSection[qIndex]"
+                    v-if="attemptLogsBySection[index][qIndex]"
                     :isSurvey="isSurvey"
-                    :attemptLog="attemptLogsForCurrentSection[qIndex]"
+                    :attemptLog="attemptLogsBySection[index][qIndex]"
                     :questionNumber="qIndex + 1"
                     displayTag="p"
                   />
@@ -198,10 +198,17 @@
         return sections.value[currentSectionIndex.value];
       });
 
-      // Computed property for attempt logs of the current section
+      // Computed property for the attempt logs for each section
+      const attemptLogsBySection = computed(() => {
+        return sections.value.map(section => {
+          const start = section.startQuestionNumber;
+          return props.attemptLogs.slice(start, start + section.questions.length);
+        });
+      });
+
+      // For mobile view: returns attempt log for currently selected section
       const attemptLogsForCurrentSection = computed(() => {
-        const start = currentSection.value.startQuestionNumber;
-        return props.attemptLogs.slice(start, start + currentSection.value.questions.length);
+        return attemptLogsBySection.value[currentSectionIndex.value];
       });
 
       const questionSelectOptions = computed(() => {
@@ -257,6 +264,7 @@
         selectedQuestion,
         questionSelectOptions,
         attemptLogsForCurrentSection,
+        attemptLogsBySection,
         selectedAttemptLog,
       };
     },


### PR DESCRIPTION


<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates `AttemptLogList.vue` to display the correct attempt logs and correct/incorrect icon within each section. 

The computed property `attemptLogsBySection` has been added to generate and return the attempt logs within every section. 

The computed property `attemptLogsForCurrentSection` has been updated to use `attemptLogsBySection` to access the correct attempt log based on the selected section + question pair when in mobile view.

The attempt log object passed to `AttemptLogItem` has been updated to use `attemptLogsBySection` as well.

Before:

https://github.com/user-attachments/assets/1f049780-71d8-4175-9a60-e9c94ee2f9b7

After:

https://github.com/user-attachments/assets/b45b2ef5-104f-44df-b230-6d3a9d1b6dfe

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13101 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Assign a quiz with at least 2 sections to a learner
2. Complete the quiz by giving only correct answers in one of the sections and only incorrect answers in the other.
3. Observe the quiz report either as a learner or a coach
