### PR TITLE
ContentCardList: Fix ultrawide radio buttons

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
@@ -44,6 +44,7 @@
           />
           <KRadioButton
             v-else-if="contentHasCheckbox(content) && showRadioButtons"
+            class="radio-selector"
             :label="content.title"
             :showLabel="false"
             :currentValue="contentIsChecked(content) ? content.id : 'none'"
@@ -312,6 +313,11 @@
     display: inline-block;
     margin: 4px 8px;
     font-size: 11px;
+  }
+
+  .radio-selector {
+    /* The default width 100% doesn't work here */
+    width: auto;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The Radio buttons in ContentCardList only show when the Coach is selecting a practice quiz and the default width for it was 100%, which squished the card.

This sets `width: auto;` instead and adds a small comment about it.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13217 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to create a new quiz by selecting a practice quiz and you should see the content cards & radio buttons showing the correct sizes.
