### PR TITLE
Fix redirection issues in coach resource selection side panels

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useFetchContentNode.js
+++ b/kolibri/plugins/coach/assets/src/composables/useFetchContentNode.js
@@ -3,13 +3,16 @@ import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource
 import { exerciseToQuestionArray } from '../utils/selectQuestions';
 
 export default function useFetchContentNode(contentId) {
-  const contentNode = ref({});
+  const contentNode = ref(null);
   const ancestors = ref([]);
   const questions = ref([]);
   const loading = ref(true);
   const store = getCurrentInstance().proxy.$store;
 
   const fetchContentNode = async () => {
+    if (!contentId) {
+      return;
+    }
     ContentNodeResource.fetchModel({
       id: contentId,
       getParams: { no_available_filtering: true },

--- a/kolibri/plugins/coach/assets/src/composables/usePreviousRoute.js
+++ b/kolibri/plugins/coach/assets/src/composables/usePreviousRoute.js
@@ -59,8 +59,11 @@ export function useGoBack({ fallbackRoute, getFallbackRoute }) {
     }
 
     if (getFallbackRoute) {
-      router.push(getFallbackRoute());
+      return router.push(getFallbackRoute());
     }
+
+    // eslint-disable-next-line no-console
+    console.warn('No fallback route provided to navigate back. No action taken.');
   }
 
   return goBack;

--- a/kolibri/plugins/coach/assets/src/composables/usePreviousRoute.js
+++ b/kolibri/plugins/coach/assets/src/composables/usePreviousRoute.js
@@ -1,0 +1,67 @@
+import { ref, provide, inject } from 'vue';
+import { onBeforeRouteUpdate, useRouter } from 'vue-router/composables';
+
+/**
+ * Composable for providing a route tracking context to track the previous route. You can
+ * then inject the `previousRoute` ref in any component that is a child of the provider using the
+ * `injectPreviousRoute` function.
+ *
+ * This composable defines the `previousRoute` ref inside the `usePreviousRoute` composable function
+ * itself and not globally, with the intention that this composable is scoped to a specific
+ * component that has a router view (i.e. renders sub-routes).
+ *
+ * This is especially useful when you need to track previous routes just in the scope
+ * of a specific sub-routes context, so you wont need to check if the previous route
+ * was from a different hierarchy as it will just be null.
+ *
+ * @returns {import('vue').Ref<import('vue-router').Route>}
+ */
+export default function usePreviousRoute() {
+  const previousRoute = ref(null);
+
+  onBeforeRouteUpdate((to, from, next) => {
+    previousRoute.value = from;
+    next();
+  });
+
+  provide('previousRoute', previousRoute);
+
+  return previousRoute;
+}
+
+/**
+ * Inject the previous route ref.
+ *
+ * @returns {import('vue').Ref<import('vue-router').Route>}
+ */
+export function injectPreviousRoute() {
+  return inject('previousRoute');
+}
+
+/**
+ * Returns a function to go back to the previous route popping the history stack if the
+ * previous route belongs to the same sub-routes context. If not, it will navigate to a fallback
+ * route defined by the `fallbackRoute` prop or the `getFallbackRoute` function.
+ */
+export function useGoBack({ fallbackRoute, getFallbackRoute }) {
+  const previousRoute = injectPreviousRoute();
+  const router = useRouter();
+
+  function goBack() {
+    // Go back just if there is a previous route that belongs to the
+    // same routes context.
+    if (previousRoute.value) {
+      return router.back();
+    }
+
+    if (fallbackRoute) {
+      return router.push(fallbackRoute);
+    }
+
+    if (getFallbackRoute) {
+      router.push(getFallbackRoute());
+    }
+  }
+
+  return goBack;
+}

--- a/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
+++ b/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
@@ -111,9 +111,16 @@ export default function useResourceSelection({
     fetchMethod: fetchChannels,
   });
 
+  // We need to wait for the proper topic to load so the `topic` ref which is a
+  // dependency of the useBaseSearch composable is correctly set before searching.
   const waitForTopicLoad = () => {
-    const { searchTopicId } = route.value.query;
-    const topicToWaitFor = searchTopicId || topicId.value;
+    const { searchTopicId, searchResultTopicId } = route.value.query;
+
+    // If we are browsing a topic from the search results (searchResultTopicId is set)
+    // then the topic to wait for is `searchTopicId`. `searchTopicId` is the topic
+    // that the search results are scoped to.
+    const topicToWaitFor = searchResultTopicId ? searchTopicId : topicId.value;
+
     if (!topicToWaitFor || topicToWaitFor === topic.value?.id) {
       return Promise.resolve();
     }

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/ManageSelectedResources.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/ManageSelectedResources.vue
@@ -92,6 +92,7 @@
 
 <script>
 
+  import { watch } from 'vue';
   import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
   import DragContainer from 'kolibri-common/components/sortable/DragContainer';
   import DragHandle from 'kolibri-common/components/sortable/DragHandle';
@@ -99,10 +100,10 @@
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
   import bytesForHumans from 'kolibri/uiText/bytesForHumans';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
-  import { getCurrentInstance, ref, watch } from 'vue';
   import { coachStrings } from '../../commonCoachStrings.js';
   import { PageNames } from '../../../../constants/index.js';
   import { SelectionTarget } from '../contants.js';
+  import { useGoBack } from '../../../../composables/usePreviousRoute.js';
 
   export default {
     name: 'ManageSelectedResources',
@@ -114,8 +115,6 @@
       LearningActivityIcon,
     },
     setup(props) {
-      const prevRoute = ref(null);
-
       const {
         upLabel$,
         downLabel$,
@@ -126,22 +125,17 @@
       } = searchAndFilterStrings;
       const { lessonLabel$, sizeLabel$ } = coachStrings;
 
-      const instance = getCurrentInstance();
-      const router = instance.proxy.$router;
-
-      const redirectBack = () => {
-        if (prevRoute.value?.name) {
-          return router.push(prevRoute.value);
-        }
-        router.push({
+      const goBack = useGoBack({
+        fallbackRoute: {
           name:
             props.target === SelectionTarget.LESSON
               ? PageNames.LESSON_SELECT_RESOURCES_INDEX
               : PageNames.QUIZ_SELECT_RESOURCES_INDEX,
-        });
-      };
+        },
+      });
+
       props.setTitle(numberOfSelectedResources$({ count: props.selectedResources.length }));
-      props.setGoBack(redirectBack);
+      props.setGoBack(goBack);
 
       watch(
         () => props.selectedResources,
@@ -151,8 +145,6 @@
       );
 
       return {
-        // eslint-disable-next-line vue/no-unused-properties
-        prevRoute,
         SelectionTarget,
         upLabel$,
         downLabel$,
@@ -215,11 +207,6 @@
           width: `100%`,
         };
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      next(vm => {
-        vm.prevRoute = from;
-      });
     },
     methods: {
       bytesForHumans,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
@@ -40,6 +40,7 @@
   import UpdatedResourceSelection from '../UpdatedResourceSelection.vue';
   import { PageNames } from '../../../../constants';
   import { SelectionTarget } from '../contants';
+  import { useGoBack } from '../../../../composables/usePreviousRoute';
   import QuizResourceSelectionHeader from '../QuizResourceSelectionHeader.vue';
 
   /**
@@ -58,15 +59,16 @@
 
       props.setTitle(selectFromBookmarks$());
 
-      const redirectBack = () => {
-        instance.proxy.$router.push({
+      const goBack = useGoBack({
+        fallbackRoute: {
           name:
             props.target === SelectionTarget.LESSON
               ? PageNames.LESSON_SELECT_RESOURCES_INDEX
               : PageNames.QUIZ_SELECT_RESOURCES_INDEX,
-        });
-      };
-      props.setGoBack(redirectBack);
+        },
+      });
+
+      props.setGoBack(goBack);
 
       const channelsLink = {
         name:

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromTopicTree.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromTopicTree.vue
@@ -117,6 +117,17 @@
       const redirectBack = () => {
         const { searchTopicId } = routeQuery;
         if (!isTopicFromSearchResult.value) {
+          if (props.topic?.parent) {
+            return instance.proxy.$router.push({
+              name:
+                props.target === SelectionTarget.LESSON
+                  ? PageNames.LESSON_SELECT_RESOURCES_TOPIC_TREE
+                  : PageNames.QUIZ_SELECT_RESOURCES_TOPIC_TREE,
+              query: {
+                topicId: props.topic.parent,
+              },
+            });
+          }
           return instance.proxy.$router.push({
             name:
               props.target === SelectionTarget.LESSON

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -105,6 +105,7 @@
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { PageNames } from '../../../../../constants';
   import { coachStrings } from '../../../../common/commonCoachStrings';
+  import usePreviousRoute from '../../../../../composables/usePreviousRoute';
   import { SelectionTarget } from '../../../../common/resourceSelection/contants';
   import useResourceSelection from '../../../../../composables/useResourceSelection';
 
@@ -114,6 +115,7 @@
       SidePanelModal,
     },
     setup() {
+      usePreviousRoute();
       const instance = getCurrentInstance();
       const { sendPoliteMessage } = useKLiveRegion();
       const {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SearchFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SearchFilters.vue
@@ -15,12 +15,13 @@
 
 <script>
 
-  import { getCurrentInstance, onMounted, ref } from 'vue';
+  import { getCurrentInstance } from 'vue';
 
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import SearchFiltersPanel from 'kolibri-common/components/SearchFiltersPanel/index.vue';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../../constants';
+  import { useGoBack } from '../../../../../../composables/usePreviousRoute';
 
   /**
    * @typedef {import('../../../../../../composables/useFetch').FetchObject} FetchObject
@@ -32,24 +33,18 @@
       SearchFiltersPanel,
     },
     setup(props) {
-      const prevRoute = ref(null);
-
       const instance = getCurrentInstance();
-      const goBack = () => {
-        const backRoute = prevRoute.value?.name
-          ? prevRoute.value
-          : {
-            name: PageNames.LESSON_SELECT_RESOURCES_INDEX,
-          };
-        instance.proxy.$router.push(backRoute);
-      };
       const { searchLabel$ } = coreStrings;
       const { chooseACategory$ } = searchAndFilterStrings;
+
       const title = searchLabel$();
-      onMounted(() => {
-        props.setTitle(title);
-        props.setGoBack(goBack);
+      const goBack = useGoBack({
+        fallbackRoute: {
+          name: PageNames.LESSON_SELECT_RESOURCES_INDEX,
+        },
       });
+      props.setTitle(title);
+      props.setGoBack(goBack);
 
       function handleCategorySearchOpen(isOpen) {
         if (isOpen) {
@@ -70,8 +65,6 @@
       const { searchInFolder$ } = searchAndFilterStrings;
 
       return {
-        // eslint-disable-next-line vue/no-unused-properties
-        prevRoute,
         searchInFolder$,
         handleCategorySearchOpen,
       };
@@ -112,11 +105,6 @@
           this.$emit('update:searchTerms', value);
         },
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      next(vm => {
-        vm.prevRoute = from;
-      });
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -188,6 +188,7 @@
   import { coachStrings } from '../../../../common/commonCoachStrings';
   import { exerciseToQuestionArray } from '../../../../../utils/selectQuestions';
   import { PageNames } from '../../../../../constants/index';
+  import usePreviousRoute from '../../../../../composables/usePreviousRoute';
   import useQuizResources from '../../../../../composables/useQuizResources';
   import { injectQuizCreation } from '../../../../../composables/useQuizCreation';
   import useResourceSelection from '../../../../../composables/useResourceSelection';
@@ -200,6 +201,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
+      usePreviousRoute();
       const { $store, $router } = getCurrentInstance().proxy;
       const route = computed(() => $store.state.route);
       const {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/ManageSelectedQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/ManageSelectedQuestions.vue
@@ -42,11 +42,12 @@
 <script>
 
   import uniq from 'lodash/uniq';
-  import { getCurrentInstance, watch } from 'vue';
+  import { watch } from 'vue';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
-  import QuestionsAccordion from '../../../../../common/QuestionsAccordion.vue';
   import { PageNames } from '../../../../../../constants';
+  import { useGoBack } from '../../../../../../composables/usePreviousRoute';
+  import QuestionsAccordion from '../../../../../common/QuestionsAccordion.vue';
 
   export default {
     name: 'ManageSelectedQuestions',
@@ -55,14 +56,17 @@
     },
     mixins: [commonCoreStrings],
     setup(props) {
-      const router = getCurrentInstance().proxy.$router;
       const { openExerciseLabel$, numberOfSelectedQuestions$, emptyQuestionsList$ } =
         searchAndFilterStrings;
 
-      props.setTitle(numberOfSelectedQuestions$({ count: props.selectedQuestions.length }));
-      props.setGoBack(() => {
-        router.back();
+      const goBack = useGoBack({
+        fallbackRoute: {
+          name: PageNames.QUIZ_SELECT_RESOURCES_INDEX,
+        },
       });
+
+      props.setTitle(numberOfSelectedQuestions$({ count: props.selectedQuestions.length }));
+      props.setGoBack(goBack);
 
       watch(
         () => props.selectedQuestions,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/QuestionsSettings.vue
@@ -72,6 +72,7 @@
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { PageNames } from '../../../../../../constants';
   import { injectQuizCreation } from '../../../../../../composables/useQuizCreation';
+  import { useGoBack } from '../../../../../../composables/usePreviousRoute';
 
   /**
    * @typedef {import('../../../../../../composables/useFetch').FetchObject} FetchObject
@@ -83,7 +84,6 @@
       UiAlert,
     },
     setup(props) {
-      const prevRoute = ref(null);
       const showAlert = ref(true);
       const instance = getCurrentInstance();
       const router = instance.proxy.$router;
@@ -121,11 +121,13 @@
         });
       }
 
-      const redirectBack = props.isLanding
-        ? null
-        : () => {
-          instance.proxy.$router.go(-1);
-        };
+      const goBack = useGoBack({
+        fallbackRoute: {
+          name: PageNames.QUIZ_SELECT_RESOURCES_INDEX,
+        },
+      });
+
+      const redirectBack = props.isLanding ? null : goBack;
 
       props.setGoBack(redirectBack);
 
@@ -149,13 +151,7 @@
           isChoosingManually: workingIsChoosingManually.value,
         });
 
-        if (!props.isLanding && prevRoute.value) {
-          instance.proxy.$router.push(prevRoute.value);
-          return;
-        }
-        instance.proxy.$router.push({
-          name: PageNames.QUIZ_SELECT_RESOURCES_INDEX,
-        });
+        goBack();
       };
 
       const { continueAction$ } = coreStrings;
@@ -181,8 +177,6 @@
       const questionCountIsEditable = computed(() => !workingIsChoosingManually.value);
 
       return {
-        // eslint-disable-next-line vue/no-unused-properties
-        prevRoute,
         showAlert,
         questionCount: workingQuestionCount,
         isChoosingManually: workingIsChoosingManually,
@@ -226,11 +220,6 @@
         type: Object,
         required: true,
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      next(vm => {
-        vm.prevRoute = from;
-      });
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SearchQuizFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SearchQuizFilters.vue
@@ -15,11 +15,12 @@
 
 <script>
 
-  import { getCurrentInstance, onMounted, ref } from 'vue';
+  import { getCurrentInstance } from 'vue';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import SearchFiltersPanel from 'kolibri-common/components/SearchFiltersPanel/index.vue';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../../constants';
+  import { useGoBack } from '../../../../../../composables/usePreviousRoute';
 
   export default {
     name: 'SearchQuizFilters',
@@ -27,27 +28,21 @@
       SearchFiltersPanel,
     },
     setup(props) {
-      const prevRoute = ref(null);
-
       const instance = getCurrentInstance();
-      const goBack = () => {
-        const backRoute = prevRoute.value?.name
-          ? prevRoute.value
-          : {
-            name: PageNames.QUIZ_SELECT_RESOURCES_INDEX,
-          };
-        instance.proxy.$router.push(backRoute);
-      };
+
       const { searchLabel$ } = coreStrings;
-      const { chooseACategory$ } = searchAndFilterStrings;
       const title = searchLabel$();
-      onMounted(() => {
-        props.setTitle(title);
-        props.setGoBack(goBack);
+      const goBack = useGoBack({
+        fallbackRoute: {
+          name: PageNames.QUIZ_SELECT_RESOURCES_INDEX,
+        },
       });
+      props.setTitle(title);
+      props.setGoBack(goBack);
 
       function handleCategorySearchOpen(isOpen) {
         if (isOpen) {
+          const { chooseACategory$ } = searchAndFilterStrings;
           props.setTitle(chooseACategory$());
           props.setGoBack(() => {
             const searchFiltersPanelRef = instance.proxy.$refs.searchFiltersPanel;
@@ -65,8 +60,6 @@
       const { searchInFolder$ } = searchAndFilterStrings;
 
       return {
-        // eslint-disable-next-line vue/no-unused-properties
-        prevRoute,
         searchInFolder$,
         handleCategorySearchOpen,
       };
@@ -107,11 +100,6 @@
           this.$emit('update:searchTerms', value);
         },
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      next(vm => {
-        vm.prevRoute = from;
-      });
     },
   };
 


### PR DESCRIPTION
## Summary

The previous pattern to redirect back used to store the previous route, and when the user clicked on a back button this pushed the previous route into the history stack. Now we are leveraging this to the router.back() method that pops out the current route from the history stack to go back, but we only do this if the previous route was in the same sub-routes context, this prevents the user to exit the current sub-routes context (e.g. exit the side panel) if they were previously redirected from anywhere outside the side panel (This even prevents that if the user had an external page opened before, we dont redirect back to that external page).


https://github.com/user-attachments/assets/87acfc6a-6808-49f5-b4e9-10a4bca3203e



## References

Closes #13073

## Reviewer guidance

* Play with back buttons both in lessons and quizzes. In quizzes test also the flow to replace questions.

**Note:**
I have wear my user hat and have tried to follow what my user instict was expecting when I clicked on a goBack button, but does it makes sense? Feel free to question if a back button dont redirect you to where you were expecting.
