### PR TITLE
Disable all ungrouped learners checkbox when there are no ungrouped leaners

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -32,13 +32,14 @@
         </KCheckbox>
         <KCheckbox
           :checked="allUngroupedLearnresIsSelected"
-          :disabled="disabled"
+          :disabled="isAllUngroupedLearnersDisabled"
           @change="selectAllUngroupedLearners($event)"
         >
           <KLabeledIcon
             :label="$tr('allUngroupedLearnres')"
             icon="people"
             class="font-size-14"
+            :color="isAllUngroupedLearnersDisabled ? $themeTokens.textDisabled : null"
           />
         </KCheckbox>
       </section>
@@ -132,7 +133,13 @@
           })
           .map(learner => learner.id);
       },
+      isAllUngroupedLearnersDisabled() {
+        return this.disabled || this.ungroupedLearnersIds.length === 0;
+      },
       allUngroupedLearnresIsSelected() {
+        if (this.ungroupedLearnersIds.length === 0) {
+          return false;
+        }
         return this.ungroupedLearnersIds.every(learnerId =>
           this.workingAdHocLearners.includes(learnerId),
         );


### PR DESCRIPTION
## Summary
* Disable all ungrouped learners checkbox when there are no ungrouped leaners

![image](https://github.com/user-attachments/assets/a83cd2e9-f89a-4a89-aeb4-f79af23baf1c)


## References
Closes #13218

## Reviewer guidance
Follow instructions in #13218
