### PR TITLE
Trim section title on save

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -364,7 +364,7 @@
 
         this.updateSection({
           sectionIndex: this.activeSectionIndex,
-          section_title: this.section_title,
+          section_title: this.section_title.trim(),
           description: this.description,
           learners_see_fixed_order: this.learners_see_fixed_order,
         });


### PR DESCRIPTION
## Summary

* Trim section title on save

The error here was because we saved the section title without trimming it, and when comparing the current section title to the one persisted in the quiz to see if this has changed [here](https://github.com/AlexVelezLl/kolibri/blob/6d3d981ad41964e6b307683a300c0acc5462603c/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue#L249), it was always true because we were comparing the un-trimmed saved section title with the trimmed section_title. Which was generating an inifinite loop in the [beforeRouteLeave guard](https://github.com/AlexVelezLl/kolibri/blob/6d3d981ad41964e6b307683a300c0acc5462603c/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue#L339).

https://github.com/user-attachments/assets/8890ee29-dc10-4eda-814d-d164ca3f04b1

## References

Closes #13216

## Reviewer guidance
Follow instructions in #13216
