### PR TITLE
Add questions auto replacement feature

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -512,6 +512,7 @@ export default function useQuizCreation() {
   provide('questionItemsToReplace', questionItemsToReplace);
   provide('setQuestionItemsToReplace', setQuestionItemsToReplace);
   provide('autoReplaceQuestions', autoReplaceQuestions);
+  provide('activeExercisesUnusedQuestionsMap', activeExercisesUnusedQuestionsMap);
 
   return {
     // Methods
@@ -568,6 +569,7 @@ export function injectQuizCreation() {
   const questionItemsToReplace = inject('questionItemsToReplace');
   const setQuestionItemsToReplace = inject('setQuestionItemsToReplace');
   const autoReplaceQuestions = inject('autoReplaceQuestions');
+  const activeExercisesUnusedQuestionsMap = inject('activeExercisesUnusedQuestionsMap');
 
   return {
     // Methods
@@ -596,5 +598,6 @@ export function injectQuizCreation() {
     activeQuestions,
     selectedActiveQuestions,
     questionItemsToReplace,
+    activeExercisesUnusedQuestionsMap,
   };
 }

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -1,5 +1,6 @@
 import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
 import uniq from 'lodash/uniq';
+import shuffled from 'kolibri-common/utils/shuffled.js';
 import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
 import ExamResource from 'kolibri-common/apiResources/ExamResource';
 import { validateObject, objectWithDefaults } from 'kolibri/utils/objectSpecs';
@@ -7,7 +8,7 @@ import { get, set } from '@vueuse/core';
 import { computed, ref, provide, inject, getCurrentInstance, watch } from 'vue';
 import { fetchExamWithContent } from 'kolibri-common/quizzes/utils';
 // TODO: Probably move this to this file's local dir
-import selectQuestions from '../utils/selectQuestions.js';
+import selectQuestions, { exerciseToQuestionArray } from '../utils/selectQuestions.js';
 import { Quiz, QuizSection, QuizQuestion } from './quizCreationSpecs.js';
 
 /** Validators **/
@@ -436,6 +437,57 @@ export default function useQuizCreation() {
     }
   });
 
+  const activeExercisesUnusedQuestionsMap = computed(() => {
+    const map = {};
+    for (const exercise of Object.values(get(activeResourceMap))) {
+      const unusedQuestions = exercise.assessmentmetadata.assessment_item_ids
+        .map(aid => `${exercise.id}:${aid}`)
+        .filter(qid => !get(allQuestionsInQuiz).find(q => q.item === qid));
+      map[exercise.id] = unusedQuestions;
+    }
+    return map;
+  });
+
+  function autoReplaceQuestions(questionItems = []) {
+    if (!questionItems?.length) {
+      return;
+    }
+    const questionsToReplace = questionItems
+      .map(questionItem => get(activeQuestions).find(q => q.item === questionItem))
+      .filter(Boolean);
+    const exercises = uniq(questionsToReplace.map(q => q.exercise_id));
+
+    const shuffledExercisesUnusedQuestionsMap = {};
+    exercises.forEach(exerciseId => {
+      const unusedQuestions = get(activeExercisesUnusedQuestionsMap)[exerciseId];
+      if (!unusedQuestions?.length) {
+        throw new Error(`No unused questions found for exercise ${exerciseId}`);
+      }
+      const shuffledQuestionItems = shuffled(unusedQuestions);
+      const exerciseQuestions = exerciseToQuestionArray(_exerciseMap[exerciseId]);
+      const shuffledQuestions = shuffledQuestionItems.map(item =>
+        exerciseQuestions.find(q => q.item === item),
+      );
+      shuffledExercisesUnusedQuestionsMap[exerciseId] = shuffledQuestions;
+    });
+
+    const newQuestions = questionsToReplace.map(question => {
+      const exerciseId = question.exercise_id;
+      const unusedQuestions = shuffledExercisesUnusedQuestionsMap[exerciseId];
+      const newQuestion = unusedQuestions.pop();
+      if (!newQuestion) {
+        throw new Error(`No enough unused questions found for exercise ${exerciseId}`);
+      }
+      return newQuestion;
+    });
+
+    const questionItemsToReplace = questionsToReplace.map(q => q.item);
+    const baseQuestions = get(activeQuestions);
+
+    const questionsToAdd = _replaceQuestions(baseQuestions, questionItemsToReplace, newQuestions);
+    updateSection({ sectionIndex: get(activeSectionIndex), questions: questionsToAdd });
+  }
+
   provide('allQuestionsInQuiz', allQuestionsInQuiz);
   provide('updateSection', updateSection);
   provide('addQuestionsToSection', addQuestionsToSection);
@@ -459,6 +511,7 @@ export default function useQuizCreation() {
   provide('deleteActiveSelectedQuestions', deleteActiveSelectedQuestions);
   provide('questionItemsToReplace', questionItemsToReplace);
   provide('setQuestionItemsToReplace', setQuestionItemsToReplace);
+  provide('autoReplaceQuestions', autoReplaceQuestions);
 
   return {
     // Methods
@@ -514,6 +567,7 @@ export function injectQuizCreation() {
   const deleteActiveSelectedQuestions = inject('deleteActiveSelectedQuestions');
   const questionItemsToReplace = inject('questionItemsToReplace');
   const setQuestionItemsToReplace = inject('setQuestionItemsToReplace');
+  const autoReplaceQuestions = inject('autoReplaceQuestions');
 
   return {
     // Methods
@@ -528,6 +582,7 @@ export function injectQuizCreation() {
     addQuestionsToSelection,
     removeQuestionsFromSelection,
     setQuestionItemsToReplace,
+    autoReplaceQuestions,
 
     // Computed
     allQuestionsInQuiz,

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -437,6 +437,10 @@ export default function useQuizCreation() {
     }
   });
 
+  /**
+   * Map of exercise id to array of question items that are not used for each exercise
+   * @type {ComputedRef<Object.<string, string[]>>}
+   */
   const activeExercisesUnusedQuestionsMap = computed(() => {
     const map = {};
     for (const exercise of Object.values(get(activeResourceMap))) {
@@ -448,6 +452,12 @@ export default function useQuizCreation() {
     return map;
   });
 
+  /**
+   * Method to replace questions in `questionItems` with new questions selected from
+   * the unused questions of the exercises that each question belongs to.
+   * @param {Array<string>} questionItems
+   * @throws {Error} If there are no enough unused questions in the exercise to replace a question
+   */
   function autoReplaceQuestions(questionItems = []) {
     if (!questionItems?.length) {
       return;

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -176,11 +176,17 @@
         >
           <template #header-trailing-actions>
             <KIconButton
+              icon="autoReplace"
+              :ariaLabel="autoReplaceAction$()"
+              :tooltip="autoReplaceAction$()"
+              @click="handleBulkAutoReplaceQuestionsClick"
+            />
+            <KIconButton
               icon="refresh"
               :ariaLabel="replaceAction$()"
               :tooltip="replaceAction$()"
               :disabled="selectedActiveQuestions.length === 0"
-              @click="handleBulkReplacementQuestionsClick(question)"
+              @click="handleBulkReplacementQuestionsClick"
             />
             <KIconButton
               icon="trash"
@@ -191,6 +197,12 @@
             />
           </template>
           <template #question-trailing-actions="{ question }">
+            <KIconButton
+              icon="autoReplace"
+              :ariaLabel="autoReplaceAction$()"
+              :tooltip="autoReplaceAction$()"
+              @click="handleAutoReplaceQuestionClick(question, $event)"
+            />
             <KIconButton
               icon="refresh"
               :ariaLabel="replaceAction$()"
@@ -258,9 +270,11 @@
         editSectionLabel$,
         deleteSectionLabel$,
         replaceAction$,
+        autoReplaceAction$,
         questionsLabel$,
         sectionDeletedNotification$,
         deleteConfirmation$,
+        numberOfQuestionsReplaced$,
         questionsDeletedNotification$,
       } = enhancedQuizManagementStrings;
 
@@ -278,8 +292,10 @@
         activeSection,
         activeResourceMap,
         activeQuestions,
+        clearSelectedQuestions,
         selectedActiveQuestions,
         setQuestionItemsToReplace,
+        autoReplaceQuestions,
       } = injectQuizCreation();
 
       const { createSnackbar } = useSnackbar();
@@ -295,6 +311,8 @@
         deleteSectionLabel$,
         replaceAction$,
         questionsLabel$,
+        autoReplaceAction$,
+        numberOfQuestionsReplaced$,
         sectionDeletedNotification$,
         deleteConfirmation$,
         questionsDeletedNotification$,
@@ -306,7 +324,9 @@
         addSection,
         removeSection,
         displaySectionTitle,
+        clearSelectedQuestions,
         setQuestionItemsToReplace,
+        autoReplaceQuestions,
 
         // Computed
         allSections,
@@ -401,6 +421,18 @@
             params: { ...this.getCurrentRouteParams(), sectionIndex },
           });
         }
+      },
+      autoReplace(questions) {
+        this.autoReplaceQuestions(questions);
+        this.clearSelectedQuestions();
+        this.createSnackbar(this.numberOfQuestionsReplaced$({ count: questions.length }));
+      },
+      handleAutoReplaceQuestionClick(question, $event) {
+        this.autoReplace([question.item]);
+        $event.stopPropagation();
+      },
+      handleBulkAutoReplaceQuestionsClick() {
+        this.autoReplace(this.selectedActiveQuestions);
       },
       handleReplaceQuestionClick(question, $event) {
         $event.stopPropagation();

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -95,6 +95,9 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   expandAll: {
     message: 'Expand all',
   },
+  autoReplaceAction: {
+    message: 'Auto-replace',
+  },
   replaceAction: {
     message: 'Replace',
   },


### PR DESCRIPTION
## Summary

* Add questions auto replacement feature


https://github.com/user-attachments/assets/5d82234b-2168-41a1-ba56-363357295e66


## References
Closes #13108

## Reviewer guidance
1. Go to coach > quizzes > add new quiz
2. Select several questions
3. Try the new auto-replace buttons both in the question row and in the bulk toolbar
4. Try different scenarios with questions comming from different resources. Resources without enough availlable questions, both mixed, etc.
