### PR TITLE
Update windows installer to prevent errors from long paths

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.5
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.6
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.5
+      ref: v1.6.6
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -88,11 +88,11 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.5
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.6
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.5
+      ref: v1.6.6
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
## Summary
* Updates the windows installer to the latest version

## References
Fixing error reported here: https://github.com/learningequality/kolibri/pull/12746#issuecomment-2737294668

## Reviewer guidance
Ensure that installation with Python 3.13 on Windows 11 works.
Ensure no breakage for installation on previous Windows versions.
