### PR TITLE
Updates "Section Settings" Side panel UI 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -4,13 +4,6 @@
     v-if="activeSection"
     class="section-settings-content"
   >
-    <h1 :style="{ color: $themeTokens.text }">
-      {{ sectionSettings$() }}
-    </h1>
-    <div>
-      <MissingResourceAlert v-if="exam.missing_resource" />
-    </div>
-
     <KTextbox
       ref="sectionTitle"
       v-model="section_title"
@@ -158,7 +151,6 @@
       const examMap = computed(() => store.state.classSummary.examMap);
 
       const {
-        sectionSettings$,
         sectionTitle$,
         sectionTitleUniqueWarning$,
         optionalDescriptionLabel$,
@@ -321,7 +313,6 @@
         maxQuestionsLabel,
         // i18n
         displaySectionTitle,
-        sectionSettings$,
         sectionTitle$,
         optionalDescriptionLabel$,
         numberOfQuestionsSelected$,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -4,6 +4,13 @@
     v-if="activeSection"
     class="section-settings-content"
   >
+    <h1 :style="{ color: $themeTokens.text }">
+      {{ sectionSettings$() }}
+    </h1>
+    <div>
+      <MissingResourceAlert v-if="exam.missing_resource" />
+    </div>
+
     <KTextbox
       ref="sectionTitle"
       v-model="section_title"

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -465,7 +465,7 @@
     padding: 1em 2em;
     margin-top: 1em;
     background-color: #ffffff;
-    @extend %dropshadow-1dp;
+    @extend %dropshadow-2dp;
   }
 
   /deep/ .textbox {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -465,9 +465,7 @@
     padding: 1em 2em;
     margin-top: 1em;
     background-color: #ffffff;
-    box-shadow:
-      0 0 2px rgba(0, 0, 0, 0.9),
-      0 2px 2px rgba(0, 0, 0, 0.15);
+    @extend %dropshadow-1dp;
   }
 
   /deep/ .textbox {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -465,7 +465,6 @@
     padding: 1em;
     margin-top: 1em;
     background-color: #ffffff;
-    border-top: 1px solid black;
   }
 
   /deep/ .textbox {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -462,9 +462,12 @@
     left: 0;
     display: flex;
     justify-content: space-between;
-    padding: 1em;
+    padding: 1em 2em;
     margin-top: 1em;
     background-color: #ffffff;
+    box-shadow:
+      0 0 2px rgba(0, 0, 0, 0.9),
+      0 2px 2px rgba(0, 0, 0, 0.15);
   }
 
   /deep/ .textbox {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
@@ -4,10 +4,6 @@
     v-if="activeSection"
     class="section-settings-content"
   >
-    <h1>
-      {{ coreString('editAction') + ' - ' + sectionOrderLabel$() }}
-    </h1>
-
     <DragContainer
       v-if="sectionOrderList.length > 0"
       :items="sectionOrderList"
@@ -110,7 +106,7 @@
     },
     mixins: [commonCoreStrings],
     setup(_, context) {
-      const { applySettings$, sectionOrderLabel$, currentSection$ } = enhancedQuizManagementStrings;
+      const { applySettings$, currentSection$ } = enhancedQuizManagementStrings;
 
       const { closeConfirmationTitle$, closeConfirmationMessage$ } = coachStrings;
 
@@ -162,7 +158,6 @@
         moveUpOne,
         // i18n
         currentSection$,
-        sectionOrderLabel$,
         applySettings$,
         closeConfirmationTitle$,
         closeConfirmationMessage$,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -10,6 +10,7 @@
     @shouldFocusFirstEl="findFirstEl()"
   >
     <template #header>
+      <h1 class="sidepanel-title">{{ editSectionLabel$() }}</h1>
       <KIconButton
         v-if="canGoBack"
         icon="back"
@@ -26,6 +27,7 @@
 
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { ref, watch, computed, getCurrentInstance } from 'vue';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { PageNames } from '../../../../../constants';
 
   export default {
@@ -40,7 +42,7 @@
 
       const canGoBack = ref(false);
       const showSidePanel = computed(() => route.value?.name !== PageNames.EXAM_CREATION_ROOT);
-
+      const { editSectionLabel$ } = enhancedQuizManagementStrings;
       function handleClosePanel() {
         router.push({
           name: PageNames.EXAM_CREATION_ROOT,
@@ -71,6 +73,7 @@
         canGoBack,
         showSidePanel,
         handleClosePanel,
+        editSectionLabel$,
       };
     },
     methods: {
@@ -84,3 +87,12 @@
   };
 
 </script>
+
+
+<style scoped>
+
+  .sidepanel-title {
+    font-size: 18px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -15,7 +15,7 @@
         v-if="$route.name === PageNames.QUIZ_SECTION_ORDER"
         class="sidepanel-title"
       >
-        {{ editAction$() }}
+        {{ editAction$() }} -
         {{ sectionOrderLabel$().toLowerCase() }}
       </h1>
       <h1

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -16,7 +16,7 @@
         class="sidepanel-title"
       >
         {{ editAction$() }} -
-        {{ sectionOrderLabel$().toLowerCase() }}
+        {{ sectionOrderLabel$() }}
       </h1>
       <h1
         v-else

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -90,10 +90,15 @@
 </script>
 
 
-<style scoped>
+<style lang="scss" scoped>
 
   .sidepanel-title {
+    padding-left: 16px;
     font-size: 18px;
+  }
+
+  /deep/ .header-content {
+    padding-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -12,10 +12,10 @@
   >
     <template #header>
       <h1
-        v-if="route.name === PageNames.QUIZ_SECTION_ORDER"
+        v-if="$route.name === PageNames.QUIZ_SECTION_ORDER"
         class="sidepanel-title"
       >
-        {{ coreString('editAction') }}
+        {{ editAction$() }}
         {{ sectionOrderLabel$().toLowerCase() }}
       </h1>
       <h1
@@ -40,7 +40,7 @@
 
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { ref, watch, computed, getCurrentInstance } from 'vue';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { PageNames } from '../../../../../constants';
 
@@ -49,16 +49,16 @@
     components: {
       SidePanelModal,
     },
-    mixins: [commonCoreStrings],
     setup() {
       const store = getCurrentInstance().proxy.$store;
       const router = getCurrentInstance().proxy.$router;
       const route = computed(() => store.state.route);
-      // const sidepanelTitle = ref('section');
 
       const canGoBack = ref(false);
       const showSidePanel = computed(() => route.value?.name !== PageNames.EXAM_CREATION_ROOT);
       const { editSectionLabel$, sectionOrderLabel$ } = enhancedQuizManagementStrings;
+      const { editAction$ } = coreStrings;
+
       function handleClosePanel() {
         router.push({
           name: PageNames.EXAM_CREATION_ROOT,
@@ -86,12 +86,12 @@
       });
 
       return {
-        route,
         canGoBack,
         showSidePanel,
         handleClosePanel,
         editSectionLabel$,
         sectionOrderLabel$,
+        editAction$,
       };
     },
     data() {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -6,6 +6,7 @@
     alignment="right"
     sidePanelWidth="700px"
     closeButtonIconType="close"
+    :addBottomBorder="false"
     @closePanel="handleClosePanel"
     @shouldFocusFirstEl="findFirstEl()"
   >

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -92,10 +92,6 @@
         editSectionLabel$,
         sectionOrderLabel$,
         editAction$,
-      };
-    },
-    data() {
-      return {
         PageNames,
       };
     },

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -11,7 +11,18 @@
     @shouldFocusFirstEl="findFirstEl()"
   >
     <template #header>
-      <h1 class="sidepanel-title">{{ editSectionLabel$() }}</h1>
+      <h1
+        v-if="route.name === PageNames.QUIZ_SECTION_ORDER"
+        class="sidepanel-title"
+      >
+        {{ coreString('editAction') }} {{ sectionOrderLabel$() }}
+      </h1>
+      <h1
+        v-else
+        class="sidepanel-title"
+      >
+        {{ editSectionLabel$() }}
+      </h1>
       <KIconButton
         v-if="canGoBack"
         icon="back"
@@ -28,6 +39,7 @@
 
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { ref, watch, computed, getCurrentInstance } from 'vue';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { PageNames } from '../../../../../constants';
 
@@ -36,14 +48,16 @@
     components: {
       SidePanelModal,
     },
+    mixins: [commonCoreStrings],
     setup() {
       const store = getCurrentInstance().proxy.$store;
       const router = getCurrentInstance().proxy.$router;
       const route = computed(() => store.state.route);
+      // const sidepanelTitle = ref('section');
 
       const canGoBack = ref(false);
       const showSidePanel = computed(() => route.value?.name !== PageNames.EXAM_CREATION_ROOT);
-      const { editSectionLabel$ } = enhancedQuizManagementStrings;
+      const { editSectionLabel$, sectionOrderLabel$ } = enhancedQuizManagementStrings;
       function handleClosePanel() {
         router.push({
           name: PageNames.EXAM_CREATION_ROOT,
@@ -71,10 +85,17 @@
       });
 
       return {
+        route,
         canGoBack,
         showSidePanel,
         handleClosePanel,
         editSectionLabel$,
+        sectionOrderLabel$,
+      };
+    },
+    data() {
+      return {
+        PageNames,
       };
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -15,7 +15,8 @@
         v-if="route.name === PageNames.QUIZ_SECTION_ORDER"
         class="sidepanel-title"
       >
-        {{ coreString('editAction') }} {{ sectionOrderLabel$() }}
+        {{ coreString('editAction') }}
+        {{ sectionOrderLabel$().toLowerCase() }}
       </h1>
       <h1
         v-else

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -130,6 +130,11 @@
         required: false,
         default: false,
       },
+      addBottomBorder: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
     },
     computed: {
       isMobile() {
@@ -160,7 +165,9 @@
       headerStyles() {
         return {
           backgroundColor: this.immersive ? this.$themeTokens.appBar : this.$themeTokens.surface,
-          borderBottom: `1px solid ${this.$themePalette.grey.v_400}`,
+          borderBottom: this.addBottomBorder
+            ? `1px solid ${this.$themePalette.grey.v_400}`
+            : 'none',
         };
       },
       sidePanelStyles() {

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -34,9 +34,6 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   addMoreQuestionsLabel: {
     message: 'Add more questions',
   },
-  sectionSettings: {
-    message: 'Section settings',
-  },
   sectionTitle: {
     message: 'Section title',
   },


### PR DESCRIPTION

## Summary
This PR updates the section title in the edit section UI

Closes #13107

### After
<img width="755" alt="Screenshot 2025-03-21 at 16 46 53" src="https://github.com/user-attachments/assets/54270458-88d3-4bab-a0ee-cb0c276c0241" />




### Before
<img width="713" alt="Screenshot 2025-03-21 at 16 48 06" src="https://github.com/user-attachments/assets/71a0b22f-804b-4441-b50a-9f12cd38f280" />


## References
#13107

## Reviewer guidance
1. See https://www.figma.com/design/lVJt5ukOrxS9qay0rXy7GC/0.18-Coach-updates?node-id=107-20607&p=f&t=VBq8IMW8iRQB1p7u-0

2. Navigate to Create quiz 
3.  Click on the Options button
4. Select the edit section
