### PR TITLE
Conditionalize Save & Finish button

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -72,7 +72,7 @@
           </KRouterLink>
           <KButton
             primary
-            :disabled="isSaving"
+            :disabled="selectedResources.length < 1 || isSaving"
             :text="saveAndFinishAction$()"
             @click="save"
           />


### PR DESCRIPTION
## Summary
Adds a condition for > 1 resource selected being required for the save & finish button to be active

## References
Fixes #13171 

Before, save and finish always active, even with no selections to save:

https://github.com/user-attachments/assets/1f65b1d7-908d-438b-a0a5-0ce874cb3ce2

After:

https://github.com/user-attachments/assets/fec5a9b8-000c-4f6c-a3f9-80cbc3a8fdc3





## Reviewer guidance
 
Confirm that in manage lessons, the button is properly conditionalized. It should not be enabled when there are no selections, but should always be available once the user has made a selection (as long as they are not currently saving their work)