### PR TITLE
Resource selection preview: Include metadata for all resource kinds

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/PreviewContent.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/PreviewContent.vue
@@ -20,30 +20,6 @@
       ></p>
       <!-- eslint-enable -->
     </SlotTruncator>
-
-    <HeaderTable class="license-detail-style">
-      <HeaderTableRow :keyText="coreString('suggestedTime')">
-        <template #value>
-          {{
-            currentContentNode.duration
-              ? getTime(currentContentNode.duration)
-              : notAvailableLabel$()
-          }}
-        </template>
-      </HeaderTableRow>
-
-      <HeaderTableRow :keyText="licenseDataHeader$()">
-        <template #value>
-          {{ licenseName }}
-        </template>
-      </HeaderTableRow>
-
-      <HeaderTableRow :keyText="copyrightHolderDataHeader$()">
-        <template #value>
-          {{ currentContentNode.license_owner }}
-        </template>
-      </HeaderTableRow>
-    </HeaderTable>
   </div>
 
 </template>
@@ -52,34 +28,17 @@
 <script>
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
-  import { licenseLongName } from 'kolibri/uiText/licenses';
   import markdownIt from 'markdown-it';
   import SlotTruncator from 'kolibri-common/components/SlotTruncator';
   import ContentArea from '../../../../lessons/LessonSelectionContentPreviewPage/LessonContentPreview/ContentArea.vue';
-  import HeaderTable from '../../../HeaderTable/index.vue';
-  import HeaderTableRow from '../../../HeaderTable/HeaderTableRow.vue';
 
   export default {
     name: 'PreviewContent',
     components: {
       ContentArea,
-      HeaderTable,
-      HeaderTableRow,
       SlotTruncator,
     },
     mixins: [commonCoreStrings],
-    setup() {
-      const { copyrightHolderDataHeader$, licenseDataHeader$, notAvailableLabel$, minutes$ } =
-        searchAndFilterStrings;
-
-      return {
-        licenseDataHeader$,
-        copyrightHolderDataHeader$,
-        notAvailableLabel$,
-        minutes$,
-      };
-    },
     props: {
       currentContentNode: {
         type: Object,
@@ -107,9 +66,6 @@
         }
         return '';
       },
-      licenseName() {
-        return licenseLongName(this.currentContentNode.license_name);
-      },
       description() {
         if (this.currentContentNode && this.currentContentNode.description) {
           const md = new markdownIt('zero', { breaks: true });
@@ -127,9 +83,6 @@
         const questionNumber = questionIndex + 1;
         return this.coreString('questionNumberLabel', { questionNumber });
       },
-      getTime(seconds) {
-        return this.minutes$({ value: Math.floor(seconds / 60) });
-      },
     },
   };
 
@@ -137,10 +90,6 @@
 
 
 <style lang="scss" scoped>
-
-  .license-detail-style {
-    margin-top: 10px;
-  }
 
   /deep/ .content-renderer {
     position: relative;

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/PreviewMetadata.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/PreviewMetadata.vue
@@ -1,0 +1,94 @@
+<template>
+
+  <HeaderTable
+    v-if="content"
+    class="license-detail-style"
+  >
+    <HeaderTableRow
+      v-if="content.duration"
+      :keyText="coreString('suggestedTime')"
+    >
+      <template #value>
+        {{ content.duration ? getTime(content.duration) : notAvailableLabel$() }}
+      </template>
+    </HeaderTableRow>
+
+    <HeaderTableRow
+      v-if="licenseName"
+      :keyText="licenseDataHeader$()"
+    >
+      <template #value>
+        {{ licenseName }}
+      </template>
+    </HeaderTableRow>
+
+    <HeaderTableRow
+      v-if="content.license_owner"
+      :keyText="copyrightHolderDataHeader$()"
+    >
+      <template #value>
+        {{ content.license_owner }}
+      </template>
+    </HeaderTableRow>
+  </HeaderTable>
+
+</template>
+
+
+<script>
+
+  import { computed, toRefs } from 'vue';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { licenseLongName } from 'kolibri/uiText/licenses';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+  import HeaderTable from '../../../HeaderTable/index.vue';
+  import HeaderTableRow from '../../../HeaderTable/HeaderTableRow.vue';
+
+  export default {
+    name: 'PreviewMetadata',
+    components: {
+      HeaderTable,
+      HeaderTableRow,
+    },
+    mixins: [commonCoreStrings],
+    setup(props) {
+      const { contentNode } = toRefs(props);
+
+      const { copyrightHolderDataHeader$, licenseDataHeader$, notAvailableLabel$, minutes$ } =
+        searchAndFilterStrings;
+
+      function getTime(seconds) {
+        return minutes$({ value: Math.floor(seconds / 60) });
+      }
+
+      const licenseName = computed(() => {
+        return licenseLongName(contentNode.value.license_name);
+      });
+
+      return {
+        content: contentNode,
+        licenseName,
+        licenseDataHeader$,
+        copyrightHolderDataHeader$,
+        notAvailableLabel$,
+        getTime,
+      };
+    },
+    props: {
+      contentNode: {
+        type: Object,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .license-detail-style {
+    margin-top: 1.5em;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -95,6 +95,8 @@
         :questions="questions"
         :isExercise="false"
       />
+
+      <PreviewMetadata :contentNode="contentNode" />
     </div>
   </div>
 
@@ -103,12 +105,12 @@
 
 <script>
 
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { getCurrentInstance, onMounted, ref, computed } from 'vue';
   import { ContentNodeKinds } from 'kolibri/constants';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings.js';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings.js';
   import { SelectionTarget } from '../../contants.js';
   import { PageNames } from '../../../../../constants/index.js';
   import { useGoBack } from '../../../../../composables/usePreviousRoute.js';
@@ -117,11 +119,13 @@
   import useFetchContentNode from '../../../../../composables/useFetchContentNode';
   import QuestionsAccordion from '../../../QuestionsAccordion.vue';
   import PreviewContent from './PreviewContent';
+  import PreviewMetadata from './PreviewMetadata';
   import ResourceActionButton from './ResourceActionButton.vue';
 
   export default {
     name: 'PreviewSelectedResources',
     components: {
+      PreviewMetadata,
       PreviewContent,
       QuestionsAccordion,
       LearningActivityIcon,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--

 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When the accordion UI was used to show exercise previews, it resulted in the table of metadata information at the bottom of the previews only being shown for non-Exercises. This moves that structure to its own component and it is rendered for all resource kinds at the bottom of the preview.

**NOTE** that I also added conditionals to hide null values (ie, if there is no duration, it doesn't just show a label)

[Screencast_20250321_155121.webm](https://github.com/user-attachments/assets/00c32312-455c-4c29-bb9c-fa00eaf5b09f)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13075 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do all resource-types show the metadata correctly at the bottom?
