### PR TITLE
Clean up outdated references to NodeJS versions less than 18.20

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-ENV NODE_VERSION=18.19.0
+ENV NODE_VERSION=18.20.7
 
 # install required packages
 RUN apt-get update && \

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-ENV NODE_VERSION=18.19.0
+ENV NODE_VERSION=18.20.7
 
 # install required packages
 RUN apt-get update && \

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -173,10 +173,7 @@ The Python project-specific dependencies installed above will install ``nodeenv`
 .. code-block:: bash
 
   # node.js, npm, and yarn
-  # If you are setting up the release-v0.15.x branch or earlier:
-  nodeenv -p --node=10.17.0
-  # If you are setting up the develop branch:
-  nodeenv -p --node=18.19.0
+  nodeenv -p --node=18.20.7
   npm install -g yarn
 
   # other required project dependencies

--- a/docs/howtos/nodeenv.md
+++ b/docs/howtos/nodeenv.md
@@ -21,13 +21,13 @@ but this lists out everything. Alternatively, here's a one line bash function th
 ```bash
 $ function latest-node() { curl -s "https://nodejs.org/dist/latest-v$1.x/" | egrep -m 1 -o "$1\.[0-9]+\.[0-9]+" | head -1; }
 $ latest-node 18
-18.19.0
+18.20.7
 ```
 
 Once you've determined the version, you can install it:
 ```bash
-$ nodeenv --python-virtualenv --node 18.19.0
- * Install prebuilt node (18.19.0) ..... done.
+$ nodeenv --python-virtualenv --node 18.20.7
+ * Install prebuilt node (18.20.7) ..... done.
  * Appending data to /home/bjester/Projects/learningequality/kolibri/venv/bin/activate
  * Appending data to /home/bjester/Projects/learningequality/kolibri/venv/bin/activate.fish
 ```


### PR DESCRIPTION
## Summary
* Updates all references to NodeJS 18.19.x and replaces them with 18.20.y

## References
Fixes #13244

## Reviewer guidance
Any concerns with the updates? This is required because we upgraded a dependency that needed at least NodeJS 18.20
