### PR TITLE
Fix accesibility issues

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
+++ b/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
@@ -41,7 +41,6 @@ export default {
     // Some KDS components like KBreadcrumbs needs at least 2 ticks to be properly rendered
     await nextTick();
     await nextTick();
-    await nextTick();
     const firstFocusableElement = getFirstFocusableElement(el);
     if (firstFocusableElement) {
       firstFocusableElement.focus();

--- a/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
+++ b/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
@@ -1,0 +1,50 @@
+import { nextTick } from 'vue';
+
+/*
+ * Checks if the element is focusable.
+ * @param {HTMLElement} el - The element to check.
+ * @returns {boolean} - True if the element is focusable, false otherwise.
+ */
+function isFocusable(el) {
+  if (el.tabIndex < 0) {
+    return false;
+  }
+  if (el.offsetParent === null && window.getComputedStyle(el).position !== 'fixed') {
+    // If the element or any of its ancestors is set display none,
+    // it will have offsetParent set to null.
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+    return false;
+  }
+  switch (el.tagName) {
+    case 'A':
+      return !!el.href;
+    case 'INPUT':
+      return el.type !== 'hidden' && !el.disabled;
+    case 'SELECT':
+    case 'TEXTAREA':
+    case 'BUTTON':
+      return !el.disabled;
+    default:
+      return false;
+  }
+}
+
+function getFirstFocusableElement(el) {
+  if (!el) return null;
+
+  const focusableSelectors = ['button', 'a', 'input', 'select', 'textarea'];
+  return Array.from(el.querySelectorAll(focusableSelectors.join(','))).find(isFocusable);
+}
+
+export default {
+  async inserted(el) {
+    // Some KDS components like KBreadcrumbs needs at least 2 ticks to be properly rendered
+    await nextTick();
+    await nextTick();
+    await nextTick();
+    const firstFocusableElement = getFirstFocusableElement(el);
+    if (firstFocusableElement) {
+      firstFocusableElement.focus();
+    }
+  },
+};

--- a/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
+++ b/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
@@ -37,7 +37,10 @@ function getFirstFocusableElement(el) {
 }
 
 export default {
-  async inserted(el) {
+  async inserted(el, binding) {
+    if (binding.value === false) {
+      return;
+    }
     // Some KDS components like KBreadcrumbs needs at least 2 ticks to be properly rendered
     await nextTick();
     await nextTick();

--- a/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
+++ b/kolibri/plugins/coach/assets/src/views/common/directives/autofocusFirstEl.js
@@ -11,7 +11,8 @@ function isFocusable(el) {
   }
   if (el.offsetParent === null && window.getComputedStyle(el).position !== 'fixed') {
     // If the element or any of its ancestors is set display none,
-    // it will have offsetParent set to null.
+    // it will have offsetParent set to null. If the element is fixed, it will also
+    // have offsetParent set to null, but this doesnt means it has display none.
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
     return false;
   }

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/ManageSelectedResources.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/ManageSelectedResources.vue
@@ -8,83 +8,60 @@
       <p>{{ lessonLabel$() }}: {{ lessonTitle }}</p>
       <p>{{ sizeLabel$() }}: {{ bytesForHumans(selectedResourcesSize) }}</p>
     </div>
-    <DragContainer
-      v-if="selectedResources.length > 0"
-      :items="selectedResources"
-      @sort="$emit('setSelectedResources', $event.newArray)"
-    >
-      <transition-group
-        tag="div"
-        name="list"
+    <div v-if="selectedResources.length > 0">
+      <div
+        v-for="resource in selectedResources"
+        :key="resource.id"
       >
-        <Draggable
-          v-for="(resource, index) in selectedResources"
-          :key="resource.id"
-          :style="{
-            background: $themeTokens.surface,
-          }"
+        <div
+          class="resource-row"
+          :style="rowStyles"
         >
-          <div
-            class="resource-row"
-            :style="rowStyles"
-          >
-            <div class="row-content">
-              <DragHandle v-if="selectedResources.length > 1 && !disabled">
-                <DragSortWidget
-                  :moveUpText="upLabel$"
-                  :moveDownText="downLabel$"
-                  :noDrag="true"
-                  :isFirst="index === 0"
-                  :isLast="index === selectedResources.length - 1"
-                  @moveUp="() => {}"
-                  @moveDown="() => {}"
-                />
-              </DragHandle>
-              <LearningActivityIcon
-                :kind="resource.learning_activities[0]"
-                class="icon-style"
-              />
-              <div>
-                <span class="arrange-item-block">
-                  <span>
-                    <KRouterLink
-                      :text="resource.title"
-                      :to="getResourceLink(resource.id)"
-                      style="font-size: 14px"
-                    />
-                  </span>
-                  <p
-                    class="resource-size"
-                    :style="{
-                      color: $themeTokens.annotation,
-                    }"
-                  >
-                    {{ bytesForHumans(getResourceSize(resource)) }}
-                  </p>
+          <div class="row-content">
+            <LearningActivityIcon
+              :kind="resource.learning_activities[0]"
+              class="icon-style"
+            />
+            <div>
+              <span class="arrange-item-block">
+                <span>
+                  <KRouterLink
+                    :text="resource.title"
+                    :to="getResourceLink(resource.id)"
+                    style="font-size: 14px"
+                  />
                 </span>
-              </div>
+                <p
+                  class="resource-size"
+                  :style="{
+                    color: $themeTokens.annotation,
+                  }"
+                >
+                  {{ bytesForHumans(getResourceSize(resource)) }}
+                </p>
+              </span>
             </div>
-            <span class="row-actions">
-              <KIconButton
-                icon="emptyTopic"
-                :ariaLabel="openParentFolderLabel$()"
-                :tooltip="openParentFolderLabel$()"
-                :disabled="disabled"
-                @click="navigateToParent(resource)"
-              />
-
-              <KIconButton
-                icon="minus"
-                :ariaLabel="removeResourceLabel$()"
-                :tooltip="removeResourceLabel$()"
-                :disabled="disabled"
-                @click="removeResource(resource)"
-              />
-            </span>
           </div>
-        </Draggable>
-      </transition-group>
-    </DragContainer>
+          <span class="row-actions">
+            <KIconButton
+              icon="emptyTopic"
+              :ariaLabel="openParentFolderLabel$()"
+              :tooltip="openParentFolderLabel$()"
+              :disabled="disabled"
+              @click="navigateToParent(resource)"
+            />
+
+            <KIconButton
+              icon="minus"
+              :ariaLabel="removeResourceLabel$()"
+              :tooltip="removeResourceLabel$()"
+              :disabled="disabled"
+              @click="removeResource(resource)"
+            />
+          </span>
+        </div>
+      </div>
+    </div>
     <p v-else>
       {{ emptyResourceList$() }}
     </p>
@@ -96,10 +73,6 @@
 <script>
 
   import { watch } from 'vue';
-  import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
-  import DragContainer from 'kolibri-common/components/sortable/DragContainer';
-  import DragHandle from 'kolibri-common/components/sortable/DragHandle';
-  import Draggable from 'kolibri-common/components/sortable/Draggable';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
   import bytesForHumans from 'kolibri/uiText/bytesForHumans';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
@@ -111,16 +84,10 @@
   export default {
     name: 'ManageSelectedResources',
     components: {
-      DragSortWidget,
-      DragContainer,
-      DragHandle,
-      Draggable,
       LearningActivityIcon,
     },
     setup(props) {
       const {
-        upLabel$,
-        downLabel$,
         emptyResourceList$,
         removeResourceLabel$,
         openParentFolderLabel$,
@@ -149,8 +116,6 @@
 
       return {
         SelectionTarget,
-        upLabel$,
-        downLabel$,
         sizeLabel$,
         lessonLabel$,
         emptyResourceList$,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -2,7 +2,10 @@
 
   <div>
     <KCircularLoader v-if="loading && !contentNode" />
-    <div v-else>
+    <div
+      v-else
+      v-autofocus-first-el
+    >
       <div
         v-if="target === SelectionTarget.LESSON"
         class="channel-header"
@@ -118,6 +121,7 @@
   import ResourceSelectionBreadcrumbs from '../../ResourceSelectionBreadcrumbs.vue';
   import useFetchContentNode from '../../../../../composables/useFetchContentNode';
   import QuestionsAccordion from '../../../QuestionsAccordion.vue';
+  import autofocusFirstEl from '../../../../common/directives/autofocusFirstEl.js';
   import PreviewContent from './PreviewContent';
   import PreviewMetadata from './PreviewMetadata';
   import ResourceActionButton from './ResourceActionButton.vue';
@@ -132,6 +136,9 @@
       ResourceActionButton,
       QuizResourceSelectionHeader,
       ResourceSelectionBreadcrumbs,
+    },
+    directives: {
+      autofocusFirstEl,
     },
     setup(props) {
       const instance = getCurrentInstance();

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -45,8 +45,8 @@
       :selectedResourcesSize="selectedResourcesSize"
       :displayingSearchResults="displayingSearchResults"
       @clearSearch="clearSearch"
-      @selectResources="handleSelectResources"
-      @deselectResources="handleDeselectResources"
+      @selectResources="selectResources"
+      @deselectResources="deselectResources"
       @setSelectedResources="setSelectedResources"
       @removeSearchFilterTag="removeSearchFilterTag"
     />
@@ -64,7 +64,7 @@
         <KButtonGroup>
           <KRouterLink
             v-if="
-              selectedResources.length > 0 &&
+              selectedResourcesMessage &&
                 $route.name !== PageNames.LESSON_SELECT_RESOURCES_PREVIEW_SELECTION
             "
             :to="{ name: PageNames.LESSON_SELECT_RESOURCES_PREVIEW_SELECTION }"
@@ -101,11 +101,10 @@
 
   import uniqBy from 'lodash/uniqBy';
   import { mapState, mapActions, mapMutations } from 'vuex';
-  import { computed, getCurrentInstance } from 'vue';
+  import { computed, getCurrentInstance, watch } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import notificationStrings from 'kolibri/uiText/notificationStrings';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import bytesForHumans from 'kolibri/uiText/bytesForHumans';
   import useSnackbar from 'kolibri/composables/useSnackbar';
@@ -176,19 +175,37 @@
       });
 
       const defaultTitle = manageLessonResourcesTitle$();
-      // Ensure we send polite aria message when the user selects/deselects resources
-      const { numberOfSelectedResources$ } = searchAndFilterStrings;
-      function handleSelectResources($evt) {
-        selectResources($evt);
-        sendPoliteMessage(numberOfSelectedResources$({ count: selectedResources?.value.length }));
-      }
-      function handleDeselectResources($evt) {
-        deselectResources($evt);
-        sendPoliteMessage(numberOfSelectedResources$({ count: selectedResources?.value.length }));
-      }
       const { isAppContext } = useUser();
       const isAppContextAndTouchDevice = computed(() => {
         return isAppContext.value && isTouchDevice;
+      });
+
+      const selectedResourcesSize = computed(() => {
+        let size = 0;
+        selectedResources.value.forEach(resource => {
+          const { files = [] } = resource;
+          files.forEach(file => {
+            size += file.file_size || 0;
+          });
+        });
+        return size;
+      });
+
+      const { someResourcesSelected$ } = coachStrings;
+      const selectedResourcesMessage = computed(() => {
+        if (!selectedResources.value.length) {
+          return '';
+        }
+        return someResourcesSelected$({
+          count: selectedResources.value.length,
+          bytesText: bytesForHumans(selectedResourcesSize.value),
+        });
+      });
+
+      watch(selectedResourcesMessage, () => {
+        if (selectedResourcesMessage.value) {
+          sendPoliteMessage(selectedResourcesMessage.value);
+        }
       });
 
       return {
@@ -205,10 +222,12 @@
         isLandingRoute,
         selectionRules,
         SelectionTarget,
+        selectedResourcesSize,
         displayingSearchResults,
+        selectedResourcesMessage,
         clearSearch,
-        handleSelectResources,
-        handleDeselectResources,
+        selectResources,
+        deselectResources,
         setSelectedResources,
         notifyResourcesAdded,
         notifySaveLessonError,
@@ -232,23 +251,6 @@
     },
     computed: {
       ...mapState('lessonSummary', ['currentLesson', 'workingResources']),
-      selectedResourcesSize() {
-        let size = 0;
-        this.selectedResources.forEach(resource => {
-          const { files = [] } = resource;
-          files.forEach(file => {
-            size += file.file_size || 0;
-          });
-        });
-        return size;
-      },
-      selectedResourcesMessage() {
-        const { someResourcesSelected$ } = coachStrings;
-        return someResourcesSelected$({
-          count: this.selectedResources.length,
-          bytesText: bytesForHumans(this.selectedResourcesSize),
-        });
-      },
       unselectableResourceIds() {
         return this.workingResources.map(resource => resource.contentnode_id);
       },

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -13,8 +13,8 @@
         <KIconButton
           v-if="goBack"
           icon="back"
-          :tooltip="backAction$()"
-          :ariaLabel="backAction$()"
+          :tooltip="goBackAction$()"
+          :ariaLabel="goBackAction$()"
           @click="goBack()"
         />
         <h1 class="side-panel-title">{{ title }}</h1>
@@ -25,6 +25,7 @@
     </div>
     <router-view
       v-else
+      v-autofocus-first-el
       :setTitle="setTitle"
       :setGoBack="setGoBack"
       :defaultTitle="defaultTitle"
@@ -115,11 +116,15 @@
   import usePreviousRoute from '../../../../../composables/usePreviousRoute';
   import { SelectionTarget } from '../../../../common/resourceSelection/contants';
   import useResourceSelection from '../../../../../composables/useResourceSelection';
+  import autofocusFirstEl from '../../../../common/directives/autofocusFirstEl';
 
   export default {
     name: 'LessonResourceSelection',
     components: {
       SidePanelModal,
+    },
+    directives: {
+      autofocusFirstEl,
     },
     setup() {
       usePreviousRoute();
@@ -161,7 +166,7 @@
         createSnackbar(saveLessonError$());
       }
 
-      const { saveAndFinishAction$, continueAction$, cancelAction$, backAction$ } = coreStrings;
+      const { saveAndFinishAction$, continueAction$, cancelAction$, goBackAction$ } = coreStrings;
 
       const subpageLoading = computed(() => {
         const skipLoading = PageNames.LESSON_SELECT_RESOURCES_SEARCH;
@@ -205,7 +210,7 @@
         notifyResourcesAdded,
         notifySaveLessonError,
         removeSearchFilterTag,
-        backAction$,
+        goBackAction$,
         cancelAction$,
         continueAction$,
         saveAndFinishAction$,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -25,7 +25,7 @@
     </div>
     <router-view
       v-else
-      v-autofocus-first-el
+      v-autofocus-first-el="!isLandingRoute"
       :setTitle="setTitle"
       :setGoBack="setGoBack"
       :defaultTitle="defaultTitle"
@@ -127,7 +127,9 @@
       autofocusFirstEl,
     },
     setup() {
-      usePreviousRoute();
+      const previousRoute = usePreviousRoute();
+      const isLandingRoute = computed(() => previousRoute.value === null);
+
       const instance = getCurrentInstance();
       const { sendPoliteMessage } = useKLiveRegion();
       const {
@@ -200,6 +202,7 @@
         channelsFetch,
         bookmarksFetch,
         searchTerms,
+        isLandingRoute,
         selectionRules,
         SelectionTarget,
         displayingSearchResults,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -69,7 +69,7 @@
       </div>
       <router-view
         v-else
-        v-autofocus-first-el
+        v-autofocus-first-el="!isLandingRoute"
         :setTitle="value => (title = value)"
         :setGoBack="value => (goBack = value)"
         :setContinueAction="value => (continueAction = value)"
@@ -193,7 +193,9 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      usePreviousRoute();
+      const previousRoute = usePreviousRoute();
+      const isLandingRoute = computed(() => previousRoute.value === null);
+
       const { $store, $router } = getCurrentInstance().proxy;
       const route = computed(() => $store.state.route);
       const {
@@ -642,6 +644,7 @@
         unusedQuestionsCount,
         activeSectionIndex,
         addSection,
+        isLandingRoute,
         workingPoolHasChanged,
         tooManyQuestions,
         notifyChanges,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -134,27 +134,11 @@
             </span>
             <KRouterLink
               v-else-if="
-                !settings.isChoosingManually &&
-                  workingResourcePool.length > 0 &&
-                  $route.name !== PageNames.QUIZ_PREVIEW_SELECTED_RESOURCES
+                numberOfSelectedElementsLabel && $route.name !== previewSelectedElementsPage
               "
-              :to="{ name: PageNames.QUIZ_PREVIEW_SELECTED_RESOURCES }"
+              :to="{ name: previewSelectedElementsPage }"
             >
-              {{
-                numberOfSelectedResources$({
-                  count: workingResourcePool.length,
-                })
-              }}
-            </KRouterLink>
-            <KRouterLink
-              v-else-if="
-                settings.isChoosingManually &&
-                  workingQuestions.length > 0 &&
-                  $route.name !== PageNames.QUIZ_PREVIEW_SELECTED_QUESTIONS
-              "
-              :to="{ name: PageNames.QUIZ_PREVIEW_SELECTED_QUESTIONS }"
-            >
-              {{ numberOfSelectedQuestionsLabel }}
+              {{ numberOfSelectedElementsLabel }}
             </KRouterLink>
           </div>
           <div class="save-button-wrapper">
@@ -183,6 +167,7 @@
     displaySectionTitle,
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { computed, ref, getCurrentInstance, watch } from 'vue';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
@@ -572,7 +557,19 @@
         NOutOfMSelectedQuestions$,
       } = searchAndFilterStrings;
 
+      const numberOfSelectedResourcesLabel = computed(() => {
+        if (!workingResourcePool.value.length) {
+          return '';
+        }
+        return numberOfSelectedResources$({
+          count: workingResourcePool.value.length,
+        });
+      });
+
       const numberOfSelectedQuestionsLabel = computed(() => {
+        if (!workingQuestions.value.length) {
+          return '';
+        }
         if (settings.value.isInReplaceMode) {
           return NOutOfMSelectedQuestions$({
             count: workingQuestions.value.length,
@@ -582,6 +579,27 @@
         return numberOfSelectedQuestions$({
           count: workingQuestions.value.length,
         });
+      });
+
+      const numberOfSelectedElementsLabel = computed(() => {
+        if (settings.value.isChoosingManually) {
+          return numberOfSelectedQuestionsLabel.value;
+        }
+        return numberOfSelectedResourcesLabel.value;
+      });
+
+      const { sendPoliteMessage } = useKLiveRegion();
+      watch(numberOfSelectedElementsLabel, () => {
+        if (numberOfSelectedElementsLabel.value) {
+          sendPoliteMessage(numberOfSelectedElementsLabel.value);
+        }
+      });
+
+      const previewSelectedElementsPage = computed(() => {
+        if (settings.value.isChoosingManually) {
+          return PageNames.QUIZ_PREVIEW_SELECTED_QUESTIONS;
+        }
+        return PageNames.QUIZ_PREVIEW_SELECTED_RESOURCES;
       });
 
       const getDefaultTitle = () => {
@@ -655,7 +673,8 @@
         settings,
         disableSave,
         saveButtonLabel,
-        numberOfSelectedQuestionsLabel,
+        previewSelectedElementsPage,
+        numberOfSelectedElementsLabel,
         closeConfirmationMessage$,
         closeConfirmationTitle$,
         tooManyQuestions$,
@@ -669,7 +688,6 @@
         dismissAction$,
         manualSelectionOnNotice$,
         manualSelectionOffNotice$,
-        numberOfSelectedResources$,
       };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -13,6 +13,8 @@
         <KIconButton
           v-if="goBack"
           icon="back"
+          :tooltip="goBackAction$()"
+          :ariaLabel="goBackAction$()"
           @click="goBack()"
         />
         <h1 class="side-panel-title">{{ title }}</h1>
@@ -67,6 +69,7 @@
       </div>
       <router-view
         v-else
+        v-autofocus-first-el
         :setTitle="value => (title = value)"
         :setGoBack="value => (goBack = value)"
         :setContinueAction="value => (continueAction = value)"
@@ -182,7 +185,7 @@
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { computed, ref, getCurrentInstance, watch } from 'vue';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { ContentNodeKinds, MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { coachStrings } from '../../../../common/commonCoachStrings';
@@ -193,11 +196,15 @@
   import { injectQuizCreation } from '../../../../../composables/useQuizCreation';
   import useResourceSelection from '../../../../../composables/useResourceSelection';
   import { SelectionTarget } from '../../../../common/resourceSelection/contants';
+  import autofocusFirstEl from '../../../../common/directives/autofocusFirstEl';
 
   export default {
     name: 'QuizResourceSelection',
     components: {
       SidePanelModal,
+    },
+    directives: {
+      autofocusFirstEl,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -604,6 +611,8 @@
         );
       }
 
+      const { goBackAction$ } = coreStrings;
+
       return {
         title,
         goBack,
@@ -633,6 +642,8 @@
         unselectableQuestionItems,
         maximumContentSelectedWarning,
         showManualSelectionNotice,
+        subpageLoading,
+        displayingSearchResults,
         addToWorkingResourcePool,
         removeFromWorkingResourcePool,
         addToWorkingQuestions,
@@ -654,12 +665,11 @@
         addQuestionsToSectionFromResources,
         workingResourcePool,
         workingQuestions,
+        goBackAction$,
         dismissAction$,
         manualSelectionOnNotice$,
         manualSelectionOffNotice$,
         numberOfSelectedResources$,
-        displayingSearchResults,
-        subpageLoading,
       };
     },
     computed: {


### PR DESCRIPTION
## Summary
* Focus first focusable element on subpages navigation on Lesson and quiz resources selection
* Add `go back` aria label to back buttons
* Add quiz selection change anouncement through aria-live=polite
* Remove d&d widgets in the PreviewSelectedResources page.

## References
Closes #13145

## Reviewer guidance
Check that all points in #13145 have been resolved (but the ones that have other follow-up issues)

For code review:
* I have added an `autofocusFirstEl` directive, based on the [logic we have in KTable to find focusable elements](https://github.com/learningequality/kolibri-design-system/blob/406705c3b4bc3bf9463d369f046c4bcc7cf551cc/lib/KTable/index.vue#L539) to focus the first focusable element in the page when the given node is inserted. This could have also been done with a composable instead of a directive, but I have chosen directives because with this I just needed to define it in the parent component and set the v-autofocus-first-el to the `router-view`, with composables I needed to call the composable in every subpage. How does it look? Is there any argument to implement this in a composable or in any other way?