### PR TITLE
Update le-utils to 0.2.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-mptt==0.14.0
 requests==2.27.1
 cheroot==10.0.1
 magicbus==4.1.2
-le-utils==0.2.8
+le-utils==0.2.9
 jsonfield==3.1.0
 morango==0.8.3
 tzlocal==4.2


### PR DESCRIPTION
## Summary
* Attempt to fix issue with installing le-utils on Python 3.12
