### PR TITLE
Conditionalize empty message string in lesson and quiz tables

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonsRootPage.vue
@@ -43,7 +43,7 @@
 
         <CoreTable
           :dataLoading="lessonsAreLoading"
-          :emptyMessage="$tr('noLessons')"
+          :emptyMessage="lessons.length > 0 ? coreString('noResultsLabel') : $tr('noLessons')"
         >
           <template #headers>
             <th>{{ coachString('titleLabel') }}</th>
@@ -116,10 +116,6 @@
           </template>
         </CoreTable>
 
-        <p v-if="showNoResultsLabel">
-          {{ coreString('noResultsLabel') }}
-        </p>
-
         <KModal
           v-if="showLessonIsVisibleModal && !userHasDismissedModal"
           :title="coachString('makeLessonVisibleTitle')"
@@ -187,7 +183,6 @@
   import Vue, { set } from 'vue';
   import { mapState, mapActions } from 'vuex';
   import LessonResource from 'kolibri-common/apiResources/LessonResource';
-  import countBy from 'lodash/countBy';
   import { LESSON_VISIBILITY_MODAL_DISMISSED, ERROR_CONSTANTS } from 'kolibri/constants';
   import Lockr from 'lockr';
   import CoreTable from 'kolibri/components/CoreTable';
@@ -261,28 +256,8 @@
           value: filter,
         }));
       },
-      activeLessonCounts() {
-        return countBy(this.lessons, 'active');
-      },
       newLessonRoute() {
         return { name: PageNames.LESSON_CREATION_ROOT };
-      },
-      hasVisibleLessons() {
-        return this.activeLessonCounts.true;
-      },
-      hasNonVisibleLessons() {
-        return this.activeLessonCounts.false;
-      },
-      showNoResultsLabel() {
-        if (!this.lessons.length) {
-          return false;
-        } else if (this.filterSelection.value === 'filterLessonVisible') {
-          return !this.hasVisibleLessons;
-        } else if (this.filterSelection.value === 'filterLessonNotVisible') {
-          return !this.hasNonVisibleLessons;
-        } else {
-          return false;
-        }
       },
       calcTotalSizeOfVisibleLessons() {
         if (this.lessons && this.lessons.length) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -76,7 +76,9 @@
             :inline="true"
           />
         </ReportsControls>
-        <CoreTable>
+        <CoreTable
+          :emptyMessage="quizzes.length > 0 ? coreString('noResultsLabel') : $tr('noExams')"
+        >
           <template #headers>
             <th>{{ titleLabel$() }}</th>
             <th style="position: relative">
@@ -156,19 +158,6 @@
             </transition-group>
           </template>
         </CoreTable>
-
-        <p v-if="!quizzes.length">
-          {{ $tr('noExams') }}
-        </p>
-        <p v-else-if="statusSelected.value === filterQuizStarted$() && !startedExams.length">
-          {{ coreString('noResultsLabel') }}
-        </p>
-        <p v-else-if="statusSelected.value === filterQuizNotStarted$() && !notStartedExams.length">
-          {{ coreString('noResultsLabel') }}
-        </p>
-        <p v-else-if="statusSelected.value === filterQuizEnded$() && !endedExams.length">
-          {{ coreString('noResultsLabel') }}
-        </p>
 
         <!-- Modals for Close & Open of quiz from right-most column -->
         <KModal


### PR DESCRIPTION
## Summary

This PR tweaks and simplifies some of the logic for displaying empty strings in lessons and quizzes. It makes use of the `CoreTable` prop `emptyMessage` to properly render the text. 

## References

Fixes: [#13079](https://github.com/learningequality/kolibri/issues/13079)

|   | None exist  |  No results match current filters |
|---|---|---|
| Lessons  | <img width="1435" alt="Screenshot 2025-03-26 at 1 31 06 PM" src="https://github.com/user-attachments/assets/f591ac9e-63d8-4f26-9e90-491f75ddc3bb" /> | <img width="1434" alt="Screenshot 2025-03-26 at 1 31 23 PM" src="https://github.com/user-attachments/assets/73fa0741-e31f-480b-9694-0f00e487282b" /> |
| Quizzes  | <img width="1430" alt="Screenshot 2025-03-26 at 1 30 50 PM" src="https://github.com/user-attachments/assets/e8d4a812-8533-44bc-9de1-025eb7584b3c" /> | <img width="1437" alt="Screenshot 2025-03-26 at 1 31 32 PM" src="https://github.com/user-attachments/assets/f4d56712-7f04-45d5-ac6e-67bd9575dd93" /> |


## Reviewer guidance

Does a correct message for the empty table, in each of these cases display properly? 

1. No lessons exist in this class 
2. The user has applied filters that result in no matches (i.e. no lessons assigned to an existing group)
3. No quizzes exist in this class 
4. The user has applied filters that result in no matches (i.e. no quizzes assigned to an existing group)
