### PR TITLE
Updates to quiz/lesson resource selection metadata display

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -311,6 +311,10 @@ class ChannelThumbnailView(View):
         return HttpResponse(thumbnail, content_type=mimetype)
 
 
+def _split_text_field(text):
+    return text.split(",") if text else []
+
+
 class BaseChannelMetadataMixin(object):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = ChannelMetadataFilter
@@ -341,6 +345,10 @@ class BaseChannelMetadataMixin(object):
         "available": "root__available",
         "lang_code": "root__lang__lang_code",
         "lang_name": "root__lang__lang_name",
+        "included_categories": lambda x: _split_text_field(x["included_categories"]),
+        "included_grade_levels": lambda x: _split_text_field(
+            x["included_grade_levels"]
+        ),
     }
 
     def get_queryset(self):
@@ -611,10 +619,6 @@ def map_file(file):
         }
     )
     return file
-
-
-def _split_text_field(text):
-    return text.split(",") if text else []
 
 
 class BaseContentNodeMixin(object):

--- a/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
+++ b/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
@@ -80,6 +80,7 @@ export default function useResourceSelection({
       return {
         ...response,
         results: annotatedResults,
+        count: annotatedResults.length,
       };
     }
     return response;

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
@@ -25,12 +25,12 @@
         @toggleBookmark="toggleBookmark"
       >
         <template #belowTitle>
-          <div
+          <KTextTruncator
             v-if="contentCardMessage(content)"
-            style="margin: 0 0 0.5rem"
-          >
-            {{ contentCardMessage(content) }}
-          </div>
+            :text="contentCardMessage(content)"
+            :maxLines="1"
+            style="margin-bottom: 8px"
+          />
         </template>
         <template #select>
           <KCheckbox

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
@@ -21,7 +21,7 @@
       :selectAllRules="selectAllRules"
       :getResourceLink="getResourceLink"
       :selectedResources="selectedResources"
-      :contentCardMessage="contentCardMessage"
+      :contentCardMessage="wrappedContentCardMessage"
       :unselectableResourceIds="unselectableResourceIds"
       @selectResources="$emit('selectResources', $event)"
       @deselectResources="$emit('deselectResources', $event)"
@@ -79,7 +79,11 @@
 
       const { data, hasMore, fetchMore, loadingMore } = props.bookmarksFetch;
 
-      const contentCardMessage = content => {
+      const wrappedContentCardMessage = content => {
+        const propsMessage = props.contentCardMessage(content);
+        if (propsMessage) {
+          return propsMessage;
+        }
         if (!content.bookmark?.created) {
           return null;
         }
@@ -104,7 +108,7 @@
         fetchMore,
         loadingMore,
         isSelectable,
-        contentCardMessage,
+        wrappedContentCardMessage,
         SelectionTarget,
       };
     },
@@ -163,6 +167,15 @@
         type: Object,
         required: false,
         default: null,
+      },
+      /**
+       * Function that returns a message to be displayed based in the content
+       * passed as argument.
+       */
+      contentCardMessage: {
+        type: Function,
+        required: false,
+        default: () => {},
       },
       /**
        * Function that receives a resourceId and returns a link to the resource.

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -70,7 +70,7 @@
           </template>
           <template #belowTitle>
             <span>
-              {{ numberOfBookmarks$({ count: bookmarksCount }) }}
+              {{ wrappedBookmarksCardMessage }}
             </span>
           </template>
         </KCard>
@@ -117,6 +117,7 @@
 
 <script>
 
+  import { computed } from 'vue';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import AccessibleChannelCard from 'kolibri-common/components/Cards/AccessibleChannelCard.vue';
   import { PageNames } from '../../../../constants';
@@ -135,7 +136,7 @@
     },
     setup(props) {
       const { bookmarksFetch, channelsFetch } = props;
-      const { count: bookmarksCount } = bookmarksFetch;
+      const { count: bookmarksCount, data: bookmarksData } = bookmarksFetch;
 
       const { data: channels } = channelsFetch;
 
@@ -148,6 +149,14 @@
         searchLabel$,
       } = coreStrings;
 
+      const wrappedBookmarksCardMessage = computed(() => {
+        const propsMessage = props.bookmarksCardMessage(bookmarksData.value);
+        if (propsMessage) {
+          return propsMessage;
+        }
+        return numberOfBookmarks$({ count: bookmarksCount.value });
+      });
+
       props.setTitle(props.defaultTitle);
       props.setGoBack(null);
 
@@ -157,7 +166,7 @@
         SelectionTarget,
         selectFromChannels$,
         noAvailableResources$,
-        numberOfBookmarks$,
+        wrappedBookmarksCardMessage,
         bookmarksLabel$,
         selectFromBookmarks$,
         searchLabel$,
@@ -191,6 +200,13 @@
       bookmarksFetch: {
         type: Object,
         required: true,
+      },
+      /**
+       * A function that takes an array of bookmarks and returns a string to describe them.
+       */
+      bookmarksCardMessage: {
+        type: Function,
+        default: () => {},
       },
       /**
        * The target entity for the selection.

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -98,7 +98,16 @@
           :contentNode="channel"
           :to="selectFromChannelsLink(channel)"
           :headingLevel="3"
-        />
+        >
+          <template #belowTitle>
+            <div
+              v-if="contentCardMessage(channel)"
+              style="margin: 0 0 0.5rem"
+            >
+              {{ contentCardMessage(channel) }}
+            </div>
+          </template>
+        </AccessibleChannelCard>
       </KCardGrid>
     </div>
   </div>
@@ -198,6 +207,15 @@
         type: Object,
         required: false,
         default: null,
+      },
+      /**
+       * Function that returns a message to be displayed based in the content
+       * passed as argument.
+       */
+      contentCardMessage: {
+        type: Function,
+        required: false,
+        default: () => '',
       },
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -69,9 +69,11 @@
             />
           </template>
           <template #belowTitle>
-            <span>
-              {{ wrappedBookmarksCardMessage }}
-            </span>
+            <KTextTruncator
+              v-if="wrappedBookmarksCardMessage"
+              :text="wrappedBookmarksCardMessage"
+              :maxLines="1"
+            />
           </template>
         </KCard>
       </KCardGrid>
@@ -100,12 +102,12 @@
           :headingLevel="3"
         >
           <template #belowTitle>
-            <div
+            <KTextTruncator
               v-if="contentCardMessage(channel)"
-              style="margin: 0 0 0.5rem"
-            >
-              {{ contentCardMessage(channel) }}
-            </div>
+              :text="contentCardMessage(channel)"
+              :maxLines="1"
+              style="margin-bottom: 8px"
+            />
           </template>
         </AccessibleChannelCard>
       </KCardGrid>

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -44,6 +44,7 @@
       :unselectableResourceIds="unselectableResourceIds"
       :selectedResourcesSize="selectedResourcesSize"
       :displayingSearchResults="displayingSearchResults"
+      :contentCardMessage="contentCardMessage"
       @clearSearch="clearSearch"
       @selectResources="selectResources"
       @deselectResources="deselectResources"
@@ -104,6 +105,7 @@
   import { computed, getCurrentInstance, watch } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+  import { ContentNodeKinds } from 'kolibri/constants';
   import notificationStrings from 'kolibri/uiText/notificationStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import bytesForHumans from 'kolibri/uiText/bytesForHumans';
@@ -191,7 +193,7 @@
         return size;
       });
 
-      const { someResourcesSelected$ } = coachStrings;
+      const { someResourcesSelected$, numberOfResources$ } = coachStrings;
       const selectedResourcesMessage = computed(() => {
         if (!selectedResources.value.length) {
           return '';
@@ -207,6 +209,12 @@
           sendPoliteMessage(selectedResourcesMessage.value);
         }
       });
+
+      const contentCardMessage = content => {
+        if (!content.kind || content.kind === ContentNodeKinds.CHANNEL) {
+          return numberOfResources$({ value: content.total_resource_count });
+        }
+      };
 
       return {
         isAppContextAndTouchDevice,
@@ -225,6 +233,7 @@
         selectedResourcesSize,
         displayingSearchResults,
         selectedResourcesMessage,
+        contentCardMessage,
         clearSearch,
         selectResources,
         deselectResources,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -214,6 +214,9 @@
         if (!content.kind || content.kind === ContentNodeKinds.CHANNEL) {
           return numberOfResources$({ value: content.total_resource_count });
         }
+        if (content.kind === ContentNodeKinds.TOPIC) {
+          return numberOfResources$({ value: content.on_device_resources });
+        }
       };
 
       return {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectFromSearchResults.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/subPages/SelectFromSearchResults.vue
@@ -25,6 +25,7 @@
 
     <UpdatedResourceSelection
       :isSelectable="isSelectable"
+      :disabled="disabled"
       :contentList="contentList"
       :hasMore="hasMore"
       :cardsHeadingLevel="2"
@@ -34,6 +35,7 @@
       :selectedResources="selectedResources"
       :getTopicLink="getTopicLink"
       :getResourceLink="getResourceLink"
+      :contentCardMessage="contentCardMessage"
       :unselectableResourceIds="unselectableResourceIds"
       @selectResources="$emit('selectResources', $event)"
       @deselectResources="$emit('deselectResources', $event)"
@@ -151,6 +153,10 @@
         required: false,
         default: null,
       },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
       /**
        * The target entity for the selection.
        * It can be either 'quiz' or 'lesson'.
@@ -178,6 +184,15 @@
         type: Array,
         required: false,
         default: null,
+      },
+      /**
+       * Function that returns a message to be displayed based in the content
+       * passed as argument.
+       */
+      contentCardMessage: {
+        type: Function,
+        required: false,
+        default: () => '',
       },
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -88,6 +88,7 @@
         :settings.sync="settings"
         :target="SelectionTarget.QUIZ"
         :contentCardMessage="contentCardMessage"
+        :bookmarksCardMessage="bookmarksCardMessage"
         :getResourceLink="getResourceLink"
         :unselectableResourceIds="unselectableResourceIds"
         :unselectableQuestionItems="unselectableQuestionItems"
@@ -648,6 +649,17 @@
         );
       }
 
+      const bookmarksCardMessage = bookmarks => {
+        const unusedQuestions = bookmarks.reduce((total, bookmark) => {
+          const unused = unusedQuestionsCount(bookmark);
+          if (unused === -1) {
+            return total;
+          }
+          return total + unused;
+        }, 0);
+        return questionsUnusedInSection$({ count: unusedQuestions });
+      };
+
       const { goBackAction$ } = coreStrings;
 
       return {
@@ -708,6 +720,7 @@
         dismissAction$,
         manualSelectionOnNotice$,
         manualSelectionOffNotice$,
+        bookmarksCardMessage,
       };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -650,6 +650,9 @@
       }
 
       const bookmarksCardMessage = bookmarks => {
+        if (isPracticeQuiz) {
+          return;
+        }
         const unusedQuestions = bookmarks.reduce((total, bookmark) => {
           const unused = unusedQuestionsCount(bookmark);
           if (unused === -1) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SelectFromQuizSearchResults.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SelectFromQuizSearchResults.vue
@@ -1,10 +1,17 @@
 <template>
 
   <div v-if="displayingSearchResults">
-    <div class="channels-header">
-      <span class="side-panel-subtitle">
-        {{ selectFromChannels$() }}
-      </span>
+    <QuizResourceSelectionHeader
+      v-if="!settings.selectPracticeQuiz"
+      class="mb-16"
+      :settings="settings"
+      @searchClick="onSearchClick"
+    />
+
+    <div
+      v-else
+      class="d-flex-end mb-16"
+    >
       <KButton
         icon="filter"
         :text="searchLabel$()"
@@ -54,10 +61,12 @@
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../../constants';
   import UpdatedResourceSelection from '../../../../../common/resourceSelection/UpdatedResourceSelection.vue';
+  import QuizResourceSelectionHeader from '../../../../../common/resourceSelection/QuizResourceSelectionHeader.vue';
 
   export default {
     name: 'SelectFromQuizSearchResults',
     components: {
+      QuizResourceSelectionHeader,
       SearchChips,
       UpdatedResourceSelection,
     },
@@ -82,7 +91,7 @@
         redirectBack();
       }
 
-      const { selectFromChannels$, searchLabel$ } = coreStrings;
+      const { searchLabel$ } = coreStrings;
 
       props.setTitle(props.defaultTitle);
       props.setGoBack(null);
@@ -94,7 +103,6 @@
         fetchMore,
         loadingMore,
         searchLabel$,
-        selectFromChannels$,
         redirectBack,
       };
     },

--- a/packages/kolibri-common/apiResources/ContentNodeResource.js
+++ b/packages/kolibri-common/apiResources/ContentNodeResource.js
@@ -83,9 +83,6 @@ export default new Resource({
   fetchRandomCollection({ getParams: params }) {
     return this.getListEndpoint('random', params);
   },
-  fetchDescendantCounts(getParams) {
-    return this.getListEndpoint('descendant_counts', { ...getParams });
-  },
   fetchDescendantsAssessments(ids) {
     return this.getListEndpoint('descendants_assessments', { ids });
   },

--- a/packages/kolibri-common/components/Cards/AccessibleChannelCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleChannelCard.vue
@@ -21,11 +21,12 @@
     <template #belowTitle>
       <div>
         <slot name="belowTitle"></slot>
+        <br v-if="contentNode.description" >
         <KTextTruncator
           v-if="contentNode.description"
           :text="contentNode.description"
           :maxLines="3"
-          style="min-height: 17px; margin-bottom: 1em"
+          style="min-height: 17px; margin-bottom: 8px"
         />
         <MetadataChips :tags="getChannelTags()" />
         <div

--- a/packages/kolibri-common/components/Cards/AccessibleChannelCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleChannelCard.vue
@@ -20,19 +20,18 @@
     </template>
     <template #belowTitle>
       <div>
-        <p style="margin-top: 0">
-          <KTextTruncator
-            :text="coachString('numberOfResources', { value: contentNode.total_resource_count })"
-            :maxLines="1"
-          />
-        </p>
-        <p>
-          <KTextTruncator
-            :text="contentNode.description"
-            :maxLines="3"
-          />
-        </p>
+        <slot name="belowTitle"></slot>
+        <KTextTruncator
+          v-if="contentNode.description"
+          :text="contentNode.description"
+          :maxLines="3"
+          style="min-height: 17px; margin-bottom: 1em"
+        />
         <MetadataChips :tags="getChannelTags()" />
+        <div
+          v-if="!contentNode.description"
+          style="min-height: 17px"
+        ></div>
       </div>
     </template>
   </KCard>
@@ -46,7 +45,6 @@
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import MetadataChips from 'kolibri-common/components/MetadataChips';
   import { useCoachMetadataTags } from 'kolibri-common/composables/useCoachMetadataTags';
-  import commonCoach from './../../../../kolibri/plugins/coach/assets/src/views/common';
 
   export default {
     name: 'AccessibleChannelCard',
@@ -54,7 +52,6 @@
       ContentIcon,
       MetadataChips,
     },
-    mixins: [commonCoach],
     setup(props) {
       const { windowBreakpoint } = useKResponsiveWindow();
 

--- a/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
@@ -23,13 +23,13 @@
 
     <template #belowTitle>
       <div>
+        <slot name="belowTitle"></slot>
         <KTextTruncator
           v-if="contentNode.description"
           :text="contentNode.description"
           :maxLines="2"
           style="min-height: 17px; margin-bottom: 1em"
         />
-        <slot name="belowTitle"></slot>
         <MetadataChips :tags="metadataTags" />
         <div
           v-if="!contentNode.description"

--- a/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleFolderCard.vue
@@ -24,11 +24,12 @@
     <template #belowTitle>
       <div>
         <slot name="belowTitle"></slot>
+        <br v-if="contentNode.description" >
         <KTextTruncator
           v-if="contentNode.description"
           :text="contentNode.description"
           :maxLines="2"
-          style="min-height: 17px; margin-bottom: 1em"
+          style="min-height: 17px; margin-bottom: 8px"
         />
         <MetadataChips :tags="metadataTags" />
         <div

--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -18,12 +18,13 @@
     <template #belowTitle>
       <div>
         <slot name="belowTitle"></slot>
+        <br v-if="contentNode.description" >
         <KTextTruncator
           v-if="contentNode.description"
           class="truncator"
           :text="contentNode.description"
           :maxLines="2"
-          style="margin-bottom: 1em"
+          style="min-height: 17px; margin-bottom: 8px"
         />
         <MetadataChips :tags="metadataTags" />
         <div

--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -17,6 +17,7 @@
     </template>
     <template #belowTitle>
       <div>
+        <slot name="belowTitle"></slot>
         <KTextTruncator
           v-if="contentNode.description"
           class="truncator"
@@ -24,7 +25,6 @@
           :maxLines="2"
           style="margin-bottom: 1em"
         />
-        <slot name="belowTitle"></slot>
         <MetadataChips :tags="metadataTags" />
         <div
           v-if="!contentNode.description"

--- a/packages/kolibri-common/composables/useCoachMetadataTags.js
+++ b/packages/kolibri-common/composables/useCoachMetadataTags.js
@@ -23,14 +23,8 @@ export function useCoachMetadataTags(contentNode) {
   // so we make sure we have the right shape.
   if (!contentNode.kind || contentNode.kind === ContentNodeKinds.CHANNEL) {
     contentNode.lang = { lang_name: contentNode.lang_name, id: contentNode.lang_code };
-    // The grade_levels and categories fields are stored as
-    // comma-separated strings in the database
-    contentNode.grade_levels = contentNode.included_grade_levels
-      ? contentNode.included_grade_levels.split(',')
-      : [];
-    contentNode.categories = contentNode.included_categories
-      ? contentNode.included_categories.split(',')
-      : [];
+    contentNode.grade_levels = contentNode.included_grade_levels;
+    contentNode.categories = contentNode.included_categories;
   }
 
   function getKindTag() {

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1590,6 +1590,7 @@ const nonconformingKeys = {
   OTHER_SUPPLIES: 'needsMaterials',
   FOR_BEGINNERS: 'forBeginners',
   BASIC_SKILLS: 'allLevelsBasicSkills',
+  PROFESSIONAL: 'specializedProfessionalTraining',
   FOUNDATIONS: 'basicSkills',
   foundations: 'basicSkills',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',


### PR DESCRIPTION
## Summary
* Updates the channel API to return `included_categories` and `included_grade_levels` in array form, parallel to how similar fields are returned from contentnode endpoints
* Adds handling for a previously uncaught bad string mapping for "Professional" in the context of the grade_levels metadata
* Reverts displayed counts in quiz resource selection for channels and folders to be for unused questions, consistent with exercises
* Makes positioning of 'count type' metadata consistent across card types (always displayed above the description if it exists)
* Enhances the content node API endpoint to return the already annotated `on_device_resources` count
* Generalizes our handling of fields that get added to the public contentnode API endpoint to systematically handle missing keys from older versions of the API (without having to fully version the API)
* Labels folders with resource counts in lesson resource selection
* Updates annotation of the Bookmarks top level card and individual bookmark cards to show unused questions when in quiz selection mode
* Updates the SelectFromQuizSearchResults component to reuse the QuizSelectionHeader when not selecting a practice quiz, parallel to the logic in SelectFromTopics.

## References
Fixes #13240 
Fixes #13255

## Reviewer guidance
Note that I went a little bit above and beyond by adding the folder counts here on lessons - but it also means we if we decide to standardize quizzes on this too, we're ready to go.

| Description | Before | After |
|---------- |----------|--------|
| Bookmarks and Channel counts for quizzes| ![Screenshot from 2025-03-26 13-06-01](https://github.com/user-attachments/assets/1e4a5c39-cbd0-4ad0-97c8-ab8704a53189) | ![Screenshot from 2025-03-26 12-33-04](https://github.com/user-attachments/assets/be7a0d1e-0260-478d-9195-95bba9a910b7) |
| Bookmark card annotation for quizzes | ![Screenshot from 2025-03-26 13-06-05](https://github.com/user-attachments/assets/cc29b747-9360-48fd-8ff3-033c637ab2e1) | ![Screenshot from 2025-03-26 12-33-08](https://github.com/user-attachments/assets/d2e274e7-ab65-4dad-8a53-03e851762a07) |
| Folder card annotation for quizzes | ![Screenshot from 2025-03-26 13-06-28](https://github.com/user-attachments/assets/f6fb6692-6082-4dd9-a2f0-8cbec954fc1c) | ![Screenshot from 2025-03-26 12-33-14](https://github.com/user-attachments/assets/bc24c38b-a381-4251-99b2-a9edf0b0326f) |
| Header for quiz search | ![Screenshot from 2025-03-26 13-06-50](https://github.com/user-attachments/assets/34d96cbc-e1f5-457f-b34d-c74e213cb2c2) | ![Screenshot from 2025-03-26 12-33-31](https://github.com/user-attachments/assets/bb8c3d6f-1d26-425d-9e39-7607dd405162) |
| Folder card annotation for lessons | ![Screenshot from 2025-03-26 13-07-13](https://github.com/user-attachments/assets/8640c02e-fc60-4595-a5f9-c1ebe19f7f73) | ![Screenshot from 2025-03-26 12-33-53](https://github.com/user-attachments/assets/9a3846dc-f051-4ed2-9b19-20980496099b)
 |