### PR TITLE
Update destroy to destroyed, to properly remove

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
@@ -300,7 +300,7 @@
       }
       this.quizInitialized = true;
     },
-    destroy() {
+    destroyed() {
       window.removeEventListener('beforeunload', this.beforeUnload);
     },
     methods: {


### PR DESCRIPTION
## Summary
After editing a quiz, navigating away from quizzes into another part of the platform caused a window prompt that the user might lose unsaved changes, even though the changes had been saved. This fixes a typo in the lifecycle hook, so that it's `destroyed` and properly removes the event listener. 

## References

Before 

![Screenshot 2025-03-26 at 3 39 12 PM](https://github.com/user-attachments/assets/38fe112d-4c48-4dec-a3f5-094e3fd15791)


After 

https://github.com/user-attachments/assets/cf41f589-88b2-4057-b69f-8f428127b9f2




## Reviewer guidance
1. Create or edit a quiz, and use the close button, rather than the "save and finish" button, to navigate away. 
2. Then move to another part of the app (learn, facility, device)
3. You should no longer see a browser pop up saying you have unsaved changes 
4. If you do have unsaved changes, you should still see the Kolibri prompt ("are you sure.....") to confirm before navigation
