### PR TITLE
Fix question count reset when isChoosingManually changed

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -181,6 +181,7 @@
         instance.proxy.$emit('update:settings', {
           ...props.settings,
           isChoosingManually: workingIsChoosingManually.value,
+          questionCount: Math.min(10, props.settings?.maxQuestions || 10),
         });
       };
       const isSaveSettingsDisabled = computed(() => {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -230,10 +230,6 @@
        */
       const workingQuestions = ref([]);
 
-      const getDefaultQuestionCount = maxQuestions => {
-        return Math.min(10, maxQuestions);
-      };
-
       const showManualSelectionNotice = ref(false);
 
       /**
@@ -254,7 +250,7 @@
           newSettings.maxQuestions = MAX_QUESTIONS_PER_QUIZ_SECTION - activeQuestions.value.length;
           if (newSettings.questionCount === null) {
             // initialize questionCount if it hasn't been set yet
-            newSettings.questionCount = getDefaultQuestionCount(newSettings.maxQuestions);
+            newSettings.questionCount = Math.min(10, newSettings.maxQuestions);
           }
           settings.value = newSettings;
         },
@@ -271,8 +267,6 @@
 
           if (newSettings.isChoosingManually) {
             newSettings.questionCount = newSettings.maxQuestions;
-          } else {
-            newSettings.questionCount = getDefaultQuestionCount(newSettings.maxQuestions);
           }
 
           resetSelection();


### PR DESCRIPTION
## Summary

* Remove questionCount reset when isChoosingManually is changed to false. This was causing that the new question count was being ignored when we were turning isChoosingManually to false.

## References
Closes #13262

## Reviewer guidance
Replicate #13262.