### PR TITLE
Add checks for exam groups and learner_ids to fix empty quiz page display

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/ExamsRootPage.vue
@@ -437,9 +437,11 @@
               );
             });
           } else {
-            selectedExams = selectedExams.filter(
-              exam => exam.groups.length === 0 && exam.learner_ids.length === 0,
-            );
+            selectedExams = selectedExams.filter(exam => {
+              const hasNoGroups = !exam.groups || exam.groups.length === 0;
+              const hasNoLearners = !exam.learner_ids || exam.learner_ids.length === 0;
+              return hasNoGroups && hasNoLearners;
+            });
           }
         }
         return selectedExams.map(quiz => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
After creating a copy of a quiz and clicking the "All quizzes" link, an empty page was displayed with the console error message: TypeError: Cannot read properties of undefined (reading 'length')

This pull requests updates the exam filtering for exams with no learners or groups to check for the existence of the `groups` and `learner_ids` array, which prevents the console error `Cannot read properties of undefined` and correctly displays the page.

Before:

https://github.com/user-attachments/assets/0923281d-87d6-4df6-84a2-d44830639395


After:

https://github.com/user-attachments/assets/0210a481-c6b4-488b-af5b-9f10ad032e08



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #12814 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Install the latest develop build
2. Go to Coach > Class home and make a copy of a quiz
3. Ensure the exam filters correctly filter all exams and exams assigned to groups/the entire class