### PR TITLE
Remove any reference to long gone DeviceOwner model in docs and docstrings

### DIFF
--- a/docs/backend_architecture/uap/implementation.rst
+++ b/docs/backend_architecture/uap/implementation.rst
@@ -208,7 +208,7 @@ Checking permissions
 
 Checking whether a user has permission to perform a CRUD operation on an
 object involves calling the appropriate methods on the
-``KolibriAbstractBaseUser`` (``FacilityUser`` or ``DeviceOwner``) instance.
+``FacilityUser`` instance.
 For instance, to check whether request.user has delete permission for
 ``ContentSummaryLog`` instance log_obj, you could do::
 
@@ -230,10 +230,8 @@ they shouldn't be able to access), use the ``filter_readable`` method::
     all_results = ContentSummaryLog.objects.filter(content_id="qq123")
     permitted_results = request.user.filter_readable(all_results)
 
-Note that for the ``DeviceOwner`` model, these methods will simply return
-``True`` (or unfiltered querysets), as device owners are considered
-superusers. For the ``FacilityUser`` model, they defer to the permissions
-encoded in the ``permission`` object on the model class.
+These methods defer to the permissions encoded in the ``permission`` object on
+the model class.
 
 
 Using Kolibri permissions with Django REST Framework

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -9,7 +9,7 @@ devices.
 Collections form a hierarchy, with Collections able to belong to other Collections. Collections are subdivided
 into several pre-defined levels (``Facility`` > ``Classroom`` > ``LearnerGroup``).
 
-A ``FacilityUser`` (but not a ``DeviceOwner``) can be marked as a member of a ``Collection`` through a ``Membership``
+A ``FacilityUser`` can be marked as a member of a ``Collection`` through a ``Membership``
 object. Being a member of a Collection also means being a member of all the Collections above that Collection in the
 hierarchy.
 


### PR DESCRIPTION
## Summary
Removes any extant references to the DeviceOwner model that was removed in.. 0.7? Long time ago.

## References
Fixes #9167
