### PR TITLE
Propagate setSelectedResources in quiz search for practice quiz selection.

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SelectFromQuizSearchResults.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/subPages/SelectFromQuizSearchResults.vue
@@ -47,6 +47,7 @@
       :unselectableResourceIds="unselectableResourceIds"
       @selectResources="$emit('selectResources', $event)"
       @deselectResources="$emit('deselectResources', $event)"
+      @setSelectedResources="$emit('setSelectedResources', $event)"
     />
   </div>
 


### PR DESCRIPTION
## Summary
* Propagates the setSelectedResources event out of the SelectFromQuizSearchResources component to ensure that practice quiz selection works within searches

## References
Fixes [#13271](https://github.com/learningequality/kolibri/issues/13271)

## Reviewer guidance
Import the Kolibri QA channel
Create a new quiz by doing "select a quiz" from the dropdown
Search for a quiz using any appropriate search label
Select the quiz with the radio button

| Before | After |
|----------|--------|
| ![Screenshot from 2025-03-28 15-16-02](https://github.com/user-attachments/assets/47f44ea9-632f-4f46-a0f1-a2a2431311ab) | ![Screenshot from 2025-03-28 15-11-32](https://github.com/user-attachments/assets/98ca9456-4c26-4100-ac8f-96e4801dc7c4) |
