### PR TITLE
Hide the  'Search' button when there's nothing to search for

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -23,7 +23,7 @@
         {{ selectFromBookmarks$() }}
       </div>
       <KButton
-        v-if="bookmarksCount > 0"
+        v-if="channels.length > 0"
         icon="filter"
         :text="searchLabel$()"
         @click="onSearchClick"

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -23,6 +23,7 @@
         {{ selectFromBookmarks$() }}
       </div>
       <KButton
+        v-if="bookmarksCount > 0"
         icon="filter"
         :text="searchLabel$()"
         @click="onSearchClick"
@@ -34,6 +35,7 @@
       class="d-flex-end mb-24"
     >
       <KButton
+        v-if="channels.length > 0"
         icon="filter"
         :text="searchLabel$()"
         @click="onSearchClick"


### PR DESCRIPTION

## Summary
This PR hides the 's  the 'Search' button at all when there's nothing to search for
## References

closes #13261
## Reviewer guidance
Navigate to Coach > Lessons > Manage resources - See if the  "Search" button is active with resources in devices Vs without it.