### PR TITLE
Optimizing Bookmarks w/ useBookmarks & applying it in Coach side panels

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
+++ b/kolibri/plugins/coach/assets/src/composables/useResourceSelection.js
@@ -35,8 +35,6 @@ import useFetch from './useFetch';
  *   use the fetch objects of each entity.
  * @property {FetchObject} channelsFetch Channels fetch object to manage the process of
  *   fetching channels. We currently don't support fetching more channels.
- * @property {FetchObject} bookmarksFetch Bookmarks fetch object to manage the process of
- *   fetching bookmarks. Fetching more bookmarks is supported.
  * @property {FetchObject} treeFetch Topic tree fetch object to manage the process of
  *   fetching topic trees and their resources. Fetching more resources is supported.
  * @property {FetchObject} searchFetch Search fetch object to manage the process of
@@ -60,7 +58,6 @@ import useFetch from './useFetch';
  */
 export default function useResourceSelection({
   searchResultsRouteName,
-  bookmarks,
   channels,
   topicTree,
   search,
@@ -72,29 +69,6 @@ export default function useResourceSelection({
   const selectionRules = ref([]);
   const selectedResources = ref([]);
   const topic = ref(null);
-
-  const fetchBookmarks = async params => {
-    const response = await ContentNodeResource.fetchBookmarks(params);
-    if (bookmarks?.annotator) {
-      const annotatedResults = await bookmarks.annotator(response.results);
-      return {
-        ...response,
-        results: annotatedResults,
-        count: annotatedResults.length,
-      };
-    }
-    return response;
-  };
-  const bookmarksFetch = useFetch({
-    fetchMethod: () =>
-      fetchBookmarks({
-        params: { limit: 25, available: true, ...bookmarks?.filters },
-      }),
-    fetchMoreMethod: more =>
-      ContentNodeResource.fetchBookmarks({
-        params: more,
-      }),
-  });
 
   const fetchChannels = async () => {
     const result = await ChannelResource.fetchCollection({
@@ -191,13 +165,12 @@ export default function useResourceSelection({
   });
 
   const loading = computed(() => {
-    const sources = [bookmarksFetch, channelsFetch, treeFetch, searchFetch];
+    const sources = [channelsFetch, treeFetch, searchFetch];
 
     return sources.some(sourceFetch => sourceFetch.loading.value);
   });
 
   const fetchInitialData = async () => {
-    bookmarksFetch.fetchData();
     channelsFetch.fetchData();
     if (topicId.value) {
       treeFetch.fetchData();
@@ -241,7 +214,6 @@ export default function useResourceSelection({
     loading,
     treeFetch,
     channelsFetch,
-    bookmarksFetch,
     searchFetch,
     selectionRules,
     selectedResources,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
@@ -18,7 +18,7 @@
         :contentNode="content"
         :thumbnailSrc="content.thumbnail"
         :headingLevel="cardsHeadingLevel"
-        :isBookmarked="isBookmarked(content.id)"
+        :isBookmarked="isBookmarked(content)"
         @toggleBookmark="toggleBookmark"
       >
         <template #belowTitle>
@@ -81,15 +81,10 @@
 
 <script>
 
-  import { computed, ref } from 'vue';
-  import urls from 'kolibri/urls';
-  import client from 'kolibri/client';
-  import useUser from 'kolibri/composables/useUser';
-  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
-  import BookmarksResource from 'kolibri-common/apiResources/BookmarksResource';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import AccessibleFolderCard from 'kolibri-common/components/Cards/AccessibleFolderCard';
   import AccessibleResourceCard from 'kolibri-common/components/Cards/AccessibleResourceCard';
+  import { injectUseBookmarks } from 'kolibri-common/composables/useBookmarks';
   import { ViewMoreButtonStates } from '../../../constants/index';
 
   export default {
@@ -100,67 +95,8 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { coreString } = commonCoreStrings.methods;
-      const { sendPoliteMessage } = useKLiveRegion();
-      // Map of contentnode_id to bookmark resource ID
-      const bookmarks = ref({});
-      // Map of contentNode IDs to bookmark resource IDs
-      const bookmarkedContentNodeIds = computed(() => Object.keys(bookmarks.value));
-      const { currentUserId } = useUser();
+      const { toggleBookmark, isBookmarked } = injectUseBookmarks();
 
-      /**
-       * Fetch bookmarks and store them in the bookmarks ref mapping
-       * their contentnode_id to the bokomark's own ID.
-       * The contentnode_id is used for creating it, but we need the
-       * bookmark's ID to delete it.
-       */
-      function getBookmarks() {
-        BookmarksResource.fetchCollection({ force: true }).then(data => {
-          bookmarks.value = data.reduce((memo, bookmark) => {
-            memo[bookmark.contentnode_id] = bookmark.id;
-            return memo;
-          }, {});
-        });
-      }
-
-      function deleteBookmark(contentnode_id) {
-        client({
-          method: 'delete',
-          url: urls['kolibri:core:bookmarks_detail'](contentnode_id),
-        }).then(() => {
-          getBookmarks();
-          sendPoliteMessage(coreString('removedFromBookmarks'));
-        });
-      }
-
-      function addBookmark(contentnode_id) {
-        client({
-          method: 'post',
-          url: urls['kolibri:core:bookmarks_list'](),
-          data: {
-            contentnode_id: contentnode_id,
-            user: currentUserId.value,
-          },
-        }).then(() => {
-          getBookmarks();
-          sendPoliteMessage(coreString('savedToBookmarks'));
-        });
-      }
-
-      function isBookmarked(contentnode_id) {
-        return bookmarkedContentNodeIds.value.includes(contentnode_id);
-      }
-
-      function toggleBookmark(contentnode_id) {
-        if (isBookmarked(contentnode_id)) {
-          const bookmarkId = bookmarks.value[contentnode_id];
-          deleteBookmark(bookmarkId);
-        } else {
-          addBookmark(contentnode_id);
-        }
-      }
-
-      getBookmarks();
       return {
         ViewMoreButtonStates,
         toggleBookmark,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
@@ -11,10 +11,10 @@
       canSelectAll
       :isSelectable="isSelectable"
       :contentList="contentList"
-      :hasMore="false"
+      :hasMore="hasMore"
       :disabled="disabled"
       :channelsLink="channelsLink"
-      :fetchMore="() => null"
+      :fetchMore="() => (viewMoreClickCount += 1)"
       :loadingMore="false"
       :multi="!settings?.selectPracticeQuiz"
       :selectionRules="selectionRules"
@@ -34,7 +34,9 @@
 
 <script>
 
-  import { computed, getCurrentInstance } from 'vue';
+  import flatMap from 'lodash/flatMap';
+  import chunk from 'lodash/chunk';
+  import { computed, ref, getCurrentInstance } from 'vue';
   import { now } from 'kolibri/utils/serverClock';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute.js';
@@ -57,7 +59,23 @@
     setup(props) {
       const { selectFromBookmarks$, bookmarkedTimeAgoLabel$ } = coreStrings;
       const instance = getCurrentInstance();
+      const viewMoreClickCount = ref(0);
       const { bookmarks } = injectUseBookmarks();
+
+      // For lazily loading them to avoid renering too many at once
+      const chunkedBookmarks = computed(() => {
+        return chunk(bookmarks.value, 25);
+      });
+
+      // Each time the view more button is clicked, we increase the count, so we return
+      // more chunks of bookmarks
+      const contentList = computed(() => {
+        return flatMap(chunkedBookmarks.value.slice(0, viewMoreClickCount.value + 1));
+      });
+
+      const hasMore = computed(() => {
+        return chunkedBookmarks.value.length > viewMoreClickCount.value + 1;
+      });
 
       props.setTitle(selectFromBookmarks$());
 
@@ -102,8 +120,10 @@
       });
 
       return {
+        hasMore,
+        viewMoreClickCount,
         channelsLink,
-        contentList: bookmarks,
+        contentList,
         isSelectable,
         wrappedContentCardMessage,
         SelectionTarget,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
@@ -79,8 +79,6 @@
             : PageNames.QUIZ_SELECT_RESOURCES_INDEX,
       };
 
-      const { data, hasMore, fetchMore, loadingMore } = props.bookmarksFetch;
-
       const wrappedContentCardMessage = content => {
         const propsMessage = props.contentCardMessage(content);
         if (propsMessage) {

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectFromBookmarks.vue
@@ -11,11 +11,11 @@
       canSelectAll
       :isSelectable="isSelectable"
       :contentList="contentList"
-      :hasMore="hasMore"
+      :hasMore="false"
       :disabled="disabled"
       :channelsLink="channelsLink"
-      :fetchMore="fetchMore"
-      :loadingMore="loadingMore"
+      :fetchMore="() => null"
+      :loadingMore="false"
       :multi="!settings?.selectPracticeQuiz"
       :selectionRules="selectionRules"
       :selectAllRules="selectAllRules"
@@ -38,6 +38,7 @@
   import { now } from 'kolibri/utils/serverClock';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute.js';
+  import { injectUseBookmarks } from 'kolibri-common/composables/useBookmarks';
   import UpdatedResourceSelection from '../UpdatedResourceSelection.vue';
   import { PageNames } from '../../../../constants';
   import { SelectionTarget } from '../contants';
@@ -56,6 +57,7 @@
     setup(props) {
       const { selectFromBookmarks$, bookmarkedTimeAgoLabel$ } = coreStrings;
       const instance = getCurrentInstance();
+      const { bookmarks } = injectUseBookmarks();
 
       props.setTitle(selectFromBookmarks$());
 
@@ -103,10 +105,7 @@
 
       return {
         channelsLink,
-        contentList: data,
-        hasMore,
-        fetchMore,
-        loadingMore,
+        contentList: bookmarks,
         isSelectable,
         wrappedContentCardMessage,
         SelectionTarget,
@@ -120,14 +119,6 @@
       setGoBack: {
         type: Function,
         default: () => {},
-      },
-      /**
-       * Fetch object for fetching bookmarks.
-       * @type {FetchObject}
-       */
-      bookmarksFetch: {
-        type: Object,
-        required: true,
       },
       selectionRules: {
         type: Array,

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -44,7 +44,7 @@
     </div>
 
     <div
-      v-if="bookmarksCount > 0"
+      v-if="bookmarks.length > 0"
       class="mb-24"
     >
       <KCardGrid layout="1-1-1">
@@ -119,6 +119,7 @@
   import { computed } from 'vue';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import AccessibleChannelCard from 'kolibri-common/components/Cards/AccessibleChannelCard.vue';
+  import { injectUseBookmarks } from 'kolibri-common/composables/useBookmarks';
   import { PageNames } from '../../../../constants';
   import { SelectionTarget } from '../contants';
   import QuizResourceSelectionHeader from '../QuizResourceSelectionHeader.vue';
@@ -136,6 +137,8 @@
     setup(props) {
       const { bookmarksFetch, channelsFetch } = props;
       const { count: bookmarksCount, data: bookmarksData } = bookmarksFetch;
+      const { channelsFetch } = props;
+      const { bookmarks } = injectUseBookmarks();
 
       const { data: channels } = channelsFetch;
 
@@ -160,7 +163,7 @@
       props.setGoBack(null);
 
       return {
-        bookmarksCount,
+        bookmarks,
         channels,
         SelectionTarget,
         selectFromChannels$,
@@ -244,13 +247,6 @@
           name: PageNames.QUIZ_SELECT_RESOURCES_BOOKMARKS,
         };
       },
-    },
-    beforeRouteEnter(_, __, next) {
-      next(vm => {
-        // Whenever we land here, we want to fetch the bookmarks again
-        // in case the user has added or removed some within the side panel
-        vm.bookmarksFetch.fetchData();
-      });
     },
     methods: {
       selectFromChannelsLink(channel) {

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -14,11 +14,11 @@
       v-if="target === SelectionTarget.LESSON"
       class="subheader"
       :style="{
-        flexDirection: bookmarksCount > 0 ? 'row' : 'row-reverse',
+        flexDirection: bookmarks.length > 0 ? 'row' : 'row-reverse',
       }"
     >
       <div
-        v-if="bookmarksCount > 0"
+        v-if="bookmarks.length > 0"
         class="side-panel-subtitle"
       >
         {{ selectFromBookmarks$() }}
@@ -135,8 +135,6 @@
       QuizResourceSelectionHeader,
     },
     setup(props) {
-      const { bookmarksFetch, channelsFetch } = props;
-      const { count: bookmarksCount, data: bookmarksData } = bookmarksFetch;
       const { channelsFetch } = props;
       const { bookmarks } = injectUseBookmarks();
 
@@ -152,11 +150,11 @@
       } = coreStrings;
 
       const wrappedBookmarksCardMessage = computed(() => {
-        const propsMessage = props.bookmarksCardMessage(bookmarksData.value);
+        const propsMessage = props.bookmarksCardMessage(bookmarks.value);
         if (propsMessage) {
           return propsMessage;
         }
-        return numberOfBookmarks$({ count: bookmarksCount.value });
+        return numberOfBookmarks$({ count: bookmarks.value.length });
       });
 
       props.setTitle(props.defaultTitle);
@@ -192,14 +190,6 @@
        * @type {FetchObject}
        */
       channelsFetch: {
-        type: Object,
-        required: true,
-      },
-      /**
-       * Fetch object for fetching bookmarks.
-       * @type {FetchObject}
-       */
-      bookmarksFetch: {
         type: Object,
         required: true,
       },

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/sidePanels/LessonResourceSelection/index.vue
@@ -34,7 +34,6 @@
       :treeFetch="treeFetch"
       :searchFetch="searchFetch"
       :channelsFetch="channelsFetch"
-      :bookmarksFetch="bookmarksFetch"
       :searchTerms.sync="searchTerms"
       :selectionRules="selectionRules"
       :target="SelectionTarget.LESSON"
@@ -113,6 +112,7 @@
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
   import useUser from 'kolibri/composables/useUser';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute.js';
+  import useBookmarks from 'kolibri-common/composables/useBookmarks';
   import { PageNames } from '../../../../../constants';
   import { coachStrings } from '../../../../common/commonCoachStrings';
   import { SelectionTarget } from '../../../../common/resourceSelection/contants';
@@ -132,6 +132,8 @@
       const isLandingRoute = computed(() => previousRoute.value === null);
 
       const instance = getCurrentInstance();
+      // Initialize it here so we can inject it in child components
+      useBookmarks();
       const { sendPoliteMessage } = useKLiveRegion();
       const {
         loading,
@@ -139,7 +141,6 @@
         treeFetch,
         searchFetch,
         channelsFetch,
-        bookmarksFetch,
         searchTerms,
         selectionRules,
         selectedResources,
@@ -228,7 +229,6 @@
         treeFetch,
         searchFetch,
         channelsFetch,
-        bookmarksFetch,
         searchTerms,
         isLandingRoute,
         selectionRules,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -82,7 +82,6 @@
         :searchTerms.sync="searchTerms"
         :searchFetch="searchFetch"
         :channelsFetch="channelsFetch"
-        :bookmarksFetch="bookmarksFetch"
         :selectAllRules="selectAllRules"
         :selectionRules="selectionRules"
         :settings.sync="settings"
@@ -165,6 +164,7 @@
   import isEqual from 'lodash/isEqual';
   import { useMemoize } from '@vueuse/core';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import useBookmarks from 'kolibri-common/composables/useBookmarks';
   import {
     displaySectionTitle,
     enhancedQuizManagementStrings,
@@ -201,6 +201,15 @@
 
       const { $store, $router } = getCurrentInstance().proxy;
       const route = computed(() => $store.state.route);
+
+      const isPracticeQuiz = item =>
+        !selectPracticeQuiz || get(item, ['options', 'modality'], false) === 'QUIZ';
+
+      useBookmarks({
+        filters: { kind: ContentNodeKinds.EXERCISE },
+        annotator: results => results.filter(isPracticeQuiz),
+      });
+
       const {
         activeSection,
         activeSectionIndex,
@@ -393,15 +402,11 @@
         { getKey: content => content.id },
       );
 
-      const isPracticeQuiz = item =>
-        !selectPracticeQuiz || get(item, ['options', 'modality'], false) === 'QUIZ';
-
       const {
         topic,
         loading,
         treeFetch,
         channelsFetch,
-        bookmarksFetch,
         searchTerms,
         searchFetch,
         displayingSearchResults,
@@ -409,11 +414,6 @@
         removeSearchFilterTag,
       } = useResourceSelection({
         searchResultsRouteName: PageNames.QUIZ_SELECT_RESOURCES_SEARCH_RESULTS,
-        bookmarks: {
-          filters: { kind: ContentNodeKinds.EXERCISE },
-          annotator: results => results.filter(isPracticeQuiz),
-        },
-
         channels: {
           filters: {
             contains_exercise: true,
@@ -690,7 +690,6 @@
         searchTerms,
         searchFetch,
         channelsFetch,
-        bookmarksFetch,
         selectionRules,
         selectAllRules,
         unselectableResourceIds,

--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -45,7 +45,7 @@
           :tooltip="
             isBookmarked ? coreString('removeFromBookmarks') : coreString('saveToBookmarks')
           "
-          @click.stop="$emit('toggleBookmark', contentNode.id)"
+          @click.stop="$emit('toggleBookmark', contentNode)"
         />
       </div>
     </template>

--- a/packages/kolibri-common/composables/__tests__/useBookmarks.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBookmarks.spec.js
@@ -1,0 +1,84 @@
+import { v4 as uuidv4 } from 'uuid';
+import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+import useBookmarks from '../useBookmarks';
+
+jest.mock('kolibri-common/apiResources/ContentNodeResource');
+jest.mock('kolibri/urls');
+jest.mock('kolibri/client');
+
+function _createBookmark(contentnode_id) {
+  return {
+    id: uuidv4(),
+    channel_id: uuidv4(),
+    content_id: uuidv4(),
+    contentnode_id,
+  };
+}
+
+function _createBookmarkedContentNode() {
+  const id = uuidv4();
+  return {
+    id,
+    kind: 'video',
+    bookmark: _createBookmark(id),
+  };
+}
+
+function _fetchBookmarksResponse(numResults = 1) {
+  return Array.from({ length: numResults }, _createBookmarkedContentNode);
+}
+
+describe('useBookmarks', () => {
+  describe('initializing', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('user has no bookmarks', () => {
+      const spy = jest
+        .spyOn(ContentNodeResource, 'fetchBookmarks')
+        .mockResolvedValue(_fetchBookmarksResponse(0));
+      const { bookmarks } = useBookmarks();
+      expect(bookmarks.value).toEqual([]);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('user has some bookmarks', async () => {
+      const spy = jest
+        .spyOn(ContentNodeResource, 'fetchBookmarks')
+        .mockResolvedValue(_fetchBookmarksResponse(1));
+      const { bookmarks } = useBookmarks();
+      expect(spy).toHaveBeenCalled();
+      await spy;
+      expect(bookmarks.value.length).toBe(1);
+    });
+  });
+
+  describe('managing bookmarks', () => {
+    it('can add a bookmark', async () => {
+      const bookmarkNode = _createBookmarkedContentNode();
+      const { addBookmark, bookmarks } = useBookmarks();
+      await addBookmark(bookmarkNode);
+      expect(bookmarks.value.map(n => n.id)).toContain(bookmarkNode.id);
+    });
+
+    it('can remove a bookmark', async () => {
+      const bookmarkNode = _createBookmarkedContentNode();
+      const { addBookmark, removeBookmark, bookmarks } = useBookmarks();
+      await addBookmark(bookmarkNode);
+      expect(bookmarks.value.map(n => n.id)).toContain(bookmarkNode.id);
+      await removeBookmark(bookmarkNode);
+      expect(bookmarks.value.map(n => n.id)).not.toContain(bookmarkNode.id);
+    });
+
+    it.skip('can toggle a bookmark', async () => {
+      const bookmarkNode = _createBookmarkedContentNode();
+      const { toggleBookmark, bookmarks } = useBookmarks();
+      await toggleBookmark(bookmarkNode);
+      expect(bookmarks.value).toContain(bookmarkNode.id);
+      await toggleBookmark(bookmarkNode);
+      expect(bookmarks.value).not.toContain(bookmarkNode.id);
+      await toggleBookmark(bookmarkNode);
+      expect(bookmarks.value).toContain(bookmarkNode.id);
+    });
+  });
+});

--- a/packages/kolibri-common/composables/__tests__/useBookmarks.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBookmarks.spec.js
@@ -70,15 +70,15 @@ describe('useBookmarks', () => {
       expect(bookmarks.value.map(n => n.id)).not.toContain(bookmarkNode.id);
     });
 
-    it.skip('can toggle a bookmark', async () => {
+    it('can toggle a bookmark', async () => {
       const bookmarkNode = _createBookmarkedContentNode();
       const { toggleBookmark, bookmarks } = useBookmarks();
       await toggleBookmark(bookmarkNode);
-      expect(bookmarks.value).toContain(bookmarkNode.id);
+      expect(bookmarks.value.map(n => n.id)).toContain(bookmarkNode.id);
       await toggleBookmark(bookmarkNode);
-      expect(bookmarks.value).not.toContain(bookmarkNode.id);
+      expect(bookmarks.value.map(n => n.id)).not.toContain(bookmarkNode.id);
       await toggleBookmark(bookmarkNode);
-      expect(bookmarks.value).toContain(bookmarkNode.id);
+      expect(bookmarks.value.map(n => n.id)).toContain(bookmarkNode.id);
     });
   });
 });

--- a/packages/kolibri-common/composables/useBookmarks.js
+++ b/packages/kolibri-common/composables/useBookmarks.js
@@ -1,0 +1,160 @@
+import urls from 'kolibri/urls';
+import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+import { inject, provide, ref } from 'vue';
+import useUser from 'kolibri/composables/useUser';
+import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+import client from 'kolibri/client';
+import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+
+/**
+ * @typedef {Object} Bookmark
+ * @property {String} id - The id of the bookmark
+ * @property {String} contentnode_id - The id of the contentnode that is bookmarked
+ * @property {String} channel_id - The id of the user that bookmarked the contentnode
+ * @property {String} content_id - The timestamp of when the bookmark was created
+ */
+
+/**
+ * A ContentNode that has a Bookmark object attached to it.
+ * @typedef {Object} BookmarkedContentNode
+ * @mixes ContentNode - Ya know, the big ol' thing I'm not gonna copy here
+ * @property {Bookmark} bookmark - The bookmark object for this contentnode
+ */
+
+/**
+ * A module for adding and removing bookmarks.
+ *
+ * It fetches the bookmarks for the current user on initialization and
+ * provide methods for adding and removing bookmarks.
+ *
+ * Initialize this at the top level of the relevant context (ie, where you'll need bookmarks)
+ *
+ * @param {Object} options
+ * @param {Object} options.filters - Filters to pass to the fetch method's params object.
+ * @param {Function} options.annotator - Function to annotate the results. The function should
+ *  take and return a BookmarkedContentNode (aka a ContentNode w/ a Bookmark object at `.bookmark`.
+ */
+export default function useBookmarks({ filters = {}, annotator = null } = {}) {
+  /**
+   * @type BookmarkedContentNode[]
+   */
+  const bookmarks = ref([]);
+
+  const { currentUserId } = useUser();
+  const { sendPoliteMessage } = useKLiveRegion();
+  const { coreString } = commonCoreStrings.methods;
+
+  /**
+   * @param {BookmarkedContentNode} node
+   * @returns {String|null} - The id of the bookmark for the given contentnode,
+   *                          or null if it doesn't exist
+   */
+  function _getBookmarkIdForContentNode(node) {
+    const bookmarkedNode = bookmarks.value.find(bNode => bNode.id === node.id);
+    if (bookmarkedNode) {
+      return bookmarkedNode.bookmark.id;
+    }
+    return null;
+  }
+
+  /**
+   * @param {BookmarkedContentNode} node
+   */
+  function isBookmarked(node) {
+    return bookmarks.value.some(n => n.id === node.id);
+  }
+
+  /**
+   * @param {BookmarkedContentNode} node
+   */
+  function addBookmark(node) {
+    client({
+      method: 'post',
+      url: urls['kolibri:core:bookmarks_list'](),
+      data: {
+        contentnode_id: node.id,
+        user: currentUserId.value,
+      },
+    }).then(response => {
+      bookmarks.value.push({ bookmark: response.data, ...node });
+      sendPoliteMessage(coreString('savedToBookmarks'));
+    });
+  }
+
+  /**
+   * @param {BookmarkedContentNode} node
+   */
+  function removeBookmark(node) {
+    const bookmarkId = _getBookmarkIdForContentNode(node);
+    if (!bookmarkId) {
+      return;
+    }
+    client({
+      method: 'delete',
+      url: urls['kolibri:core:bookmarks_detail'](bookmarkId),
+    }).then(() => {
+      bookmarks.value = bookmarks.value.filter(n => n.id !== node.id);
+      sendPoliteMessage(coreString('removedFromBookmarks'));
+    });
+  }
+
+  /**
+   * @param {BookmarkedContentNode} node
+   */
+  function toggleBookmark(node) {
+    if (isBookmarked(node)) {
+      removeBookmark(node);
+    } else {
+      addBookmark(node);
+    }
+  }
+
+  /**
+   * Fetches bookmarks for the current user.
+   * @affects bookmarks
+   */
+  async function fetchBookmarks() {
+    // Fetches contentnodes w/ their bookmark information.
+    const response = await ContentNodeResource.fetchBookmarks({
+      params: {
+        available: true,
+        force: true,
+        ...filters,
+      },
+    });
+    if (annotator) {
+      const annotatedResults = await annotator(response);
+      bookmarks.value = annotatedResults;
+    } else {
+      bookmarks.value = response;
+    }
+  }
+
+  // Initialize
+  fetchBookmarks();
+
+  // Provide for injection
+  provide('bookmarks', bookmarks);
+  provide('isBookmarked', isBookmarked);
+  provide('addBookmark', addBookmark);
+  provide('removeBookmark', removeBookmark);
+  provide('toggleBookmark', toggleBookmark);
+
+  return {
+    bookmarks,
+    isBookmarked,
+    addBookmark,
+    removeBookmark,
+    toggleBookmark,
+  };
+}
+
+export function injectUseBookmarks() {
+  return {
+    bookmarks: inject('bookmarks'),
+    isBookmarked: inject('isBookmarked'),
+    addBookmark: inject('addBookmark'),
+    removeBookmark: inject('removeBookmark'),
+    toggleBookmark: inject('toggleBookmark'),
+  };
+}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

We've been fetching the bookmarks over and over in the Coach side panel to keep things up-to-date with the user's behavior. This PR takes inspiration from @AlexVelezLl 's suggestion that we manage all of this client-side and only touch the API when the user updates their bookmarks.

This results in substantially fewer calls to the bookmarks API - see how there is a call on every navigation in this **Before:**

[spammingthebookmarks.webm](https://github.com/user-attachments/assets/e6a00d2f-2a7d-4280-a7dd-b671172f6cbd)

Now the bookmarks API is only called on the initial side panel load and then when the user toggles a bookmark.

### Notes 

- I've made the module do it's work with what I've typed as a "BookmarkedContentNode" - which is a ContentNode w/ a `.bookmark` property which shows the user's proper Bookmark object.
- This structure is what we get back from ContentNodeResource.fetchBookmarks, so it makes sense to just pass that around when dealing with bookmarks
- This should continue making the polite ARIA messages when the user adds/removes a bookmark (cc @radinamatic)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #13077 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

When you navigate the Lesson and Quiz resource side panel, keep your Dev Tools Network tab open and you can filter it by typing "book" into the filter bar. In the screencast above, you can see an API call made every time you navigate the topic tree - but when testing this PR you should not see that and only see a call on page load and when you toggle a bookmark.

Just go around using the side panel - select/deselect content and bookmarks. See that your decisions are reflected as expected. Go back to the root page and see that your # of bookmarks is reflected accurately as you make changes to your bookmarks.

Refresh the page after you make changes and see what happens - did it save your decision correctly?
