### PR TITLE
Clean up resource preview for practice quiz selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/PreviewSelectedResources/index.vue
@@ -21,7 +21,7 @@
         />
       </div>
       <QuizResourceSelectionHeader
-        v-if="target === SelectionTarget.QUIZ"
+        v-if="target === SelectionTarget.QUIZ && !settings.selectPracticeQuiz"
         hideSearch
         :settings="settings"
       >
@@ -56,7 +56,7 @@
       </h2>
 
       <div
-        v-if="target === SelectionTarget.QUIZ"
+        v-if="target === SelectionTarget.QUIZ && !settings.selectPracticeQuiz"
         class="update-settings-container"
         :style="{
           backgroundColor: $themePalette.grey.v_100,

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -631,19 +631,13 @@
       const defaultTitle = getDefaultTitle();
 
       const { createSnackbar } = useSnackbar();
-      function notifyChanges() {
-        const { numberOfQuestionsAdded$, numberOfQuestionsReplaced$ } =
-          enhancedQuizManagementStrings;
-
+      const { numberOfQuestionsAdded$, numberOfQuestionsReplaced$ } = enhancedQuizManagementStrings;
+      function notifyChanges(count) {
         const message$ = settings.value.isInReplaceMode
           ? numberOfQuestionsReplaced$
           : numberOfQuestionsAdded$;
 
-        createSnackbar(
-          message$({
-            count: workingQuestions.value.length || settings.value.questionCount,
-          }),
-        );
+        createSnackbar(message$({ count }));
       }
 
       const bookmarksCardMessage = bookmarks => {
@@ -741,6 +735,7 @@
     },
     methods: {
       async saveSelectedResource() {
+        let numQuestions;
         if (this.settings.selectPracticeQuiz) {
           if (this.$route.name === PageNames.QUIZ_PREVIEW_RESOURCE) {
             try {
@@ -757,6 +752,8 @@
           }
           const remainder = exerciseToQuestionArray(this.workingResourcePool[0]);
 
+          numQuestions = remainder.length;
+
           let sectionIndex = this.activeSectionIndex;
           while (remainder.length) {
             if (sectionIndex !== this.activeSectionIndex) {
@@ -771,6 +768,7 @@
             sectionIndex++;
           }
         } else if (this.settings.isChoosingManually) {
+          numQuestions = this.workingQuestions.length;
           this.addQuestionsToSection({
             sectionIndex: this.activeSectionIndex,
             questions: this.workingQuestions,
@@ -778,6 +776,7 @@
             questionItemsToReplace: this.settings.questionItemsToReplace,
           });
         } else {
+          numQuestions = this.settings.questionCount;
           this.addQuestionsToSectionFromResources({
             sectionIndex: this.activeSectionIndex,
             resourcePool: this.workingResourcePool,
@@ -790,7 +789,7 @@
           // could be removed, so we need to clear it
           this.clearQuizSelectedQuestions();
         }
-        this.notifyChanges();
+        this.notifyChanges(numQuestions);
         this.handleClosePanel();
       },
       // The message put onto the content's card when listed

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -175,6 +175,7 @@
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { ContentNodeKinds, MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
+  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
   import { coachStrings } from '../../../../common/commonCoachStrings';
   import { exerciseToQuestionArray } from '../../../../../utils/selectQuestions';
   import { PageNames } from '../../../../../constants/index';
@@ -499,7 +500,9 @@
 
       const disableSave = computed(() => {
         if (selectPracticeQuiz) {
-          return !workingPoolHasChanged.value;
+          return (
+            !workingPoolHasChanged.value && route.value.name !== PageNames.QUIZ_PREVIEW_RESOURCE
+          );
         }
         const disabledConditions = [
           !workingPoolHasChanged.value,
@@ -737,8 +740,18 @@
       }
     },
     methods: {
-      saveSelectedResource() {
+      async saveSelectedResource() {
         if (this.settings.selectPracticeQuiz) {
+          if (this.$route.name === PageNames.QUIZ_PREVIEW_RESOURCE) {
+            try {
+              const contentNode = await ContentNodeResource.fetchModel({
+                id: this.$route.query.contentId,
+              });
+              this.setWorkingResourcePool([contentNode]);
+            } catch (e) {
+              this.$store.dispatch('handleApiError', e);
+            }
+          }
           if (this.workingResourcePool.length !== 1) {
             throw new Error('Only one resource can be selected for a practice quiz');
           }


### PR DESCRIPTION
## Summary
* Don't show inaccurate headers for practice quizzes.
* Allow direct pressing of the "Select quiz" button when previewing the quiz.

## References
Fixes issues observed by @marcellamaki while reviewing another PR

## Reviewer guidance
Follow the select practice quiz workflow
Preview the quiz
Ensure all displayed buttons and information are relevant and functional.
Ensure quiz can be selected from the select quiz button and that it properly handles the selection action.
