### PR TITLE
Don't allow any learn subnavigation if the user isn't logged in.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.js
+++ b/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.js
@@ -1,5 +1,6 @@
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
+import useUser from 'kolibri/composables/useUser';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import baseRoutes from '../routes/baseRoutes';
 import { learnStrings } from './commonLearnStrings';
@@ -9,6 +10,10 @@ registerNavItem({
     return urls['kolibri:kolibri.plugins.learn:learn']();
   },
   get routes() {
+    const { isUserLoggedIn } = useUser();
+    if (!isUserLoggedIn.value) {
+      return [];
+    }
     return [
       {
         label: coreStrings.$tr('homeLabel'),


### PR DESCRIPTION
## Summary
* In response to user feedback, the ability to click on "home" and have it simply redirect back to the library when a user wasn't logged in was confusing
* Removes all subnavigation items from learn when a user isn't logged in to address this

## References


## Reviewer guidance
![Screenshot from 2025-04-02 15-45-38](https://github.com/user-attachments/assets/82107684-ef9b-4e30-b983-f9c04b87d4e1)

