### PR TITLE
handles errors at editing quiz when there are no resources

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -444,14 +444,6 @@ export default function useQuizCreation() {
   const activeExercisesUnusedQuestionsMap = computed(() => {
     const map = {};
     for (const exercise of Object.values(get(activeResourceMap))) {
-      if (
-        !exercise ||
-        !exercise.assessmentmetadata ||
-        !Array.isArray(exercise.assessmentmetadata.assessment_item_ids)
-      ) {
-        continue;
-      }
-
       const unusedQuestions = exercise.assessmentmetadata.assessment_item_ids
         .map(aid => `${exercise.id}:${aid}`)
         .filter(qid => !get(allQuestionsInQuiz).find(q => q.item === qid));

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -444,9 +444,18 @@ export default function useQuizCreation() {
   const activeExercisesUnusedQuestionsMap = computed(() => {
     const map = {};
     for (const exercise of Object.values(get(activeResourceMap))) {
+      if (
+        !exercise ||
+        !exercise.assessmentmetadata ||
+        !Array.isArray(exercise.assessmentmetadata.assessment_item_ids)
+      ) {
+        continue;
+      }
+
       const unusedQuestions = exercise.assessmentmetadata.assessment_item_ids
         .map(aid => `${exercise.id}:${aid}`)
         .filter(qid => !get(allQuestionsInQuiz).find(q => q.item === qid));
+
       map[exercise.id] = unusedQuestions;
     }
     return map;

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -100,7 +100,7 @@
                 :style="{ userSelect: dragActive ? 'none !important' : 'text' }"
               >
                 <ContentRenderer
-                  v-if="getQuestionContent(question).available"
+                  v-if="getQuestionContent(question)"
                   :ref="`contentRenderer-${question.item}`"
                   :kind="getQuestionContent(question).kind"
                   :lang="getQuestionContent(question).lang"

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -56,7 +56,7 @@
           }"
         >
           <AccordionItem
-            :title="displayQuestionTitle(question, getQuestionContent(question)?.title)"
+            :title="getDisplayQuestionTitle(question, getQuestionContent(question)?.title)"
             :disabledTitle="questionItemsToReplace?.includes(question.item)"
             :aria-selected="questionIsChecked(question)"
             :headerAppearanceOverrides="{
@@ -141,10 +141,7 @@
 <script>
 
   import { computed, ref } from 'vue';
-  import {
-    enhancedQuizManagementStrings,
-    displayQuestionTitle,
-  } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import Draggable from 'kolibri-common/components/sortable/Draggable';
   import DragHandle from 'kolibri-common/components/sortable/DragHandle';
   import DragContainer from 'kolibri-common/components/sortable/DragContainer';
@@ -254,7 +251,6 @@
         moveUpOne,
         moveDownOne,
         questionIsChecked,
-        displayQuestionTitle,
         questionCheckboxDisabled,
 
         selectAllLabel$,
@@ -358,6 +354,9 @@
             this.selectableQuestions.map(question => question.item),
           );
         }
+      },
+      getDisplayQuestionTitle(question, title) {
+        return title || this.coreString('resourceNotFoundOnDevice');
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -56,7 +56,7 @@
           }"
         >
           <AccordionItem
-            :title="displayQuestionTitle(question, getQuestionContent(question).title)"
+            :title="displayQuestionTitle(question, getQuestionContent(question)?.title)"
             :disabledTitle="questionItemsToReplace?.includes(question.item)"
             :aria-selected="questionIsChecked(question)"
             :headerAppearanceOverrides="{
@@ -100,6 +100,7 @@
                 :style="{ userSelect: dragActive ? 'none !important' : 'text' }"
               >
                 <ContentRenderer
+                  v-if="getQuestionContent(question).available"
                   :ref="`contentRenderer-${question.item}`"
                   :kind="getQuestionContent(question).kind"
                   :lang="getQuestionContent(question).lang"
@@ -115,6 +116,13 @@
                   @updateContentState="() => null"
                   @error="err => $emit('error', err)"
                 />
+                <div v-else>
+                  <KIcon
+                    icon="warning"
+                    :style="{ fill: $themePalette.yellow.v_600 }"
+                  />
+                  {{ coreString('resourceNotFoundOnDevice') }}
+                </div>
                 <slot
                   name="questionExtraContent"
                   :question="question"
@@ -142,6 +150,7 @@
   import DragContainer from 'kolibri-common/components/sortable/DragContainer';
   import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
   import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
   import useDrag from './useDrag.js';
 
@@ -155,6 +164,7 @@
       AccordionItem,
       AccordionContainer,
     },
+    mixins: [commonCoreStrings],
     setup(props) {
       const dragActive = ref(false);
 

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -5,6 +5,7 @@
       v-if="target === SelectionTarget.QUIZ && !settings.selectPracticeQuiz"
       class="mb-24"
       :settings="settings"
+      :hideSearch="channels.length === 0"
       @searchClick="onSearchClick"
     />
     <!-- flexDirection is set to row-reverse to align the search button to the right

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div>
+    <MissingResourceAlert v-if="selectedActiveQuestions.length === 0" />
     <KGrid :style="tabsWrapperStyles">
       <KGridItem
         :layout4="{ span: 4 }"
@@ -248,6 +249,7 @@
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import { injectQuizCreation } from '../../../composables/useQuizCreation';
   import commonCoach from '../../common';
   import { PageNames } from '../../../constants';
@@ -261,6 +263,7 @@
     components: {
       TabsWithOverflow,
       QuestionsAccordion,
+      MissingResourceAlert,
     },
     mixins: [commonCoreStrings, commonCoach],
     setup() {
@@ -581,7 +584,10 @@
         this.createSnackbar(this.questionsDeletedNotification$({ count }));
       },
       isQuestionAutoReplaceable(question) {
-        return this.activeExercisesUnusedQuestionsMap[question.exercise_id].length > 0;
+        if (this.selectedActiveQuestions.length > 0) {
+          return this.activeExercisesUnusedQuestionsMap[question.exercise_id].length > 0;
+        }
+        return false;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -581,7 +581,14 @@
         this.createSnackbar(this.questionsDeletedNotification$({ count }));
       },
       isQuestionAutoReplaceable(question) {
-        return this.activeExercisesUnusedQuestionsMap[question.exercise_id]?.length > 0;
+        // Check if question has assessmentmetadata and exercise_id is null or undefined
+        // otherwise it will break the composable
+        // I think the better way is to gurd against this in the composable itself in future
+        return (
+          question.assessmentmetadata &&
+          question.exercise_id &&
+          this.activeExercisesUnusedQuestionsMap[question.exercise_id].length > 0
+        );
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -1,7 +1,6 @@
 <template>
 
   <div>
-    <MissingResourceAlert v-if="Object.keys(activeResourceMap).length === 0" />
     <KGrid :style="tabsWrapperStyles">
       <KGridItem
         :layout4="{ span: 4 }"
@@ -249,7 +248,6 @@
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import { injectQuizCreation } from '../../../composables/useQuizCreation';
   import commonCoach from '../../common';
   import { PageNames } from '../../../constants';
@@ -263,7 +261,6 @@
     components: {
       TabsWithOverflow,
       QuestionsAccordion,
-      MissingResourceAlert,
     },
     mixins: [commonCoreStrings, commonCoach],
     setup() {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <MissingResourceAlert v-if="selectedActiveQuestions.length === 0" />
+    <MissingResourceAlert v-if="Object.keys(activeResourceMap).length === 0" />
     <KGrid :style="tabsWrapperStyles">
       <KGridItem
         :layout4="{ span: 4 }"

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -581,10 +581,7 @@
         this.createSnackbar(this.questionsDeletedNotification$({ count }));
       },
       isQuestionAutoReplaceable(question) {
-        if (this.selectedActiveQuestions.length > 0) {
-          return this.activeExercisesUnusedQuestionsMap[question.exercise_id].length > 0;
-        }
-        return false;
+        return this.activeExercisesUnusedQuestionsMap[question.exercise_id]?.length > 0;
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/index.vue
@@ -15,31 +15,6 @@
     </UiAlert>
 
     <KPageContainer :style="{ maxWidth: '1000px', margin: '0 auto 2em', paddingTop: '2rem' }">
-      <div
-        v-if="hasNoChannels"
-        class="alert banner-spacing"
-        :style="{ backgroundColor: $themePalette.yellow.v_200 }"
-      >
-        <div>
-          <KIcon
-            icon="warning"
-            class="warning-icon"
-            :color="$themePalette.yellow.v_600"
-          />
-        </div>
-
-        <div
-          v-if="hasNoChannels"
-          class="error-message"
-        >
-          <p>{{ noResourcesAvailable$() }}</p>
-          <KExternalLink
-            v-if="deviceContentUrl"
-            :text="$tr('adminLink')"
-            :href="deviceContentUrl"
-          />
-        </div>
-      </div>
       <AssignmentDetailsModal
         v-if="quizInitialized"
         ref="detailsModal"
@@ -93,8 +68,7 @@
           </KRadioButtonGroup>
         </KGrid>
       </div>
-
-      <CreateQuizSection v-if="quizInitialized && quiz.draft && channels.length > 0" />
+      <CreateQuizSection v-if="quizInitialized && quiz.draft" />
 
       <BottomAppBar>
         <span
@@ -143,13 +117,10 @@
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import { ref, getCurrentInstance } from 'vue';
   import pickBy from 'lodash/pickBy';
-  import urls from 'kolibri/urls';
-  import useUser from 'kolibri/composables/useUser';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
   import { PageNames } from '../../../constants';
   import CoachImmersivePage from '../../CoachImmersivePage';
   import { coachStrings } from '../../common/commonCoachStrings';
@@ -168,19 +139,10 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const channels = ref([]);
       const store = getCurrentInstance().proxy.$store;
       const closeConfirmationToRoute = ref(null);
       const { createSnackbar } = useSnackbar();
       const { classId, initClassInfo, groups } = useCoreCoach();
-      const { canManageContent } = useUser();
-
-      function _loadChannels() {
-        return ContentNodeResource.fetchCollection({}).then(res => {
-          channels.value = res;
-        });
-      }
-      _loadChannels();
 
       const {
         quizHasChanged,
@@ -205,7 +167,6 @@
         fixedLabel$,
         randomizedSectionOptionDescription$,
         fixedSectionOptionDescription$,
-        noResourcesAvailable$,
       } = enhancedQuizManagementStrings;
 
       const { closeConfirmationTitle$, closeConfirmationMessage$ } = coachStrings;
@@ -234,9 +195,6 @@
         randomizedSectionOptionDescription$,
         fixedSectionOptionDescription$,
         createSnackbar,
-        channels,
-        noResourcesAvailable$,
-        canManageContent,
       };
     },
     provide() {
@@ -277,17 +235,6 @@
           return this.$tr('createNewExamLabel');
         }
         return this.quiz.title;
-      },
-      deviceContentUrl() {
-        const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
-        if (deviceContentUrl && this.canManageContent) {
-          return `${deviceContentUrl()}#/content`;
-        }
-
-        return '';
-      },
-      hasNoChannels() {
-        return this.channels.length === 0;
       },
     },
     watch: {
@@ -421,10 +368,6 @@
         message: 'Create new quiz',
         context: "Title of the screen launched from the 'New quiz' button on the 'Plan' tab.",
       },
-      adminLink: {
-        message: 'Import channels to your device',
-        context: 'Message for admin indicating the possibility of importing channels into Kolibri.',
-      },
     },
   };
 
@@ -444,32 +387,6 @@
 
   .edit-section-order-btn {
     margin-left: 2em;
-  }
-
-  .alert {
-    position: relative;
-    width: 100%;
-    max-width: 1000px;
-    padding: 0.5em;
-    padding-left: 2em;
-    margin: 1em auto 0;
-  }
-
-  .warning-icon {
-    position: absolute;
-    top: 1em;
-    left: 1em;
-    width: 24px;
-    height: 24px;
-  }
-
-  .error-message {
-    margin-left: 3em;
-    font-size: 14px;
-  }
-
-  .banner-spacing {
-    margin: 0 0 1em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -7,6 +7,9 @@
     <h1 :style="{ color: $themeTokens.text }">
       {{ sectionSettings$() }}
     </h1>
+    <div>
+      <MissingResourceAlert v-if="resource.missing_resource" />
+    </div>
 
     <KTextbox
       ref="sectionTitle"
@@ -134,6 +137,7 @@
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { PageNames } from '../../../../../constants/index';
   import { coachStrings } from '../../../../common/commonCoachStrings.js';
@@ -141,12 +145,17 @@
 
   export default {
     name: 'SectionEditor',
+    components: {
+      MissingResourceAlert,
+    },
     mixins: [commonCoreStrings],
     setup(_, context) {
       const router = getCurrentInstance().proxy.$router;
       const store = getCurrentInstance().proxy.$store;
       const route = computed(() => store.state.route);
       const { createSnackbar } = useSnackbar();
+
+      const examMap = computed(() => store.state.classSummary.examMap);
 
       const {
         sectionSettings$,
@@ -308,6 +317,7 @@
         section_title,
         resourceButtonLabel,
         showResourceButton,
+        examMap,
         maxQuestionsLabel,
         // i18n
         displaySectionTitle,
@@ -328,6 +338,12 @@
       };
     },
     computed: {
+      exam() {
+        return this.examMap[this.$route.params.quizId] || {};
+      },
+      resource() {
+        return this.examOrLesson === 'lesson' ? this.lesson : this.exam;
+      },
       dividerStyle() {
         return `color : ${this.$themeTokens.fineLine}`;
       },

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -8,7 +8,7 @@
       {{ sectionSettings$() }}
     </h1>
     <div>
-      <MissingResourceAlert v-if="resource.missing_resource" />
+      <MissingResourceAlert v-if="exam.missing_resource" />
     </div>
 
     <KTextbox
@@ -340,9 +340,6 @@
     computed: {
       exam() {
         return this.examMap[this.$route.params.quizId] || {};
-      },
-      resource() {
-        return this.examOrLesson === 'lesson' ? this.lesson : this.exam;
       },
       dividerStyle() {
         return `color : ${this.$themeTokens.fineLine}`;


### PR DESCRIPTION
## Summary
This PR fixe the  error  when a coach  has already created some quizzes, then deleted some or all of the resources and attempt to edit a quiz  and will see the error in the console has seen from the video attached.
![image](https://github.com/user-attachments/assets/95523b89-ccd1-43a7-a259-31eba621517b)

closes #13281
## References
[#13281](https://github.com/learningequality/kolibri/issues/13281)

## Reviewer guidance
1. create quiz add resources and later delete some or all resources from the device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visual alert for missing resources when creating quiz sections.
  - Improved handling of missing question content by displaying a warning and a localized message if content is unavailable.
  
- **Bug Fixes**
  - The search bar in the quiz resource selection header is now hidden when no channels are available.

- **Refactor**
  - Enhanced robustness in question title and content display, ensuring graceful handling of missing data.
  - Added a guard condition to prevent auto-replacement of questions when none are selected.

- **Style**
  - Minor formatting improvements for better code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->