### PR TITLE
Fixes regression in cli plugin apply command.

### DIFF
--- a/kolibri/plugins/facility/test/test_api.py
+++ b/kolibri/plugins/facility/test/test_api.py
@@ -211,8 +211,6 @@ class UserCSVExportTestCase(APITestCase):
         cls.admin = FacilityUserFactory.create(facility=cls.facility)
         cls.user1 = FacilityUserFactory.create(facility=cls.facility)
         cls.facility.add_admin(cls.admin)
-
-    def test_csv_download_anonymous_permissions(self):
         try:
             call_command(
                 "bulkexportusers",
@@ -226,6 +224,7 @@ class UserCSVExportTestCase(APITestCase):
             # decided to bypass it this way for now
             pass
 
+    def test_csv_download_anonymous_permissions(self):
         response = self.client.get(
             reverse(
                 "kolibri:kolibri.plugins.facility:download_csv_file",
@@ -235,12 +234,6 @@ class UserCSVExportTestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_csv_download_non_admin_permissions(self):
-        call_command(
-            "bulkexportusers",
-            use_storage=True,
-            overwrite=True,
-        )
-
         self.client.login(
             username=self.user1.username,
             password=DUMMY_PASSWORD,
@@ -255,11 +248,6 @@ class UserCSVExportTestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_csv_download_admin_permissions(self):
-        call_command(
-            "bulkexportusers",
-            use_storage=True,
-            overwrite=True,
-        )
         self.client.login(
             username=self.admin.username,
             password=DUMMY_PASSWORD,

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -218,6 +218,19 @@ def enable_plugin(plugin_name, initialize_hooks=False):
         logger.error(str(e))
 
 
+def enable_plugins(plugin_names):
+    error = False
+    for name in plugin_names:
+        logger.info("Enabling plugin '{}'".format(name))
+        success = enable_plugin(name, initialize_hooks=True)
+        error = error or not success
+    return error
+
+
+def enable_default_plugins():
+    return enable_plugins(DEFAULT_PLUGINS)
+
+
 def disable_plugin(plugin_name, initialize_hooks=False):
     try:
         obj = initialize_kolibri_plugin(plugin_name, initialize_hooks=initialize_hooks)
@@ -231,6 +244,19 @@ def disable_plugin(plugin_name, initialize_hooks=False):
         )
         config.clear_plugin(plugin_name)
         logger.info("Removed '{}'".format(plugin_name))
+
+
+def disable_plugins(plugin_names):
+    error = False
+    for name in plugin_names:
+        logger.info("Disabling plugin '{}'".format(name))
+        success = disable_plugin(name)
+        error = error or not success
+    return error
+
+
+def disable_all_plugins():
+    return disable_plugins(config.ACTIVE_PLUGINS)
 
 
 def _get_plugin_version(plugin_name):


### PR DESCRIPTION
## Summary
Fixes regression introduced by https://github.com/learningequality/kolibri/pull/12874 which caused the apply command to error rather than properly disabling and enabling the appropriate plugins.
This error was caused by invoking the CLI enable and disable commands.
Does this by migrating most of the CLI functionality into new utility functions (where they probably should have been anyway)
Then reuses those utility functions for enabling, disabling, and applying plugins.

## References
Fixes regression from https://github.com/learningequality/kolibri/pull/12874

## Reviewer guidance
Do `kolibri plugin enable <plugin_names...>` `kolibri plugin disable <plugin_names...>` and `kolibri plugin apply <plugin_names...>` all work without errors and produce the appropriate effects to plugin activation?
