### PR TITLE
fix repetitive strings for drag and drop aria labels

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionsAccordion.vue
@@ -67,8 +67,8 @@
               <DragHandle v-if="isSortable">
                 <div>
                   <DragSortWidget
-                    :moveUpText="upLabel$"
-                    :moveDownText="downLabel$"
+                    :moveUpText="moveUpLabel$"
+                    :moveDownText="moveDownLabel$"
                     :noDrag="true"
                     :isFirst="index === 0"
                     :isLast="index === questions.length - 1"
@@ -145,7 +145,7 @@
   import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
   import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import useDrag from './useDrag.js';
 
   export default {
@@ -161,7 +161,7 @@
     setup(props) {
       const dragActive = ref(false);
 
-      const { upLabel$, downLabel$ } = searchAndFilterStrings;
+      const { moveUpLabel$, moveDownLabel$ } = coreStrings;
       const { selectAllLabel$, expandAll$, collapseAll$, replacingThisQuestionLabel$ } =
         enhancedQuizManagementStrings;
 
@@ -251,8 +251,8 @@
         displayQuestionTitle,
         questionCheckboxDisabled,
 
-        upLabel$,
-        downLabel$,
+        moveUpLabel$,
+        moveDownLabel$,
         selectAllLabel$,
         expandAll$,
         collapseAll$,

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -29,8 +29,8 @@
             >
               <div class="move-handle">
                 <DragSortWidget
-                  :moveUpText="moveResourceUpButtonDescription$"
-                  :moveDownText="moveResourceDownButtonDescription$"
+                  :moveUpText="moveUpLabel$"
+                  :moveDownText="moveDownLabel$"
                   :isFirst="index === 0"
                   :isLast="index === resourceListItems.length - 1"
                   @moveUp="moveUpOne(index)"
@@ -107,10 +107,9 @@
   import DragHandle from 'kolibri-common/components/sortable/DragHandle';
   import Draggable from 'kolibri-common/components/sortable/Draggable';
   import ContentIcon from 'kolibri-common/components/labels/ContentIcon';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import CoachContentLabel from 'kolibri-common/components/labels/CoachContentLabel';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { coachStrings } from '../../common/commonCoachStrings';
   import { PageNames } from '../../../constants';
 
@@ -130,15 +129,14 @@
     setup() {
       const { createSnackbar, clearSnackbar } = useSnackbar();
       const { noResourcesInLessonLabel$ } = coachStrings;
-      const { moveResourceUpButtonDescription$, moveResourceDownButtonDescription$ } =
-        searchAndFilterStrings;
+      const { moveUpLabel$, moveDownLabel$ } = coreStrings;
       return {
         PageNames,
         noResourcesInLessonLabel$,
         createSnackbar,
         clearSnackbar,
-        moveResourceUpButtonDescription$,
-        moveResourceDownButtonDescription$,
+        moveUpLabel$,
+        moveDownLabel$,
       };
     },
     props: {

--- a/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
@@ -1,10 +1,10 @@
 <template>
 
-  <CoreTable :emptyMessage="coachString('noResourcesInLessonLabel')">
+  <CoreTable :emptyMessage="noResourcesInLessonLabel$()">
     <template #headers>
-      <th>{{ coachString('titleLabel') }}</th>
-      <th>{{ coreString('progressLabel') }}</th>
-      <th>{{ coachString('avgTimeSpentLabel') }}</th>
+      <th>{{ titleLabel$() }}</th>
+      <th>{{ progressLabel$() }}</th>
+      <th>{{ avgTimeSpentLabel$() }}</th>
       <td v-if="editable"><!-- Actions --></td>
     </template>
     <template #tbody>
@@ -27,8 +27,8 @@
                     <!-- Mousedown.prevent is needed to avoid user selection -->
                     <DragSortWidget
                       class="sort-widget"
-                      :moveUpText="moveResourceUpButtonDescription$"
-                      :moveDownText="moveResourceDownButtonDescription$"
+                      :moveUpText="moveUpLabel$"
+                      :moveDownText="moveDownLabel$"
                       :isFirst="index === 0"
                       :isLast="index === entries.length - 1"
                       @moveUp="moveUpOne(index)"
@@ -70,7 +70,7 @@
                 <div class="actions">
                   <KIconButton
                     icon="clear"
-                    :ariaLabel="coreString('removeAction')"
+                    :ariaLabel="removeAction$()"
                     @click="() => handleRemoveEntry(tableRow)"
                   />
                 </div>
@@ -90,16 +90,15 @@
   import { mapState } from 'vuex';
   import CoreTable from 'kolibri/components/CoreTable';
   import TimeDuration from 'kolibri-common/components/TimeDuration';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import DragContainer from 'kolibri-common/components/sortable/DragContainer';
   import DragHandle from 'kolibri-common/components/sortable/DragHandle';
   import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import Draggable from 'kolibri-common/components/sortable/Draggable';
+  import { coachStrings } from '../../../common/commonCoachStrings';
   import CSVExporter from '../../../../csv/exporter';
   import * as csvFields from '../../../../csv/fields';
   import StatusSummary from '../../../common/status/StatusSummary';
-  import { coachStringsMixin } from '../../../common/commonCoachStrings';
 
   export default {
     name: 'LessonResourcesTable',
@@ -112,14 +111,20 @@
       DragSortWidget,
       Draggable,
     },
-    mixins: [coachStringsMixin, commonCoreStrings],
     setup() {
-      const { moveResourceUpButtonDescription$, moveResourceDownButtonDescription$ } =
-        searchAndFilterStrings;
+      const { resourcesLabel$, removeAction$, progressLabel$, moveUpLabel$, moveDownLabel$ } =
+        coreStrings;
+      const { noResourcesInLessonLabel$, titleLabel$, avgTimeSpentLabel$ } = coachStrings;
 
       return {
-        moveResourceUpButtonDescription$,
-        moveResourceDownButtonDescription$,
+        resourcesLabel$,
+        removeAction$,
+        moveUpLabel$,
+        moveDownLabel$,
+        noResourcesInLessonLabel$,
+        titleLabel$,
+        progressLabel$,
+        avgTimeSpentLabel$,
       };
     },
     props: {
@@ -171,13 +176,13 @@
         const columns = [
           ...csvFields.title(),
           ...csvFields.tally(),
-          ...csvFields.timeSpent('avgTimeSpent', this.coachString('avgTimeSpentLabel')),
+          ...csvFields.timeSpent('avgTimeSpent', this.avgTimeSpentLabel$),
         ];
 
         const exporter = new CSVExporter(columns, this.className);
         exporter.addNames({
           lesson: this.title,
-          resources: this.coreString('resourcesLabel'),
+          resources: this.resourcesLabel$,
         });
 
         if (this.group) {

--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
@@ -28,8 +28,8 @@
             >
               <DragSortWidget
                 class="drag-title"
-                :moveUpText="upLabel$"
-                :moveDownText="downLabel$"
+                :moveUpText="moveUpLabel$"
+                :moveDownText="moveDownLabel$"
                 :noDrag="true"
                 :isFirst="index === 0"
                 :isLast="index === sectionOrderList.length - 1"
@@ -92,12 +92,11 @@
     displaySectionTitle,
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import Draggable from 'kolibri-common/components/sortable/Draggable';
   import DragContainer from 'kolibri-common/components/sortable/DragContainer';
   import DragHandle from 'kolibri-common/components/sortable/DragHandle';
   import DragSortWidget from 'kolibri-common/components/sortable/DragSortWidget';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
   import { PageNames } from '../../../../../constants/index';
   import { coachStrings } from '../../../../common/commonCoachStrings.js';
   import { injectQuizCreation } from '../../../../../composables/useQuizCreation.js';
@@ -119,7 +118,7 @@
 
       const { activeSectionIndex, activeSection, allSections, updateQuiz } = injectQuizCreation();
 
-      const { upLabel$, downLabel$ } = searchAndFilterStrings;
+      const { moveUpLabel$, moveDownLabel$ } = coreStrings;
 
       const { moveDownOne, moveUpOne } = useDrag();
 
@@ -171,8 +170,8 @@
         applySettings$,
         closeConfirmationTitle$,
         closeConfirmationMessage$,
-        upLabel$,
-        downLabel$,
+        moveUpLabel$,
+        moveDownLabel$,
       };
     },
     computed: {

--- a/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/RearrangeChannelsPage.vue
@@ -36,8 +36,8 @@
                 >
                   <DragSortWidget
                     class="sort-widget"
-                    :moveUpText="moveChannelUpLabel$"
-                    :moveDownText="moveChannelDownLabel$"
+                    :moveUpText="moveUpLabel$"
+                    :moveDownText="moveDownLabel$"
                     :isFirst="index === 0"
                     :isLast="index === channels.length - 1"
                     @moveUp="shiftOne(index, -1)"
@@ -69,7 +69,7 @@
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import DeviceChannelResource from '../apiResources/deviceChannel';
   import useContentTasks from '../composables/useContentTasks';
   import { PageNames } from '../constants';
@@ -92,13 +92,13 @@
       useContentTasks();
       const { canManageContent } = useUser();
       const { createSnackbar } = useSnackbar();
-      const { moveChannelUpLabel$, moveChannelDownLabel$ } = searchAndFilterStrings;
+      const { moveUpLabel$, moveDownLabel$ } = coreStrings;
 
       return {
         canManageContent,
         createSnackbar,
-        moveChannelUpLabel$,
-        moveChannelDownLabel$,
+        moveUpLabel$,
+        moveDownLabel$,
       };
     },
     data() {

--- a/packages/kolibri-common/strings/searchAndFilterStrings.js
+++ b/packages/kolibri-common/strings/searchAndFilterStrings.js
@@ -7,34 +7,6 @@ export const searchAndFilterStrings = createTranslator('SearchAndFilterStrings',
     context:
       'Label for a section of the page that contains options for searching and filtering content',
   },
-  moveChannelUpLabel: {
-    message: 'Move up one',
-    context: 'Label to rearrange channel order. Not seen on UI.',
-  },
-  moveChannelDownLabel: {
-    message: 'Move down one',
-    context: 'Label to rearrange channel order. Not seen on UI.',
-  },
-
-  upLabel: {
-    message: 'Up',
-    context: 'Label to move an item up in a list',
-  },
-
-  downLabel: {
-    message: 'Down',
-    context: 'Label to move an item down in a list',
-  },
-
-  moveResourceUpButtonDescription: {
-    message: 'Move this resource one position up in this lesson',
-    context: 'Refers to changing the order of resources in a lesson.',
-  },
-
-  moveResourceDownButtonDescription: {
-    message: 'Move this resource one position down in this lesson',
-    context: 'Refers to changing the order of resources in a lesson.',
-  },
   saveLessonResources: {
     message: 'save & finish',
     context: 'Button to save resources in a lesson',

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1569,6 +1569,16 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Your library',
     context: '',
   },
+
+  // aria and a11y related strings
+  moveUpLabel: {
+    message: 'Move up',
+    context: 'Label for the button that moves a resource up in the list. Not visible in the UI.',
+  },
+  moveDownLabel: {
+    message: 'Move down',
+    context: 'Label for the button that moves a resource down in the list. Not visible in the UI.',
+  },
 });
 
 /**


### PR DESCRIPTION
Screenshots of where the aria labels are used:

Section ordering
<img width="1433" alt="Screenshot 2025-04-04 at 5 28 52 PM" src="https://github.com/user-attachments/assets/d0681024-f0cd-434f-a4a5-94efa0e80f9f" />

Question ordering
<img width="1438" alt="Screenshot 2025-04-04 at 5 24 35 PM" src="https://github.com/user-attachments/assets/61ff9b51-1b55-4bd4-97c6-bc108617684f" />

<img width="1436" alt="Screenshot 2025-04-04 at 5 09 39 PM" src="https://github.com/user-attachments/assets/92f7f0a5-44a1-47a7-b971-0baa434c4ca6" />

Lessons 

<img width="1438" alt="Screenshot 2025-04-04 at 5 44 46 PM" src="https://github.com/user-attachments/assets/24e17b62-8677-45cb-8a1c-748ef7999ac7" />

