### PR TITLE
Fixed Misallignment of folder name heading in view folder resources

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -419,4 +419,8 @@
     }
   }
 
+  .content-title {
+    margin-bottom: 8px;
+  }
+
 </style>


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixed Misalignment of folder name heading in view folder resources 

- Added minor css changes 
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
#13238 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Open the Learn app.
- Navigate to the Library section.
- Open any lecture.
- Click on "View Folder Resources" in the top-right corner.
- Observe the folder name is aligned correctly
…
![Screenshot from 2025-04-13 16-15-21](https://github.com/user-attachments/assets/40f68869-6eea-49a0-bfb0-a49f0e39c219)
