### PR TITLE
Remove empty div in favor of cards sync metrics

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
@@ -52,12 +52,6 @@
             :disabled="contentCheckboxDisabled(content)"
             @change="handleCheckboxChange(content, true)"
           />
-          <!-- As a fallback, if any contents have checkboxes at all, we'll want to
-               ensure the folder cards align w/ the resources -->
-          <div
-            v-else-if="contentsHaveCheckboxes"
-            style="width: 24px"
-          ></div>
         </template>
       </component>
     </KCardGrid>
@@ -248,9 +242,6 @@
     computed: {
       gridLayoutOverrides() {
         return [{ breakpoints: [0, 1, 2, 3, 4, 5, 6, 7], rowGap: '24px', cardsPerRow: 1 }];
-      },
-      contentsHaveCheckboxes() {
-        return this.contentList.some(this.contentHasCheckbox);
       },
       showButton() {
         return this.viewMoreButtonState === this.ViewMoreButtonStates.HAS_MORE;


### PR DESCRIPTION
## Summary

* PR for testing https://github.com/learningequality/kolibri-design-system/pull/990. 
  * [KDS#990](https://github.com/learningequality/kolibri-design-system/pull/990) introduces some changes in KCardGrid that makes that we no longer need to add an empty div in the select controller slot to have cards aligned even when they dont have a checkbox.

![image](https://github.com/user-attachments/assets/4f6ea1db-5cbf-41a3-9c58-23fa34ca7beb)



## References

Closes https://github.com/learningequality/kolibri-design-system/issues/980

## Reviewer guidance

1. Go to Lesson/Quizzes select resources.
2. Navigate through the topic tree, ensuring that all cards are still aligned.
