### PR TITLE
Fix deprecated ui toolbar deep selectors

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -33,7 +33,6 @@
         :progress="contentProgress"
         class="progress-icon"
       />
-
       <template #icon>
         <KIconButton
           icon="back"
@@ -597,35 +596,28 @@
   }
 
   /*
-  Make truncation via text ellipsis work well in UIToolbar's body flex item:
+  Make truncation via text ellipsis work well in KToolbar's default slot:
   By default, `min-width` is `auto`  for a flex item which means it
   cannot be smaller than the size of its content which causes the whole
   title being visible even in cases when it should be already truncated.
   Overriding it to `0` allows the title to be shrinked and then truncated
-  properly. Labeled icon wrapper needs to have this set too for its parent
-  flex item to shrink.
+  properly.
 */
-  /deep/ .ui-toolbar__body,
   /deep/ .labeled-icon-wrapper {
     min-width: 0;
   }
 
-  /deep/ .ui-toolbar__left {
+  /deep/ .k-toolbar-left {
     margin-left: 5px;
     overflow: hidden;
   }
 
-  /deep/ .ui-toolbar__right {
+  /deep/ .k-toolbar-right {
     display: flex;
   }
 
-  /deep/ .ui-toolbar__nav-icon {
+  /deep/ .k-toolbar-nav-icon {
     margin-left: 0; // prevents icon cutoff
-  }
-
-  /deep/ .ui-toolbar__body {
-    flex-grow: 0; // make sure that the completion icon is right next to the title
-    align-items: center;
   }
 
   /deep/ .progress-icon .ui-icon {

--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -377,27 +377,12 @@
     margin-left: 16px;
   }
 
-  /deep/ .ui-toolbar__body {
-    display: inline-block;
-    margin-bottom: 12px;
-  }
-
-  /deep/ .ui-toolbar__title {
+  /deep/ .k-toolbar-right {
     display: flex;
     align-items: center;
   }
 
-  /deep/ .ui-toolbar__nav-icon {
-    display: flex;
-    align-items: center;
-  }
-
-  /deep/ .ui-toolbar__right {
-    display: flex;
-    align-items: center;
-  }
-
-  /deep/ .ui-toolbar__left {
+  /deep/ .k-toolbar-left {
     display: flex;
     align-items: center;
     margin-left: 8px;

--- a/packages/kolibri/components/pages/ImmersivePage/internal/ImmersiveToolbar.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/internal/ImmersiveToolbar.vue
@@ -146,16 +146,16 @@
     outline-offset: -4px;
   }
 
-  /deep/ .ui-toolbar__left {
+  /deep/ .k-toolbar-left {
     margin-left: 5px;
     overflow: hidden;
   }
 
-  /deep/ .ui-toolbar__nav-icon {
+  /deep/ .k-toolbar-nav-icon {
     margin-left: 0;
   }
 
-  /deep/ .ui-toolbar__title {
+  /deep/ .k-toolbar-title {
     text-overflow: ellipsis;
   }
 


### PR DESCRIPTION
## Summary
Fixes deprecated ui toolbar deep selectors replacing them with the current KToolbar selectors.

| 0.17 | 0.18 Before | 0.18 After |
| --- | --- | --- |
| | LearningActivityBar without handling overflowed titles | |
| ![image](https://github.com/user-attachments/assets/30853033-caac-4967-9690-3c4eb00d6456) | ![image](https://github.com/user-attachments/assets/c5b9db23-d7ca-4333-8017-53cb885dffde) | ![image](https://github.com/user-attachments/assets/eb8fd383-7541-4bce-b2e3-99497233bcad) |
| | Immersive pages without handling overflowed titles | |
| ![image](https://github.com/user-attachments/assets/4761234a-1d08-48b5-a5a6-bd8e79b40ff7) | ![image](https://github.com/user-attachments/assets/e290cf2c-318e-4d92-b3ab-48599ac3b26b) | ![image](https://github.com/user-attachments/assets/329f18ac-8dca-41ac-858e-4651831bd273) |
| | Little difference in margin-left on appbars | |
| ![image](https://github.com/user-attachments/assets/d8ea7232-0fc9-4e31-8d7a-4a86c3865668) | ![image](https://github.com/user-attachments/assets/1dde478c-0472-4c49-9597-f48fdf71686e) | ![image](https://github.com/user-attachments/assets/0a8d9e7b-803a-4c97-a264-092f7799c6e9) |

This is just a provisional solution as using /deep/ selectors would cause this again in the future if something inside KToolbar changes, so we should seek a more robust solution in the future.



## References
Closes #13325.

## Reviewer guidance
Replicate steps in #13325
