### PR TITLE
Add defensive programming checks for progress setting and calculation

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -249,10 +249,18 @@ class Job(object):
         self.storage.save_job_meta(self)
 
     def update_progress(self, progress, total_progress):
-        if self.track_progress:
-            self.progress = progress
-            self.total_progress = total_progress
-            self.storage.update_job_progress(self.job_id, progress, total_progress)
+        if not self.track_progress:
+            return
+        if not isinstance(progress, (int, float)) or not isinstance(
+            total_progress, (int, float)
+        ):
+            logger.warning(
+                f"Tried to set invalid progress values on job {self.job_id} for task {self.func} with progress: {progress} and total_progress {total_progress}"
+            )
+            return
+        self.progress = progress
+        self.total_progress = total_progress
+        self.storage.update_job_progress(self.job_id, progress, total_progress)
 
     def update_metadata(self, **kwargs):
         for key, value in kwargs.items():

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -373,7 +373,7 @@ class Job(object):
         :return: float corresponding to the total percentage progress of the job.
         """
 
-        if self.total_progress != 0:
+        if self.total_progress != 0 and self.total_progress is not None:
             return float(self.progress) / self.total_progress
         return self.progress
 


### PR DESCRIPTION
## Summary
* Adds a check so we don't accidentally try to divide by None
* Adds a check and warning to prevent invalid values for progress and total_progress from being set

## References
Fixes https://github.com/learningequality/kolibri/issues/13321

## Reviewer guidance
Do a quick smoke test of content import for a new channel to ensure against regressions in task calculation
