### PR TITLE
Add scopedLabelsLoading to useBaseSearch to handle loading states for non-search displaying label fetching 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -161,6 +161,7 @@
               </div>
             </div>
 
+            <KCircularLoader v-else-if="searchLoading" />
             <!-- search results -->
             <!-- TODO: Should card preference be permitted in Topics page as well? At least for
                 search results? -->

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -22,6 +22,7 @@
         ref="searchInput"
         v-model.trim="newSearchTerm"
         type="search"
+        :disabled="disabled"
         class="search-input"
         :class="$computedClass(searchInputStyle)"
         dir="auto"
@@ -93,6 +94,10 @@
         type: String,
         default: null,
       },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -113,7 +118,7 @@
       },
       searchBarDisabled() {
         // Disable the search bar if it has been cleared or has not been changed
-        return this.searchInputValue === '';
+        return this.searchInputValue === '' || this.disabled;
       },
       searchInputStyle() {
         return {

--- a/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/AccordionSelectGroup.vue
@@ -15,7 +15,16 @@
         "
         :style="accordionItemStyles"
       >
-        <template #content>
+        <template
+          v-if="searchLoading"
+          #content
+        >
+          <KCircularLoader />
+        </template>
+        <template
+          v-else
+          #content
+        >
           <KButton
             v-for="(category, key) in availableLibraryCategories"
             :key="'cat-' + key"
@@ -73,7 +82,7 @@
         :headerAppearanceOverrides="
           accordionHeaderStyles(anySelectedFor('languages', languageOptionsList))
         "
-        :disabled="languageOptionsList.every(opt => opt.disabled)"
+        :disabled="searchLoading || languageOptionsList.every(opt => opt.disabled)"
         :contentAppearanceOverrides="{
           maxHeight: '256px',
           overflowY: 'scroll',
@@ -95,7 +104,7 @@
         v-if="contentLevelOptions.length"
         class="accordion-select"
         :title="coreString('levelLabel')"
-        :disabled="contentLevelOptions.every(opt => opt.disabled)"
+        :disabled="searchLoading || contentLevelOptions.every(opt => opt.disabled)"
         :headerAppearanceOverrides="
           accordionHeaderStyles(anySelectedFor('grade_levels', contentLevelOptions))
         "
@@ -123,7 +132,7 @@
         :headerAppearanceOverrides="
           accordionHeaderStyles(anySelectedFor('accessibility_labels', accessibilityOptionsList))
         "
-        :disabled="accessibilityOptionsList.every(opt => opt.disabled)"
+        :disabled="searchLoading || accessibilityOptionsList.every(opt => opt.disabled)"
         :contentAppearanceOverrides="{
           maxHeight: '256px',
           overflowY: 'scroll',
@@ -147,7 +156,7 @@
         :headerAppearanceOverrides="
           accordionHeaderStyles(anySelectedFor('learner_needs', needsOptionsList))
         "
-        :disabled="needsOptionsList.every(opt => opt.disabled)"
+        :disabled="searchLoading || needsOptionsList.every(opt => opt.disabled)"
         :contentAppearanceOverrides="{
           maxHeight: '256px',
           overflowY: 'scroll',
@@ -191,6 +200,7 @@
         availableAccessibilityOptions,
         availableLanguages,
         availableLibraryCategories,
+        searchLoading,
         searchableLabels,
       } = injectBaseSearch();
 
@@ -200,6 +210,7 @@
         availableAccessibilityOptions,
         availableLanguages,
         availableLibraryCategories,
+        searchLoading,
         searchableLabels,
       };
     },

--- a/packages/kolibri-common/components/SearchFiltersPanel/ActivityButtonsGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/ActivityButtonsGroup.vue
@@ -1,7 +1,10 @@
 <template>
 
   <div>
-    <h2 class="title">
+    <h2
+      v-if="Object.keys(availableLearningActivities).length > 0"
+      class="title"
+    >
       {{ $tr('activities') }}
     </h2>
     <div class="wrapper">
@@ -15,7 +18,9 @@
           :appearanceOverrides="
             isKeyActive(key) ? { ...activityStyles, ...activityActiveStyles } : activityStyles
           "
-          :disabled="availableActivities && !availableActivities[key] && !isKeyActive(key)"
+          :disabled="
+            searchLoading || (availableActivities && !availableActivities[key] && !isKeyActive(key))
+          "
           @click="$emit('input', key)"
         >
           <KIcon
@@ -44,12 +49,13 @@
     name: 'ActivityButtonsGroup',
     mixins: [commonCoreStrings],
     setup() {
-      const { availableLearningActivities, searchableLabels, activeSearchTerms } =
+      const { availableLearningActivities, searchableLabels, activeSearchTerms, searchLoading } =
         injectBaseSearch();
       return {
         availableLearningActivities,
         searchableLabels,
         activeSearchTerms,
+        searchLoading,
       };
     },
     computed: {

--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -4,7 +4,7 @@
     <KSelect
       v-if="languageOptionsList.length"
       :options="languageOptionsList"
-      :disabled="!langId && enabledLanguageOptions.length < 2"
+      :disabled="searchLoading || (!langId && enabledLanguageOptions.length < 2)"
       :clearable="!(!langId && enabledLanguageOptions.length < 2)"
       :clearText="coreString('clearAction')"
       :value="selectedLanguage"
@@ -15,7 +15,7 @@
     <KSelect
       v-if="contentLevelsList.length"
       :options="contentLevelsList"
-      :disabled="!levelId && enabledContentLevels.length < 2"
+      :disabled="searchLoading || (!levelId && enabledContentLevels.length < 2)"
       class="selector"
       :clearable="!(!levelId && enabledContentLevels.length < 2)"
       :clearText="coreString('clearAction')"
@@ -27,7 +27,7 @@
     <KSelect
       v-if="accessibilityOptionsList.length"
       :options="accessibilityOptionsList"
-      :disabled="!accessId && enabledAccessibilityOptions.length < 2"
+      :disabled="searchLoading || (!accessId && enabledAccessibilityOptions.length < 2)"
       class="selector"
       :clearable="!(!accessId && enabledAccessibilityOptions.length < 2)"
       :clearText="coreString('clearAction')"
@@ -58,12 +58,14 @@
         availableAccessibilityOptions,
         availableLanguages,
         searchableLabels,
+        searchLoading,
       } = injectBaseSearch();
       return {
         availableGradeLevels,
         availableAccessibilityOptions,
         availableLanguages,
         searchableLabels,
+        searchLoading,
       };
     },
     props: {

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -22,6 +22,10 @@
       :class="windowIsLarge ? '' : 'drawer-panel'"
     >
       <div v-if="!accordion">
+        <KLinearLoader
+          v-if="searchLoading"
+          class="linear-loader"
+        />
         <!-- search by keyword -->
         <h2 class="title">
           {{ $tr('keywords') }}
@@ -30,6 +34,7 @@
           key="channel-search"
           ref="searchBox"
           :placeholder="coreString('findSomethingToLearn')"
+          :disabled="searchLoading"
           :value="value.keywords || ''"
           @change="val => $emit('input', { ...value, keywords: val })"
         />
@@ -53,9 +58,10 @@
                   : categoryListItemStyles
               "
               :disabled="
-                availableRootCategories &&
-                  !availableRootCategories[category.value] &&
-                  !isCategoryActive(category.value)
+                searchLoading ||
+                  (availableRootCategories &&
+                    !availableRootCategories[category.value] &&
+                    !isCategoryActive(category.value))
               "
               :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
               @click="handleCategory(key)"
@@ -68,6 +74,7 @@
             <KButton
               :text="coreString('uncategorized')"
               appearance="flat-button"
+              :disabled="searchLoading"
               :appearanceOverrides="
                 isCategoryActive('no_categories')
                   ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
@@ -104,7 +111,7 @@
             <KCheckbox
               :checked="value.learner_needs[val]"
               :label="coreString(activity)"
-              :disabled="availableNeeds && !availableNeeds[val]"
+              :disabled="searchLoading || (availableNeeds && !availableNeeds[val])"
               @change="handleNeed(val)"
             />
           </div>
@@ -119,6 +126,7 @@
           key="channel-search"
           ref="searchBox"
           style="margin-bottom: 1em"
+          :disabled="searchLoading"
           :placeholder="$tr('searchByKeyword')"
           :value="value.keywords || ''"
           @change="val => $emit('input', { ...value, keywords: val })"
@@ -202,6 +210,7 @@
         availableResourcesNeeded,
         searchableLabels,
         activeSearchTerms,
+        searchLoading,
       } = injectBaseSearch();
       const currentCategory = ref(null);
       const { filterAndSearchLabel$ } = searchAndFilterStrings;
@@ -212,6 +221,7 @@
         currentCategory,
         searchableLabels,
         activeSearchTerms,
+        searchLoading,
         windowIsLarge,
       };
     },
@@ -494,6 +504,12 @@
 
   .categoryButton:not(:last-child) {
     margin-bottom: 0.5em;
+  }
+
+  .linear-loader {
+    right: 35px;
+    bottom: 25px;
+    width: 120%;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates the `useBaseSearch` composable and `AccordionSelectGroup` component to use `scopedLabelsLoading` to handle the loading state when global labels are available, but the  sub-labels are still being fetched, blocking user interactions with search terms that are not actually available after loading has finished.


Before:

https://github.com/user-attachments/assets/7a978d97-7255-445b-897c-a7820ac3ad3f

After:

https://github.com/user-attachments/assets/0de9ee68-67be-4986-a553-a9da1708708e

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #13280 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
 * 

-->
1. Import Kolibri QA channel.
2. Go to create a quiz and choose "select a quiz" option to look for practice quizzes.
3. Click on search.
4. The labels should be interactive only when they are have completed loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added loading indicators (spinners and progress bars) to the topics page and search filters panel, providing visual feedback during search operations.

- **Enhancements**
  - Disabled search inputs, filters, and activity buttons while search results are loading to prevent user interaction during loading states.
  - Improved accessibility and responsiveness of search-related UI components during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->