### PR TITLE
Separate side panel closing with prompt to catch and unsaved quiz que…

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -107,7 +107,7 @@
         :cancelText="coreString('cancelAction')"
         :title="closeConfirmationTitle$()"
         @cancel="handleCancelClose"
-        @submit="handleClosePanel"
+        @submit="handleCloseContinue"
       >
         {{ closeConfirmationMessage$() }}
       </KModal>
@@ -445,7 +445,7 @@
         showCloseConfirmation.value = false;
       }
 
-      function handleClosePanel() {
+      function handleCloseContinue() {
         setWorkingResourcePool();
         setQuestionItemsToReplace([]);
         $router.push({
@@ -457,6 +457,14 @@
           },
           query: { ...route.value.query },
         });
+      }
+
+      function handleClosePanel() {
+        if (workingPoolHasChanged.value) {
+          showCloseConfirmation.value = true;
+        } else {
+          handleCloseContinue();
+        }
       }
 
       const workingPoolHasChanged = computed(() => {
@@ -673,6 +681,7 @@
         notifyChanges,
         handleClosePanel,
         handleCancelClose,
+        handleCloseContinue,
         topic,
         showCloseConfirmation,
         treeFetch,
@@ -790,7 +799,7 @@
           this.clearQuizSelectedQuestions();
         }
         this.notifyChanges(numQuestions);
-        this.handleClosePanel();
+        this.handleCloseContinue();
       },
       // The message put onto the content's card when listed
       contentCardMessage(content) {


### PR DESCRIPTION
## Summary
Resolves a slight regression with the "are you sure" modal not displaying properly when questions were selected in a quiz, but the user navigates away without saving. Now, when there are selected but unsaved resources, if the user clicks the X or the backdrop, they should be prompted whether or not they want to save their work, or continue.

## References
Fixes #13318

Before: 


https://github.com/user-attachments/assets/8a83aef0-1688-4dea-89ae-1fd69077da76



After:


https://github.com/user-attachments/assets/e4072124-986d-48ac-99a4-c22d8961553e




## Reviewer guidance
Code review: 
- The changes I made are maybe not the most straightforward, but given the timeline for release I think it's the best short term approach. The updates should maybe be considered as some of the overall refactoring for the side panel and bring more consistency between lessons and quizzes, and overall streamlining the API for planned patch 1. But, if this feels too annoying even for a bandaid fix, or if you have other suggestions, they are welcome.

Manual QA: 
Testing the following scenarios to make sure we follow the expected behavior
- in the quiz side panel, but NO questions/resources are selected: clicking the backdrop or close button just navigates the user away without a prompt
- in the quiz side panel, and one or more questions or resources are selected: clicking the backdrop or close button prompts the user to confirm. If the click cancel, the modal closes and they return to where they were. if the click continue, their 