### PR TITLE
Make Manual Question Selection alert non-sticky on scroll

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -23,7 +23,7 @@
     <template #default="{ isScrolled }">
       <div
         v-if="showManualSelectionNotice && $route.name !== PageNames.QUIZ_SELECT_RESOURCES_SETTINGS"
-        class="alert-warning d-flex-between"
+        class="alert d-flex-between"
         :class="{
           shadow: isScrolled,
         }"
@@ -52,7 +52,7 @@
 
       <div
         v-if="maximumContentSelectedWarning"
-        class="alert-warning"
+        class="alert warning"
         :class="{
           shadow: isScrolled,
         }"
@@ -861,14 +861,17 @@
     }
   }
 
-  .alert-warning {
-    position: sticky;
+  .alert {
     top: 0;
-    z-index: 1;
     width: 100%;
     padding: 16px;
     margin-bottom: 16px;
     border-radius: 4px;
+  }
+
+  .alert.warning {
+    position: sticky;
+    z-index: 2;
     transition: $core-time ease;
 
     &.shadow {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request divides the class `alert-warning` into two classes to ensure that the manual question selection banner is not sticky, while the banner for the selected maximum content remains sticky when scrolling in the `SidePanelModal`.

Before:

https://github.com/user-attachments/assets/3342ac0c-f5ce-43c7-9e8d-13dc07c11feb

After:

https://github.com/user-attachments/assets/dd1add1b-9dc2-44b3-a309-50596673fe67



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13299 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. As a coach, create a new quiz
2. Add questions to a section
3. Select or unselect the option to manually select questions to see the manualSelectionOnNotice or manualSelectionOffNotice
4. Open content with enough questions to scroll down the side panel modal. The manual selection notice should not be sticky when scrolling
