### PR TITLE
Fix media player index responsiveness

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -99,6 +99,7 @@
   import { languageIdToCode } from 'kolibri/utils/i18n';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import useKResponsiveElement from 'kolibri-design-system/lib/composables/useKResponsiveElement';
   import Settings from '../utils/settings';
   import { ReplayButton, ForwardButton } from './customButtons';
   import MediaPlayerFullscreen from './MediaPlayerFullscreen';
@@ -125,7 +126,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
-      return { windowIsSmall, windowIsPortrait };
+      const { elementWidth } = useKResponsiveElement();
+      return { windowIsSmall, windowIsPortrait, elementWidth };
     },
     data: () => ({
       dummyTime: 0,


### PR DESCRIPTION
## Summary

MediaPlayerIndex component was relying on the removed `KResponsiveElementMixin` to get the `elementWidth` property. This PR gets this property from the new `useKResponsiveElement` composable.


https://github.com/user-attachments/assets/364da80f-5f72-41bd-bed1-b43c6b57557f



## References
Closes #13334

## Reviewer guidance

* Open a video resource, and check its responsiveness

