### PR TITLE
Fix folder name alignment in view folder resources

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -767,11 +767,4 @@
     margin-left: 8px;
   }
 
-  .header-content h2 {
-    position: absolute;
-    top: 50%;
-    text-align: left;
-    transform: translate(0, -50%);
-  }
-
 </style>


### PR DESCRIPTION
## Summary

* Fix folder name alignment in view folder resources side panel.
  * This was caused by other `position: absolute` way of centering content. This is no longer needed since [we now center the title within the side panel component itself](https://github.com/AlexVelezLl/kolibri/blob/4e68ffe693c5a2bf3fe97d3d62d972d4ebb3fbf6/packages/kolibri-common/components/SidePanelModal/index.vue#L230).

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e401b8d2-399a-484f-bb2c-618776176d86) | ![image](https://github.com/user-attachments/assets/6bc798c9-04c9-494a-a7fb-8567f3552cf6) |
## References
Closes #13333.

## Reviewer guidance

Follow instructions of #13333

