### PR TITLE
Fix LearnerSummaryPage lesson count discrepency

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
@@ -56,7 +56,7 @@
           <div class="value-box">
             <p class="value">{{ lessonsCompleted }}</p>
             <p style="display: inline; word-wrap: break-word">
-              {{ $tr('totalLessons', { total: lessons.length }) }}
+              {{ $tr('totalLessons', { total: learnerLessons.length }) }}
             </p>
           </div>
         </div>
@@ -121,6 +121,13 @@
       ReportsControls,
     },
     mixins: [commonCoach, commonCoreStrings],
+    // A list of all lessons assigned to the relevant Learner
+    props: {
+      learnerLessons: {
+        type: Array,
+        required: true,
+      },
+    },
     computed: {
       learner() {
         return this.learnerMap[this.$route.params.learnerId];
@@ -129,9 +136,11 @@
         return this.contentStatuses.filter(status => this.learner.id === status.learner_id);
       },
       lessonsCompleted() {
+        const learnerLessonIds = this.learnerLessons.map(l => l.id);
         const statuses = this.lessonStatuses.filter(
           status =>
-            this.learner.id === status.learner_id && status.status === this.STATUSES.completed,
+            status.status === this.STATUSES.completed &&
+            learnerLessonIds.includes(status.lesson_id),
         );
         if (!statuses.length) {
           return 0;

--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/index.vue
@@ -2,7 +2,7 @@
 
   <CoachAppBarPage>
     <KPageContainer>
-      <LearnerHeader />
+      <LearnerHeader :learnerLessons="getLessons" />
     </KPageContainer>
     <KGrid>
       <KGridItem


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some of the lessons logic between components is a little inconsistent here. This PR introduces a quick patch to ensure consistency in the LearnerSummaryPage data.

At a high level, the mixing-in of things using commonCoach obscures things a bit in that it isn't usually clear how they're to be used, in particular. So the index page has all of its own logic for how to get a list of the Learners' lessons and the header was relying on some data from the mixin which appears to have it's intended use elsewhere.

I think that encapsulating some of the reporting logic into more purpose-built composables will be a more solid solution here, but we'll cross that bridge the next time we find ourselves updating this part of coach.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13317 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

View the learner summary page and see that the reported issue has been resolved. Basically, the count at the top should match what is presented in the "Assigned lessons" box below.
