### PR TITLE
RTL fixes in Quiz Creation

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/AssignmentDetailsModal.vue
@@ -43,7 +43,7 @@
               :invalidText="titleIsInvalidText"
               :showInvalidText="titleIsInvalid"
               :disabled="disabled || formIsSubmitted"
-              :style="{ marginLeft: windowIsLarge ? '-1em' : 0 }"
+              :class="{ 'textbox-lg': windowIsLarge }"
               @input="showTitleError = false"
               @keydown.enter="submitData"
             />
@@ -70,8 +70,7 @@
                     ? afterLearnerSubmitsQuizDescription$()
                     : afterCoachEndsQuizDescription$()
                 "
-                :style="windowIsSmall ? 'margin-left: -1em' : 'margin-left: -3em'"
-                class="visibility-score-select"
+                :class="['visibility-score-select', windowIsSmall ? 'select-sm' : 'select-lg']"
                 @change="option => (instantReportVisibility = option.value)"
               />
             </KGridItem>
@@ -96,7 +95,7 @@
               :maxlength="200"
               :disabled="disabled || formIsSubmitted"
               :textArea="true"
-              :style="{ marginLeft: windowIsLarge ? '-1em' : 0 }"
+              :class="{ 'textbox-lg': windowIsLarge }"
             />
           </KGridItem>
         </KGrid>
@@ -508,6 +507,18 @@
   legend {
     font-size: 16px;
     font-weight: bold;
+  }
+
+  .textbox-lg {
+    margin-left: -1em;
+  }
+
+  .select-sm {
+    margin-left: -1em;
+  }
+
+  .select-lg {
+    margin-left: -3em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/assignments/SidePanelRecipientsSelector/index.vue
@@ -20,38 +20,29 @@
         :buttonValue="ClassRecipients.GROUP_OR_INDIVIDUAL"
         :disabled="disabled"
       >
-        <div>
-          <div
-            :style="{
-              display: 'flex',
-              columnGap: '8px',
-              flexDirection: hasGroupOrIndividualRecipients ? 'column' : 'row',
-              alignItems: hasGroupOrIndividualRecipients ? 'flex-start' : 'center',
-            }"
-          >
-            <KLabeledIcon
-              :label="coachString('groupsAndLearnersLabel')"
-              icon="people"
-              style="width: auto"
-            />
-            <span v-if="hasGroupOrIndividualRecipients">
-              {{ selectedMessage }}
-            </span>
-            <KButton
-              v-if="selectedRecipients === ClassRecipients.GROUP_OR_INDIVIDUAL"
-              appearance="basic-link"
-              :text="hasGroupOrIndividualRecipients ? $tr('changeAction') : $tr('selectAction')"
-              @click="isLearnersSelectorOpen = true"
-            />
-          </div>
-          <div
-            v-if="assignmentInvalidText"
-            :style="{
-              color: $themeTokens.error,
-            }"
-          >
-            {{ assignmentInvalidText }}
-          </div>
+        <div :dir="isRtl ? 'rtl' : 'ltr'">
+          <KLabeledIcon
+            :label="coachString('groupsAndLearnersLabel')"
+            icon="people"
+          />
+          <span v-if="hasGroupOrIndividualRecipients">
+            {{ selectedMessage }}
+          </span>
+          <KButton
+            v-if="selectedRecipients === ClassRecipients.GROUP_OR_INDIVIDUAL"
+            appearance="basic-link"
+            :text="hasGroupOrIndividualRecipients ? $tr('changeAction') : $tr('selectAction')"
+            style="margin: 0 0.5em"
+            @click="isLearnersSelectorOpen = true"
+          />
+        </div>
+        <div
+          v-if="assignmentInvalidText"
+          :style="{
+            color: $themeTokens.error,
+          }"
+        >
+          {{ assignmentInvalidText }}
         </div>
       </KRadioButton>
     </KRadioButtonGroup>
@@ -257,6 +248,14 @@
     display: flex;
     gap: 8px;
     align-items: center;
+  }
+
+  /deep/ .k-radio-button-label {
+    text-align: left;
+  }
+
+  /deep/ .labeled-icon-wrapper {
+    width: auto;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

**Fixes issue with radio button text not being aligned correctly in rtl.** 

I removed use of flex altogether here and made sure the wrapping div's dir is set properly so that the elements render in the correct order and text-alignment.

**Fixes issue where form elements were not contained (even after fixing the above bug)**

The inline `:style={ marginLeft: windowIsLarge ? '-1em' : '0' }` were not being converted properly when in RTL, resulting in 


**Before**

![image](https://github.com/user-attachments/assets/28723e55-693f-4b65-8db6-b0d394c20555)


**After**

![image](https://github.com/user-attachments/assets/4d7886a4-eab6-4efb-b32e-c0bbfff2d9c1)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13326 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check out quiz creation in LTR and RTL languages and observe:

- All form elements are aligned as expected
- All form elements are visible
- No horizontal scroll bar
- When you click the "Groups and individual learners" button, the "Select" link-button is at the end of the label text per the reading direction of that language.
