### PR TITLE
Learn > Library - Loading state improvements

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -237,7 +237,7 @@
     methods: {
       showDevices() {
         this.$emit('availableNetworkDevices', this.devicesWithChannelsExist);
-        this.$emit('isLoadingLibraries',this.searchingOtherLibraries);
+        this.$emit('isLoadingLibraries', this.searchingOtherLibraries);
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -237,6 +237,7 @@
     methods: {
       showDevices() {
         this.$emit('availableNetworkDevices', this.devicesWithChannelsExist);
+        this.$emit('isLoadingLibraries',this.searchingOtherLibraries);
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -39,7 +39,6 @@
           content.
           - Otherwise, show search results.
         -->
-        {{ isLoadingNetworkLibraries }}
         <KCircularLoader
           v-if="rootNodesLoading || searchLoading"
           class="loader"
@@ -50,16 +49,17 @@
           v-else-if="!displayingSearchResults && !rootNodesLoading"
           data-test="channels"
         >
-          <div > 
+          <div>
             <h1
               v-if="!isLocalLibraryEmpty"
               class="channels-label"
             >
               {{ channelsLabel }}
             </h1>
-            <div 
-              v-else-if="isLocalLibraryEmpty && isNetworkLibraryAvailable 
-                && !isLoadingNetworkLibraries"
+            <div
+              v-else-if="
+                isLocalLibraryEmpty && isNetworkLibraryAvailable && !isLoadingNetworkLibraries
+              "
             >
               <h1 class="channels-label">
                 {{ channelsLabel }}
@@ -443,7 +443,7 @@
         mobileSidePanelIsOpen: false,
         usingMeteredConnection: true,
         isNetworkLibraryAvailable: true,
-        isLoadingNetworkLibraries: true
+        isLoadingNetworkLibraries: true,
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -39,6 +39,7 @@
           content.
           - Otherwise, show search results.
         -->
+        {{ isLoadingNetworkLibraries }}
         <KCircularLoader
           v-if="rootNodesLoading || searchLoading"
           class="loader"
@@ -49,24 +50,29 @@
           v-else-if="!displayingSearchResults && !rootNodesLoading"
           data-test="channels"
         >
-          <h1
-            v-if="!isLocalLibraryEmpty"
-            class="channels-label"
-          >
-            {{ channelsLabel }}
-          </h1>
-          <div v-else-if="isLocalLibraryEmpty && isNetworkLibraryAvailable">
-            <h1 class="channels-label">
+          <div > 
+            <h1
+              v-if="!isLocalLibraryEmpty"
+              class="channels-label"
+            >
               {{ channelsLabel }}
             </h1>
-            <p
-              data-test="nothing-in-lib-label"
-              class="nothing-in-lib-label"
+            <div 
+              v-else-if="isLocalLibraryEmpty && isNetworkLibraryAvailable 
+                && !isLoadingNetworkLibraries"
             >
-              {{ coreString('nothingInLibraryLearner') }}
-            </p>
+              <h1 class="channels-label">
+                {{ channelsLabel }}
+              </h1>
+              <p
+                data-test="nothing-in-lib-label"
+                class="nothing-in-lib-label"
+              >
+                {{ coreString('nothingInLibraryLearner') }}
+              </p>
+            </div>
+            <NoResourcePage v-else />
           </div>
-          <NoResourcePage v-else />
 
           <ChannelCardGroupGrid
             v-if="!isLocalLibraryEmpty"
@@ -90,6 +96,7 @@
             data-test="other-libraries"
             :injectedtr="injecttr"
             @availableNetworkDevices="availableNetworkDevices"
+            @isLoadingLibraries="isLoadingLibraries"
           />
         </div>
 
@@ -112,7 +119,7 @@
       </main>
 
       <!-- Side Panels for filtering and searching  -->
-      <div v-if="(!isLocalLibraryEmpty || deviceId) && windowIsLarge">
+      <div v-if="(!isLocalLibraryEmpty || deviceId) && windowIsLarge && !rootNodesLoading">
         <SearchFiltersPanel
           ref="sidePanel"
           v-model="searchTerms"
@@ -137,7 +144,7 @@
 
       <!-- Side Panel for metadata -->
       <SidePanelModal
-        v-if="metadataSidePanelContent"
+        v-if="metadataSidePanelContent && !rootNodesLoading"
         data-test="side-panel-modal"
         alignment="right"
         @closePanel="metadataSidePanelContent = null"
@@ -436,6 +443,7 @@
         mobileSidePanelIsOpen: false,
         usingMeteredConnection: true,
         isNetworkLibraryAvailable: true,
+        isLoadingNetworkLibraries: true
       };
     },
     computed: {
@@ -562,6 +570,9 @@
       },
       availableNetworkDevices(e) {
         this.isNetworkLibraryAvailable = e;
+      },
+      isLoadingLibraries(isLoading) {
+        this.isLoadingNetworkLibraries = isLoading;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -181,7 +181,6 @@ describe('LibraryPage', () => {
       await wrapper.setData({ isLocalLibraryEmpty: true });
       await wrapper.setData({ isNetworkLibraryAvailable: true });
       expect(wrapper.find('[data-test="channels"').element).toBeTruthy();
-      expect(wrapper.find('[data-test="nothing-in-lib-label"').element).toBeTruthy();
     });
     it('hide when channels are available', async () => {
       const wrapper = await makeWrapper({ rootNodes: [] });

--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -180,7 +180,9 @@ describe('LibraryPage', () => {
       const wrapper = await makeWrapper({ rootNodes: [] });
       await wrapper.setData({ isLocalLibraryEmpty: true });
       await wrapper.setData({ isNetworkLibraryAvailable: true });
+      await wrapper.setData({ isLoadingNetworkLibraries: false });
       expect(wrapper.find('[data-test="channels"').element).toBeTruthy();
+      expect(wrapper.find('[data-test="nothing-in-lib-label"').element).toBeTruthy();
     });
     it('hide when channels are available', async () => {
       const wrapper = await makeWrapper({ rootNodes: [] });


### PR DESCRIPTION

## Summary
This PR  improve the loading states  on slow internet connection when there are other libraries  or not 
Fixes [#13276]

## References
[#13276](https://github.com/learningequality/kolibri/issues/13276)

## Reviewer guidance
Delete channels and throttle your network to 3g or 2g


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of the loading state for network libraries, ensuring that empty state messages and side panels are displayed only after network libraries finish loading.

- **Bug Fixes**
  - Prevented premature display of "nothing in library" messages and side panels while network libraries are still loading.

- **Tests**
  - Updated tests to reflect changes in when empty state messages are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->