### PR TITLE
Fix section deletion from the KDropdownMenu

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue
@@ -493,10 +493,11 @@
         }
       },
       handleConfirmDelete() {
+        const sectionIndexToDelete = this.activeSectionIndex;
         const section_title = displaySectionTitle(this.activeSection, this.activeSectionIndex);
-        const newIndex = this.activeSectionIndex > 0 ? this.activeSectionIndex - 1 : 0;
+        const newIndex = sectionIndexToDelete > 0 ? sectionIndexToDelete - 1 : 0;
         this.setActiveSection(newIndex);
-        this.removeSection(this.activeSectionIndex);
+        this.removeSection(sectionIndexToDelete);
         this.$nextTick(() => {
           this.createSnackbar(this.sectionDeletedNotification$({ section_title }));
           this.focusActiveSectionTab();


### PR DESCRIPTION
## Summary
* Fixes issue where we were changing deleting the newly active section, rather than the previously active section on deletion confirmation

## References
Fixes [#13346](https://github.com/learningequality/kolibri/issues/13346)

## Reviewer guidance
See the path to replication in the issue, make sure to test deletion from the dropdown menu, as deletion from the Section Edit side panel was already working.
