### PR TITLE
Fix design issue in Facility > Class tables on Mac app and Safari

### DIFF
--- a/packages/kolibri-common/components/UserTable/index.vue
+++ b/packages/kolibri-common/components/UserTable/index.vue
@@ -560,4 +560,8 @@
     max-width: 120px;
   }
 
+  td.visuallyhidden {
+    overflow: hidden;
+  }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request removes the small gray scrollbars that were displayed in the Mac app and Safari within the `UserTable` component. The CSS property to hide the overflow for visually hidden labels was being overridden by the `CoreTable` component’s CSS, which set the overflow to auto for table data cells.

The `UserTable` has been updated to set the overflow to hidden for table cells, removing the cut-off gray scrollbars.


Before:
![Before](https://github.com/user-attachments/assets/51318520-3553-40ad-a59a-6489aca9af19)


After:
![After](https://github.com/user-attachments/assets/dab025c2-05dd-4073-948d-31ceb23e2c02)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13312 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Facility > Classes > Your class and observe the Coach, Learners, Assign coaches and Enroll learners tables


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved table cell styling in the UserTable component to better handle hidden content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->