### PR TITLE
Speed up csv_export for large datasets (by throttling yield)

### DIFF
--- a/devscripts/generate_fake_sessions.py
+++ b/devscripts/generate_fake_sessions.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+"""
+Script to generate ContentSessionLog entries for testing
+
+Usage:
+    python devscripts/generate_fake_sessions.py
+
+Notes:
+- All session logs are tied to a content item and a test user.
+- Timestamps are spread throughout the current day.
+- Requires imported content with at least one exercise.
+
+This script is intended for development and benchmarking only.
+"""
+
+NUM_ROWS = 10000  # Set the number of rows to generate
+
+import os
+import random
+import uuid
+from datetime import timedelta
+from django.utils import timezone
+
+from kolibri.utils.cli import initialize
+initialize()
+import sqlite3
+import os
+
+# Get real channel_id and content_id from your database
+# we do this directly as the kolibri dev setup doesn't always
+# work through kolibri.content
+def get_content_ids():
+    db_path = os.path.expanduser("~/.kolibri/db.sqlite3")
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT id FROM content_channelmetadata LIMIT 1;")
+    channel_result = cursor.fetchone()
+
+    cursor.execute("SELECT content_id FROM content_contentnode WHERE kind = 'exercise' LIMIT 1;")
+    content_result = cursor.fetchone()
+
+    conn.close()
+
+    if not channel_result or not content_result:
+        print("Error: No valid channel or exercise content found.")
+        return None, None
+
+    return channel_result[0], content_result[0]
+
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.auth.models import FacilityUser, Facility
+from django.db import transaction
+
+def main():
+
+    from kolibri.core.content.models import ChannelMetadata, ContentNode
+    channel_id, content_id = get_content_ids()
+    if not channel_id or not content_id:
+        return
+    content_id = ContentNode.objects.filter(kind="exercise").values_list("content_id", flat=True).first()
+
+    if not channel_id or not content_id:
+        print("Error: No valid channel or exercise content found.")
+        return
+    # Get or create facility and test user
+    facility = Facility.objects.first()
+    if not facility:
+        print("No facility found. Please create one via the UI first.")
+        return
+
+    user, _ = FacilityUser.objects.get_or_create(
+        username="testuser",
+        defaults={"facility": facility}
+    )
+
+    dataset_id = uuid.UUID(str(user.dataset_id))
+    now = timezone.now()
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    logs = []
+    for i in range(NUM_ROWS):
+        start = today_start + timedelta(seconds=random.randint(0, 86400))
+        end = start + timedelta(minutes=random.randint(1, 10))
+
+        log = ContentSessionLog(
+            id=uuid.uuid4(),
+            user=user,
+            dataset_id=dataset_id,
+            channel_id=channel_id,
+            content_id=content_id,
+            kind="exercise",
+            start_timestamp=start,
+            end_timestamp=end,
+            time_spent=(end - start).seconds,
+            progress=random.uniform(0.0, 1.0),
+            extra_fields={"source": "test"}
+        )
+
+        logs.append(log)
+
+        if len(logs) >= 1000:
+            # Optional: sanity check
+            for check in logs:
+                assert isinstance(check.id, uuid.UUID)
+                assert isinstance(check.dataset_id, uuid.UUID)
+
+            with transaction.atomic():
+                ContentSessionLog.objects.bulk_create(logs)
+            print("Inserted {} logs...".format(i + 1))
+            logs = []
+
+    if logs:
+        with transaction.atomic():
+            ContentSessionLog.objects.bulk_create(logs)
+        print("Final batch inserted.")
+
+    print("Done. {} content session logs inserted for user 'testuser'.".format(NUM_ROWS))
+
+if __name__ == "__main__":
+    main()

--- a/devscripts/generate_fake_sessions.py
+++ b/devscripts/generate_fake_sessions.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Script to generate ContentSessionLog entries for testing
 
@@ -14,56 +12,33 @@ Notes:
 This script is intended for development and benchmarking only.
 """
 
-NUM_ROWS = 10000  # Set the number of rows to generate
-
 import os
 import random
 import uuid
 from datetime import timedelta
+
 from django.utils import timezone
 
 from kolibri.utils.cli import initialize
+
 initialize()
-import sqlite3
-import os
-
-# Get real channel_id and content_id from your database
-# we do this directly as the kolibri dev setup doesn't always
-# work through kolibri.content
-def get_content_ids():
-    db_path = os.path.expanduser("~/.kolibri/db.sqlite3")
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
-
-    cursor.execute("SELECT id FROM content_channelmetadata LIMIT 1;")
-    channel_result = cursor.fetchone()
-
-    cursor.execute("SELECT content_id FROM content_contentnode WHERE kind = 'exercise' LIMIT 1;")
-    content_result = cursor.fetchone()
-
-    conn.close()
-
-    if not channel_result or not content_result:
-        print("Error: No valid channel or exercise content found.")
-        return None, None
-
-    return channel_result[0], content_result[0]
 
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.auth.models import FacilityUser, Facility
+from kolibri.core.content.models import ChannelMetadata, ContentNode
 from django.db import transaction
+
+NUM_ROWS = 10000  # Set the number of rows to generate
 
 def main():
 
-    from kolibri.core.content.models import ChannelMetadata, ContentNode
-    channel_id, content_id = get_content_ids()
-    if not channel_id or not content_id:
-        return
+    channel_id = ChannelMetadata.objects.values_list("id", flat=True).first()
     content_id = ContentNode.objects.filter(kind="exercise").values_list("content_id", flat=True).first()
 
     if not channel_id or not content_id:
         print("Error: No valid channel or exercise content found.")
         return
+
     # Get or create facility and test user
     facility = Facility.objects.first()
     if not facility:

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -300,8 +300,11 @@ def csv_file_generator(
     ) as f:
         writer = csv.DictWriter(f, header_labels)
         writer.writeheader()
+        row_count = 0
         for item in queryset.select_related("user", "user__facility").values(
             *log_info["db_columns"]
         ):
             writer.writerow(map_object(item, len(topic_headers)))
-            yield
+            row_count += 1
+            if row_count % 1000 == 0:
+                yield


### PR DESCRIPTION
## Summary

* Speeds up large CSV exports by throttling `yield` calls to once every 1000 rows instead of every row
* Manual verification with 100,000 row exports on both high-end and low-end hardware
* No UI changes

**Benchmark Results**

**Mac Mini M2 Pro:**

- **Before:** 100k rows in 78.7s  
- **After:**  100k rows in 24.4s  
- 69% (~3.2x) faster

**RACHEL-Plus (1.1GHz Celeron):**

- **Before:** 100k rows in 1512s  
- **After:**  100k rows in 193s  
- 87% (~7.8x) faster

Timing was captured by inserting `time.time()`-based print statements in `csv_export.py` No external profiling tools were used.

## References

* No related issue (optimized after running into trouble in the field)

## Reviewer guidance

* Add ContentSessionLog data if your db has < 100k (see: devscripts/generate_fake_sessions.py)
* Under Facility > Data > Session logs, generate a session log 
* Confirm export completes successfully
* Note improved export time and fewer updates to the job_storage db
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a script for generating large numbers of fake session logs to assist with testing and benchmarking in development environments.

- **Performance Improvements**
  - Improved the efficiency of CSV export by batching progress updates, resulting in faster exports for large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->