### PR TITLE
Upgrade mac app installer to latest version.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -34,10 +34,10 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.3
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.4
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v0.4.3
+      ref: v0.4.4
   deb:
     name: Build DEB file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -54,11 +54,11 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.3
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.4
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v0.4.3
+      ref: v0.4.4
     secrets:
       KOLIBRI_MAC_APP_IDENTITY: ${{ secrets.KOLIBRI_MAC_APP_IDENTITY }}
       KOLIBRI_MAC_APP_CERTIFICATE: ${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE }}


### PR DESCRIPTION
## Summary
* Does a range of dependency upgrades for the mac app
* Includes fix for zoom behaviours where zooming would previously trigger CSP errors

## References
Diff: https://github.com/learningequality/kolibri-app/compare/v0.4.3...v0.4.4

## Reviewer guidance
All changes have been confirmed by @pcenov on the repo, but a quick smoke check of the mac app, plus checking the zoom behaviour in the app would be sufficient.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build and release workflows to use a newer version of the external workflow for creating DMG files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->