### PR TITLE
Remove deep KTextTruncator styles from AccessibleResourceCard

### DIFF
--- a/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
+++ b/packages/kolibri-common/components/Cards/AccessibleResourceCard.vue
@@ -138,13 +138,4 @@
     }
   }
 
-  /* Override KTextTruncator's use of break-word to avoid
-     the description text breaking weirdly on long words
-     which results in the card being too wide */
-  /deep/ .truncator {
-    span {
-      overflow-wrap: anywhere !important;
-    }
-  }
-
 </style>


### PR DESCRIPTION
## Summary

* Remove `/deep/` KTextTruncator styles from AccessibleResourceCard.
* Updates KDS dependency reference to https://github.com/learningequality/kolibri-design-system/pull/1023

## References

Addresses https://github.com/learningequality/kolibri-design-system/issues/958

## Reviewer guidance
* Import resources with long words/ links in the description.
* Go to coach > Lessons > Manage resources and check that cards are displayed correctly.
* Check that no regressions exists in any other card within the resource selection side panels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed custom word-breaking CSS for description text in resource cards, restoring default text wrapping behavior.

- **Chores**
  - Updated design system dependency to reference a specific commit from a GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->