### PR TITLE
Fix truncated learn filters select options

### DIFF
--- a/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/SelectGroup.vue
@@ -10,6 +10,7 @@
       :value="selectedLanguage"
       :label="coreString('languageLabel')"
       :style="selectorStyle"
+      :truncateOptionsLabel="false"
       @change="val => handleChange('languages', val)"
     />
     <KSelect
@@ -22,6 +23,7 @@
       :value="selectedLevel"
       :label="coreString('levelLabel')"
       :style="selectorStyle"
+      :truncateOptionsLabel="false"
       @change="val => handleChange('grade_levels', val)"
     />
     <KSelect
@@ -34,6 +36,7 @@
       :value="selectedAccessibilityFilter"
       :label="coreString('accessibility')"
       :style="selectorStyle"
+      :truncateOptionsLabel="false"
       @change="val => handleChange('accessibility_labels', val)"
     />
   </div>


### PR DESCRIPTION
## Summary

* Upgrate KDS to use the change from https://github.com/learningequality/kolibri-design-system/pull/1027.
* Fix truncated learn filters select options by setting the new `truncateOptionsLabel` KSelect prop to false. 

## References
Closes #12166.

## Reviewer guidance
1. Go to learn > library
2. Check KSelect options wrapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Option labels in language, grade level, and accessibility filters will now display in full without being truncated in the dropdown menus.

- **Chores**
	- Updated a design system dependency to use a specific commit from a GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->