### PR TITLE
Fix coach filtering

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -317,6 +317,12 @@ class FacilityUserFilter(FilterSet):
     def filter_user_type(self, queryset, name, value):
         if value == "learner":
             return queryset.filter(roles__isnull=True)
+        if value == "coach":
+            # Return users with either coach or classroom assignable coach roles
+            return queryset.filter(
+                Q(roles__kind=role_kinds.COACH)
+                | Q(roles__kind=role_kinds.ASSIGNABLE_COACH)
+            )
         if value == "superuser":
             return queryset.filter(devicepermissions__is_superuser=True)
         return queryset.filter(roles__kind=value)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -332,7 +332,12 @@ class FacilityUserFilter(FilterSet):
 
     def filter_exclude_coach_for(self, queryset, name, value):
         return queryset.exclude(
-            Q(roles__in=Role.objects.filter(kind=role_kinds.COACH, collection=value))
+            Q(
+                roles__in=Role.objects.filter(
+                    Q(kind=role_kinds.COACH) | Q(kind=role_kinds.ASSIGNABLE_COACH),
+                    collection=value,
+                )
+            )
         )
 
     def filter_exclude_user_type(self, queryset, name, value):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes a filtering bug for class and facility coach user types (roles)

**Before**

https://github.com/user-attachments/assets/d2b94cc6-d0e4-43a9-b7de-91d90a5993ef

**After**

https://github.com/user-attachments/assets/2d964b03-157b-4da9-a6cd-3d23e2f0d505

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13382

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go to Facility > Users and create both a Facility coach and a Coach
2. Apply the filter by 'Coaches'
3. Filtering should return both facility and class coaches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user filtering to include both "coach" and "assignable coach" roles when filtering by coach user type.
- **Tests**
	- Added and updated tests to verify correct filtering and retrieval of users with coach and assignable coach roles.
	- Improved test structure for easier maintenance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->