### PR TITLE
Override get_queryset to exclude soft deleted users

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -632,6 +632,9 @@ class KolibriAnonymousUser(AnonymousUser, KolibriBaseUserMixin):
 
 
 class FacilityUserModelManager(SyncableModelManager, UserManager):
+    def get_queryset(self):
+        return super().get_queryset().filter(date_deleted__isnull=True)
+
     def create_user(self, username, email=None, password=None, **extra_fields):
         """
         Creates and saves a User with the given username.

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -23,6 +23,7 @@ from ..models import Role
 from .helpers import create_superuser
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.device.models import DeviceSettings
+from kolibri.utils.time_utils import local_now
 
 
 class CollectionRoleMembershipDeletionTestCase(TestCase):
@@ -697,6 +698,21 @@ class FacilityUserTestCase(TestCase):
         )
         with self.assertRaises(ValidationError):
             user3.full_clean()
+
+    def test_no_soft_deleted_users_are_returned(self):
+        self.facility = Facility.objects.create()
+        self.device_settings = DeviceSettings.objects.create()
+        FacilityUser.objects.create(
+            username="bob",
+            password="password",
+            facility=self.facility,
+            date_deleted=local_now(),  # Soft deleted user
+        )
+        user2 = FacilityUser.objects.create(
+            username="alice", password="password", facility=self.facility
+        )
+
+        self.assertEqual(list(FacilityUser.objects.all()), [user2])
 
 
 class CollectionHierarchyTestCase(TestCase):


### PR DESCRIPTION
## Summary

Overrides `get_queryset` in `FacilityUserModelManager` to exclude soft deleted users

## References

Closes #13377.

## Reviewer guidance

* Manually set a `date_deleted` value to any user in the db.
* Check that this user is never shown in any page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Users marked as deleted are now automatically excluded from user lists and queries, ensuring only active users are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->