### PR TITLE
Quiz Creation: Sections have fixed question order by default

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
+++ b/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
@@ -134,7 +134,7 @@ export const QuizSection = {
   },
   learners_see_fixed_order: {
     type: Boolean,
-    default: false,
+    default: true,
   },
 };
 


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In response to user feedback documented in #13414 about the sections having random question ordering by default, this PR updates the default value for a quiz section to show the questions in a fixed order.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13414

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- See that the default value for question ordering for sections is set to "Fixed" by viewing the section's options side panel.
- Save a quiz with that default value and test it as two separate users to see that the questions are shown in the same order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Learners will now see quiz questions in a fixed order by default when accessing quiz sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->