### PR TITLE
Set min-width: 0 to fix always truncated titles in Safari and Mac app

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -617,6 +617,7 @@
   }
 
   /deep/ .k-toolbar-nav-icon {
+    min-width: 0; // avoids early resource title truncation on Safari and Mac
     margin-left: 0; // prevents icon cutoff
   }
 


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR fixes the unnecessary text trimming of titles in Safari and the Kolibri Mac app only, when there was enough space for the full text. Setting a minimum width for the `k-toolbar-nav-icon` class allowed the text in KTextTruncator to expand and use the space available.

This solution ensures that the full text is appropriately truncated when using Safari or Mac devices, while also keeping the original functionality for all other browsers the exact same.

**Before**
Safari

https://github.com/user-attachments/assets/8ad19988-44a7-4f1a-9545-a7758834a50a

Chrome

https://github.com/user-attachments/assets/03b7dfff-1afc-4491-bb65-a7e9148078bd

**After**

Safari


https://github.com/user-attachments/assets/1015b3c9-d663-4a3a-9e62-827d513635e2


Chrome


https://github.com/user-attachments/assets/0b8e1a2d-75dd-4e54-81c3-a19feb00dade



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13360 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Import the Kolibri QA Channel (nakav-mafak)
2. Go to the Library page and view some resources in responsive design mode and in full screen 
