### PR TITLE
Don't override the adHoc learner assignments with the whole class

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/index.vue
@@ -284,17 +284,15 @@
         const title = examTitle.trim().substring(0, 100).trim();
 
         const assignments = serverAssignmentPayload(groupIds, classroomId);
-
         const newQuiz = {
           title,
           draft: true,
           collection: classroomId,
-          assignments,
+          assignments: adHocLearnerIds.length > 0 ? [] : assignments,
           learner_ids: adHocLearnerIds,
           // This ensures backward compatibility for all question_sources versions
           question_sources: (await convertExamQuestionSources(this.exam)).question_sources,
         };
-
         ExamResource.saveModel({ data: newQuiz })
           .then(result => {
             this.showSnackbarNotification('quizCopied');


### PR DESCRIPTION
## Summary
This fixes a regression that was introduced where, when copying a class, we were inadvertently sending both the classroomId (and thus all learners in the class) AND the adhoc learners (i.e. 1 or more individual learners) when copying a quiz, even if we had only selected "1 or more individual learners" when copying. 

So, I have a class with learners 1, 2, 3, 4, and 5, and I make a copy of the quiz, and I assigned it to only learners 2 and 3, we were sending essentially the "class list" as the assignment, and "learners 2 and 3". This was resulting in the class list effectively overriding the sub-selection of learners, and the quiz getting assigned to all learners in a class.

## References
Fixes #13422 

https://github.com/user-attachments/assets/63fb3215-485a-4501-aea2-10c7d3276cae


## Reviewer guidance
1. Set up a class with multiple learners 
2. Set up a couple of quizzes
3. Make a copy of one quiz, and assign it to the entire class - it should work as expected 
4. Make a copy of a different quiz, and assign it to specific individual learners - it should (now) work as expected
