### PR TITLE
fix inadvertently swapped icons

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
@@ -25,14 +25,14 @@ registerNavItem({
       {
         label: coreStrings.$tr('facilitiesLabel'),
         route: baseRoutes.facilities.path,
-        icon: 'permissions',
+        icon: 'facility',
         name: baseRoutes.facilities.name,
         condition: get(isSuperuser) && !get(isLearnerOnlyImport),
       },
       {
         label: deviceString('permissionsLabel'),
         route: baseRoutes.permissions.path,
-        icon: 'facility',
+        icon: 'permissions',
         name: baseRoutes.permissions.name,
         condition: get(isSuperuser),
       },


### PR DESCRIPTION
## Summary
Fixes inadvertently swapped icons on the device navigation bar

## References
Fixes #13405

Before: 
![image](https://github.com/user-attachments/assets/d9a0a84a-36c8-4136-9a38-724c3c5a6d44)

After:
<img width="521" alt="Screenshot 2025-06-04 at 2 21 42 PM" src="https://github.com/user-attachments/assets/b378e538-2309-427a-bc4b-3afdbb2d6c83" />


## Reviewer guidance
Are the icons correct now on the Device page?
