### PR TITLE
Ensure "Submit quiz" button is visible in portrait mode on mobile when viewing practice quizzes

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -132,7 +132,10 @@
           </BottomAppBar>
 
           <!-- below prev/next buttons in tab and DOM order, in page -->
-          <KPageContainer v-if="!windowIsLarge">
+          <KPageContainer
+            v-if="!windowIsLarge"
+            style="margin-bottom: 45px"
+          >
             <div
               class="bottom-block"
               :class="{ 'window-is-small': windowIsSmall }"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR fixes the "Submit quiz" button not being visible in portrait mode on mobile devices by adding a bottom margin to the `KPageContainer` that contains the submission button. This gives the element more room below it and allows the page to scroll and show the submission button.

Before:


https://github.com/user-attachments/assets/e60dc202-ddaa-4171-86ed-20c44cee2add


After:


https://github.com/user-attachments/assets/f1876392-550a-414e-b8aa-761d7c7b801b



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13457 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Add a practice quiz with a lot of content to a lesson and assign it to a learner
2. Using a mobile device or Chrome's device toolbar attempt to submit the quiz
3. Ensure there is no change on larger screen views.