### PR TITLE
Add Python 3.9 requirement and WSL note to setup docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -68,12 +68,14 @@ Python and Pip
 
 To develop on Kolibri, you'll need:
 
-* Python 3.6+ (Kolibri doesn't currently support Python 3.12.0 or higher)
+* Python 3.9 or higher (Note: Kolibri does not yet support Python 3.12 or above)
 * `pip <https://pypi.python.org/pypi/pip>`__
 
 Managing Python installations can be quite tricky. We *highly* recommend using `pyenv <https://github.com/pyenv/pyenv>`__ or if you are more comfortable using a package manager, then package managers like `Homebrew <http://brew.sh/>`__ on Mac or ``apt`` on Debian for this.
 
 To install pyenv see the detailed instructions here :doc:`/howtos/installing_pyenv`.
+..note::
+  If you are using a package manager, make sure to install a Python version compatible with Kolibri (3.9 or above, but below 3.12). If you're using `pyenv`, you can install it with a command like `pyenv install 3.9.9`.
 
 .. warning::
   Never modify your system's built-in version of Python
@@ -87,6 +89,7 @@ There are many ways to set up Python virtual environments: You can use `pyenv-vi
 
 .. note::
   Most virtual environments will require special setup for non-Bash shells such as Fish and ZSH.
+ Direct development on Windows is not supported. If you're using a Windows machine, please set up your development environment using WSL (Windows Subsystem for Linux).
 
 To setup and start using pyenv-virtualenv, follow the instructions here :doc:`/howtos/pyenv_virtualenv`.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -68,14 +68,14 @@ Python and Pip
 
 To develop on Kolibri, you'll need:
 
-* Python 3.9 or higher (Note: Kolibri does not yet support Python 3.12 or above)
+* Python 3.9 or higher (Note: Kolibri does not yet support Python 3.14 or above)
 * `pip <https://pypi.python.org/pypi/pip>`__
 
 Managing Python installations can be quite tricky. We *highly* recommend using `pyenv <https://github.com/pyenv/pyenv>`__ or if you are more comfortable using a package manager, then package managers like `Homebrew <http://brew.sh/>`__ on Mac or ``apt`` on Debian for this.
 
 To install pyenv see the detailed instructions here :doc:`/howtos/installing_pyenv`.
 ..note::
-  If you are using a package manager, make sure to install a Python version compatible with Kolibri (3.9 or above, but below 3.12). If you're using `pyenv`, you can install it with a command like `pyenv install 3.9.9`.
+  If you are using a package manager, make sure to install a Python version compatible with Kolibri (3.9 or above, but below 3.14). If you're using `pyenv`, you can install it with a command like `pyenv install 3.9.9`.
 
 .. warning::
   Never modify your system's built-in version of Python
@@ -98,7 +98,7 @@ Once pyenv-virtualenv is installed, you can use the following commands to set up
 
 .. code-block:: bash
 
-  pyenv virtualenv 3.9.9 kolibri-py3.9  # can also make a python 2 environment
+  pyenv virtualenv 3.9.9 kolibri-py3.9  # can also make an environment for other Python versions, e.g. 3.10
   pyenv activate kolibri-py3.9  # activates the virtual environment
 
 Now, any commands you run will target your virtual environment rather than the global Python installation. To deactivate the virtualenv, simply run:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
This PR updates docs/getting_started.rst to:

- Clarify that Python 3.9 is required for development.
- Recommend using WSL instead of native Windows for Kolibri development.


### Motivation

During setup, I encountered issues due to:

- pre-commit needing `Python 3.9+` (not mentioned explicitly).

- Running Kolibri directly on Windows (unsupported as per maintainers).

This documentation improvement aims to save new contributors from similar issues.


### Related Issue
Closes https://github.com/learningequality/kolibri/issues/13458


### Notes

- Fixed CRLF to LF line endings to avoid whole-file diffs.
- Re-submission after feedback on previous PR.

### Screenshots / Changes
![Screenshot (60)-fotor-20250606135614](https://github.com/user-attachments/assets/4e8c4e78-7248-4462-b11b-76e6da5aa5ed)
