### PR TITLE
Fix learnergroup adhocgroup exam syncing

### DIFF
--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -448,7 +448,6 @@ class IndividualSyncableExam(AbstractFacilityDataModel):
             "creator_id",
             "date_created",
             "date_activated",
-            "collection_id",
         ]:
             serialized.pop(key, None)
         return serialized


### PR DESCRIPTION
## Summary
Fixed single-user sync for exam assignments to LearnerGroups and AdHocGroups by fixing the exam assignment logic. Previously, the exam's collection_id was being set to the target collection (i.e. the group) rather than the classroom id, which broke the proper association. These changes ensure that the collection for the assignment object is set to the group, and the collection for the exam object is set to the classroom. 

## References
Fixes #13456

## Reviewer guidance
1. Create a quiz and assign to either a learner group, or a collection of individual learner (an adhoc group). These learners should be on LODs
2. Ensure that the quizzes properly sync to the LOD devices