### PR TITLE
Handle all bad foreign keys

### DIFF
--- a/kolibri/utils/database.py
+++ b/kolibri/utils/database.py
@@ -1,0 +1,106 @@
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime
+
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_violations_by_table(cursor):
+    cursor.execute("PRAGMA foreign_key_check;")
+    result = cursor.fetchall()
+    if len(result) == 0:
+        return {}
+
+    violations_by_table = {}
+    for row in result:
+        bad_table = row[0]
+        rowid = row[1]
+        if bad_table not in violations_by_table:
+            violations_by_table[bad_table] = []
+        violations_by_table[bad_table].append(rowid)
+
+    return violations_by_table
+
+
+def _collect_and_delete_violating_records(cursor, violations_by_table):
+    records_to_backup = []
+
+    for bad_table, rowids in violations_by_table.items():
+        cursor.execute(f"PRAGMA table_info({bad_table});")
+        columns_info = cursor.fetchall()
+        column_names = [col[1] for col in columns_info]
+
+        rowid_placeholders = ",".join("?" * len(rowids))
+        cursor.execute(
+            f"SELECT * FROM {bad_table} WHERE rowid IN ({rowid_placeholders});",
+            rowids,
+        )
+        violating_data = cursor.fetchall()
+
+        for data_row in violating_data:
+            fields = dict(zip(column_names, data_row))
+            record = {"model": bad_table, "fields": fields}
+            records_to_backup.append(record)
+
+        for rowid in rowids:
+            cursor.execute(f"DELETE FROM {bad_table} WHERE rowid = {rowid};")
+            logger.info(
+                f"Deleted foreign key constraint violation from {bad_table} table, rowid {rowid}"
+            )
+
+    return records_to_backup
+
+
+def _backup_records(records_to_backup, db_name):
+    from kolibri.core.deviceadmin.utils import default_backup_folder
+
+    backup_dir = default_backup_folder()
+    if not os.path.exists(backup_dir):
+        os.makedirs(backup_dir)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_filename = f"foreign_key_violations_{db_name}_{timestamp}.json"
+    backup_path = os.path.join(backup_dir, backup_filename)
+
+    with open(backup_path, "w", encoding="utf-8") as jsonfile:
+        json.dump(
+            records_to_backup,
+            jsonfile,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+    logger.info(
+        f"Backed up {len(records_to_backup)} violating records to {backup_path}"
+    )
+
+
+def sqlite_check_foreign_keys(database_paths):
+    for name in database_paths:
+        if not os.path.exists(name):
+            continue
+
+        db_connection = sqlite3.connect(name)
+        with sqlite3.connect(name) as db_connection:
+            cursor = db_connection.cursor()
+
+            violations_by_table = _collect_violations_by_table(cursor)
+            if not violations_by_table:
+                continue
+
+            logger.warning(
+                "Foreign key constraint failed. Trying to fix integrity errors..."
+            )
+
+            records_to_backup = _collect_and_delete_violating_records(
+                cursor, violations_by_table
+            )
+
+            if records_to_backup:
+                db_name = os.path.basename(name).replace(".sqlite3", "")
+                _backup_records(records_to_backup, db_name)
+
+            db_connection.commit()

--- a/kolibri/utils/tests/test_database.py
+++ b/kolibri/utils/tests/test_database.py
@@ -1,0 +1,329 @@
+import glob
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from mock import patch
+
+from kolibri.utils.database import sqlite_check_foreign_keys
+
+
+class TestSqliteForeignKeyCheck(unittest.TestCase):
+    """Test foreign key constraint handling in sqlite_check_foreign_keys"""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "test.sqlite3")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir)
+
+    def _create_test_db_with_foreign_key_violations(
+        self, include_logger_table=True, include_other_table=True
+    ):
+        """Create a test database with foreign key constraint violations"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        # Start with foreign keys disabled to set up the violation scenario
+        cursor.execute("PRAGMA foreign_keys = OFF;")
+
+        # Create parent table
+        cursor.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY);")
+        cursor.execute("INSERT INTO parent (id) VALUES (1);")
+
+        if include_logger_table:
+            # Create logger table with foreign key
+            cursor.execute(
+                """
+                CREATE TABLE logger_test (
+                    id INTEGER PRIMARY KEY,
+                    parent_id INTEGER,
+                    FOREIGN KEY (parent_id) REFERENCES parent(id)
+                );
+            """
+            )
+            cursor.execute("INSERT INTO logger_test (parent_id) VALUES (1);")
+
+        if include_other_table:
+            # Create non-logger table with foreign key
+            cursor.execute(
+                """
+                CREATE TABLE user_data (
+                    id INTEGER PRIMARY KEY,
+                    parent_id INTEGER,
+                    FOREIGN KEY (parent_id) REFERENCES parent(id)
+                );
+            """
+            )
+            cursor.execute("INSERT INTO user_data (parent_id) VALUES (1);")
+
+        # Delete the parent record while foreign keys are off
+        cursor.execute("DELETE FROM parent WHERE id = 1;")
+        conn.commit()
+
+        # Enable foreign keys - now the PRAGMA foreign_key_check will detect violations
+        cursor.execute("PRAGMA foreign_keys = ON;")
+        conn.commit()
+        conn.close()
+
+    def test_foreign_key_check_logger_table_auto_delete(self):
+        """Test that foreign key violations in logger tables are automatically deleted"""
+        self._create_test_db_with_foreign_key_violations(
+            include_logger_table=True, include_other_table=False
+        )
+
+        # Create backup directory in temp dir
+        backup_dir = os.path.join(self.temp_dir, "backups")
+        os.makedirs(backup_dir, exist_ok=True)
+
+        # Test the function directly with our test database as non-default to auto-delete
+        with patch(
+            "kolibri.core.deviceadmin.utils.default_backup_folder",
+            return_value=backup_dir,
+        ):
+            sqlite_check_foreign_keys([self.db_path])
+
+        # Verify the violating row was deleted
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM logger_test;")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        self.assertEqual(
+            count, 0, "Logger table violation should have been automatically deleted"
+        )
+
+        # Verify JSON backup file was created
+        json_files = glob.glob(
+            os.path.join(backup_dir, "foreign_key_violations_*.json")
+        )
+        self.assertEqual(
+            len(json_files), 1, "Exactly one JSON backup file should have been created"
+        )
+
+        # Verify JSON file contains the deleted data in Django fixture format
+        with open(json_files[0], "r", encoding="utf-8") as jsonfile:
+            data = json.load(jsonfile)
+            self.assertIsInstance(data, list, "JSON should be a list of records")
+            self.assertEqual(
+                len(data), 1, "JSON should contain exactly 1 deleted record"
+            )
+
+            # Check Django fixture format
+            record = data[0]
+            self.assertIn("model", record, "Record should have 'model' field")
+            self.assertIn("fields", record, "Record should have 'fields' field")
+            self.assertEqual(
+                record["model"], "logger_test", "Model should match table name"
+            )
+
+    def test_foreign_key_check_non_logger_table_auto_delete(self):
+        """Test that foreign key violations in non-logger tables are automatically deleted and backed up"""
+        self._create_test_db_with_foreign_key_violations(
+            include_logger_table=False, include_other_table=True
+        )
+
+        # Create backup directory in temp dir
+        backup_dir = os.path.join(self.temp_dir, "backups")
+        os.makedirs(backup_dir, exist_ok=True)
+
+        # Test the function with our test database as the default database (first in list)
+        with patch(
+            "kolibri.core.deviceadmin.utils.default_backup_folder",
+            return_value=backup_dir,
+        ):
+            sqlite_check_foreign_keys([self.db_path])
+
+        # Verify the violating row was deleted
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM user_data;")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        self.assertEqual(
+            count,
+            0,
+            "Non-logger table violation should have been automatically deleted",
+        )
+
+        # Verify JSON backup file was created
+        json_files = glob.glob(
+            os.path.join(backup_dir, "foreign_key_violations_*.json")
+        )
+        self.assertEqual(
+            len(json_files), 1, "Exactly one JSON backup file should have been created"
+        )
+
+        # Verify JSON file contains the deleted data
+        with open(json_files[0], "r", encoding="utf-8") as jsonfile:
+            data = json.load(jsonfile)
+            self.assertIsInstance(data, list, "JSON should be a list of records")
+            self.assertEqual(
+                len(data), 1, "JSON should contain exactly 1 deleted record"
+            )
+            record = data[0]
+            self.assertEqual(
+                record["model"], "user_data", "Model should match table name"
+            )
+
+    def test_foreign_key_check_non_default_db_auto_delete(self):
+        """Test that foreign key violations in non-default databases are automatically deleted"""
+        # Create additional database
+        additional_db_path = os.path.join(self.temp_dir, "additional.sqlite3")
+
+        # Set up the additional database with violations
+        conn = sqlite3.connect(additional_db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA foreign_keys = OFF;")
+        cursor.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY);")
+        cursor.execute("INSERT INTO parent (id) VALUES (1);")
+        cursor.execute(
+            """
+            CREATE TABLE user_data (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER,
+                FOREIGN KEY (parent_id) REFERENCES parent(id)
+            );
+        """
+        )
+        cursor.execute("INSERT INTO user_data (parent_id) VALUES (1);")
+        cursor.execute("DELETE FROM parent WHERE id = 1;")
+        conn.commit()
+        cursor.execute("PRAGMA foreign_keys = ON;")
+        conn.commit()
+        conn.close()
+
+        # Create backup directory in temp dir
+        backup_dir = os.path.join(self.temp_dir, "backups")
+        os.makedirs(backup_dir, exist_ok=True)
+
+        # Test the function with additional database as non-default (second in list)
+        with patch(
+            "kolibri.core.deviceadmin.utils.default_backup_folder",
+            return_value=backup_dir,
+        ):
+            sqlite_check_foreign_keys([self.db_path, additional_db_path])
+
+        # Verify the violating row was deleted in the additional database
+        conn = sqlite3.connect(additional_db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM user_data;")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        self.assertEqual(
+            count,
+            0,
+            "Non-logger table violation in additional DB should have been automatically deleted",
+        )
+
+        # Verify JSON backup file was created
+        json_files = glob.glob(
+            os.path.join(backup_dir, "foreign_key_violations_*.json")
+        )
+        self.assertEqual(
+            len(json_files), 1, "Exactly one JSON backup file should have been created"
+        )
+
+        # Verify JSON file contains the deleted data
+        with open(json_files[0], "r", encoding="utf-8") as jsonfile:
+            data = json.load(jsonfile)
+            self.assertIsInstance(data, list, "JSON should be a list of records")
+            self.assertEqual(
+                len(data), 1, "JSON should contain exactly 1 deleted record"
+            )
+            record = data[0]
+            self.assertEqual(
+                record["model"], "user_data", "Model should match table name"
+            )
+
+    def test_foreign_key_check_mixed_tables(self):
+        """Test handling of both logger and non-logger table violations in default database"""
+        self._create_test_db_with_foreign_key_violations(
+            include_logger_table=True, include_other_table=True
+        )
+
+        # Create backup directory in temp dir
+        backup_dir = os.path.join(self.temp_dir, "backups")
+        os.makedirs(backup_dir, exist_ok=True)
+
+        # Test the function with our test database as the default database (first in list)
+        with patch(
+            "kolibri.core.deviceadmin.utils.default_backup_folder",
+            return_value=backup_dir,
+        ):
+            sqlite_check_foreign_keys([self.db_path])
+
+        # Verify logger table violation was deleted
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM logger_test;")
+        logger_count = cursor.fetchone()[0]
+
+        # Verify non-logger table violation was NOT deleted
+        cursor.execute("SELECT COUNT(*) FROM user_data;")
+        user_count = cursor.fetchone()[0]
+        conn.close()
+
+        self.assertEqual(
+            logger_count, 0, "Logger table violation should have been deleted"
+        )
+        self.assertEqual(
+            user_count, 0, "Non-logger table violation should also have been deleted"
+        )
+
+        # Verify JSON backup file was created for both table deletions
+        json_files = glob.glob(
+            os.path.join(backup_dir, "foreign_key_violations_*.json")
+        )
+        self.assertEqual(
+            len(json_files), 1, "Exactly one JSON backup file should have been created"
+        )
+
+        # Verify JSON file contains both deleted records
+        with open(json_files[0], "r", encoding="utf-8") as jsonfile:
+            data = json.load(jsonfile)
+            self.assertIsInstance(data, list, "JSON should be a list of records")
+            self.assertEqual(
+                len(data), 2, "JSON should contain exactly 2 deleted records"
+            )
+
+            # Find the logger_test record
+            logger_records = [r for r in data if r["model"] == "logger_test"]
+            self.assertEqual(
+                len(logger_records),
+                1,
+                "Should have exactly 1 logger_test record in backup",
+            )
+
+            # Should also have user_data record since it was also deleted
+            user_records = [r for r in data if r["model"] == "user_data"]
+            self.assertEqual(
+                len(user_records), 1, "Should have exactly 1 user_data record in backup"
+            )
+
+    def test_foreign_key_check_no_violations(self):
+        """Test that no actions are taken when there are no foreign key violations"""
+        # Create a database with no violations
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY);")
+        conn.commit()
+        conn.close()
+
+        # This should not raise any exceptions
+        sqlite_check_foreign_keys([self.db_path])
+
+    def test_foreign_key_check_nonexistent_database(self):
+        """Test that nonexistent databases are skipped without error"""
+        nonexistent_path = os.path.join(self.temp_dir, "nonexistent.sqlite3")
+
+        # This should not raise any exceptions
+        sqlite_check_foreign_keys([nonexistent_path])


### PR DESCRIPTION
## Summary
We received reports that there were additional foreign key issues on Windows devices
This enhances our foreign key referential integrity checks for SQLite to delete all invalid foreign key rows
Also enhances it to make a JSON backup of any deleted data for safety
Adds tests for the behaviour and the JSON backup

## Reviewer guidance
Check that the logic makes sense. Please contact @rtibbles for access to a Google Drive folder with sample databases.