### PR TITLE
Upgrade Kolibri windows installer for new signing workflow.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.7
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.8
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.7
+      ref: v1.6.8
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -88,14 +88,15 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.7
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.8
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.7
+      ref: v1.6.8
     secrets:
-      KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
-      KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
   upload_exe:
     uses: ./.github/workflows/upload_github_release_asset.yml
     needs: exe


### PR DESCRIPTION
## Summary
Upgrades the kolibri windows installer action to the latest version
Switches secrets that are passed in for the new ones required for the new secret workflow

## References
Brings updates from https://github.com/learningequality/kolibri-installer-windows/pull/230


## Reviewer guidance
No way to check the signed build - the signing is tested in the PR linked above
