### PR TITLE
Tweak content queue polling to prevent overloading the server

### DIFF
--- a/kolibri/plugins/device/assets/src/composables/useContentTasks.js
+++ b/kolibri/plugins/device/assets/src/composables/useContentTasks.js
@@ -1,4 +1,4 @@
-import { useIntervalFn } from '@vueuse/core';
+import { useTimeoutPoll } from '@vueuse/core';
 import { getCurrentInstance, onMounted, onUnmounted } from 'vue';
 import useUser from 'kolibri/composables/useUser';
 
@@ -6,9 +6,9 @@ export default function useContentTasks() {
   const $store = getCurrentInstance().proxy.$store;
   const { canManageContent } = useUser();
 
-  const polling = useIntervalFn(() => {
-    $store.dispatch('manageContent/refreshTaskList');
-  }, 1000);
+  const polling = useTimeoutPoll(() => {
+    return $store.dispatch('manageContent/refreshTaskList');
+  }, 5000);
 
   function startTaskPolling() {
     if (canManageContent.value) {


### PR DESCRIPTION
## Summary
* Use useTimeoutPoll instead of useIntervalFn to wait for completion before repolling.
* Return promise to defer, increase interval to reduce server load.

## References
Fixes #13412

## Reviewer guidance
I reduced this in scope to more directly address the issue, as I think using the task polling composable more generally would require a very large refactor of the Vuex state.

To test this, I added a time.sleep to the tasks/api.py list method, and these updates ensured that while the request was still pending a new request was not initiated.
