### PR TITLE
Deleted facilityuser viewset

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -549,19 +549,13 @@ class DeletedFacilityUserViewSet(
     ordering_fields = FacilityUserViewSet.ordering_fields + ("date_deleted",)
     field_map = FacilityUserViewSet.field_map
 
-    def allow_bulk_restore(self):
-        """
-        Hook to ensure that the bulk restore should be allowed.
-        By default, these restrictions are the same as for bulk deletion,
-        """
-        return self.allow_bulk_destroy(self.get_queryset())
-
     @decorators.action(detail=False, methods=["post"])
     def restore(self, request):
         """
         Restore soft-deleted FacilityUsers.
         """
-        if not self.allow_bulk_restore():
+        # Permissions for allowing bulk restore are the same as for bulk destroy
+        if not self.allow_bulk_destroy():
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -457,6 +457,7 @@ class FacilityUserViewSet(ValuesViewset, BulkDeleteMixin):
         "id",
         "username",
         "full_name",
+        "id_number",
         "gender",
         "birth_year",
         "date_joined",
@@ -504,8 +505,9 @@ class FacilityUserViewSet(ValuesViewset, BulkDeleteMixin):
             if ordering_param.startswith("-"):
                 ordering_param = ordering_param[1:]
                 reverse = True
-
-        output = sorted(output, key=lambda x: x[ordering_param], reverse=reverse)
+        output = sorted(
+            output, key=lambda x: x.get(ordering_param, ""), reverse=reverse
+        )
         return output
 
     def perform_update(self, serializer):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -533,9 +533,8 @@ class DeletedFacilityUserViewSet(FacilityUserViewSet):
             user = self.get_object()
             user.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
-        else:
-            # Bulk deletion
-            return self.bulk_destroy(request, *args, **kwargs)
+        # Bulk deletion
+        return self.bulk_destroy(request, *args, **kwargs)
 
     def perform_bulk_destroy(self, objects):
         if objects.filter(id=self.request.user.id).exists():
@@ -548,9 +547,7 @@ class DeletedFacilityUserViewSet(FacilityUserViewSet):
         By default this checks that the restore is only applied to
         filtered querysets.
         """
-        return any(
-            key in self.filterset_fields for key in self.request.query_params.keys()
-        )
+        return any(key in self.filterset_fields for key in self.request.query_params)
 
     @decorators.action(detail=False, methods=["patch"])
     def restore(self, request):

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -2,6 +2,7 @@ from django.urls import re_path
 from rest_framework import routers
 
 from .api import ClassroomViewSet
+from .api import DeletedFacilityUserViewSet
 from .api import FacilityDatasetViewSet
 from .api import FacilityUsernameViewSet
 from .api import FacilityUserViewSet
@@ -36,6 +37,9 @@ bulk_delete_router = BulkDeleteRouter()
 
 bulk_delete_router.register(
     r"facilityuser", FacilityUserViewSet, basename="facilityuser"
+)
+bulk_delete_router.register(
+    r"deletedfacilityuser", DeletedFacilityUserViewSet, basename="deletedfacilityuser"
 )
 bulk_delete_router.register(r"membership", MembershipViewSet, basename="membership")
 bulk_delete_router.register(r"role", RoleViewSet, basename="role")

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1344,6 +1344,7 @@ class UserRetrieveTestCase(APITestCase):
 
     def test_user_list(self):
         response = self._make_request(self.superuser)
+        self.maxDiff = None
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(
             response.data,

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1344,7 +1344,6 @@ class UserRetrieveTestCase(APITestCase):
 
     def test_user_list(self):
         response = self._make_request(self.superuser)
-        self.maxDiff = None
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(
             response.data,

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -30,12 +30,13 @@ class BulkDeleteMixin(object):
 
     # Taken from https://github.com/miki725/django-rest-framework-bulk
 
-    def allow_bulk_destroy(self, qs):
+    def allow_bulk_destroy(self):
         """
         Hook to ensure that the bulk destroy should be allowed.
         By default this checks that the destroy is only applied to
         filtered querysets.
         """
+        qs = self.get_queryset()
         filter_fields = set()
 
         for backend in list(self.filter_backends):
@@ -56,7 +57,7 @@ class BulkDeleteMixin(object):
         qs = self.get_queryset()
 
         filtered = self.filter_queryset(qs)
-        if not self.allow_bulk_destroy(qs):
+        if not self.allow_bulk_destroy():
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         self.perform_bulk_destroy(filtered)

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -9,7 +9,9 @@ from django.db.models import ForeignKey
 from django.db.models import QuerySet
 from django.db.models.fields import CharField
 from django.db.models.lookups import In
+from django_filters.rest_framework import DjangoFilterBackend
 from morango.models import UUIDField
+from rest_framework import filters
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -28,22 +30,33 @@ class BulkDeleteMixin(object):
 
     # Taken from https://github.com/miki725/django-rest-framework-bulk
 
-    def allow_bulk_destroy(self, qs, filtered):
+    def allow_bulk_destroy(self, qs):
         """
         Hook to ensure that the bulk destroy should be allowed.
         By default this checks that the destroy is only applied to
         filtered querysets.
         """
+        filter_fields = set()
+
+        for backend in list(self.filter_backends):
+            if issubclass(backend, DjangoFilterBackend):
+                filterset_class = backend.get_filterset_class(backend, self, qs)
+                if filterset_class:
+                    filter_fields.update(filterset_class.get_fields().keys())
+
+            if issubclass(backend, filters.SearchFilter):
+                search_param = backend.search_param
+                if search_param:
+                    filter_fields.add(search_param)
+
         # Only let a bulk destroy if the queryset is being filtered by a valid filter_field parameter
-        return any(
-            key in self.filterset_fields for key in self.request.query_params.keys()
-        )
+        return any(key in filter_fields for key in self.request.query_params.keys())
 
     def bulk_destroy(self, request, *args, **kwargs):
         qs = self.get_queryset()
 
         filtered = self.filter_queryset(qs)
-        if not self.allow_bulk_destroy(qs, filtered):
+        if not self.allow_bulk_destroy(qs):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         self.perform_bulk_destroy(filtered)

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -231,7 +231,7 @@
             dataType: 'string',
             minWidth: '150px',
             width: '10%',
-            columnId: 'identifier',
+            columnId: 'id_number',
           },
           {
             label: this.coreString('genderLabel'),


### PR DESCRIPTION
## Summary
* Adds DeletedFacilityUserViewSet for soft-deleted users management
* Adds tests for listing, hard deleting and restoring soft deleted users.
* Fix identifier filter column id that was causing a 500 error when trying to sort users by id_number, and prevented that 500 errors are thrown when a worng sorting field is passed.

### Comments
* Since the trash users table (in the UI) is pretty much the same table as the users table, I have decided to inherit from the current `FacilityUserViewSet` to reuse all the current sorting, filtering, searching, pagination machinery without having to duplicate too much code. Is this is not a common pattern I can just duplicate the relevant parts of the code.
* I tried to restore the users just by overriding the `date_delted` with a patch request, and it correctly restored the user, but the api was returning an error 404 because it was trying to query the just updated user, and it wasnt finding it because after the update, this user wasnt belonging to the current queryset (soft_delted_objects) anymore. Gemini suggested that we could override the `get_object` method, but it said that a cleaner option here was to implement a new action to better encapsulate the restore behavior. Im open to look for the best solution here.

## References
Closes #13445.

## Reviewer guidance
* Run pytest.
