### PR TITLE
[HTML5 Article Renderer] Apply text styling

### DIFF
--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -96,4 +96,9 @@
     left: calc(50% - 16px);
   }
 
+  .content-renderer > div {
+    padding: 40px 16px;
+    background-color: white;
+  }
+
 </style>

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -1,9 +1,99 @@
+@mixin text-style($weight: normal, $size: 16px, $line-height: 150%, $max-width: 640px) {
+  max-width: $max-width;
+  font-size: $size;
+  font-weight: $weight;
+  line-height: $line-height;
+}
+
+body {
+  padding-bottom: 40px;
+  background-color: white;
+}
+
+.content-renderer > div {
+  margin: 40px 16px;
+}
+
 .safe-html {
   // Due to the recursive rendering every sub-element has the safe-html class applied
   // so we use these combinatorial selectors to specify styling.
-  &h1 {
-    font-size: 32px;
-    font-weight: bold;
-    line-height: 130%;
+  h1 {
+    @include text-style(bold, 32px, 130%);
+
+    margin: 32px auto 24px;
+  }
+
+  h2 {
+    @include text-style(bold, 28px, 130%);
+
+    margin: 24px auto 16px;
+  }
+
+  h3 {
+    @include text-style(bold, 24px, 130%);
+
+    margin: 12px auto;
+  }
+
+  h4 {
+    @include text-style(600, 20px, 130%);
+
+    margin: 8px auto;
+  }
+
+  h5 {
+    @include text-style(600, 18px, 130%);
+
+    margin: 8px auto;
+  }
+
+  h6 {
+    @include text-style(600, 16px, 130%);
+
+    margin: 8px auto;
+  }
+
+  p {
+    @include text-style();
+
+    margin: 8px auto;
+  }
+
+  ul,
+  ol {
+    @include text-style();
+
+    padding-left: 24px;
+    margin: 8px auto;
+  }
+
+  li {
+    margin-left: 18px;
+  }
+
+  li ~ li {
+    margin-top: 4px;
+  }
+
+  dl {
+    max-width: 640px;
+    margin: 8px auto;
+  }
+
+  dt {
+    @include text-style(600);
+  }
+
+  dd {
+    @include text-style();
+
+    padding-left: 24px;
+    margin-top: 4px;
+    margin-left: 0;
+  }
+
+  strong,
+  b {
+    @include text-style(bold);
   }
 }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -5,95 +5,84 @@
   line-height: $line-height;
 }
 
-body {
-  padding-bottom: 40px;
-  background-color: white;
+// Due to the recursive rendering every sub-element has the safe-html class applied
+// so we use these compound selectors to specify styling.
+h1.safe-html {
+  @include text-style(bold, 32px, 130%);
+
+  margin: 32px auto 24px;
 }
 
-.content-renderer > div {
-  margin: 40px 16px;
+h2.safe-html {
+  @include text-style(bold, 28px, 130%);
+
+  margin: 24px auto 16px;
 }
 
-.safe-html {
-  // Due to the recursive rendering every sub-element has the safe-html class applied
-  // so we use these combinatorial selectors to specify styling.
-  h1 {
-    @include text-style(bold, 32px, 130%);
+h3.safe-html {
+  @include text-style(bold, 24px, 130%);
 
-    margin: 32px auto 24px;
-  }
+  margin: 12px auto;
+}
 
-  h2 {
-    @include text-style(bold, 28px, 130%);
+h4.safe-html {
+  @include text-style(600, 20px, 130%);
 
-    margin: 24px auto 16px;
-  }
+  margin: 8px auto;
+}
 
-  h3 {
-    @include text-style(bold, 24px, 130%);
+h5.safe-html {
+  @include text-style(600, 18px, 130%);
 
-    margin: 12px auto;
-  }
+  margin: 8px auto;
+}
 
-  h4 {
-    @include text-style(600, 20px, 130%);
+h6.safe-html {
+  @include text-style(600, 16px, 130%);
 
-    margin: 8px auto;
-  }
+  margin: 8px auto;
+}
 
-  h5 {
-    @include text-style(600, 18px, 130%);
+p.safe-html {
+  @include text-style();
 
-    margin: 8px auto;
-  }
+  margin: 8px auto;
+}
 
-  h6 {
-    @include text-style(600, 16px, 130%);
+ul.safe-html,
+ol.safe-html {
+  @include text-style();
 
-    margin: 8px auto;
-  }
+  padding-left: 24px;
+  margin: 8px auto;
+}
 
-  p {
-    @include text-style();
+li.safe-html {
+  margin-left: 18px;
+}
 
-    margin: 8px auto;
-  }
+li.safe-html ~ li.safe-html {
+  margin-top: 4px;
+}
 
-  ul,
-  ol {
-    @include text-style();
+dl.safe-html {
+  max-width: 640px;
+  margin: 8px auto;
+}
 
-    padding-left: 24px;
-    margin: 8px auto;
-  }
+dt.safe-html {
+  @include text-style(600);
+}
 
-  li {
-    margin-left: 18px;
-  }
+dd.safe-html {
+  @include text-style();
 
-  li ~ li {
-    margin-top: 4px;
-  }
+  padding-left: 24px;
+  margin-top: 4px;
+  margin-left: 0;
+}
 
-  dl {
-    max-width: 640px;
-    margin: 8px auto;
-  }
-
-  dt {
-    @include text-style(600);
-  }
-
-  dd {
-    @include text-style();
-
-    padding-left: 24px;
-    margin-top: 4px;
-    margin-left: 0;
-  }
-
-  strong,
-  b {
-    @include text-style(bold);
-  }
+strong.safe-html,
+b.safe-html {
+  @include text-style(bold);
 }


### PR DESCRIPTION
## Summary
- Applied relevant styles to all text elements.
- Adjusted background color and margin of the page.

### Screenshots - Desktop

#### Before
![before-text-styling-desktop1](https://github.com/user-attachments/assets/96098c52-9122-4cbc-8bc0-7e489f834fdf)
![before-text-styling-desktop2](https://github.com/user-attachments/assets/fbfb4332-5d81-4caf-9758-83475aa40ec8)
![before-text-styling-desktop3](https://github.com/user-attachments/assets/6bcaab57-8206-4c32-9420-1f23cb04364b)

#### After
<img width="1721" alt="after-text-styling-desktop1" src="https://github.com/user-attachments/assets/58e2a78d-4676-4098-9314-437926d0be16" />
<img width="1721" alt="after-text-styling-desktop2" src="https://github.com/user-attachments/assets/7be23224-3c87-43e8-bf60-4ac643ca1468" />
<img width="1721" alt="after-text-styling-desktop3" src="https://github.com/user-attachments/assets/2119acec-0dac-43a1-a830-bf1f25613483" />

### Screenshots - Mobile (Pixel 7)

#### Before
<img width="22%" alt="before-text-styling-mobile1" src="https://github.com/user-attachments/assets/9ac6cfcb-d4c5-4cae-94bc-bb035c171980" />
<img width="22%" alt="before-text-styling-mobile2" src="https://github.com/user-attachments/assets/9e90406f-06dc-43e6-ad83-7d94dccd55b2" />
<img width="22%" alt="before-text-styling-mobile3" src="https://github.com/user-attachments/assets/df308757-4e39-4f8d-a80b-194e3502889e" />

#### After
<img width="22%" alt="after-text-styling-mobile1" src="https://github.com/user-attachments/assets/faecb012-7340-4cd3-a13a-1c9ca04030f5" />
<img width="22%" alt="after-text-styling-mobile2" src="https://github.com/user-attachments/assets/c634a638-3d23-49af-bd69-6b99b0b9ab98" />
<img width="22%" alt="after-text-styling-mobile3" src="https://github.com/user-attachments/assets/c531dee8-f9ff-44a2-ac69-4e8c377e485b" />
<img width="22%" alt="after-text-styling-mobile4" src="https://github.com/user-attachments/assets/997b5dfa-bcbe-4887-8b41-e0b1936b8b03" />

## References
Closes #13481

## Reviewer guidance
Check if:
- All styled text elements visually match the Figma specification.
- Text elements wrap to the next line as expected when they reach the defined max width (640px) or when viewed on small screens, ensuring no text overflow occurs.