### PR TITLE
Introduce copy class functionality

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/ManageExamModals.vue
@@ -89,6 +89,7 @@
         context:
           'Description on confirmation window that displays when a user attempts to delete a quiz.',
       },
+
       copyOfExam: {
         message: 'Copy of { examTitle }',
         context:

--- a/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/QuizSummaryPage/ManageExamModals.vue
@@ -89,7 +89,6 @@
         context:
           'Description on confirmation window that displays when a user attempts to delete a quiz.',
       },
-
       copyOfExam: {
         message: 'Copy of { examTitle }',
         context:

--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -28,6 +28,7 @@ export const Modals = {
   EDIT_USER: 'EDIT_USER',
   RESET_USER_PASSWORD: 'RESET_USER_PASSWORD',
   DELETE_USER: 'DELETE_USER',
+  COPY_CLASS: 'COPY_CLASS',
 };
 
 export const pageNameToModuleMap = {

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/ClassRenameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/ClassRenameModal.vue
@@ -89,12 +89,25 @@
     },
     methods: {
       ...mapActions('classEditManagement', ['updateClass']),
-      updateName() {
+      async updateName() {
         this.formSubmitted = true;
         if (this.formIsValid) {
-          this.submitting = true;
-          this.updateClass({ id: this.classid, updateData: { name: this.name } });
-          this.$emit('success');
+          try {
+            this.submitting = true;
+            await this.updateClass({ id: this.classid, updateData: { name: this.name } });
+
+            const updatedClasses = this.classes.map(c => {
+              if (c.id === this.classid) {
+                return { ...c, name: this.name };
+              }
+              return c;
+            });
+
+            this.$store.commit('classManagement/SET_STATE', { classes: updatedClasses });
+            this.$emit('success');
+          } finally {
+            this.submitting = false;
+          }
         } else {
           this.$refs.name.focus();
         }

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/ClassRenameModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/ClassRenameModal.vue
@@ -94,6 +94,7 @@
         if (this.formIsValid) {
           this.submitting = true;
           this.updateClass({ id: this.classid, updateData: { name: this.name } });
+          this.$emit('success');
         } else {
           this.$refs.name.focus();
         }

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
@@ -17,7 +17,7 @@
             type="text"
             :label="classTitleLabel$()"
             :autofocus="true"
-            :maxlength="120"
+            :maxlength="100"
             :showInvalidText="true"
             :invalid="isClassNameInvalid"
             :invalidText="classNameAlreadyExists$()"

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
@@ -1,0 +1,260 @@
+<template>
+
+  <div>
+    <SidePanelModal
+      alignment="right"
+      sidePanelWidth="700px"
+      closeButtonIconType="close"
+      @closePanel="closeSidePanelModal"
+    >
+      <template #header>
+        <h1 class="side-panel-title">{{ copyClasslabel$() }}</h1>
+      </template>
+      <template #default>
+        <div>
+          <KTextbox
+            v-model="copiedClassName"
+            type="text"
+            :label="classTitleLabel$()"
+            :autofocus="true"
+            :maxlength="120"
+            :showInvalidText="true"
+            :invalid="isClassNameInvalid"
+            :invalidText="classNameAlreadyExists$()"
+          />
+
+          <p
+            id="coaches-assigned-label"
+            class="side-panel-subtitle"
+          >
+            {{ coachesAssignedToClassLabel$() }}
+          </p>
+          <SelectableList
+            :value="classCoachesIds"
+            :options="classCoaches"
+            ariaLabelledby="coaches-assigned-label"
+            :selectAllLabel="selectAllLabel$()"
+            :searchLabel="coreString('searchLabel')"
+            @input="handleSelection"
+          >
+            <template #option="{ option }">
+              <span>
+                {{ option }}
+                <UserTypeDisplay
+                  aria-hidden="true"
+                  userType="coach"
+                  :omitLearner="true"
+                  :distinguishCoachTypes="false"
+                  data-test="userRoleBadge"
+                  :class="$computedClass(userRoleBadgeStyle)"
+                />
+              </span>
+            </template>
+          </SelectableList>
+        </div>
+      </template>
+
+      <template #bottomNavigation>
+        <div class="bottom-nav">
+          <div>{{ numCoachesSelected$({ n: classCoachesIds.length }) }}</div>
+          <div>
+            <KButton
+              :text="coreString('cancelAction')"
+              appearance="raised-button"
+              class="cancel-copy-class-button"
+              @click="closeSidePanelModal"
+            />
+
+            <KButton
+              :text="copyClasslabel$()"
+              :primary="true"
+              :disabled="isClassNameInvalid"
+              @click="handleSubmitingClassCopy"
+            />
+          </div>
+        </div>
+      </template>
+    </SidePanelModal>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+  import { mapActions } from 'vuex';
+  import SidePanelModal from 'kolibri-common/components/SidePanelModal';
+  import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import SelectableList from './SelectableList.vue';
+
+  export default {
+    name: 'CopyClassSidePanel',
+    components: {
+      SelectableList,
+      SidePanelModal,
+      UserTypeDisplay,
+    },
+    mixins: [commonCoreStrings],
+    setup(props) {
+      const classCoachesIds = ref([]);
+      const copiedClassName = ref(null);
+      const { className } = props;
+
+      const {
+        coachesAssignedToClassLabel$,
+        classTitleLabel$,
+        selectAllLabel$,
+        numCoachesSelected$,
+        classNameAlreadyExists$,
+        copyClasslabel$,
+        classCopiedSuccessfully$,
+      } = bulkUserManagementStrings;
+      const { createSnackbar } = useSnackbar();
+
+      const handleSelection = newSelection => {
+        classCoachesIds.value = newSelection;
+      };
+
+      const setClassNameAndCoachIds = () => {
+        copiedClassName.value = className;
+        classCoachesIds.value = props.coachesIds;
+      };
+
+      setClassNameAndCoachIds();
+
+      return {
+        coachesAssignedToClassLabel$,
+        classTitleLabel$,
+        selectAllLabel$,
+        numCoachesSelected$,
+        copyClasslabel$,
+        classNameAlreadyExists$,
+        classCopiedSuccessfully$,
+        handleSelection,
+        copiedClassName,
+        createSnackbar,
+        classCoachesIds,
+      };
+    },
+    props: {
+      coachesIds: {
+        type: Array,
+        required: true,
+      },
+      classroom: {
+        type: Array,
+        required: true,
+      },
+      classCoaches: {
+        type: Array,
+        required: true,
+      },
+      className: {
+        type: String,
+        required: true,
+      },
+      classes: {
+        type: Array,
+        required: true,
+      },
+    },
+    computed: {
+      isClassNameInvalid() {
+        return this.classroom.some(row => row[0] === this.copiedClassName) && !this.submitting;
+      },
+      userRoleBadgeStyle() {
+        return {
+          color: this.$themePalette.grey.v_800,
+          backgroundColor: this.$themePalette.grey.v_300,
+          padding: '0.3em',
+          borderRadius: '2px',
+          fontSize: '10px',
+          '::selection': {
+            color: this.$themeTokens.text,
+          },
+        };
+      },
+    },
+    methods: {
+      ...mapActions('classAssignMembers', ['assignCoachesToClass']),
+      closeSidePanelModal() {
+        this.$emit('closeSidePanel');
+      },
+      async handleSubmitingClassCopy() {
+        this.submitting = true;
+
+        try {
+          await this.$store.dispatch('classManagement/createClass', this.copiedClassName);
+          await this.$nextTick();
+
+          const createdClass = this.classes.find(cls => cls.name === this.copiedClassName);
+
+          if (createdClass?.id) {
+            const coaches = this.classCoachesIds;
+
+            await this.assignCoachesToClass({
+              classId: createdClass.id,
+              coaches,
+            });
+
+            const updatedClasses = this.classes.map(c => {
+              if (c.name === this.copiedClassName) {
+                const updatedCoaches = coaches
+                  .map(coachId => this.classCoaches.find(coach => coach.id === coachId))
+                  .filter(Boolean);
+
+                return { ...c, coaches: updatedCoaches };
+              }
+              return c;
+            });
+
+            this.closeSidePanelModal();
+            this.$store.commit('classManagement/SET_STATE', { classes: updatedClasses });
+            this.createSnackbar(this.classCopiedSuccessfully$());
+          }
+        } finally {
+          this.submitting = false;
+        }
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .bottom-nav {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .cancel-copy-class-button {
+    margin-right: 1em;
+  }
+
+  .side-panel-subtitle {
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  .side-panel-title {
+    margin-left: 15px;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  /deep/ .textbox {
+    max-width: 100% !important;
+  }
+
+  .description-ktextbox-style /deep/ .ui-textbox-label {
+    width: 100%;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/SelectableList.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/SelectableList.vue
@@ -77,7 +77,22 @@
           presentational
           :checked="isOptionSelected(option)"
           :label="option.label"
-        />
+        >
+          <template v-if="displayUserRole">
+            <span>
+              {{ option.label }}
+              <UserTypeDisplay
+                aria-hidden="true"
+                userType="coach"
+                :omitLearner="true"
+                class="role-badge"
+                :distinguishCoachTypes="false"
+                data-test="userRoleBadge"
+                :class="$computedClass(userRoleBadgeStyle)"
+              />
+            </span>
+          </template>
+        </KCheckbox>
       </li>
     </ul>
     <p
@@ -103,11 +118,13 @@
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+  import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
 
   export default {
     name: 'SelectableList',
     components: {
       FilterTextbox,
+      UserTypeDisplay,
     },
     setup(props, { emit }) {
       const { value, options } = toRefs(props);
@@ -364,6 +381,24 @@
       searchLabel: {
         type: String,
         required: true,
+      },
+      displayUserRole: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      userRoleBadgeStyle() {
+        return {
+          color: this.$themePalette.grey.v_800,
+          backgroundColor: this.$themePalette.grey.v_300,
+          padding: '0.3em',
+          borderRadius: '2px',
+          fontSize: '10px',
+          '::selection': {
+            color: this.$themeTokens.text,
+          },
+        };
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/SelectableList.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/SelectableList.vue
@@ -78,20 +78,10 @@
           :checked="isOptionSelected(option)"
           :label="option.label"
         >
-          <template v-if="displayUserRole">
-            <span>
-              {{ option.label }}
-              <UserTypeDisplay
-                aria-hidden="true"
-                userType="coach"
-                :omitLearner="true"
-                class="role-badge"
-                :distinguishCoachTypes="false"
-                data-test="userRoleBadge"
-                :class="$computedClass(userRoleBadgeStyle)"
-              />
-            </span>
-          </template>
+          <slot
+            :option="option.label"
+            name="option"
+          ></slot>
         </KCheckbox>
       </li>
     </ul>
@@ -118,13 +108,11 @@
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
-  import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
 
   export default {
     name: 'SelectableList',
     components: {
       FilterTextbox,
-      UserTypeDisplay,
     },
     setup(props, { emit }) {
       const { value, options } = toRefs(props);
@@ -381,24 +369,6 @@
       searchLabel: {
         type: String,
         required: true,
-      },
-      displayUserRole: {
-        type: Boolean,
-        default: false,
-      },
-    },
-    computed: {
-      userRoleBadgeStyle() {
-        return {
-          color: this.$themePalette.grey.v_800,
-          backgroundColor: this.$themePalette.grey.v_300,
-          padding: '0.3em',
-          borderRadius: '2px',
-          fontSize: '10px',
-          '::selection': {
-            color: this.$themeTokens.text,
-          },
-        };
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -100,11 +100,12 @@
       />
 
       <ClassRenameModal
-        v-if="modalShown === Modals.EDIT_CLASS_NAME"
+        v-if="openRenameModal"
         :classname="classDetails.name"
         :classid="classDetails.id"
         :classes="classes"
         @cancel="closeModal"
+        @success="handleRenameSuccess()"
       />
       <SidePanelModal
         v-if="openCopyClassPanel"
@@ -202,6 +203,7 @@
       const classCoachesIds = ref([]);
       const classCoaches = ref([]);
       const openCopyClassPanel = ref(false);
+      const openRenameModal = ref(false);
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
       const { createSnackbar } = useSnackbar();
@@ -240,7 +242,8 @@
         }
 
         if (selection.value === Modals.EDIT_CLASS_NAME) {
-          this.displayModal(Modals.EDIT_CLASS_NAME);
+          // this.displayModal(Modals.EDIT_CLASS_NAME);
+          openRenameModal.value = true;
           return;
         }
 
@@ -270,6 +273,7 @@
         handleOptionSelection,
         createSnackbar,
         copyOfClass$,
+        openRenameModal,
       };
     },
     computed: {
@@ -356,6 +360,10 @@
           // Update the core facilities object to update classroom number
           this.getFacilities();
         }
+      },
+      handleRenameSuccess() {
+        this.openRenameModal = false;
+        this.refreshCoreFacilities();
       },
       // Duplicated in class-list-page
       coachNames(classes) {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -130,6 +130,9 @@
               :label="classTitleLabel$()"
               :autofocus="true"
               :maxlength="120"
+              :showInvalidText="true"
+              :invalid="isClassNameInvalid"
+              :invalidText="classNameAlreadyExists$()"
             />
 
             <p class="side-panel-subtitle">{{ coachesAssignedToClassLabel$() }}</p>
@@ -158,6 +161,7 @@
               <KButton
                 :text="copyClasslabel$()"
                 :primary="true"
+                :disabled="isClassNameInvalid"
                 @click="handleSubmitingClassCopy"
               />
             </div>
@@ -179,6 +183,7 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { UserKinds } from 'kolibri/constants';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import useUserManagement from '../../composables/useUserManagement';
@@ -227,6 +232,7 @@
         numCoachesSelected$,
         classCopiedSuccessfully$,
         copyOfClass$,
+        classNameAlreadyExists$,
       } = bulkUserManagementStrings;
 
       const handleSelection = newSelection => {
@@ -239,7 +245,7 @@
 
         classCoachesIds.value = classDetails.value.coaches.map(coach => coach.id);
         classCoaches.value = facilityUsers.value
-          .filter(user => user.kind === 'coach')
+          .filter(user => user.kind === UserKinds.COACH)
           .map(coach => ({
             id: coach.id,
             username: coach.username,
@@ -284,6 +290,7 @@
         createSnackbar,
         openRenameModal,
         copiedClassName,
+        classNameAlreadyExists$,
       };
     },
     computed: {
@@ -349,6 +356,9 @@
             id: 'delete',
           },
         ];
+      },
+      isClassNameInvalid() {
+        return this.tableRows.some(row => row[0] === this.copiedClassName);
       },
     },
     methods: {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -385,8 +385,12 @@
     font-weight: bold;
   }
 
-  /deep/ .ui-textbox-label {
-    width: 100% !important;
+  /deep/ .textbox {
+    max-width: 100% !important;
+  }
+
+  .description-ktextbox-style /deep/ .ui-textbox-label {
+    width: 100%;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -175,17 +175,15 @@
 
 <script>
 
-  import { ref, getCurrentInstance } from 'vue';
+  import { ref } from 'vue';
   import { mapState, mapActions, mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { UserKinds } from 'kolibri/constants';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
-  import useUserManagement from '../../composables/useUserManagement';
   import ClassRenameModal from '../ClassEditPage/ClassRenameModal.vue';
   import ClassCreateModal from './ClassCreateModal';
   import ClassDeleteModal from './ClassDeleteModal';
@@ -209,10 +207,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const classDetails = ref({
-        id: '',
-        name: '',
-      });
+      const classDetails = ref({});
       const classCoachesIds = ref([]);
       const classCoaches = ref([]);
       const copiedClassName = ref(null);
@@ -221,10 +216,6 @@
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
       const { createSnackbar } = useSnackbar();
-      const { $store, $router } = getCurrentInstance().proxy;
-      const activeFacilityId =
-        $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
-      const { facilityUsers } = useUserManagement(activeFacilityId);
       const {
         copyClasslabel$,
         renameClassLabel$,
@@ -246,14 +237,12 @@
         copiedClassName.value = copyOfClass$({ class: classDetails.value.name });
 
         classCoachesIds.value = classDetails.value.coaches.map(coach => coach.id);
-        classCoaches.value = facilityUsers.value
-          .filter(user => user.kind === UserKinds.COACH)
-          .map(coach => ({
-            id: coach.id,
-            username: coach.username,
-            full_name: coach.full_name,
-            label: coach.full_name,
-          }));
+        classCoaches.value = classDetails.value.coaches.map(coach => ({
+          id: coach.id,
+          username: coach.username,
+          full_name: coach.full_name,
+          label: coach.full_name,
+        }));
 
         if (selection.value === Modals.DELETE_CLASS) {
           selectClassToDelete(row);
@@ -443,10 +432,9 @@
             return c;
           });
 
-          this.$store.commit('classManagement/SET_STATE', { classes: updatedClasses });
-
-          this.createSnackbar(this.classCopiedSuccessfully$());
           this.openCopyClassPanel = false;
+          this.$store.commit('classManagement/SET_STATE', { classes: updatedClasses });
+          this.createSnackbar(this.classCopiedSuccessfully$());
         }
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -131,11 +131,28 @@
 
             <SelectableList
               :value="[]"
-              :options="[]"
-              ariaLabelledby="ssss"
-              selectAllLabel="ddd"
-              searchLabel="hfhhf"
+              :options="classDetails.coaches"
+              :ariaLabelledby="coachesAssignedToClassLabel$()"
+              :selectAllLabel="selectAllLabel$()"
+              :searchLabel="coreString('searchLabel')"
             />
+          </div>
+        </template>
+
+        <template #bottomNavigation>
+          <div class="bottom-nav">
+            <div>{{ numCoachesSelected$({ n: 3 }) }}</div>
+            <div>
+              <KButton
+                :text="coreString('cancelAction')"
+                appearance="raised-button"
+                class="cancel-copy-class-button"
+              />
+              <KButton
+                :text="copyClasslabel$()"
+                :primary="true"
+              />
+            </div>
           </div>
         </template>
       </SidePanelModal>
@@ -182,8 +199,14 @@
       const openCopyClassPanel = ref(false);
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
-      const { copyClasslabel$, renameClassLabel$, coachesAssignedToClassLabel$, classTitleLabel$ } =
-        bulkUserManagementStrings;
+      const {
+        copyClasslabel$,
+        renameClassLabel$,
+        coachesAssignedToClassLabel$,
+        classTitleLabel$,
+        selectAllLabel$,
+        numCoachesSelected$,
+      } = bulkUserManagementStrings;
 
       return {
         classToDelete,
@@ -197,6 +220,8 @@
         openCopyClassPanel,
         coachesAssignedToClassLabel$,
         classTitleLabel$,
+        selectAllLabel$,
+        numCoachesSelected$,
       };
     },
     computed: {
@@ -391,6 +416,16 @@
 
   .description-ktextbox-style /deep/ .ui-textbox-label {
     width: 100%;
+  }
+
+  .bottom-nav {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .cancel-copy-class-button {
+    margin-right: 1em;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -152,6 +152,7 @@
               <KButton
                 :text="copyClasslabel$()"
                 :primary="true"
+                @click="handleSubmitingClassCopy"
               />
             </div>
           </div>
@@ -171,6 +172,7 @@
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
   import { Modals } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ClassRenameModal from '../ClassEditPage/ClassRenameModal.vue';
@@ -202,6 +204,7 @@
       const openCopyClassPanel = ref(false);
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
+      const { createSnackbar } = useSnackbar();
       const {
         copyClasslabel$,
         renameClassLabel$,
@@ -209,6 +212,7 @@
         classTitleLabel$,
         selectAllLabel$,
         numCoachesSelected$,
+        classCopiedSuccessfully$,
       } = bulkUserManagementStrings;
 
       const handleSelection = newSelection => {
@@ -260,9 +264,11 @@
         classTitleLabel$,
         selectAllLabel$,
         numCoachesSelected$,
+        classCopiedSuccessfully$,
         handleSelection,
         classCoaches,
         handleOptionSelection,
+        createSnackbar,
       };
     },
     computed: {
@@ -329,10 +335,6 @@
           },
         ];
       },
-
-      // classCoachesIds() {
-      //   return this.classDetails.map(coach => coach.id).filter(id => id !== undefined);
-      // },
     },
     methods: {
       ...mapActions('classManagement', ['displayModal']),
@@ -382,6 +384,9 @@
           return coach_names.join('\n');
         }
         return null;
+      },
+      handleSubmitingClassCopy() {
+        this.createSnackbar(this.classCopiedSuccessfully$());
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -34,7 +34,6 @@
           />
         </KGridItem>
       </KGrid>
-
       <KTable
         :headers="tableHeaders"
         :rows="tableRows"
@@ -104,7 +103,7 @@
       />
 
       <ClassRenameModal
-        v-if="openRenameModal"
+        v-show="openRenameModal"
         :classname="classDetails.name"
         :classid="classDetails.id"
         :classes="classes"
@@ -112,7 +111,7 @@
         @success="handleRenameSuccess()"
       />
       <SidePanelModal
-        v-if="openCopyClassPanel"
+        v-show="openCopyClassPanel"
         ref="resourcePanel"
         alignment="right"
         sidePanelWidth="700px"
@@ -210,7 +209,10 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const classDetails = ref({});
+      const classDetails = ref({
+        id: '',
+        name: '',
+      });
       const classCoachesIds = ref([]);
       const classCoaches = ref([]);
       const copiedClassName = ref(null);

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -135,6 +135,7 @@
               :ariaLabelledby="coachesAssignedToClassLabel$()"
               :selectAllLabel="selectAllLabel$()"
               :searchLabel="coreString('searchLabel')"
+              :displayUserRole="true"
               @input="handleSelection"
             />
           </div>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -44,17 +44,7 @@
         sortable
       >
         <template #header="{ header, colIndex }">
-          <span
-            v-if="colIndex === 2"
-            style="display: flex; justify-content: start"
-            :class="{ visuallyhidden: colIndex === 3 }"
-          >
-            {{ header.label }}</span>
-          <span
-            v-else
-            :class="{ visuallyhidden: colIndex === 3 }"
-          >
-            {{ header.label }}</span>
+          <span :class="{ visuallyhidden: colIndex === 3 }"> {{ header.label }}</span>
         </template>
         <template #cell="{ content, colIndex, row }">
           <span v-if="colIndex === 0">

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -128,10 +128,9 @@
             />
 
             <p class="side-panel-subtitle">{{ coachesAssignedToClassLabel$() }}</p>
-
             <SelectableList
-              :value="[]"
-              :options="classDetails.coaches"
+              :value="classCoachesIds"
+              :options="classCoaches"
               :ariaLabelledby="coachesAssignedToClassLabel$()"
               :selectAllLabel="selectAllLabel$()"
               :searchLabel="coreString('searchLabel')"
@@ -288,6 +287,17 @@
             id: 'delete',
           },
         ];
+      },
+      classCoaches() {
+        return this.classDetails.coaches.map(coach => ({
+          id: coach.id,
+          username: coach.username,
+          full_name: coach.full_name,
+          label: coach.full_name,
+        }));
+      },
+      classCoachesIds() {
+        return this.classCoaches.map(coach => coach.id).filter(id => id !== undefined);
       },
     },
     methods: {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -34,10 +34,24 @@
           />
         </KGridItem>
       </KGrid>
+      <KGrid>
+        <KGridItem
+          :layout12="{ span: 4 }"
+          :layout6="{ span: 2 }"
+          :layout4="{ span: 2 }"
+        >
+          <FilterTextbox
+            v-model="search"
+            placeholder="search"
+            class="search-bar"
+          />
+        </KGridItem>
+      </KGrid>
 
+      {{ filteredList }}
       <KTable
         :headers="tableHeaders"
-        :rows="tableRows"
+        :rows="filteredList"
         :caption="$tr('tableCaption')"
         :emptyMessage="$tr('noClassesExist')"
         :dataLoading="dataLoading"
@@ -49,6 +63,7 @@
         <template #cell="{ content, colIndex, row }">
           <span v-if="colIndex === 0">
             <KRouterLink
+              class="class-name"
               :text="content"
               :to="$store.getters.facilityPageLinks.ClassEditPage(row[3].id)"
               icon="classes"
@@ -173,6 +188,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import FilterTextbox from 'kolibri/components/FilterTextbox';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { Modals } from '../../constants';
@@ -197,6 +213,7 @@
       ClassRenameModal,
       SidePanelModal,
       SelectableList,
+      FilterTextbox,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -205,6 +222,7 @@
       const classCoaches = ref([]);
       const openCopyClassPanel = ref(false);
       const openRenameModal = ref(false);
+      const search = ref(null);
       const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
       const { getFacilities, userIsMultiFacilityAdmin } = useFacilities();
       const { createSnackbar } = useSnackbar();
@@ -255,6 +273,7 @@
       };
 
       return {
+        search,
         classToDelete,
         clearClassToDelete,
         userIsMultiFacilityAdmin,
@@ -287,28 +306,28 @@
           {
             label: this.coreString('classNameLabel'),
             dataType: 'string',
-            minWidth: '150px',
-            width: '20%',
+            minWidth: '300px',
+            width: '30%',
             columnId: 'classname',
           },
           {
             label: this.coreString('coachesLabel'),
-            dataType: 'undefined',
-            minWidth: '150px',
+            dataType: 'string',
+            minWidth: '250px',
             width: '30%',
             columnId: 'coaches',
           },
           {
             label: this.coreString('learnersLabel'),
             dataType: 'number',
-            minWidth: '150px',
-            width: '20%',
+            minWidth: '250px',
+            width: '30%',
             columnId: 'learners',
           },
           {
             label: this.coreString('userActionsColumnHeader'),
             dataType: 'undefined',
-            minWidth: '150px',
+            minWidth: '100px',
             width: '30%',
             columnId: 'userActions',
           },
@@ -321,6 +340,15 @@
           this.$formatNumber(classroom.learner_count),
           classroom,
         ]);
+      },
+      filteredList() {
+        if (this.search === null || this.search === '') {
+          return this.tableRows;
+        } else {
+          return this.tableRows.map(classroom => {
+            classroom[0].toLowerCase().startsWith(this.search.toLowerCase());
+          });
+        }
       },
       dropDownOptions() {
         return [
@@ -480,6 +508,14 @@
 
   .cancel-copy-class-button {
     margin-right: 1em;
+  }
+
+  .class-name {
+    font-size: 14px;
+  }
+
+  .search-bar {
+    margin-bottom: 0.5em;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -147,6 +147,7 @@
                 :text="coreString('cancelAction')"
                 appearance="raised-button"
                 class="cancel-copy-class-button"
+                @click="openCopyClassPanel = false"
               />
               <KButton
                 :text="copyClasslabel$()"

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -125,7 +125,7 @@
         <template #default>
           <div>
             <KTextbox
-              v-model="classDetails.name"
+              :value="copyOfClass$({ class: classDetails.name })"
               type="text"
               :label="classTitleLabel$()"
               :autofocus="true"

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -213,6 +213,7 @@
         selectAllLabel$,
         numCoachesSelected$,
         classCopiedSuccessfully$,
+        copyOfClass$,
       } = bulkUserManagementStrings;
 
       const handleSelection = newSelection => {
@@ -234,7 +235,7 @@
         }));
 
         if (selection.value === Modals.DELETE_CLASS) {
-          this.selectClassToDelete(row);
+          selectClassToDelete(row);
           return;
         }
 
@@ -251,7 +252,6 @@
 
       return {
         classToDelete,
-        selectClassToDelete,
         clearClassToDelete,
         userIsMultiFacilityAdmin,
         getFacilities,
@@ -269,6 +269,7 @@
         classCoaches,
         handleOptionSelection,
         createSnackbar,
+        copyOfClass$,
       };
     },
     computed: {
@@ -338,6 +339,7 @@
     },
     methods: {
       ...mapActions('classManagement', ['displayModal']),
+      ...mapActions('classAssignMembers', ['assignCoachesToClass']),
       closeModal() {
         this.displayModal(false);
       },
@@ -386,7 +388,17 @@
         return null;
       },
       handleSubmitingClassCopy() {
-        this.createSnackbar(this.classCopiedSuccessfully$());
+        const className = this.copyOfClass$({ class: this.classDetails.name });
+        this.$store.dispatch('classManagement/createClass', className).then(() => {
+          const classId = this.classes.find(cls => cls.name === className).id;
+          if (classId) {
+            const coaches = this.classCoachesIds;
+            this.assignCoachesToClass({ classId: classId, coaches }).then(() => {
+              this.createSnackbar(this.classCopiedSuccessfully$());
+              this.openCopyClassPanel = false;
+            });
+          }
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -139,7 +139,7 @@
             <SelectableList
               :value="classCoachesIds"
               :options="classCoaches"
-              :ariaLabelledby="'coaches-assigned-label'"
+              ariaLabelledby="coaches-assigned-label"
               :selectAllLabel="selectAllLabel$()"
               :searchLabel="coreString('searchLabel')"
               @input="handleSelection"

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -301,7 +301,7 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     context: 'Action button label for beginning bulk actions',
   },
   copyOfClass: {
-    message: `Copy of '{class}'`,
+    message: 'Copy of {class}',
     context: 'Initial name of a class upon being copied',
   },
   classTitleLabel: {

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -77,6 +77,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Delete selection',
     context: 'Label for bulk-action button that will allow user to delete selected users',
   },
+  selectAllLabel: {
+    message: 'Select all',
+    context: 'Label for bulk-action button that will select all users in the current view',
+  },
   resetPassword: {
     message: 'Reset password',
     context: 'Label that will allow user to reset passwords for selected user',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -312,4 +312,9 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Class title',
     context: 'Label for the class title input field in the copy class modal',
   },
+  // Error Handling
+  defaultErrorMessage: {
+    message: 'Sorry! Something went wrong, please try again.',
+    context: 'Default error message for API errors.',
+  },
 });

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -250,6 +250,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Class copied successfully',
     context: 'Message shown when class copying succeeds',
   },
+  classNameAlreadyExists: {
+    message: 'Class name already exists',
+    context: 'Error message shown when trying to copy a class with a name that already exists',
+  },
 
   // User Creation
   newUsers: {

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -48,6 +48,14 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'View trash',
     context: 'Label for dropdown item that links user to trash page of soft-deleted users',
   },
+  copyClasslabel: {
+    message: 'Copy class',
+    context: 'Label for dropdown item that duplicates a class',
+  },
+  renameClassLabel: {
+    message: 'Rename class',
+    context: 'Label for dropdown item that allows user to modify the name of a class',
+  },
 
   // Bulk actions
   enrollToClass: {
@@ -126,6 +134,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Assign action has been undone',
     context:
       'Notification shown after the user has chosen to undo a recent coach assignment action.',
+  },
+  coachesAssignedToClassLabel: {
+    message: 'Coaches assigned to this class',
+    context: 'label to indicate coaches assigned to a class in sidepanel',
   },
 
   // Remove from class
@@ -288,9 +300,8 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: `Copy of '{class}'`,
     context: 'Initial name of a class upon being copied',
   },
-  // Error Handling
-  defaultErrorMessage: {
-    message: 'Sorry! Something went wrong, please try again.',
-    context: 'Default error message for API errors.',
+  classTitleLabel: {
+    message: 'Class title',
+    context: 'Label for the class title input field in the copy class modal',
   },
 });


### PR DESCRIPTION

 
## Summary
This pull request introduces the ability to make copy of  classes, along with improvements to class management actions, on the ManageClassPage.

## References
 Closes [#13443](https://github.com/learningequality/kolibri/issues/13443)
## Reviewer guidance

1. Navigate to  class in the table and click the vertical ellipsis icon in the final column.
2. Verify the dropdown menu contains "Copy Class", "Rename Class", and "Delete" options.
3. Test "Rename Class": 1. Select "Rename Class". 2. Verify the KModal appears with a textbox. 3. Enter a new name and confirm the rename.
4. Test "Delete": 1. Select "Delete". 2. Verify the ClassDeleteModal appears. 
5. Test "Copy Class": 1. Select "Copy Class". 2. Verify the SidePanelModal appears. 
6. Check that the class name textbox is pre-filled with "Copy of {original class name}". 
7. Verify the coach dropdown lists available coaches and pre-selects existing ones. and Test selecting and deselecting coaches
 8. Click the "Copy Class" button within the side panel. and confirm the if the copy of the  class appears in the  class table.