### PR TITLE
[HTML5 Article Renderer] Apply table styling

### DIFF
--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -79,13 +79,31 @@
       this.$emit('startTracking');
       this.pollProgress();
     },
+    mounted() {
+      this.$nextTick(() => {
+        this.applyTabIndexes();
+        window.addEventListener('resize', this.applyTabIndexes);
+      });
+    },
     beforeDestroy() {
       if (this.timeout) {
         clearTimeout(this.timeout);
       }
+      window.removeEventListener('resize', this.applyTabIndexes);
       this.$emit('stopTracking');
     },
     methods: {
+      applyTabIndexes() {
+        const tableContainers = this.$el.querySelectorAll('.table-container');
+        tableContainers.forEach(container => {
+          const scrollable = container.scrollWidth > container.clientWidth;
+          if (scrollable) {
+            container.setAttribute('tabindex', '0');
+          } else {
+            container.removeAttribute('tabindex');
+          }
+        });
+      },
       recordProgress() {
         let progress;
         if (this.forceDurationBasedProgress) {

--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div :style="cssVars">
     <KCircularLoader
       v-if="loading || !html"
       :delay="false"
@@ -52,6 +52,14 @@
       },
       scrollBasedProgress() {
         return 0.5;
+      },
+      cssVars() {
+        return {
+          '--color-primary-500': this.$themeBrand.primary.v_500,
+          '--color-primary-100': this.$themeBrand.primary.v_100,
+          '--color-grey-300': this.$themePalette.grey.v_300,
+          '--color-grey-100': this.$themePalette.grey.v_100,
+        };
       },
     },
     async created() {

--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -9,6 +9,7 @@
     <SafeHTML
       v-else
       :html="html"
+      :windowSizeClass="windowSizeClass"
     />
   </div>
 
@@ -20,6 +21,8 @@
   import ZipFile from 'kolibri-zip';
   import SafeHTML from 'kolibri-common/components/SafeHTML';
   import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { computed } from 'vue';
 
   export default {
     name: 'SafeHtml5RendererIndex',
@@ -28,12 +31,17 @@
       SafeHTML,
     },
     setup(props, context) {
+      const { windowIsSmall } = useKResponsiveWindow();
+      const windowSizeClass = computed(() => {
+        return windowIsSmall.value ? ' small-window' : '';
+      });
       const { defaultFile, forceDurationBasedProgress, durationBasedProgress } = useContentViewer(
         props,
         context,
         { defaultDuration: 300 },
       );
       return {
+        windowSizeClass,
         defaultFile,
         forceDurationBasedProgress,
         durationBasedProgress,

--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -9,7 +9,9 @@
     <SafeHTML
       v-else
       :html="html"
-      :windowSizeClass="windowSizeClass"
+      :styleOverrides="{
+        windowSizeClass: windowSizeClass,
+      }"
     />
   </div>
 

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.js
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.js
@@ -1,0 +1,50 @@
+export default {
+  name: 'SafeHtmlTable',
+  functional: true,
+  props: {
+    node: { required: true },
+    attributes: { type: Object, required: true },
+    tableCounter: { type: Number, required: true },
+    windowSizeClass: { type: String, default: '' },
+    mapNode: { type: Function, required: true },
+    mapChildren: { type: Function, required: true },
+  },
+  render(h, context) {
+    const { node, attributes, tableCounter, windowSizeClass, mapNode, mapChildren } = context.props;
+    const captionId = `table-caption-${tableCounter}`;
+
+    const children = [];
+    for (const childNode of node.childNodes) {
+      if (
+        childNode.nodeType === Node.ELEMENT_NODE &&
+        childNode.tagName.toLowerCase() === 'caption'
+      ) {
+        const captionAttrs = {};
+        for (const attr of childNode.attributes) {
+          captionAttrs[attr.name] = attr.value;
+        }
+        captionAttrs.id = captionId;
+        captionAttrs.class = 'safe-html' + windowSizeClass;
+        children.push(h('caption', { attrs: captionAttrs }, mapChildren(childNode.childNodes)));
+      } else {
+        children.push(mapNode(childNode));
+      }
+    }
+
+    const firstRow = node.querySelector && node.querySelector('tr');
+    const colCount = firstRow ? firstRow.children.length : 0;
+    let tableWidth = '640px';
+    if (colCount > 3) {
+      tableWidth = `${colCount * 200}px`;
+    }
+
+    return h(
+      'div',
+      {
+        class: 'table-container',
+        attrs: { role: 'region', 'aria-labelledby': captionId },
+      },
+      [h('table', { attrs: attributes, style: { width: tableWidth } }, children)],
+    );
+  },
+};

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -14,6 +14,12 @@ DOMPurify.setConfig({
   KEEP_CONTENT: false,
 });
 
+DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+  if ((node.nodeName === 'TD' || node.nodeName === 'TH') && data.attrName === 'colspan') {
+    data.forceKeepAttr = true;
+  }
+});
+
 export default {
   name: 'SafeHTML',
   functional: true,

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -80,7 +80,7 @@ export default {
             'div',
             {
               class: 'table-container',
-              attrs: { role: 'region', 'aria-labelledby': captionId, tabindex: 0 },
+              attrs: { role: 'region', 'aria-labelledby': captionId },
             },
             [h(tag, { attrs: attributes, style: { width: tableWidth } }, children)],
           );

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -1,7 +1,7 @@
 import DOMPurify from 'dompurify';
 import './style.scss';
 
-const ALLOWED_URI_REGEXP = /^blob:https?:/i;
+const ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 const FORBID_TAGS = ['style', 'link'];
 const FORBID_ATTR = ['style'];
 
@@ -12,12 +12,6 @@ DOMPurify.setConfig({
   ALLOWED_URI_REGEXP,
   FORBID_ATTR,
   KEEP_CONTENT: false,
-});
-
-DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
-  if ((node.nodeName === 'TD' || node.nodeName === 'TH') && data.attrName === 'colspan') {
-    data.forceKeepAttr = true;
-  }
 });
 
 export default {

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -22,6 +22,10 @@ export default {
       required: true,
       type: String,
     },
+    windowSizeClass: {
+      required: true,
+      type: String,
+    },
   },
   render(h, context) {
     const sanitizedHTML = DOMPurify.sanitize(context.props.html);
@@ -55,7 +59,7 @@ export default {
               }
               // Inject the captionId into captions
               captionAttrs.id = captionId;
-              captionAttrs.class = 'safe-html';
+              captionAttrs.class = 'safe-html' + context.props.windowSizeClass;
               children.push(
                 h('caption', { attrs: captionAttrs }, mapChildren(childNode.childNodes)),
               );

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -38,8 +38,18 @@ export default {
         }
         attributes.class = 'safe-html';
         if (tag === 'table') {
+          const firstRow = node.querySelector('tr');
+          const colCount = firstRow ? firstRow.children.length : 0;
+          let tableWidth = '640px';
+          if (colCount > 3) {
+            tableWidth = `${colCount * 200}px`;
+          }
           return h('div', { class: 'table-responsive' }, [
-            h(tag, { attrs: attributes }, mapChildren(node.childNodes)),
+            h(
+              tag,
+              { attrs: attributes, style: { width: tableWidth } },
+              mapChildren(node.childNodes),
+            ),
           ]);
         }
         return h(tag, { attrs: attributes }, mapChildren(node.childNodes));

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -31,12 +31,18 @@ export default {
 
     function mapNode(node) {
       if (node.nodeType === Node.ELEMENT_NODE) {
+        const tag = node.tagName.toLowerCase();
         const attributes = {};
         for (const attr of node.attributes) {
           attributes[attr.name] = attr.value;
         }
         attributes.class = 'safe-html';
-        return h(node.tagName.toLowerCase(), { attrs: attributes }, mapChildren(node.childNodes));
+        if (tag === 'table') {
+          return h('div', { class: 'table-responsive' }, [
+            h(tag, { attrs: attributes }, mapChildren(node.childNodes)),
+          ]);
+        }
+        return h(tag, { attrs: attributes }, mapChildren(node.childNodes));
       } else if (node.nodeType === Node.TEXT_NODE) {
         return node.textContent;
       }

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -22,9 +22,9 @@ export default {
       required: true,
       type: String,
     },
-    windowSizeClass: {
-      required: true,
-      type: String,
+    styleOverrides: {
+      type: Object,
+      default: () => ({}),
     },
   },
   render(h, context) {
@@ -59,7 +59,7 @@ export default {
               }
               // Inject the captionId into captions
               captionAttrs.id = captionId;
-              captionAttrs.class = 'safe-html' + context.props.windowSizeClass;
+              captionAttrs.class = 'safe-html' + context.props.styleOverrides.windowSizeClass;
               children.push(
                 h('caption', { attrs: captionAttrs }, mapChildren(childNode.childNodes)),
               );

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -88,13 +88,15 @@ b.safe-html {
 }
 
 .table-container {
-  width: 100%;
+  width: calc(100% + 32px);
+  padding: 0 16px;
+  margin-left: -16px;
   overflow-x: auto;
 }
 
-.table-container:focus {
+.table-container:focus-visible {
   outline: 3px solid rgb(51, 172, 245) !important;
-  outline-offset: 4px !important;
+  outline-offset: -3px !important;
 }
 
 table.safe-html {
@@ -110,6 +112,10 @@ caption.safe-html {
   margin: 0 auto 12px;
   font-weight: 600;
   color: var(--color-primary-500);
+}
+
+caption.safe-html.small-window {
+  text-align: start;
 }
 
 thead.safe-html {

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -87,6 +87,11 @@ b.safe-html {
   @include text-style(bold);
 }
 
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+}
+
 table.safe-html {
   width: auto;
   min-width: 640px;
@@ -121,4 +126,10 @@ td.safe-html {
   min-width: 200px;
   padding: 16px;
   border: 1px solid var(--color-grey-300);
+}
+
+img.safe-html {
+  display: block;
+  width: 360px;
+  margin: 16px auto;
 }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -92,6 +92,11 @@ b.safe-html {
   overflow-x: auto;
 }
 
+.table-responsive:focus {
+  outline: 3px solid rgb(51, 172, 245) !important;
+  outline-offset: 4px !important;
+}
+
 table.safe-html {
   min-width: 640px;
   margin: 16px auto;

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -93,10 +93,10 @@ b.safe-html {
 }
 
 table.safe-html {
-  width: auto;
   min-width: 640px;
   margin: 16px auto;
   font-size: 16px;
+  table-layout: fixed;
   border-collapse: collapse;
   border: 1px solid var(--color-grey-300);
 }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -86,3 +86,39 @@ strong.safe-html,
 b.safe-html {
   @include text-style(bold);
 }
+
+table.safe-html {
+  width: auto;
+  min-width: 640px;
+  margin: 16px auto;
+  font-size: 16px;
+  border-collapse: collapse;
+  border: 1px solid var(--color-grey-300);
+}
+
+caption.safe-html {
+  margin: 0 auto 12px;
+  font-weight: 600;
+  color: var(--color-primary-500);
+}
+
+thead.safe-html {
+  font-weight: 600;
+  background-color: var(--color-primary-100);
+}
+
+tfoot.safe-html {
+  background-color: var(--color-grey-100);
+}
+
+th.safe-html {
+  font-weight: 600;
+  text-align: left;
+}
+
+th.safe-html,
+td.safe-html {
+  min-width: 200px;
+  padding: 16px;
+  border: 1px solid var(--color-grey-300);
+}

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -87,12 +87,12 @@ b.safe-html {
   @include text-style(bold);
 }
 
-.table-responsive {
+.table-container {
   width: 100%;
   overflow-x: auto;
 }
 
-.table-responsive:focus {
+.table-container:focus {
   outline: 3px solid rgb(51, 172, 245) !important;
   outline-offset: 4px !important;
 }
@@ -135,6 +135,6 @@ td.safe-html {
 
 img.safe-html {
   display: block;
-  width: 360px;
+  width: 300px;
   margin: 16px auto;
 }


### PR DESCRIPTION
## Summary
- Applied relevant styles to all table elements.
- Enabled horizontal scrolling for tables on smaller screens.
- Added a visible focus outline to the table container when focused.

Note: Temporary image styles have been applied to prevent horizontal page stretching.

### Screenshots - Desktop

#### Before
![before-table-styling-desktop](https://github.com/user-attachments/assets/2119acec-0dac-43a1-a830-bf1f25613483)

#### After
![after-table-styling-desktop](https://github.com/user-attachments/assets/040196e8-bd6f-490b-ab98-460d6d374788)

### Screenshots - Mobile (Pixel 7)

#### Before
<img width="30%" alt="before-table-styling-mobile" src="https://github.com/user-attachments/assets/997b5dfa-bcbe-4887-8b41-e0b1936b8b03" />

#### After
<img width="30%" alt="after-table-styling-mobile" src="https://github.com/user-attachments/assets/d60557b8-17f6-406a-a9bc-022c87c9d9a4" />

### Screenshot - Focus outline
<img width="50%" alt="after-table-styling-focus" src="https://github.com/user-attachments/assets/bf26feae-94d5-4109-af3d-37e901eb5b4e" />

### Screen Recordings
https://github.com/user-attachments/assets/47c84987-a82d-4ae5-ab03-9e8c2c17b3a4

https://github.com/user-attachments/assets/ded73333-243d-4c05-a712-9e2fefbf290d

https://github.com/user-attachments/assets/f32bd70c-eb46-4268-8611-26809ee5544e

## References
Issue - [#13482](https://github.com/learningequality/kolibri/issues/13482)

## Reviewer guidance
Check if:
- All styled table elements visually match the Figma specification.
- Tables become horizontally scrollable on small screens when their width exceeds the viewport, without breaking the layout or causing horizontal page scrolling.
- Tables are keyboard-tabbable when scrollable, with a visible focus outline.