### PR TITLE
BUM SidePanel: Implement Enroll (learners) to classes functionality

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -656,7 +656,6 @@ class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet)
     queryset = Membership.objects.all()
     serializer_class = MembershipSerializer
     filterset_class = MembershipFilter
-    fields = ["user", "collection", "user_ids", "by_ids"]
 
 
 class RoleFilter(FilterSet):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -637,13 +637,17 @@ class FacilityUsernameViewSet(ReadOnlyValuesViewset):
 
 class MembershipFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")
+    by_ids = CharFilter(method="filter_by_ids")
 
     def filter_user_ids(self, queryset, name, value):
         return queryset.filter(user_id__in=value.split(","))
 
+    def filter_by_ids(self, queryset, name, value):
+        return queryset.filter(id__in=value.split(","))
+
     class Meta:
         model = Membership
-        fields = ["user", "collection", "user_ids"]
+        fields = ["user", "collection", "user_ids", "by_ids"]
 
 
 class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
@@ -652,7 +656,7 @@ class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet)
     queryset = Membership.objects.all()
     serializer_class = MembershipSerializer
     filterset_class = MembershipFilter
-    filterset_fields = ["user", "collection", "user_ids"]
+    fields = ["user", "collection", "user_ids", "by_ids"]
 
 
 class RoleFilter(FilterSet):

--- a/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
@@ -1,40 +1,356 @@
 <template>
 
-  <SidePanelModal
-    alignment="right"
-    sidePanelWidth="700px"
-    @closePanel="$router.back()"
-  >
-    <template #header>
-      <h1>{{ coreString('classesLabel') }}</h1>
-    </template>
-  </SidePanelModal>
+  <div>
+    <KModal
+      v-if="showUndoModal"
+      :title="undoUsersEnrolledHeading$({ num: selectedUsers.size })"
+      :submitText="undoAction$()"
+      :cancelText="dismissAction$()"
+      :submitDisabled="loading"
+      :cancelDisabled="loading"
+      @cancel="handleDismissConfirmation"
+      @submit="handleUndoEnrollments"
+    >
+      <KCircularLoader v-if="loading" />
+      <span v-else>{{
+        undoUsersEnrolledMessage$({
+          numUsers: selectedUsers.size,
+          numClasses: selectedOptions.length,
+        })
+      }}</span>
+    </KModal>
+    <SidePanelModal
+      v-else
+      alignment="right"
+      sidePanelWidth="700px"
+      @closePanel="closeSidePanel(false)"
+    >
+      <template #header>
+        <h1>{{ enrollToClass$() }}</h1>
+      </template>
+      <KCircularLoader v-if="loading" />
+      <div v-else>
+        <div
+          v-if="showErrorWarning"
+          class="enroll-warning-label"
+          :style="{ color: $themeTokens.error }"
+        >
+          <span>{{ defaultErrorMessage$() }}</span>
+        </div>
+        <div class="enroll-warning-label">
+          <span>{{ numUsersYouHaveSelected$({ num: selectedUsers.size }) }}</span>
+        </div>
+        <div
+          v-if="usersNotEnrolled > 0"
+          class="enroll-warning-label"
+        >
+          <KIcon
+            icon="warningIncomplete"
+            class="enroll-warning-icon"
+          />
+          <span>{{ numUsersNotEnrolled$({ num: usersNotEnrolled }) }}</span>
+        </div>
+        <div
+          v-if="classCoaches.length > 0"
+          class="enroll-warning-label"
+        >
+          <KIcon
+            icon="warningIncomplete"
+            class="enroll-warning-icon"
+          />
+          <span>{{ numUsersCoaches$({ num: classCoaches.length }) }}</span>
+        </div>
+        <div
+          v-if="selectedUsers.size > 0"
+          class="enroll-warning-label"
+        >
+          <KIcon
+            icon="info"
+            :color="$themePalette.orange.v_400"
+            class="enroll-warning-icon"
+          />
+          <span>{{ usersInClassNotAffected$() }}</span>
+        </div>
+        <h2 id="enroll-in-selected-classes">{{ enrollInSelectedClasses$() }}</h2>
+        <SelectableList
+          v-model="selectedOptions"
+          :options="classList"
+          :selectAllLabel="enrollInAllClasses$()"
+          aria-labelledby="enroll-in-selected-classes"
+          :searchLabel="searchForAClass$()"
+        />
+      </div>
+      <template #bottomNavigation>
+        <div class="bottom-nav-container">
+          <KButton
+            :text="coreString('cancelAction')"
+            :disabled="loading"
+            @click="closeSidePanel(selectedOptions.length > 0 ? true : false)"
+          />
+          <KButton
+            primary
+            :text="enrollAction$()"
+            :disabled="!selectedOptions.length || loading"
+            @click="enrollLearners"
+          />
+        </div>
+      </template>
+      <KModal
+        v-if="showCloseConfirmationModal"
+        :submitText="discardAction$()"
+        :cancelText="keepEditingAction$()"
+        :title="disgardChanges$()"
+        @cancel="showCloseConfirmationModal = false"
+        @submit="closeSidePanel(false)"
+      >
+        <span>{{ discardWarning$() }}</span>
+      </KModal>
+    </SidePanelModal>
+  </div>
 
 </template>
 
 
 <script>
 
+  import { ref } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
+  import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+  import { UserKinds } from 'kolibri/constants';
+  import groupBy from 'lodash/groupBy';
+  import SelectableList from '../../ManageClassPage/SelectableList.vue';
 
   export default {
     name: 'EnrollLearnersSidePanel',
     components: {
       SidePanelModal,
+      SelectableList,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const showUndoModal = ref(false);
+      const showCloseConfirmationModal = ref(false);
+      const showErrorWarning = ref(false);
+      const {
+        enrollToClass$,
+        numUsersNotEnrolled$,
+        usersInClassNotAffected$,
+        numUsersCoaches$,
+        searchForAClass$,
+        enrollInAllClasses$,
+        enrollInSelectedClasses$,
+        enrollUndoneNotice$,
+        numUsersYouHaveSelected$,
+        undoUsersEnrolledHeading$,
+        undoUsersEnrolledMessage$,
+        enrollAction$,
+        discardAction$,
+        discardWarning$,
+        keepEditingAction$,
+        disgardChanges$,
+        undoAction$,
+        defaultErrorMessage$,
+        usersEnrolledNotice$,
+      } = bulkUserManagementStrings;
+      const { createSnackbar } = useSnackbar();
+      const { dismissAction$ } = searchAndFilterStrings;
+      return {
+        enrollToClass$,
+        numUsersNotEnrolled$,
+        usersInClassNotAffected$,
+        numUsersCoaches$,
+        searchForAClass$,
+        enrollInAllClasses$,
+        enrollInSelectedClasses$,
+        numUsersYouHaveSelected$,
+        undoUsersEnrolledHeading$,
+        undoUsersEnrolledMessage$,
+        defaultErrorMessage$,
+        dismissAction$,
+        enrollAction$,
+        discardAction$,
+        discardWarning$,
+        keepEditingAction$,
+        disgardChanges$,
+        undoAction$,
+        enrollUndoneNotice$,
+        usersEnrolledNotice$,
+        showUndoModal,
+        showCloseConfirmationModal,
+        showErrorWarning,
+        createSnackbar,
+      };
+    },
     props: {
-      /* eslint-disable vue/no-unused-properties */
       selectedUsers: {
         type: Set,
-        default: () => new Set(),
+        required: true,
       },
       classes: {
         type: Array,
-        default: () => [],
+        required: true,
+      },
+    },
+    data() {
+      return {
+        selectedOptions: [],
+        classCoaches: [],
+        classLearners: [],
+        loading: false,
+        memberships: [],
+        enrollments: [],
+      };
+    },
+    computed: {
+      classList() {
+        return this.classes.map(classObj => ({
+          label: classObj.name,
+          id: classObj.id,
+        }));
+      },
+      usersNotEnrolled() {
+        const enrolledUsers = new Set(this.classLearners);
+        return [...this.selectedUsers].filter(userId => !enrolledUsers.has(userId)).length;
+      },
+    },
+    created() {
+      this.setClassUsers();
+    },
+    methods: {
+      async setClassUsers() {
+        // Clear previous data
+        this.classLearners = [];
+        this.classCoaches = [];
+        this.loading = true;
+        // Fetch memberships and user models for all selected users
+        const membershipsPromise = MembershipResource.fetchCollection({
+          getParams: { user_ids: { user_ids: Array.from(this.selectedUsers).join(',') } },
+        });
+        const userModelsPromise = Promise.all(
+          Array.from(this.selectedUsers).map(id => FacilityUserResource.fetchModel({ id })),
+        );
+        try {
+          const [membershipsData, userModels] = await Promise.all([
+            membershipsPromise,
+            userModelsPromise,
+          ]);
+          // group memberships by user
+          this.memberships = groupBy(membershipsData, 'user');
+          this.classLearners = Object.keys(this.memberships);
+          // filter coaches by role
+          this.classCoaches = Array.from(
+            userModels
+              .filter(user => user.roles.some(role => role.kind.includes(UserKinds.COACH)))
+              .reduce((set, user) => set.add(user.id), new Set()),
+          );
+        } finally {
+          this.loading = false;
+        }
+      },
+      async enrollLearners() {
+        this.loading = true;
+        try {
+          // Find users already enrolled in the selected classes and filter them out
+          this.enrollments = this.selectedOptions
+            .map(collection_id => {
+              const user_ids = Array.from(this.selectedUsers).filter(userId => {
+                const userMemberships = this.memberships[userId] || [];
+                return !userMemberships.some(m => m.collection === collection_id);
+              });
+              return { collection_id, user_ids };
+            })
+            // remove classes that have an empty user_ids array
+            .filter(e => e.user_ids.length > 0);
+          // If there’s no users to enroll, return early
+          if (this.enrollments.length === 0) {
+            this.createSnackbar(this.usersEnrolledNotice$());
+            this.showUndoModal = true;
+            return;
+          }
+          for (const membership of this.enrollments) {
+            await MembershipResource.saveCollection({
+              getParams: {
+                collection: membership.collection_id,
+              },
+              data: membership.user_ids.map(user => ({
+                collection: membership.collection_id,
+                user: user,
+              })),
+            });
+          }
+          this.createSnackbar(this.usersEnrolledNotice$());
+          this.showUndoModal = true;
+        } catch (error) {
+          this.$store.dispatch('handleApiError', { error });
+          this.showUndoModal = false;
+          this.showErrorWarning = true;
+        } finally {
+          this.loading = false;
+        }
+      },
+      closeSidePanel(close = true) {
+        if (close) {
+          this.showCloseConfirmationModal = true;
+        } else {
+          this.$router.back();
+        }
+      },
+      handleDismissConfirmation() {
+        this.showUndoModal = false;
+        this.$router.back();
+      },
+      async handleUndoEnrollments() {
+        this.loading = true;
+        try {
+          if (this.enrollments.length > 0) {
+            await Promise.all(
+              this.enrollments.flatMap(({ collection_id, user_ids }) =>
+                MembershipResource.deleteCollection({
+                  collection: collection_id,
+                  user_id: user_ids,
+                }),
+              ),
+            );
+          }
+          this.createSnackbar(this.enrollUndoneNotice$());
+        } catch (error) {
+          this.$store.dispatch('handleApiError', { error });
+          this.createSnackbar(this.defaultErrorMessage$());
+        } finally {
+          this.showUndoModal = false;
+          this.loading = false;
+          this.$router.back();
+        }
       },
     },
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .enroll-warning-icon {
+    position: relative;
+    top: 0.4em;
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: 0.5em;
+  }
+
+  .enroll-warning-label {
+    margin-bottom: 10px;
+  }
+
+  .bottom-nav-container {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
@@ -193,7 +193,7 @@
         classCoaches.value = [];
         loading.value = true;
         const membershipsPromise = MembershipResource.fetchCollection({
-          getParams: { user_ids: { user_ids: Array.from(props.selectedUsers).join(',') } },
+          getParams: { user_ids: Array.from(props.selectedUsers).join(',') },
         });
         const userModelsPromise = FacilityUserResource.fetchCollection({
           getParams: {
@@ -228,9 +228,10 @@
             )
             .map(user => ({ collection: collection_id, user }));
         });
-        if (!enrollments.length) {
+        if (enrollments.length === 0) {
           createSnackbar(usersEnrolledNotice$());
           showUndoModal.value = true;
+          loading.value = false;
           return;
         }
         try {

--- a/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
@@ -195,9 +195,11 @@
         const membershipsPromise = MembershipResource.fetchCollection({
           getParams: { user_ids: { user_ids: Array.from(props.selectedUsers).join(',') } },
         });
-        const userModelsPromise = Promise.all(
-          Array.from(props.selectedUsers).map(id => FacilityUserResource.fetchModel({ id })),
-        );
+        const userModelsPromise = FacilityUserResource.fetchCollection({
+          getParams: {
+            by_ids: Array.from(props.selectedUsers).join(','),
+          },
+        });
         try {
           const [membershipsData, userModels] = await Promise.all([
             membershipsPromise,

--- a/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/SidePanels/EnrollLearnersSidePanel.vue
@@ -82,17 +82,19 @@
       </div>
       <template #bottomNavigation>
         <div class="bottom-nav-container">
-          <KButton
-            :text="coreString('cancelAction')"
-            :disabled="loading"
-            @click="closeSidePanel(selectedOptions.length > 0 ? true : false)"
-          />
-          <KButton
-            primary
-            :text="enrollAction$()"
-            :disabled="!selectedOptions.length || loading"
-            @click="enrollLearners"
-          />
+          <KButtonGroup>
+            <KButton
+              :text="coreString('cancelAction')"
+              :disabled="loading"
+              @click="closeSidePanel(selectedOptions.length > 0 ? true : false)"
+            />
+            <KButton
+              primary
+              :text="enrollAction$()"
+              :disabled="!selectedOptions.length || loading"
+              @click="enrollLearners"
+            />
+          </KButtonGroup>
         </div>
       </template>
       <KModal

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -34,6 +34,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: "You've selected {num, number} {num, plural, one {user} other {users}}",
     context: 'Label showing the number of users selected',
   },
+  searchForAClass: {
+    message: 'Search for a class',
+    context: 'Placeholder text for class search input',
+  },
 
   // Dropdown options
   viewNewUsers: {
@@ -68,6 +72,26 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   resetPassword: {
     message: 'Reset password',
     context: 'Label that will allow user to reset passwords for selected user',
+  },
+  undoAction: {
+    message: 'Undo',
+    context: 'Label for the button that will undo the last action taken on the users',
+  },
+  disgardChanges: {
+    message: 'Discard changes?',
+    context: 'Heading for the confirmation modal that asks user if they want to discard changes',
+  },
+  discardAction: {
+    message: 'Discard',
+    context: 'Label for the button to dismiss selection changes',
+  },
+  discardWarning: {
+    message: "Any selections you've made in this panel will be lost.",
+    context: 'Warning message to inform user of lost selections if they discard changes',
+  },
+  keepEditingAction: {
+    message: 'Keep editing',
+    context: 'Label for the button to keep editing selections in the side panel',
   },
 
   // Selection warnings
@@ -149,6 +173,18 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   enrollUndoneNotice: {
     message: 'Enroll action has been undone',
     context: 'Confirmation message when enroll action is undone',
+  },
+  enrollInAllClasses: {
+    message: 'Enroll in all classes',
+    context: 'Label for the selection to enroll users in all classes',
+  },
+  enrollInSelectedClasses: {
+    message: 'Enroll users in selected classes',
+    context: 'Heading for the selection to enroll users in the selected classes',
+  },
+  enrollAction: {
+    message: 'Enroll',
+    context: 'Label for the button that will enroll users in classes',
   },
 
   // Move to trash
@@ -250,5 +286,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   copyOfClass: {
     message: `Copy of '{class}'`,
     context: 'Initial name of a class upon being copied',
+  },
+  // Error Handling
+  defaultErrorMessage: {
+    message: 'Sorry! Something went wrong, please try again.',
+    context: 'Default error message for API errors.',
   },
 });

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -158,7 +158,8 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     context: 'Warning message about users already in selected classes',
   },
   undoUsersEnrolledHeading: {
-    message: '{num, number} {num, plural, one {user} other {users}} have been enrolled. Undo this?',
+    message:
+      '{num, number} {num, plural, one {user has} other {users have}} been enrolled. Undo this?',
     context: 'Heading for undo confirmation after enrolling users',
   },
   undoUsersEnrolledMessage: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates the EnrollLearnersSidePanel component to carry out the bulk action to enroll learners into one or more classes.

Functionality added:
- A selectable and filterable list of unchecked classes are shown when the EnrollLearnersSidePanel component is opened.
-  A loading spinner is shown within the side panel while the API request is being made and the side panel closes once the request has succeeded.
- A notice is shown at the top of the side panel when an API request fails.
- If the Admin has not selected a class, the **Cancel** button closes the side panel without confirmation. Otherwise, a confirmation modal appears.
- After the selected users are enrolled, the side panel closes and a `KModal` allowing the enrollment to be undone is displayed.
-`MembershipResource` is used to bulk enroll or un-enroll (undo) learners.
![enrollSidePanelError](https://github.com/user-attachments/assets/c9ce19f1-6ae5-4c18-a79f-7a7a2782a4f6)

Enrolling users using the side panel:

https://github.com/user-attachments/assets/aec4216b-996d-4460-b5fd-24fa85589843


Enrolling and undoing enrollment using the side panel:

https://github.com/user-attachments/assets/056abaea-d637-4675-a72a-7c563d96ca9e




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #13406 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. On the Facility > Users page, select one or most users and click the enroll icon button.
2. Once the side panel opens, confirm that the correct warnings apply based on if the selected users are coaches, learners, and not enrolled in any classes.
3. Select a class to enroll the users into and undo the enrollment to confirm that the functionality works as intended. **Note:** Users that are already enrolled into the selected class(es) will not be affected by selecting ENROLL or UNDO.