### PR TITLE
Remove unnecessary max-width on the Kolibri logo

### DIFF
--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -452,7 +452,6 @@
 
   .logo {
     width: 100%;
-    max-width: 65vh; // not compatible with older browsers
     height: auto;
   }
 


### PR DESCRIPTION
## Summary
Removes unnecessary max width on Kolibri logo that caused weird resize behaviour

## Reviewer guidance
Before:
[Screencast from 07-10-2025 02:40:17 PM.webm](https://github.com/user-attachments/assets/edbb9c16-0aba-4421-a0d6-a7942d16a570)

After:
[Screencast from 07-10-2025 02:53:02 PM.webm](https://github.com/user-attachments/assets/a960b872-ecdd-49ee-80aa-f8539dd2435b)
