### PR TITLE
Fix build failures

### DIFF
--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
     - name: Install Ubuntu dependencies
       run: |
+        echo "deb http://archive.debian.org/debian-archive/debian/ buster main" > /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
+        echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99archive
         apt-get -y -qq update
         apt-get install -y gettext sudo sqlite3 binutils-aarch64-linux-gnu binutils-arm-linux-gnueabihf git-lfs
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
* Builds have been failing since 2025/07/12 as it seems that buster packages are only on the Debian archive now.
* Update package installation to user debian archive.

