### PR TITLE
[HTML5 Article Renderer] Apply image styling

### DIFF
--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -12,6 +12,7 @@
       :styleOverrides="{
         windowSizeClass: windowSizeClass,
       }"
+      @expand-img="openLightbox"
     />
   </div>
 
@@ -126,6 +127,10 @@
         this.timeout = setTimeout(() => {
           this.recordProgress();
         }, 5000);
+      },
+      openLightbox(/* payload */) {
+        // TODO: Implement lightbox when ready
+        // payload contains: { src, alt }
       },
     },
   };

--- a/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/assets/src/views/SafeHtml5RendererIndex.vue
@@ -69,6 +69,7 @@
           '--color-primary-100': this.$themeBrand.primary.v_100,
           '--color-grey-300': this.$themePalette.grey.v_300,
           '--color-grey-100': this.$themePalette.grey.v_100,
+          '--color-fineline': this.$themeTokens.fineLine,
         };
       },
     },

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -1,0 +1,69 @@
+<template>
+
+  <div class="image-container">
+    <div class="img-wrapper">
+      <img
+        :src="src"
+        :alt="alt"
+        v-bind="$attrs"
+        tabindex="0"
+        role="button"
+        :aria-label="`Expand image: ${alt}`"
+        aria-haspopup="dialog"
+        @click="handleExpand"
+        @keydown="onImgKeydown"
+      >
+      <KIconButton
+        class="expand-btn expand-btn-transition"
+        icon="expand"
+        appearance="raised-button"
+        aria-label="Expand image"
+        aria-haspopup="dialog"
+        tooltip="Expand image"
+        @click="handleExpand"
+      />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'SafeHtmlImage',
+    inheritAttrs: false,
+    props: {
+      src: { type: String, required: true },
+      alt: { type: String, default: '' },
+    },
+    methods: {
+      handleExpand() {
+        this.$emit('expand-img', { src: this.src, alt: this.alt });
+      },
+      onImgKeydown(event) {
+        if (event.key === ' ') {
+          event.preventDefault();
+          this.handleExpand();
+        }
+        if (event.key === 'Enter') {
+          this.handleExpand();
+        }
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .expand-btn-transition {
+    transition:
+      color 0.15s,
+      background-color 0.15s,
+      box-shadow 0.15s,
+      opacity 0.15s;
+  }
+
+</style>

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -6,12 +6,7 @@
         :src="src"
         :alt="alt"
         v-bind="$attrs"
-        tabindex="0"
-        role="button"
-        :aria-label="`Expand image: ${alt}`"
-        aria-haspopup="dialog"
         @click="handleExpand"
-        @keydown="onImgKeydown"
       >
       <KIconButton
         class="expand-btn expand-btn-transition"
@@ -40,15 +35,6 @@
     methods: {
       handleExpand() {
         this.$emit('expand-img', { src: this.src, alt: this.alt });
-      },
-      onImgKeydown(event) {
-        if (event.key === ' ') {
-          event.preventDefault();
-          this.handleExpand();
-        }
-        if (event.key === 'Enter') {
-          this.handleExpand();
-        }
       },
     },
   };

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -1,10 +1,11 @@
 import DOMPurify from 'dompurify';
 import './style.scss';
 import SafeHtmlTable from './SafeHtmlTable.js';
+import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
 
 const ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 const FORBID_TAGS = ['style', 'link'];
-const FORBID_ATTR = ['style'];
+const FORBID_ATTR = ['style', 'width', 'height'];
 
 const parser = new DOMParser();
 
@@ -66,7 +67,24 @@ export default {
             // Wrap each image in a container to constrain its size
             'div',
             { class: 'image-container' },
-            [h(tag, { attrs: attributes }, mapChildren(node.childNodes))],
+            [
+              h('div', { class: 'img-wrapper' }, [
+                h(tag, { attrs: attributes }, mapChildren(node.childNodes)),
+                h(KIconButton, {
+                  class: 'expand-btn',
+                  style: {
+                    transition:
+                      'color 0.15s, background-color 0.15s, box-shadow 0.15s, opacity 0.15s',
+                  },
+                  props: {
+                    icon: 'expand',
+                    appearance: 'raised-button',
+                    ariaLabel: 'Expand image',
+                    tooltip: 'Expand image',
+                  },
+                }),
+              ]),
+            ],
           );
         }
         return h(tag, { attrs: attributes }, mapChildren(node.childNodes));

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -60,6 +60,15 @@ export default {
             },
           });
         }
+        if (tag === 'img') {
+          attributes.tabindex = '0';
+          return h(
+            // Wrap each image in a container to constrain its size
+            'div',
+            { class: 'image-container' },
+            [h(tag, { attrs: attributes }, mapChildren(node.childNodes))],
+          );
+        }
         return h(tag, { attrs: attributes }, mapChildren(node.childNodes));
       } else if (node.nodeType === Node.TEXT_NODE) {
         return node.textContent;

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -1,7 +1,7 @@
 import DOMPurify from 'dompurify';
 import './style.scss';
 import SafeHtmlTable from './SafeHtmlTable.js';
-import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
+import SafeHtmlImage from './SafeHtmlImage.vue';
 
 const ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 const FORBID_TAGS = ['style', 'link'];
@@ -61,32 +61,15 @@ export default {
             },
           });
         }
+
         if (tag === 'img') {
-          attributes.tabindex = '0';
-          return h(
-            // Wrap each image in a container to constrain its size
-            'div',
-            { class: 'image-container' },
-            [
-              h('div', { class: 'img-wrapper' }, [
-                h(tag, { attrs: attributes }, mapChildren(node.childNodes)),
-                h(KIconButton, {
-                  class: 'expand-btn',
-                  style: {
-                    transition:
-                      'color 0.15s, background-color 0.15s, box-shadow 0.15s, opacity 0.15s',
-                  },
-                  props: {
-                    icon: 'expand',
-                    appearance: 'raised-button',
-                    ariaLabel: 'Expand image',
-                    tooltip: 'Expand image',
-                  },
-                }),
-              ]),
-            ],
-          );
+          const handler = context.listeners && context.listeners['expand-img'];
+          return h(SafeHtmlImage, {
+            attrs: attributes,
+            on: handler ? { 'expand-img': handler } : {},
+          });
         }
+
         return h(tag, { attrs: attributes }, mapChildren(node.childNodes));
       } else if (node.nodeType === Node.TEXT_NODE) {
         return node.textContent;

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -140,28 +140,53 @@ td.safe-html {
 }
 
 .image-container {
+  display: flex;
+  justify-content: center;
   width: 100%;
   max-width: 1200px;
   max-height: 80vh;
-  margin: 0 auto;
+  margin: 16px auto;
+}
+
+.img-wrapper {
+  position: relative;
+  display: inline-block;
+  transition: box-shadow 0.15s;
+}
+
+.img-wrapper:hover {
+  cursor: pointer;
 }
 
 img.safe-html {
   display: block;
   max-width: 100%;
   max-height: 80vh;
-  margin: 16px auto;
+  margin: 0 auto;
   border: 1px solid var(--color-fineline);
-}
-
-img.safe-html:hover,
-img.safe-html:focus-visible {
-  box-shadow:
-    3px 0 8px 1px rgba(16, 24, 40, 0.1),
-    -3px 6px 8px 1px rgba(16, 24, 40, 0.1);
+  transition: box-shadow 0.15s;
 }
 
 img.safe-html:focus-visible {
   outline: 3px solid rgb(51, 172, 245) !important;
   outline-offset: 4px !important;
+}
+
+.img-wrapper:hover,
+.img-wrapper:focus-within {
+  box-shadow:
+    3px 0 8px 1px rgba(16, 24, 40, 0.1),
+    -3px 6px 8px 1px rgba(16, 24, 40, 0.1);
+}
+
+.expand-btn {
+  position: absolute;
+  top: 13px;
+  right: 13px;
+  opacity: 0;
+}
+
+.img-wrapper:hover .expand-btn,
+.img-wrapper:focus-within .expand-btn {
+  opacity: 1;
 }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -156,6 +156,9 @@ td.safe-html {
 
 .img-wrapper:hover {
   cursor: pointer;
+  box-shadow:
+    3px 0 8px 1px rgba(16, 24, 40, 0.1),
+    -3px 6px 8px 1px rgba(16, 24, 40, 0.1);
 }
 
 img.safe-html {
@@ -164,19 +167,6 @@ img.safe-html {
   max-height: 80vh;
   margin: 0 auto;
   border: 1px solid var(--color-fineline);
-  transition: box-shadow 0.15s;
-}
-
-img.safe-html:focus-visible {
-  outline: 3px solid rgb(51, 172, 245) !important;
-  outline-offset: 4px !important;
-}
-
-.img-wrapper:hover,
-.img-wrapper:focus-within {
-  box-shadow:
-    3px 0 8px 1px rgba(16, 24, 40, 0.1),
-    -3px 6px 8px 1px rgba(16, 24, 40, 0.1);
 }
 
 .expand-btn {
@@ -187,6 +177,6 @@ img.safe-html:focus-visible {
 }
 
 .img-wrapper:hover .expand-btn,
-.img-wrapper:focus-within .expand-btn {
+.expand-btn:focus {
   opacity: 1;
 }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -139,8 +139,29 @@ td.safe-html {
   border: 1px solid var(--color-grey-300);
 }
 
+.image-container {
+  width: 100%;
+  max-width: 1200px;
+  max-height: 80vh;
+  margin: 0 auto;
+}
+
 img.safe-html {
   display: block;
-  width: 300px;
+  max-width: 100%;
+  max-height: 80vh;
   margin: 16px auto;
+  border: 1px solid var(--color-fineline);
+}
+
+img.safe-html:hover,
+img.safe-html:focus-visible {
+  box-shadow:
+    3px 0 8px 1px rgba(16, 24, 40, 0.1),
+    -3px 6px 8px 1px rgba(16, 24, 40, 0.1);
+}
+
+img.safe-html:focus-visible {
+  outline: 3px solid rgb(51, 172, 245) !important;
+  outline-offset: 4px !important;
 }

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -79,7 +79,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "kolibri-constants": "0.2.10",
-    "kolibri-design-system": "5.1.0",
+    "kolibri-design-system": "5.2.1",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "path-to-regexp": "1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,6 +2906,15 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+"aphrodite@git+https://github.com/learningequality/aphrodite.git":
+  version "2.2.3"
+  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
+  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
+  dependencies:
+    asap "^2.0.3"
+    inline-style-prefixer "^4.0.2"
+    string-hash "^1.1.3"
+
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
@@ -7882,10 +7891,10 @@ kolibri-constants@0.2.10:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.10.tgz#45f0dbf7156dedc350507df8d1c78d72ed441568"
   integrity sha512-MvaAPUHFjknQ7V1LsnAZyRF4Px/lHVnwBq+v5N7nxd8QMyesr+LqNPn+BR6F7lrkvJKRQjPDX3eOfdmk8S6gjw==
 
-kolibri-design-system@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.1.0.tgz#d8e57fe7ac2124add3532ca415b091b435a9857e"
-  integrity sha512-SvLVA00HByWF+BTdxNlp4Ff+HmJUvtZLV6sdAXwKbO1hsglk8+7pTOQVfdl/X1G5EMb25w/Xy04f9mLOJEHehg==
+kolibri-design-system@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.2.1.tgz#db39bd3ad73622963e242dda85805dafe47bd3f1"
+  integrity sha512-KGZmhnqTBSetkrqc71BzlvWEiH4Hi8FQjqy0pYzpxdnRjb4Xx9l5Bp6w7WnAECQm10pEfbxUcfTBXUic0ecFmQ==
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "3.0.21"
@@ -10933,7 +10942,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11011,7 +11029,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12346,7 +12371,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary
- Applied relevant styles to the image element.
- Added a custom `expand` icon to KDS and used it on the expand icon button.
- Manually tested the hover and focus effects with both mouse and keyboard.

### Screen Recordings - Mouse Hover Effects and Responsive Sizing
#### Before
https://github.com/user-attachments/assets/17290237-9c1d-4e28-a3fe-3f749ffd873c

#### After
https://github.com/user-attachments/assets/6de14396-5a77-4ca6-bfb0-33fb97124201

### Screen Recordings - Tab Navigation
#### Before
https://github.com/user-attachments/assets/4568c351-5d3a-49ee-b37b-27e94f9204da

#### After
https://github.com/user-attachments/assets/6659d120-f7d8-406c-a5e7-a30a96da5439

## References
Issue - #13504 
Add expand icon PR - https://github.com/learningequality/kolibri-design-system/pull/1068

## Reviewer guidance
Check if:
- [x] The image is displayed with the specified margin, border, and alignment.
- [x] The image size is responsive and maintains its aspect ratio.
- [x] The “expand” icon button and image's drop shadow appear on hover.
- [x] The “expand” icon button is keyboard-focusable and appears on focus.