### PR TITLE
Fix urls.js module regression

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -289,7 +289,7 @@
       </section>
 
       <!-- List of separate links to Facility Settings pages -->
-      <section v-if="isMultiFacilitySuperuser">
+      <section v-if="isMultiFacilitySuperuser && getFacilitySettingsPath()">
         <h2>{{ $tr('configureFacilitySettingsHeader') }}</h2>
         <ul class="ul-reset">
           <template>

--- a/packages/kolibri/__tests__/urls.spec.js
+++ b/packages/kolibri/__tests__/urls.spec.js
@@ -136,7 +136,7 @@ describe('UrlResolver', () => {
 
   describe('Error handling', () => {
     test('throws error for non-existent patterns', () => {
-      expect(() => Urls.nonExistentPattern()).toThrow('URL pattern "nonExistentPattern" not found');
+      expect(Urls.nonExistentPattern).toBeUndefined();
     });
 
     test('handles initialization with no plugin data', () => {
@@ -144,9 +144,7 @@ describe('UrlResolver', () => {
       plugin_data.urls = undefined;
       const UrlsNoData = createUrlResolver();
 
-      expect(() => UrlsNoData['user_profile_detail'](123)).toThrow(
-        'URL pattern "user_profile_detail" not found',
-      );
+      expect(UrlsNoData['user_profile_detail']).toBeUndefined;
     });
     test('throws error if URL pattern contains a dash', () => {
       jest.resetModules();

--- a/packages/kolibri/urls.js
+++ b/packages/kolibri/urls.js
@@ -65,19 +65,16 @@ class UrlResolver {
 
     const patterns = this._patterns[name];
     if (!patterns) {
-      urlFunc = () => {
-        if (process.env.NODE_ENV !== 'production') {
-          if (name.includes('-')) {
-            throw new Error(
-              `URL pattern names should use underscores instead of dashes. Try "${name.replace('-', '_')}"`,
-            );
-          }
+      if (process.env.NODE_ENV !== 'production') {
+        if (name.includes('-')) {
+          throw new Error(
+            `URL pattern names should use underscores instead of dashes. Try "${name.replace('-', '_')}"`,
+          );
         }
-        throw new Error(`URL pattern "${name}" not found`);
-      };
-    } else {
-      urlFunc = this._createUrlFunction(name, patterns);
+      }
+      return;
     }
+    urlFunc = this._createUrlFunction(name, patterns);
 
     // Cache the function
     this._functionCache.set(name, urlFunc);


### PR DESCRIPTION
## Summary
* Reverts accidental API change where the urls.js module would always return a function instead of returning nothing when no matching pattern was found
* Disables facility settings section when the facility plugin is not available

## References
Fixes #13566 

## Reviewer guidance
Follow the steps to reproduce in the issue, confirm this is no longer a concern.

Note that the settings page restart does not work for the development server.
