### PR TITLE
Update build tools to allow building JS on Python 3.13

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -9,3 +9,5 @@ beautifulsoup4==4.8.2
 requests==2.21.0
 pkginfo==1.8.2
 wheel>=0.31.1
+importlib-metadata==4.8.3
+importlib_resources==5.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,5 +8,5 @@ tox==3.1.3
 django-debug-toolbar==4.3.0
 drf-yasg==1.21.7
 coreapi==2.3.3
-nodeenv==1.3.3
+nodeenv>=1.3.3
 sqlacodegen==2.3.0.post1


### PR DESCRIPTION
## Summary
I realized after reviewing https://github.com/learningequality/kolibri/pull/13463 that our Python webpack JSON tool in kolibri-tools is not Python 3.13 compatible.
This updates this tooling to be Python 3.13 compatible by default, and then require backports on older Python versions.

## References
Fixes #13548

## Reviewer guidance
Create a Python 3.13 venv, make sure the yarn run devserver works on it.
Ensure the build still works on CI (in Python 3.6)!
