### PR TITLE
Remove unnecessary menu items displaying along with the "Sync all facility data"

### DIFF
--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -5,7 +5,7 @@
       <HeaderWithOptions :headerText="coreString('facilitiesLabel')">
         <template #options>
           <!-- Margins to and bottom adds space when buttons are vertically stacked -->
-          <div style="display: flex; gap: 8px; justify-content: flex-end">
+          <KButtonGroup>
             <KButton
               v-if="isAnyFacilityRegistered"
               :text="$tr('syncAllAction')"
@@ -20,12 +20,13 @@
             >
               <template #menu>
                 <KDropdownMenu
+                  v-if="!showSyncAllModal"
                   :options="options"
                   @select="handleSelect"
                 />
               </template>
             </KButton>
-          </div>
+          </KButtonGroup>
         </template>
       </HeaderWithOptions>
 

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -5,7 +5,7 @@
       <HeaderWithOptions :headerText="coreString('facilitiesLabel')">
         <template #options>
           <!-- Margins to and bottom adds space when buttons are vertically stacked -->
-          <KButtonGroup>
+          <div style="display: flex; gap: 8px; justify-content: flex-end">
             <KButton
               v-if="isAnyFacilityRegistered"
               :text="$tr('syncAllAction')"
@@ -25,7 +25,7 @@
                 />
               </template>
             </KButton>
-          </KButtonGroup>
+          </div>
         </template>
       </HeaderWithOptions>
 


### PR DESCRIPTION


## Summary
This PR fixes unnecessary menu items displays along with the "Sync all facility data"
#### Before 

https://github.com/user-attachments/assets/127f8146-78ae-4535-9f26-4b9e99a2b959

#### After


https://github.com/user-attachments/assets/37c74f33-8421-45ff-bafc-72bd7229feb9





## References
[#13476](https://github.com/learningequality/kolibri/issues/13476)

## Reviewer guidance

1. Go to Device > Facilities and create and register at least 2 facilities to KDP
2. Click the "Sync all" button