### PR TITLE
Implement repeating cleanup task for hard-deleting expired soft-deleted FacilityUsers

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -83,6 +83,7 @@ from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
 from kolibri.core.auth.permissions.general import DenyAll
 from kolibri.core.auth.utils.delete import delete_imported_user
+from kolibri.core.auth.tasks import cleanup_expired_deleted_users
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access
@@ -98,6 +99,7 @@ from kolibri.core.mixins import BulkDeleteMixin
 from kolibri.core.query import annotate_array_aggregate
 from kolibri.core.query import SQCount
 from kolibri.core.serializers import HexOnlyUUIDField
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.core.utils.urls import reverse_path
 from kolibri.plugins.app.utils import interface
@@ -521,6 +523,10 @@ class FacilityUserViewSet(FacilityUserConsolidateMixin, ValuesViewset, BulkDelet
             user = self.get_object()
             user.date_deleted = now()
             user.save()
+            try:
+                cleanup_expired_deleted_users.enqueue()
+            except JobRunning:
+                pass  # Task is already running, do nothing
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             # Bulk deletion

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -82,8 +82,8 @@ from kolibri.core.auth.constants import user_kinds
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
 from kolibri.core.auth.permissions.general import DenyAll
-from kolibri.core.auth.utils.delete import delete_imported_user
 from kolibri.core.auth.tasks import cleanup_expired_deleted_users
+from kolibri.core.auth.utils.delete import delete_imported_user
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import ntpath
 
@@ -17,6 +18,7 @@ from kolibri.core.auth.constants.user_kinds import ASSIGNABLE_COACH
 from kolibri.core.auth.constants.user_kinds import COACH
 from kolibri.core.auth.constants.user_kinds import SUPERUSER
 from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.utils.sync import find_soud_sync_sessions
 from kolibri.core.auth.utils.sync import validate_and_create_sync_credentials
 from kolibri.core.auth.utils.users import get_remote_users_info
@@ -677,3 +679,28 @@ def cleanupsync(**kwargs):
 
     sync_filter = kwargs.pop("sync_filter")
     call_command("cleanupsyncs", sync_filter=str(sync_filter), expiration=1, **kwargs)
+
+
+@register_task(
+    job_id="cleanup_expired_deleted_users",
+    queue=facility_task_queue,
+)
+def cleanup_expired_deleted_users():
+    """
+    Delete FacilityUsers whose date_deleted is more than 30 days ago.
+    If any soft-deleted users remain, re-enqueue this task to run again in 24 hours.
+    """
+    now = timezone.now()
+    threshold = now - datetime.timedelta(days=30)
+    expired_users = FacilityUser.soft_deleted_objects.filter(
+        date_deleted__lte=threshold
+    )
+    expired_users_count = expired_users.count()
+    if expired_users_count > 0:
+        expired_users.delete()
+
+    # Check if any soft-deleted users remain (regardless of date_deleted)
+    if FacilityUser.soft_deleted_objects.exists():
+        job = get_current_job()
+        # Re-enqueue to run again in 24 hours
+        job.retry_in(24 * 60 * 60)

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -695,9 +695,8 @@ def cleanup_expired_deleted_users():
     expired_users = FacilityUser.soft_deleted_objects.filter(
         date_deleted__lte=threshold
     )
-    expired_users_count = expired_users.count()
-    if expired_users_count > 0:
-        expired_users.delete()
+
+    expired_users.delete()
 
     # Check if any soft-deleted users remain (regardless of date_deleted)
     if FacilityUser.soft_deleted_objects.exists():

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -42,7 +42,6 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.signals import cascade_delete_user
 from kolibri.core.device.models import OSUser
 from kolibri.core.device.utils import set_device_settings
-from kolibri.core.tasks.main import job_storage
 
 
 class FacilityFactory(factory.DjangoModelFactory):
@@ -1032,6 +1031,7 @@ class UserUpdateTestCase(APITestCase):
         self.assertEqual(response.data[0]["metadata"]["field"], "extra_demographics")
 
 
+@patch("kolibri.core.auth.api.cleanup_expired_deleted_users")
 class UserDeleteTestCase(APITestCase):
     databases = "__all__"
 
@@ -1052,7 +1052,7 @@ class UserDeleteTestCase(APITestCase):
     def tearDown(self):
         self.user.delete()
 
-    def test_user_delete(self):
+    def test_user_delete(self, mock_cleanup_task):
         response = self.client.delete(
             reverse("kolibri:core:facilityuser-detail", kwargs={"pk": self.user.pk}),
             format="json",
@@ -1064,10 +1064,7 @@ class UserDeleteTestCase(APITestCase):
             ).exists()
         )
         self.assertFalse(models.FacilityUser.objects.filter(id=self.user.id).exists())
-        jobs = job_storage.get_all_jobs()
-        self.assertTrue(
-            any(job.job_id == "cleanup_expired_deleted_users" for job in jobs)
-        )
+        mock_cleanup_task.enqueue.assert_called_once()
 
     def test_superuser_delete_self(self):
         response = self.client.delete(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -42,6 +42,7 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.signals import cascade_delete_user
 from kolibri.core.device.models import OSUser
 from kolibri.core.device.utils import set_device_settings
+from kolibri.core.tasks.main import job_storage
 
 
 class FacilityFactory(factory.DjangoModelFactory):
@@ -1063,6 +1064,10 @@ class UserDeleteTestCase(APITestCase):
             ).exists()
         )
         self.assertFalse(models.FacilityUser.objects.filter(id=self.user.id).exists())
+        jobs = job_storage.get_all_jobs()
+        self.assertTrue(
+            any(job.job_id == "cleanup_expired_deleted_users" for job in jobs)
+        )
 
     def test_superuser_delete_self(self):
         response = self.client.delete(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1066,7 +1066,7 @@ class UserDeleteTestCase(APITestCase):
         self.assertFalse(models.FacilityUser.objects.filter(id=self.user.id).exists())
         mock_cleanup_task.enqueue.assert_called_once()
 
-    def test_superuser_delete_self(self):
+    def test_superuser_delete_self(self, mock_cleanup_task):
         response = self.client.delete(
             reverse(
                 "kolibri:core:facilityuser-detail", kwargs={"pk": self.superuser.pk}
@@ -1075,7 +1075,7 @@ class UserDeleteTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    def test_bulk_delete_users(self):
+    def test_bulk_delete_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
 
@@ -1092,7 +1092,7 @@ class UserDeleteTestCase(APITestCase):
             )
             self.assertFalse(models.FacilityUser.objects.filter(id=user.id).exists())
 
-    def test_bulk_delete_excludes_superuser(self):
+    def test_bulk_delete_excludes_superuser(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(2)]
         user_ids = [str(user.id) for user in users] + [str(self.superuser.id)]
 
@@ -1105,7 +1105,7 @@ class UserDeleteTestCase(APITestCase):
             models.FacilityUser.objects.filter(id=self.superuser.id).exists()
         )
 
-    def test_get_soft_deleted_users(self):
+    def test_get_soft_deleted_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         self.client.delete(
@@ -1130,7 +1130,7 @@ class UserDeleteTestCase(APITestCase):
             )
         )
 
-    def test_date_deleted_ordering(self):
+    def test_date_deleted_ordering(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         for idx, user in enumerate(users):
@@ -1162,7 +1162,7 @@ class UserDeleteTestCase(APITestCase):
         for idx, deleted_user in enumerate(response.data):
             self.assertEqual(deleted_user["id"], str(expected_users[idx]))
 
-    def test_bulk_hard_delete_without_filters(self):
+    def test_bulk_hard_delete_without_filters(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         # Soft delete users
@@ -1178,7 +1178,7 @@ class UserDeleteTestCase(APITestCase):
             models.FacilityUser.all_objects.filter(id__in=user_ids).count(), len(users)
         )
 
-    def test_bulk_hard_delete_non_soft_deleted_users(self):
+    def test_bulk_hard_delete_non_soft_deleted_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
 
@@ -1193,7 +1193,7 @@ class UserDeleteTestCase(APITestCase):
             models.FacilityUser.all_objects.filter(id__in=user_ids).count(), len(users)
         )
 
-    def test_bulk_hard_delete_users(self):
+    def test_bulk_hard_delete_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         # Soft delete users
@@ -1212,7 +1212,7 @@ class UserDeleteTestCase(APITestCase):
             models.FacilityUser.all_objects.filter(id__in=user_ids).exists()
         )
 
-    def test_restore_soft_deleted_users_without_filters(self):
+    def test_restore_soft_deleted_users_without_filters(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         # Soft delete users
@@ -1229,7 +1229,7 @@ class UserDeleteTestCase(APITestCase):
             len(users),
         )
 
-    def test_restore_non_soft_deleted_users(self):
+    def test_restore_non_soft_deleted_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
 
@@ -1241,7 +1241,7 @@ class UserDeleteTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 404)
 
-    def test_restore_soft_deleted_users(self):
+    def test_restore_soft_deleted_users(self, mock_cleanup_task):
         users = [FacilityUserFactory.create(facility=self.facility) for _ in range(3)]
         user_ids = [str(user.id) for user in users]
         # Soft delete users
@@ -1263,7 +1263,7 @@ class UserDeleteTestCase(APITestCase):
             models.FacilityUser.objects.filter(id__in=user_ids).count(), len(users)
         )
 
-    def test_not_able_to_create_soft_deleted_user(self):
+    def test_not_able_to_create_soft_deleted_user(self, mock_cleanup_task):
         # Try to create a new user with the same username as a soft-deleted user
         new_user_data = {
             "username": "testuser",
@@ -1278,7 +1278,7 @@ class UserDeleteTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 405)
 
-    def test_not_able_to_update_soft_deleted_user(self):
+    def test_not_able_to_update_soft_deleted_user(self, mock_cleanup_task):
         # Create a user and then soft delete it
         user = FacilityUserFactory.create(facility=self.facility, username="testuser")
         self.client.delete(


### PR DESCRIPTION
## Summary
Adds a repeating backend task to hard-delete FacilityUsers whose 30-day soft-deletion period has expired. The task is triggered when a user is soft-deleted via the API and will re-enqueue itself every 24 hours as long as there are soft-deleted users remaining.

## References
closes #13373

## Reviewer guidance
- Verify the deletion logic
- Check if the unit tests make sense.
- Run pytest!