### PR TITLE
Remove flake8 requirements, unpin other dev dependencies for ease of use.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 	@echo "Development"
 	@echo "-----------"
 	@echo ""
-	@echo "lint: check Python style with flake8"
+	@echo "lint: lint and format the codebase with pre-commit hooks"
 	@echo "test: run tests quickly with the default Python"
 	@echo "test-all: run tests on every Python version with Tox"
 	@echo "test-with-postgres: run tests quickly with a temporary postgresql backend"
@@ -90,7 +90,7 @@ clean-test-pypi:
 	pypi-cleanup --host https://test.pypi.org --package kolibri --leave-most-recent-only --yes --do-it --username aronleqtest
 
 lint:
-	flake8 kolibri
+	pre-commit run --all-files
 
 test:
 	python -O -m pytest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,8 @@
 setuptools
 -r base.txt
-ipdb==0.13.2
-flake8==3.8.3
-flake8-print==5.0.0
-pre-commit==3.8.0
-tox==3.1.3
+ipdb
+pre-commit
+tox<4
 django-debug-toolbar==4.3.0
 drf-yasg==1.21.7
 coreapi==2.3.3


### PR DESCRIPTION
## Summary
* Removes flake8 and flake8-print from dev dependencies, as they are now independently handled using pre-commit hooks
* Updates `make lint` to just run the pre-commit hooks on all files
* Unpins other dev dependencies to make them easier to install on all Python versions