### PR TITLE
removed gridLayoutOverrides for KCardGrid

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue
@@ -9,10 +9,7 @@
       :disabled="isSelectAllDisabled"
       @change="$emit('changeselectall', $event)"
     />
-    <KCardGrid
-      layout="1-1-1"
-      :layoutOverride="gridLayoutOverrides"
-    >
+    <KCardGrid layout="1-1-1">
       <component
         :is="content.is_leaf ? 'AccessibleResourceCard' : 'AccessibleFolderCard'"
         v-for="content in contentList"
@@ -240,9 +237,6 @@
     },
 
     computed: {
-      gridLayoutOverrides() {
-        return [{ breakpoints: [0, 1, 2, 3, 4, 5, 6, 7], rowGap: '24px', cardsPerRow: 1 }];
-      },
       showButton() {
         return this.viewMoreButtonState === this.ViewMoreButtonStates.HAS_MORE;
       },

--- a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/resourceSelection/subPages/SelectionIndex.vue
@@ -47,10 +47,7 @@
       v-if="bookmarksCount > 0"
       class="mb-24"
     >
-      <KCardGrid
-        layout="1-1-1"
-        :layoutOverride="gridLayoutOverrides"
-      >
+      <KCardGrid layout="1-1-1">
         <KCard
           :title="bookmarksLabel$()"
           :headingLevel="3"
@@ -93,10 +90,7 @@
       >
         {{ noAvailableResources$() }}
       </p>
-      <KCardGrid
-        layout="1-1-1"
-        :layoutOverride="gridLayoutOverrides"
-      >
+      <KCardGrid layout="1-1-1">
         <AccessibleChannelCard
           v-for="channel of channels"
           :key="channel.id"
@@ -240,9 +234,6 @@
       },
     },
     computed: {
-      gridLayoutOverrides() {
-        return [{ breakpoints: [0, 1, 2, 3, 4, 5, 6, 7], rowGap: '24px', cardsPerRow: 1 }];
-      },
       selectFromBookmarksLink() {
         if (this.target === SelectionTarget.LESSON) {
           return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Removed gridLayout overrides for KCardGrid to now use updated default grid gap which is set to 24px.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses issue [#996]( https://github.com/learningequality/kolibri-design-system/issues/996) of KDS
Referenced PR [#999](https://github.com/learningequality/kolibri-design-system/pull/999) in KDS

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…
