### PR TITLE
Fix lesson completed number to be filtered by user

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/learners/LearnerSummaryPage/LearnerHeader.vue
@@ -55,7 +55,10 @@
           </p>
           <div class="value-box">
             <p class="value">{{ lessonsCompleted }}</p>
-            <p style="display: inline; word-wrap: break-word">
+            <p
+              v-if="learnerLessons.length > 0"
+              style="display: inline; word-wrap: break-word"
+            >
               {{ $tr('totalLessons', { total: learnerLessons.length }) }}
             </p>
           </div>
@@ -140,6 +143,7 @@
         const statuses = this.lessonStatuses.filter(
           status =>
             status.status === this.STATUSES.completed &&
+            status.learner_id === this.learner.id &&
             learnerLessonIds.includes(status.lesson_id),
         );
         if (!statuses.length) {


### PR DESCRIPTION
## Summary
This fixes #[13598](https://github.com/learningequality/kolibri/issues/13598) by updating the "lessons completed" header to properly filter by learner, and 

## References

Before

https://github.com/user-attachments/assets/ae4c2315-f2f5-4419-bf84-14239c8f1909

After

https://github.com/user-attachments/assets/65aed08e-f5b6-475c-a587-d03254d989c8


No lessons


https://github.com/user-attachments/assets/0ba25234-691b-4922-9635-8d54c78f1767



## Reviewer guidance
No lessons to display 
1. Create a class with no lessons but enrolled learners
2. Go to Coach > Learners > <Learner> and look at the "Lessons completed" section for each learner. You should see "0", rather than "0 in   "

Lesson completion accuracy 
1. Create 1 lesson and assign it to a class with learners
3. Complete the lesson with one of the learners
4. Go to Coach > Learners > <Learner> and look at the "Lessons completed" section for each learner
