### PR TITLE
Fix answer saving for quizzes, practice quizzes, and surveys

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -169,6 +169,10 @@
         type: String,
         required: true,
       },
+      currentQuestionAnswered: {
+        type: Boolean,
+        required: true,
+      },
       // hack to get access to the scrolling pane
       wrapperComponentRefs: {
         type: Object,
@@ -246,6 +250,9 @@
         return this.questionNumberLabel$({ questionNumber: num });
       },
       isAnswered(question) {
+        if (question.item === this.questionItem && this.currentQuestionAnswered) {
+          return this.currentQuestionAnswered;
+        }
         const attempt = this.pastattempts.find(attempt => attempt.item === question.item);
         return attempt && attempt.answer;
       },

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/AnswerHistory.vue
@@ -53,6 +53,10 @@
         type: Number,
         required: true,
       },
+      currentQuestionAnswered: {
+        type: Boolean,
+        required: true,
+      },
       // hack to get access to the scrolling pane
       wrapperComponentRefs: {
         type: Object,
@@ -78,6 +82,9 @@
         return this.$tr('question', { num });
       },
       isAnswered(question) {
+        if (question === this.questions[this.questionNumber] && this.currentQuestionAnswered) {
+          return this.currentQuestionAnswered;
+        }
         const attempt = this.pastattempts.find(attempt => attempt.item === question);
         return attempt && attempt.answer;
       },

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -299,7 +299,7 @@
       itemIdArray() {
         if (this.content.assessmentmetadata.randomize) {
           // Differentiate the seed for each 'try' indicated by the masteryLevel.
-          const seed = this.userid ? this.userid + this.masteryLevel : Date.now();
+          const seed = this.userId ? this.userId + this.masteryLevel : Date.now();
           return shuffled(this.content.assessmentmetadata.assessment_item_ids, seed);
         }
         return this.content.assessmentmetadata.assessment_item_ids;

--- a/packages/kolibri-common/components/quizzes/InteractionList/index.vue
+++ b/packages/kolibri-common/components/quizzes/InteractionList/index.vue
@@ -3,7 +3,7 @@
   <div class="interaction-list">
     <div class="attempt-container">
       <InteractionItem
-        v-for="(interaction, index) in interactions"
+        v-for="(interaction, index) in reverse ? interactions.toReversed() : interactions"
         :key="index"
         :selected="isSelected(index)"
         :interaction="interaction"
@@ -35,6 +35,10 @@
         type: Number,
         required: true,
       },
+      reverse: {
+        type: Boolean,
+        default: false,
+      },
     },
     computed: {
       interactionsMessage() {
@@ -43,7 +47,10 @@
           return this.$tr('noInteractions');
         }
         if (numAttempts > 1) {
-          return this.$tr('currAnswer', { value: this.selectedInteractionIndex + 1 });
+          const value = this.reverse
+            ? numAttempts - this.selectedInteractionIndex
+            : this.selectedInteractionIndex + 1;
+          return this.$tr('currAnswer', { value });
         }
         return '';
       },

--- a/packages/kolibri-common/components/quizzes/QuizReport/index.vue
+++ b/packages/kolibri-common/components/quizzes/QuizReport/index.vue
@@ -159,6 +159,7 @@
               v-if="!showCorrectAnswer"
               :interactions="currentInteractionHistory"
               :selectedInteractionIndex="selectedInteractionIndex"
+              :reverse="reverseInteractions"
               @select="navigateToQuestionAttempt"
             />
           </div>
@@ -446,11 +447,17 @@
           ) || []
           : [];
       },
+      reverseInteractions() {
+        return this.isQuiz || this.isSurvey;
+      },
       currentInteraction() {
-        return (
-          this.currentInteractionHistory &&
-          this.currentInteractionHistory[this.selectedInteractionIndex]
-        );
+        if (!this.currentInteractionHistory) {
+          return null;
+        }
+        const history = this.reverseInteractions
+          ? this.currentInteractionHistory.toReversed()
+          : this.currentInteractionHistory;
+        return history[this.selectedInteractionIndex];
       },
       titleIcon() {
         if (this.isSurvey) {


### PR DESCRIPTION
## Summary
* Removes the debounce save behaviour that has caused issues with multiple attempts being recorded
* Updates to only saving when changing question or submitting the quiz
* Does an optimistic update of current question answer state with an additional tracking ref
* Does a flyby fix of polling on the class assignment page, switches to useTimeout and passes in the classId value instead of the computed object. 

## References
Fixes https://github.com/learningequality/kolibri/issues/9444
Fixes issue noted in https://github.com/learningequality/kolibri/issues/13599

## Reviewer guidance
Engage with:

A coach created quiz
A practice quiz
A survey

Ensure in each case that responses are correctly recorded, and that the UI updates appropriately (showing total number of questions answered, correctly filled in blob indicators etc). Check reports for data persistence.

Go to a learner's class page, ensure that the backend is polled roughly every 30 seconds and it doesn't error. 
