### PR TITLE
Disable class copy submission if class name is empty

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
@@ -19,8 +19,8 @@
             :autofocus="true"
             :maxlength="100"
             :showInvalidText="true"
-            :invalid="isClassNameInvalid"
-            :invalidText="classNameAlreadyExists$()"
+            :invalid="Boolean(classNameInvalidText)"
+            :invalidText="classNameInvalidText"
           />
 
           <p
@@ -68,7 +68,7 @@
             <KButton
               :text="copyClasslabel$()"
               :primary="true"
-              :disabled="isClassNameInvalid"
+              :disabled="Boolean(classNameInvalidText) || submitting"
               @click="handleSubmitingClassCopy"
             />
           </div>
@@ -102,6 +102,7 @@
     setup(props) {
       const classCoachesIds = ref([]);
       const copiedClassName = ref(null);
+      const submitting = ref(false);
       const { className } = props;
 
       const {
@@ -138,6 +139,7 @@
         copiedClassName,
         createSnackbar,
         classCoachesIds,
+        submitting,
       };
     },
     props: {
@@ -163,8 +165,16 @@
       },
     },
     computed: {
-      isClassNameInvalid() {
-        return this.classroom.some(row => row[0] === this.copiedClassName) && !this.submitting;
+      classNameInvalidText() {
+        if (!this.submitting) {
+          const name = (this.copiedClassName || '').trim();
+          if (!name) {
+            return this.coreString('requiredFieldError');
+          } else if (this.classroom.some(row => row[0] === name)) {
+            return this.classNameAlreadyExists$();
+          }
+        }
+        return '';
       },
       userRoleBadgeStyle() {
         return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request adds a validation check within `CopyClassSidePanel` to disable the COPY CLASS submission button if the class name textbox is an empty string. The error text "This field is required" is also shown below the textbox.

Before:

https://github.com/user-attachments/assets/723b5df2-35a2-4169-896f-263e0cad12e3



After:

https://github.com/user-attachments/assets/3f0df8de-77ef-4383-821d-f14cd6c72316



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13555 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go to Facility > Classes and try to copy a class without entering a name