### PR TITLE
BUM SidePanel: Implement Assign (coaches) to classes functionality

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -1441,6 +1441,23 @@ class Role(AbstractFacilityDataModel):
                     collection__in=self.collection.children.all(),
                     kind=role_kinds.COACH,
                 ).delete()
+            elif (
+                self.collection.kind == collection_kinds.CLASSROOM
+                and self.kind == role_kinds.COACH
+            ):
+                other_coach_roles = Role.objects.filter(
+                    user=self.user,
+                    kind=role_kinds.COACH,
+                    collection__kind=collection_kinds.CLASSROOM,
+                ).exclude(id=self.id)
+
+                if not other_coach_roles.exists():
+                    Role.objects.filter(
+                        user=self.user,
+                        collection=self.collection.parent,
+                        kind=role_kinds.ASSIGNABLE_COACH,
+                    ).delete()
+
             return super(Role, self).delete(**kwargs)
 
 

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -1441,23 +1441,6 @@ class Role(AbstractFacilityDataModel):
                     collection__in=self.collection.children.all(),
                     kind=role_kinds.COACH,
                 ).delete()
-            elif (
-                self.collection.kind == collection_kinds.CLASSROOM
-                and self.kind == role_kinds.COACH
-            ):
-                other_coach_roles = Role.objects.filter(
-                    user=self.user,
-                    kind=role_kinds.COACH,
-                    collection__kind=collection_kinds.CLASSROOM,
-                ).exclude(id=self.id)
-
-                if not other_coach_roles.exists():
-                    Role.objects.filter(
-                        user=self.user,
-                        collection=self.collection.parent,
-                        kind=role_kinds.ASSIGNABLE_COACH,
-                    ).delete()
-
             return super(Role, self).delete(**kwargs)
 
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -29,17 +29,12 @@ logger = logging.getLogger(__name__)
 
 class RoleListSerializer(serializers.ListSerializer):
     def create(self, validated_data):
-        ModelClass = self.child.Meta.model
         created_objects = []
 
         for model_data in validated_data:
-            try:
-                obj, created = ModelClass.objects.get_or_create(**model_data)
-                if created:
-                    created_objects.append(obj)
-            except Exception as e:
-                logger.warning(f"Error creating role {model_data}: {e}")
-                continue
+            obj, created = Role.objects.get_or_create(**model_data)
+            if created:
+                created_objects.append(obj)
 
         return created_objects
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MinLengthValidator
@@ -27,10 +28,51 @@ from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 logger = logging.getLogger(__name__)
 
 
+class RoleListSerializer(serializers.ListSerializer):
+    def create(self, validated_data):
+        ModelClass = self.child.Meta.model
+        objects_to_create = []
+
+        for model_data in validated_data:
+            object_to_create = self.child.create(model_data)
+            objects_to_create.append(object_to_create)
+
+        try:
+            created_objects = ModelClass._default_manager.bulk_create(
+                objects_to_create, ignore_conflicts=True
+            )
+        except TypeError:
+            tb = traceback.format_exc()
+            msg = (
+                "Got a `TypeError` when calling `%s.%s.create()`. "
+                "This may be because you have a writable field on the "
+                "serializer class that is not a valid argument to "
+                "`%s.%s.create()`. You may need to make the field "
+                "read-only, or override the %s.create() method to handle "
+                "this correctly.\nOriginal exception was:\n %s"
+                % (
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    self.__class__.__name__,
+                    tb,
+                )
+            )
+            raise TypeError(msg)
+
+        return created_objects
+
+
 class RoleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Role
         fields = ("id", "kind", "collection", "user")
+        list_serializer_class = RoleListSerializer
+        validators = []
+
+    def validate(self, attrs):
+        return attrs
 
 
 class FacilityUserSerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -702,4 +702,4 @@ def cleanup_expired_deleted_users():
     if FacilityUser.soft_deleted_objects.exists():
         job = get_current_job()
         # Re-enqueue to run again in 24 hours
-        job.retry_in(24 * 60 * 60)
+        job.retry_in(datetime.timedelta(days=1))

--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -956,7 +956,7 @@ class CleanupExpiredDeletedUsersTaskTestCase(TestCase):
         mock_job = Mock()
         mock_get_current_job.return_value = mock_job
         cleanup_expired_deleted_users()
-        mock_job.retry_in.assert_called_once_with(24 * 60 * 60)
+        mock_job.retry_in.assert_called_once_with(datetime.timedelta(days=1))
 
     @patch("kolibri.core.auth.tasks.get_current_job")
     def test_soft_deleted_users_future_deletion_date_does_reenqueue(
@@ -971,7 +971,7 @@ class CleanupExpiredDeletedUsersTaskTestCase(TestCase):
         mock_job = Mock()
         mock_get_current_job.return_value = mock_job
         cleanup_expired_deleted_users()
-        mock_job.retry_in.assert_called_once_with(24 * 60 * 60)
+        mock_job.retry_in.assert_called_once_with(datetime.timedelta(days=1))
 
     @patch("kolibri.core.auth.tasks.get_current_job")
     def test_expired_soft_deleted_user_gets_deleted_and_no_reenqueue(

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -122,7 +122,6 @@
       :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
       :classes="classes"
       :selectedUsers="selectedUsers"
-      :facilityUsers="facilityUsers"
       @change="onUsersChange"
       @hook:beforeDestroy="selectedUsers = new Set()"
     />

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -37,38 +37,55 @@
       >
         <template #userActions>
           <router-link
-            :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS })"
+            :to="
+              overrideRoute($route, {
+                name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
+              })
+            "
+            :class="{ 'disabled-link': !canAssignCoaches }"
           >
             <KIconButton
               icon="assignCoaches"
               :ariaLabel="assignCoach$()"
               :tooltip="assignCoach$()"
+              :disabled="!canAssignCoaches"
             />
           </router-link>
           <router-link
-            :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS })"
+            :to="
+              overrideRoute($route, {
+                name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
+              })
+            "
+            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
           >
             <KIconButton
               icon="add"
               :ariaLabel="enrollToClass$()"
               :tooltip="enrollToClass$()"
+              :disabled="!canEnrollOrRemoveFromClass"
             />
           </router-link>
           <router-link
             :to="
-              overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS })
+              overrideRoute($route, {
+                name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
+              })
             "
+            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
           >
             <KIconButton
               icon="remove"
               :ariaLabel="removeFromClass$()"
               :tooltip="removeFromClass$()"
+              :disabled="!canEnrollOrRemoveFromClass"
             />
           </router-link>
           <KIconButton
             icon="trash"
             :ariaLabel="deleteSelection$()"
             :tooltip="deleteSelection$()"
+            :disabled="!hasSelectedUsers || listContainsLoggedInUser"
             @click="isMoveToTrashModalOpen = true"
           />
         </template>
@@ -105,6 +122,7 @@
       :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
       :classes="classes"
       :selectedUsers="selectedUsers"
+      :facilityUsers="facilityUsers"
       @change="onUsersChange"
       @hook:beforeDestroy="selectedUsers = new Set()"
     />
@@ -131,10 +149,11 @@
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
-  import { overrideRoute } from '../../utils';
-  import { PageNames } from '../../constants';
+  import { UserKinds } from 'kolibri/constants';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
+  import { PageNames } from '../../constants';
+  import { overrideRoute } from '../../utils';
   import UsersTable from './common/UsersTable.vue';
   import MoveToTrashModal from './common/MoveToTrashModal.vue';
 
@@ -234,6 +253,39 @@
         addNewUserLabel$,
         noNewUsersDescription$,
       };
+    },
+    computed: {
+      hasSelectedUsers() {
+        return this.selectedUsers && this.selectedUsers.size > 0;
+      },
+      listContainsLoggedInUser() {
+        return this.selectedUsers.has(this.currentUserId);
+      },
+      canAssignCoaches() {
+        if (!this.hasSelectedUsers) return false;
+        return this.facilityUsers
+          .filter(user => this.selectedUsers.has(user.id))
+          .some(
+            user =>
+              user.kind.includes(UserKinds.COACH) ||
+              user.kind === UserKinds.ADMIN ||
+              user.kind === UserKinds.SUPERUSER ||
+              user.is_superuser,
+          );
+      },
+      canEnrollOrRemoveFromClass() {
+        if (!this.hasSelectedUsers) return false;
+        return this.facilityUsers
+          .filter(user => this.selectedUsers.has(user.id))
+          .every(
+            user =>
+              user.kind === UserKinds.LEARNER ||
+              user.kind.includes(UserKinds.COACH) ||
+              user.kind === UserKinds.ADMIN ||
+              user.kind === UserKinds.SUPERUSER ||
+              user.is_superuser,
+          );
+      },
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -97,6 +97,7 @@
         :classes="classes"
         :facilityUsers="facilityUsers"
         @change="onUsersChange"
+        @clearSelection="clearSelectedUsers"
         @hook:beforeDestroy="selectedUsers = new Set()"
       />
 
@@ -185,6 +186,10 @@
         fetchClasses();
       });
 
+      function clearSelectedUsers() {
+        selectedUsers.value = new Set();
+      }
+
       return {
         PageNames,
         userIsMultiFacilityAdmin,
@@ -206,6 +211,7 @@
         deleteSelection$,
         selectedUsers,
         currentUserId,
+        clearSelectedUsers,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -95,7 +95,6 @@
       <router-view
         :selectedUsers="selectedUsers"
         :classes="classes"
-        :facilityUsers="facilityUsers"
         @change="onUsersChange"
         @clearSelection="clearSelectedUsers"
         @hook:beforeDestroy="selectedUsers = new Set()"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -95,6 +95,7 @@
       <router-view
         :selectedUsers="selectedUsers"
         :classes="classes"
+        :facilityUsers="facilityUsers"
         @change="onUsersChange"
         @hook:beforeDestroy="selectedUsers = new Set()"
       />
@@ -232,7 +233,7 @@
         if (!this.hasSelectedUsers) return false;
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
-          .every(
+          .some(
             user =>
               user.kind.includes(UserKinds.COACH) ||
               user.kind === UserKinds.ADMIN ||

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -44,7 +44,7 @@
         <div v-else>
           <div
             v-if="showErrorWarning"
-            class="enroll-warning-label"
+            class="assign-warning-label"
             :style="{ color: $themeTokens.error }"
           >
             <span>{{ defaultErrorMessage$() }}</span>
@@ -56,7 +56,7 @@
               color="yellow"
               class="sidepanel-icon"
             />
-            {{ numUsersNotEnrolled$({ num: selectedUsersCount }) }}
+            {{ numUsersNotAssigned$({ num: selectedUsersCount }) }}
           </div>
           <div class="warning-message">
             <KIcon
@@ -80,7 +80,7 @@
             v-model="selectedClasses"
             :options="formattedClasses"
             aria-labelledby="classes-heading"
-            :selectAllLabel="selectAllLabel$()"
+            :selectAllLabel="assignToAllClasses$()"
             :searchLabel="searchForAClass$()"
           />
 
@@ -96,9 +96,9 @@
               primary
               appearance="raised-button"
               :disabled="!hasSelectedClasses || isLoading"
-              @click="handleEnroll"
+              @click="handleAssign"
             >
-              {{ enrollAction$() }}
+              {{ assignAction$() }}
             </KButton>
           </div>
         </div>
@@ -147,12 +147,12 @@
         undoAction$,
         assignCoach$,
         numUsersYouHaveSelected$,
-        numUsersNotEnrolled$,
+        numUsersNotAssigned$,
         numUsersCoaches$,
         usersNotInClassNotAffected$,
         assignToAClassLabel$,
-        enrollAction$,
-        selectAllLabel$,
+        assignAction$,
+        assignToAllClasses$,
         searchForAClass$,
       } = bulkUserManagementStrings;
       const { createSnackbar } = useSnackbar();
@@ -175,7 +175,7 @@
       );
 
       // Methods
-      async function handleEnroll() {
+      async function handleAssign() {
         if (!hasSelectedClasses.value) {
           return;
         }
@@ -255,14 +255,14 @@
         defaultErrorMessage$,
         assignCoach$,
         numUsersYouHaveSelected$,
-        numUsersNotEnrolled$,
+        numUsersNotAssigned$,
         numUsersCoaches$,
         usersNotInClassNotAffected$,
         assignToAClassLabel$,
-        enrollAction$,
-        selectAllLabel$,
+        assignAction$,
+        assignToAllClasses$,
         searchForAClass$,
-        handleEnroll,
+        handleAssign,
         handleCancel,
         handleDismissConfirmation,
         handleUndoAssignments,
@@ -295,7 +295,7 @@
     position: relative;
   }
 
-  .enroll-warning-label {
+  .assign-warning-label {
     margin-bottom: 10px;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -134,6 +134,7 @@
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+  import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import SelectableList from '../../common/SelectableList.vue';
@@ -269,7 +270,7 @@
           throw new Error('No classes selected');
         }
 
-        const roleData = selectedClassObjects.flatMap(classObj =>
+        const roleData = flatMap(selectedClassObjects, classObj =>
           eligibleUserIds.map(userId => ({
             collection: classObj.id,
             user: userId,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -217,7 +217,6 @@
           user => props.selectedUsers.has(user.id) && user.kind === UserKinds.LEARNER,
         );
       });
-
       const ineligibleUsersCount = computed(() => ineligibleUsers.value.length);
 
       const eligibleUsersCount = computed(() => {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -3,7 +3,12 @@
   <div>
     <KModal
       v-if="showUndoModal"
-      :title="undoAssignCoachHeading$({ num: selectedUsersCount })"
+      :title="
+        undoAssignCoachHeading$({
+          numUsers: selectedUsersCount,
+          numClasses: selectedClasses.length,
+        })
+      "
       :submitText="undoAction$()"
       :cancelText="dismissAction$()"
       :submitDisabled="isLoading"
@@ -204,7 +209,9 @@
               kind: UserKinds.COACH,
             })),
           });
-          createdRoles.value.push(...newRoles);
+          // Only add roles that were actually created (have an id)
+          const actuallyCreatedRoles = newRoles.filter(role => role.id);
+          createdRoles.value.push(...actuallyCreatedRoles);
         }
       }
 
@@ -223,7 +230,7 @@
           if (createdRoles.value.length > 0) {
             for (const role of createdRoles.value) {
               if (role.id) {
-                await RoleResource.deleteModel(role.id);
+                await RoleResource.deleteModel({ id: role.id });
               }
             }
           }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -33,10 +33,11 @@
       v-else
       alignment="right"
       sidePanelWidth="700px"
+      :addBottomBorder="false"
       @closePanel="closeSidePanel(false)"
     >
       <template #header>
-        <h1>{{ assignCoach$() }}</h1>
+        <h1>{{ assignUsersHeading$({ num: selectedUsersCount }) }}</h1>
       </template>
 
       <div class="assign-coaches-content">
@@ -49,46 +50,33 @@
           >
             <span>{{ defaultErrorMessage$() }}</span>
           </div>
-          <p>{{ numUsersYouHaveSelected$({ num: selectedUsersCount }) }}</p>
 
           <div
-            v-if="ineligibleUsersCount > 0"
-            class="warning-message"
+            class="top-info-box"
+            :style="{ backgroundColor: $themePalette.grey.v_100 }"
           >
-            <KIcon
-              icon="warning"
-              color="yellow"
-              class="sidepanel-icon"
-            />
-            {{ numUsersNotEligible$({ num: ineligibleUsersCount }) }}
+            <template v-if="ineligibleUsersCount > 0">
+              <div class="info-flex">
+                <KIcon
+                  icon="infoOutline"
+                  class="info-icon"
+                />
+                <div class="info-lines">
+                  <div class="info-line">
+                    {{ numUsersNotEligible$({ num: ineligibleUsersCount }) }}
+                  </div>
+                  <div class="info-line">{{ usersInClassNotAffected$() }}</div>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="info-lines">
+                <div class="info-line">{{ usersInClassNotAffected$() }}</div>
+              </div>
+            </template>
           </div>
 
-          <div class="warning-message">
-            <KIcon
-              icon="warning"
-              color="yellow"
-              class="sidepanel-icon"
-            />
-            {{ numUsersNotAssigned$({ num: selectedUsersCount }) }}
-          </div>
-          <div class="warning-message">
-            <KIcon
-              icon="warning"
-              color="yellow"
-              class="sidepanel-icon"
-            />
-            {{ numUsersCoaches$({ num: selectedUsersCount }) }}
-          </div>
-          <div class="info-message">
-            <KIcon
-              icon="info"
-              color="orange"
-              class="sidepanel-icon"
-            />
-            {{ usersNotInClassNotAffected$() }}
-          </div>
-          <hr class="divider" >
-          <h2>{{ assignToAClassLabel$() }}</h2>
+          <h2>{{ selectClassesLabel$() }}</h2>
           <SelectableList
             v-model="selectedClasses"
             :options="formattedClasses"
@@ -100,7 +88,6 @@
           <!-- Footer Buttons -->
           <div class="footer-buttons">
             <KButton
-              appearance="secondary-button"
               :disabled="isLoading"
               @click="closeSidePanel(selectedClasses.length > 0 ? true : false)"
             >
@@ -173,20 +160,17 @@
         coachesAssignedNotice$,
         assignCoachUndoneNotice$,
         undoAction$,
-        assignCoach$,
-        numUsersYouHaveSelected$,
-        numUsersNotAssigned$,
-        numUsersCoaches$,
-        usersNotInClassNotAffected$,
-        assignToAClassLabel$,
+        usersInClassNotAffected$,
         assignAction$,
-        assignToAllClasses$,
         searchForAClass$,
         discardAction$,
         discardWarning$,
         keepEditingAction$,
         disgardChanges$,
         numUsersNotEligible$,
+        selectClassesLabel$,
+        assignUsersHeading$,
+        assignToAllClasses$,
       } = bulkUserManagementStrings;
       const { createSnackbar } = useSnackbar();
       const { dismissAction$ } = searchAndFilterStrings;
@@ -331,15 +315,10 @@
         showUndoModal,
         showCloseConfirmationModal,
         defaultErrorMessage$,
-        assignCoach$,
-        numUsersYouHaveSelected$,
-        numUsersNotAssigned$,
-        numUsersCoaches$,
-        usersNotInClassNotAffected$,
-        assignToAClassLabel$,
+        usersInClassNotAffected$,
         assignAction$,
-        assignToAllClasses$,
         searchForAClass$,
+        selectClassesLabel$,
         handleAssign,
         handleDismissConfirmation,
         handleUndoAssignments,
@@ -353,6 +332,8 @@
         keepEditingAction$,
         disgardChanges$,
         numUsersNotEligible$,
+        assignUsersHeading$,
+        assignToAllClasses$,
       };
     },
     props: {
@@ -386,33 +367,15 @@
     margin-bottom: 10px;
   }
 
-  .warning-message {
-    display: flex;
-    align-items: center;
-  }
-
-  .warning-icon {
-    margin-right: 4px;
-  }
-
   .info-message {
     display: flex;
     align-items: center;
-  }
-
-  .info-icon {
-    margin-right: 4px;
   }
 
   .sidepanel-icon {
     padding-right: 8px;
     padding-left: 8px;
     font-size: 32px;
-  }
-
-  .divider {
-    margin: 16px 0 0;
-    border-top: 2px solid #f0f0f0;
   }
 
   .footer-buttons {
@@ -428,6 +391,47 @@
     /* Override default global line-height of 1.15 to prevent
        scrollbars in KModal and add space for single-line content */
     line-height: 1.5;
+  }
+
+  .top-info-box {
+    padding: 12px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+  }
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+  ::v-deep(.side-panel-content) {
+    padding-top: 0 !important ;
+  }
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+  ::v-deep(.side-panel-header) {
+    padding-right: 32px !important ;
+    padding-left: 32px !important ;
+  }
+
+  .info-flex {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .info-icon {
+    flex: 0 0 24px;
+    width: 24px;
+    height: 24px;
+    margin-right: 4px;
+  }
+
+  .info-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .info-line {
+    line-height: 1.4;
+  }
+
+  .info-line:last-child {
+    margin-bottom: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -33,7 +33,7 @@
       v-else
       alignment="right"
       sidePanelWidth="700px"
-      @closePanel="$router.back()"
+      @closePanel="closeSidePanel(false)"
     >
       <template #header>
         <h1>{{ assignCoach$() }}</h1>
@@ -88,7 +88,8 @@
           <div class="footer-buttons">
             <KButton
               appearance="secondary-button"
-              @click="handleCancel"
+              :disabled="isLoading"
+              @click="closeSidePanel(selectedClasses.length > 0 ? true : false)"
             >
               {{ coreString('cancelAction') }}
             </KButton>
@@ -103,6 +104,16 @@
           </div>
         </div>
       </div>
+      <KModal
+        v-if="showCloseConfirmationModal"
+        :submitText="discardAction$()"
+        :cancelText="keepEditingAction$()"
+        :title="disgardChanges$()"
+        @cancel="showCloseConfirmationModal = false"
+        @submit="closeSidePanel(false)"
+      >
+        <span class="adjust-line-height">{{ discardWarning$() }}</span>
+      </KModal>
     </SidePanelModal>
   </div>
 
@@ -135,6 +146,7 @@
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
       const showUndoModal = ref(false);
+      const showCloseConfirmationModal = ref(false);
       const createdRoles = ref([]);
       const instance = getCurrentInstance();
 
@@ -154,6 +166,10 @@
         assignAction$,
         assignToAllClasses$,
         searchForAClass$,
+        discardAction$,
+        discardWarning$,
+        keepEditingAction$,
+        disgardChanges$,
       } = bulkUserManagementStrings;
       const { createSnackbar } = useSnackbar();
       const { dismissAction$ } = searchAndFilterStrings;
@@ -215,10 +231,6 @@
         }
       }
 
-      function handleCancel() {
-        instance.proxy.$router.back();
-      }
-
       function handleDismissConfirmation() {
         showUndoModal.value = false;
         instance.proxy.$router.back();
@@ -244,6 +256,14 @@
         }
       }
 
+      function closeSidePanel(saveChanges = false) {
+        if (saveChanges) {
+          showCloseConfirmationModal.value = true;
+        } else {
+          instance.proxy.$router.back();
+        }
+      }
+
       return {
         selectedClasses,
         isLoading,
@@ -252,6 +272,7 @@
         hasSelectedClasses,
         showErrorWarning,
         showUndoModal,
+        showCloseConfirmationModal,
         defaultErrorMessage$,
         assignCoach$,
         numUsersYouHaveSelected$,
@@ -263,13 +284,17 @@
         assignToAllClasses$,
         searchForAClass$,
         handleAssign,
-        handleCancel,
         handleDismissConfirmation,
         handleUndoAssignments,
         undoAction$,
         dismissAction$,
         undoAssignCoachHeading$,
         undoAssignCoachMessage$,
+        closeSidePanel,
+        discardAction$,
+        discardWarning$,
+        keepEditingAction$,
+        disgardChanges$,
       };
     },
     props: {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -34,7 +34,7 @@
       alignment="right"
       sidePanelWidth="700px"
       :addBottomBorder="false"
-      @closePanel="closeSidePanel(false)"
+      @closePanel="closeSidePanel(selectedClasses.length > 0)"
     >
       <template #header>
         <h1>{{ assignUsersHeading$({ num: selectedUsersCount }) }}</h1>
@@ -92,7 +92,7 @@
             <KButton
               :text="coreString('cancelAction')"
               :disabled="isLoading"
-              @click="closeSidePanel(selectedClasses.length > 0 ? true : false)"
+              @click="closeSidePanel(selectedClasses.length > 0)"
             />
             <KButton
               primary
@@ -294,8 +294,8 @@
         }
       }
 
-      function closeSidePanel(saveChanges = false) {
-        if (saveChanges) {
+      function closeSidePanel(close = true) {
+        if (close) {
           showCloseConfirmationModal.value = true;
         } else {
           instance.proxy.$router.back();

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -5,7 +5,7 @@
       v-if="showUndoModal"
       :title="
         undoAssignCoachHeading$({
-          numUsers: selectedUsersCount,
+          numUsers: eligibleUsersCount,
           numClasses: selectedClasses.length,
         })
       "
@@ -23,7 +23,7 @@
       >
         {{
           undoAssignCoachMessage$({
-            numUsers: selectedUsersCount,
+            numUsers: eligibleUsersCount,
             numClasses: selectedClasses.length,
           })
         }}
@@ -236,6 +236,13 @@
 
       const ineligibleUsersCount = computed(() => ineligibleUsers.value.length);
 
+      const eligibleUsersCount = computed(() => {
+        if (!props.facilityUsers || props.facilityUsers.length === 0) {
+          return props.selectedUsers.size; // fallback
+        }
+        return eligibleUsers.value.length;
+      });
+
       // Methods
       async function handleAssign() {
         if (!hasSelectedClasses.value) {
@@ -249,9 +256,7 @@
         try {
           await assignCoachesToClasses();
           createSnackbar(coachesAssignedNotice$());
-          if (createdRoles.value.length > 0) {
-            showUndoModal.value = true;
-          }
+          showUndoModal.value = true;
         } catch (error) {
           showErrorWarning.value = true;
         } finally {
@@ -320,6 +325,7 @@
         formattedClasses,
         selectedUsersCount,
         hasSelectedClasses,
+        eligibleUsersCount,
         ineligibleUsersCount,
         showErrorWarning,
         showUndoModal,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -131,7 +131,7 @@
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
-  import SelectableList from '../../ManageClassPage/SelectableList';
+  import SelectableList from '../../common/SelectableList.vue';
 
   export default {
     name: 'AssignCoachesSidePanel',

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -6,8 +6,70 @@
     @closePanel="$router.back()"
   >
     <template #header>
-      <h1>{{ coreString('classesLabel') }}</h1>
+      <h1>Assign to class</h1>
     </template>
+
+    <div class="assign-coaches-content">
+      <div
+        v-if="isLoading"
+        class="sidepanel-loading-overlay"
+      >
+        <KCircularLoader :size="48" />
+      </div>
+
+      <p>You've selected {{ selectedUsersCount }} users</p>
+      <div class="warning-message">
+        <KIcon
+          icon="warning"
+          color="yellow"
+          class="sidepanel-icon"
+        />
+        {{ selectedUsersCount }} users are not enrolled in any class
+      </div>
+      <div class="warning-message">
+        <KIcon
+          icon="warning"
+          color="yellow"
+          class="sidepanel-icon"
+        />
+        {{ selectedUsersCount }} users are coaches
+      </div>
+      <div class="info-message">
+        <KIcon
+          icon="info"
+          color="orange"
+          class="sidepanel-icon"
+        />
+        Users already not in selected classes will not be affected.
+      </div>
+      <hr class="divider" >
+      <h2>Assign users to selected classes</h2>
+      <SelectableList
+        v-model="selectedClasses"
+        :options="formattedClasses"
+        aria-labelledby="classes-heading"
+        :selectAllLabel="'Select all classes'"
+        :searchLabel="'Search classes...'"
+      />
+
+      <!-- Footer Buttons -->
+      <div class="footer-buttons">
+        <KButton
+          appearance="secondary-button"
+          @click="handleCancel"
+        >
+          Cancel
+        </KButton>
+        <KButton
+          primary
+          appearance="raised-button"
+          :disabled="!hasSelectedClasses || isLoading"
+          @click="handleEnroll"
+        >
+          {{ 'Enroll' }}
+        </KButton>
+      </div>
+    </div>
   </SidePanelModal>
 
 </template>
@@ -16,12 +78,18 @@
 <script>
 
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
+  import KIcon from 'kolibri-design-system/lib/KIcon';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { UserKinds } from 'kolibri/constants';
+  import RoleResource from 'kolibri-common/apiResources/RoleResource';
+  import SelectableList from '../../ManageClassPage/SelectableList';
 
   export default {
     name: 'AssignCoachesSidePanel',
     components: {
       SidePanelModal,
+      KIcon,
+      SelectableList,
     },
     mixins: [commonCoreStrings],
     props: {
@@ -30,11 +98,136 @@
         type: Set,
         default: () => new Set(),
       },
+      /* eslint-enable vue/no-unused-properties */
       classes: {
         type: Array,
         default: () => [],
       },
     },
+    data() {
+      return {
+        selectedClasses: [], // Array of selected class IDs
+        isLoading: false,
+      };
+    },
+    computed: {
+      formattedClasses() {
+        return this.classes.map(cls => ({
+          id: cls.id,
+          label: cls.name,
+        }));
+      },
+      selectedUsersCount() {
+        return this.selectedUsers.size;
+      },
+      hasSelectedClasses() {
+        return this.selectedClasses.length > 0;
+      },
+      getSelectedClassObjects() {
+        return this.classes.filter(cls => this.selectedClasses.includes(cls.id));
+      },
+      userIds() {
+        return Array.from(this.selectedUsers);
+      },
+    },
+    methods: {
+      async handleEnroll() {
+        if (!this.hasSelectedClasses) {
+          return;
+        }
+
+        this.isLoading = true;
+
+        try {
+          await this.assignCoachesToClasses();
+          this.$router.back();
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to assign coaches:', error);
+        } finally {
+          this.isLoading = false;
+        }
+      },
+
+      async assignCoachesToClasses() {
+        const selectedClasses = this.getSelectedClassObjects;
+        const userIds = this.userIds;
+
+        for (const classObj of selectedClasses) {
+          await RoleResource.saveCollection({
+            data: userIds.map(userId => ({
+              collection: classObj.id,
+              user: userId,
+              kind: UserKinds.COACH,
+            })),
+          });
+        }
+      },
+
+      handleCancel() {
+        this.$router.back();
+      },
+    },
   };
 
 </script>
+
+
+<style scoped>
+
+  .assign-coaches-content {
+    position: relative;
+  }
+
+  .sidepanel-loading-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(255, 255, 255, 0.8);
+  }
+
+  .warning-message {
+    display: flex;
+    align-items: center;
+  }
+
+  .warning-icon {
+    margin-right: 4px;
+  }
+
+  .info-message {
+    display: flex;
+    align-items: center;
+  }
+
+  .info-icon {
+    margin-right: 4px;
+  }
+
+  .sidepanel-icon {
+    padding-right: 8px;
+    padding-left: 8px;
+    font-size: 32px;
+  }
+
+  .divider {
+    margin: 16px 0 0;
+    border-top: 2px solid #f0f0f0;
+  }
+
+  .footer-buttons {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    padding-top: 16px;
+    margin-top: 24px;
+    border-top: 1px solid #eeeeee;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -176,12 +176,11 @@
       const { dismissAction$ } = searchAndFilterStrings;
 
       // Computed properties
-      const formattedClasses = computed(() =>
-        props.classes.map(cls => ({
-          id: cls.id,
-          label: cls.name,
-        })),
-      );
+      const formattedClasses = computed(() => {
+        return [...props.classes]
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map(({ id, name }) => ({ id, label: name }));
+      });
 
       const selectedUsersCount = computed(() => props.selectedUsers.size);
 
@@ -271,6 +270,7 @@
 
       function handleDismissConfirmation() {
         showUndoModal.value = false;
+        instance.proxy.$emit('clearSelection');
         instance.proxy.$router.back();
       }
 
@@ -290,6 +290,7 @@
         } finally {
           showUndoModal.value = false;
           isLoading.value = false;
+          instance.proxy.$emit('clearSelection');
           instance.proxy.$router.back();
         }
       }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -145,39 +145,15 @@
         const userIds = Array.from(props.selectedUsers);
 
         for (const classObj of selectedClasses) {
-          try {
-            // First, get existing coaches for this class
-            const existingRoles = await RoleResource.fetchCollection({
-              getParams: {
-                collection: classObj.id,
-                kind: UserKinds.COACH,
-              },
-            });
-            // Filter out users who are already coaches
-            const existingCoachIds = new Set(existingRoles.map(role => role.user));
-            const newCoachIds = userIds.filter(userId => !existingCoachIds.has(userId));
-
-            if (newCoachIds.length === 0) {
-              console.log(`All selected users are already coaches for class: ${classObj.name}`);
-              continue;
-            }
-
-            // Only assign new coaches
-            await RoleResource.saveCollection({
-              data: newCoachIds.map(userId => ({
-                collection: classObj.id,
-                user: userId,
-                kind: UserKinds.COACH,
-              })),
-            });
-          } catch (error) {
-            console.error(`Failed to assign coaches to class ${classObj.id} (${classObj.name}):`, error);
-            throw error;
-          }
+          await RoleResource.saveCollection({
+            data: userIds.map(userId => ({
+              collection: classObj.id,
+              user: userId,
+              kind: UserKinds.COACH,
+            })),
+          });
         }
       }
-
-
 
       function handleCancel() {
         instance.proxy.$router.back();

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -84,26 +84,26 @@
             :selectAllLabel="assignToAllClasses$()"
             :searchLabel="searchForAClass$()"
           />
-
-          <!-- Footer Buttons -->
-          <div class="footer-buttons">
-            <KButton
-              :disabled="isLoading"
-              @click="closeSidePanel(selectedClasses.length > 0 ? true : false)"
-            >
-              {{ coreString('cancelAction') }}
-            </KButton>
-            <KButton
-              primary
-              appearance="raised-button"
-              :disabled="!hasSelectedClasses || isLoading"
-              @click="handleAssign"
-            >
-              {{ assignAction$() }}
-            </KButton>
-          </div>
         </div>
       </div>
+      <template #bottomNavigation>
+        <div class="bottom-nav-container">
+          <KButtonGroup>
+            <KButton
+              :text="coreString('cancelAction')"
+              :disabled="isLoading"
+              @click="closeSidePanel(selectedClasses.length > 0 ? true : false)"
+            />
+            <KButton
+              primary
+              :text="assignAction$()"
+              :disabled="!hasSelectedClasses || isLoading"
+              @click="handleAssign"
+            />
+          </KButtonGroup>
+        </div>
+      </template>
+
       <KModal
         v-if="showCloseConfirmationModal"
         :submitText="discardAction$()"
@@ -367,24 +367,10 @@
     margin-bottom: 10px;
   }
 
-  .info-message {
+  .bottom-nav-container {
     display: flex;
-    align-items: center;
-  }
-
-  .sidepanel-icon {
-    padding-right: 8px;
-    padding-left: 8px;
-    font-size: 32px;
-  }
-
-  .footer-buttons {
-    display: flex;
-    gap: 12px;
     justify-content: flex-end;
-    padding-top: 16px;
-    margin-top: 24px;
-    border-top: 1px solid #eeeeee;
+    width: 100%;
   }
 
   .adjust-line-height {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -255,6 +255,7 @@
 
       function handleDismissConfirmation() {
         showUndoModal.value = false;
+        instance.proxy.$emit('clearSelection');
         instance.proxy.$router.back();
       }
 
@@ -271,6 +272,7 @@
         } finally {
           showUndoModal.value = false;
           loading.value = false;
+          instance.proxy.$emit('clearSelection');
           instance.proxy.$router.back();
         }
       }

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -223,6 +223,12 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     context:
       'A notice indicating the number of users that are selected which are not assigned to a class as coaches',
   },
+  numUsersNotEligible: {
+    message:
+      "{num, number} {num, plural, one {learner} other {learners}} can't be assigned as coaches. They won't be added.",
+    context:
+      'A notice indicating the number of learners that are selected which cannot be assigned as coaches and will be skipped',
+  },
 
   // Remove from class
   usersNotInClassNotAffected: {

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -308,6 +308,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Assign to a class',
     context: 'Label for the classes input field in the create user modal',
   },
+  selectClassesLabel: {
+    message: 'Select classes',
+    context: 'Heading label for selecting classes in side panels',
+  },
   assignToAllClasses: {
     message: 'Assign to all classes',
     context: 'Label for checkbox that allows user to assign selected users to all classes',
@@ -482,7 +486,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Add new user',
     context: 'Label for button that opens the user creation modal',
   },
-
+  assignUsersHeading: {
+    message: 'Assign {num, number} {num, plural, one {user} other {users}}',
+    context: 'Side panel H1 heading showing the number of selected users to assign as coaches',
+  },
   // Trash page
   removedUsersTitle: {
     message: 'Removed users',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -308,10 +308,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Assign to a class',
     context: 'Label for the classes input field in the create user modal',
   },
-  selectClassesLabel: {
-    message: 'Select classes',
-    context: 'Heading label for selecting classes in side panels',
-  },
   assignToAllClasses: {
     message: 'Assign to all classes',
     context: 'Label for checkbox that allows user to assign selected users to all classes',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -213,6 +213,16 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Coaches assigned to this class',
     context: 'label to indicate coaches assigned to a class in sidepanel',
   },
+  assignAction: {
+    message: 'Assign',
+    context: 'Label for the button that will assign coaches to classes',
+  },
+  numUsersNotAssigned: {
+    message:
+      '{num, number} {num, plural, one {user is} other {users are}} not assigned to any class',
+    context:
+      'A notice indicating the number of users that are selected which are not assigned to a class as coaches',
+  },
 
   // Remove from class
   usersNotInClassNotAffected: {

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -191,8 +191,8 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   // Assign coaches to class
   undoAssignCoachHeading: {
     message:
-      '{num, number} {num, plural, one {coach has} other {coaches have}} been removed. Undo this?',
-    context: 'Confirmation heading that allows user to undo their action of removing users',
+      'You have successfully assigned {numUsers, number} {numUsers, plural, one {user} other {users}} to {numClasses, number} {numClasses, plural, one {class} other {classes}}. If this was a mistake, you can undo it.',
+    context: 'Confirmation heading that allows user to undo their action of assigning coaches',
   },
   undoAssignCoachMessage: {
     message:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
This pull request updates the AssignCoachesSidePanel component to carry out the bulk action to assign coaches to one or more classes, with intelligent filtering to handle mixed user selections. 

 **AssignCoaches in Bulk:** Uses RoleResource to bulk assign or un-assign (undo) coaches to classes with proper role management and duplicate prevention.

**User Filtering:** The component now automatically filters out learners from the assignment process, only assigning coaches, admins, and superusers to classes. Users can now select a mix of coaches/admins and learners, with the system automatically handling the filtering and showing appropriate warnings.

**Fixed Button Assign Logic**: The "Assign coach" button on the main users page is now enabled when at least one eligible user (coach/admin/superuser) is selected, rather than requiring all selected users to be eligible.

**Discard functionality:** Added a confirmation modal that appears when users try to close the side panel with unsaved class selections, preventing accidental loss of work.

**Undo System**: After successful assignment, a confirmation modal allows users to undo the coach assignments, with proper API calls to remove the created roles. changes also properly handle reassigning coaches who are already assigned to classes, preventing duplicate assignments and ensuring clean role management.

**_Assigning coaches using SidePanel:_**

https://github.com/user-attachments/assets/3a6e41dc-96ad-482d-95ca-25d360f1c04e

**_Assigning coaches and undoing:_**


https://github.com/user-attachments/assets/08f6b047-e691-47ff-b25d-4399cde2323a





## References
 closes #13407 

## Reviewer guidance
- On the Facility > Users page, select one or more users and click the assign coach icon button.
- Once the side panel opens, confirm that the correct warnings apply based on if the selected users are coaches, learners, and not assigned to any classes.
- Select a class to assign the coaches to and undo the assignment to confirm that the functionality works as intended. Note: Users that are already assigned as coaches to the selected classes will not be affected by selecting assign or undo.
