### PR TITLE
improves title truncation on the resource and folder cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -54,12 +54,6 @@
             :maxLines="titleMaxLines(contentNode)"
           />
         </h3>
-        <p>
-          <KTextTruncator
-            :text="contentNode.description"
-            :maxLines="1"
-          />
-        </p>
         <KButton
           v-if="contentNode.copies && contentNode.copies.length"
           appearance="basic-link"
@@ -130,6 +124,9 @@
     },
     methods: {
       titleMaxLines(content) {
+        // If the content is a folder,show 3 lines of title text.
+        // If a resource card, we show 1 line of title if it has a description,
+        // or 3 lines if it does not.
         if (!content.is_leaf) {
           return 3;
         }

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -123,14 +123,12 @@
       },
     },
     methods: {
-      titleMaxLines(content) {
-        // If the content is a folder,show 3 lines of title text.
-        // If a resource card, we show 1 line of title if it has a description,
-        // or 3 lines if it does not.
-        if (!content.is_leaf) {
-          return 3;
-        }
-        return content.description ? 1 : 3;
+      titleMaxLines() {
+        // All content cards now display up to 3 lines of title text.
+        // Previously, the number of lines varied based on whether the card
+        // displayed a description, but since descriptions are no longer shown,
+        // we  are  now using 3 lines for all cards for consistency.
+        return 3;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -51,9 +51,15 @@
         >
           <KTextTruncator
             :text="contentNode.title"
-            :maxLines="1"
+            :maxLines="titleMaxLines(contentNode)"
           />
         </h3>
+        <p>
+          <KTextTruncator
+            :text="contentNode.description"
+            :maxLines="1"
+          />
+        </p>
         <KButton
           v-if="contentNode.copies && contentNode.copies.length"
           appearance="basic-link"
@@ -120,6 +126,14 @@
       },
       channelTitle() {
         return this.getChannelTitle(this.contentNode && this.contentNode.channel_id);
+      },
+    },
+    methods: {
+      titleMaxLines(content) {
+        if (!content.is_leaf) {
+          return 3;
+        }
+        return content.description ? 1 : 3;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -54,6 +54,12 @@
             :maxLines="titleMaxLines(contentNode)"
           />
         </h3>
+        <p>
+          <KTextTruncator
+            :text="contentNode.description"
+            :maxLines="1"
+          />
+        </p>
         <KButton
           v-if="contentNode.copies && contentNode.copies.length"
           appearance="basic-link"
@@ -124,9 +130,6 @@
     },
     methods: {
       titleMaxLines(content) {
-        // If the content is a folder,show 3 lines of title text.
-        // If a resource card, we show 1 line of title if it has a description,
-        // or 3 lines if it does not.
         if (!content.is_leaf) {
           return 3;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,15 +2906,6 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-"aphrodite@git+https://github.com/learningequality/aphrodite.git":
-  version "2.2.3"
-  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
-  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
-  dependencies:
-    asap "^2.0.3"
-    inline-style-prefixer "^4.0.2"
-    string-hash "^1.1.3"
-
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,6 +2906,15 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+"aphrodite@git+https://github.com/learningequality/aphrodite.git":
+  version "2.2.3"
+  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
+  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
+  dependencies:
+    asap "^2.0.3"
+    inline-style-prefixer "^4.0.2"
+    string-hash "^1.1.3"
+
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"


### PR DESCRIPTION


## Summary
This PR improves title truncation on folder and resource cards.

#### Before
<img width="1116" height="397" alt="Screenshot 2025-08-04 at 22 04 19" src="https://github.com/user-attachments/assets/8ff2efda-b464-4d62-ae8f-3eb9ebf30230" />


#### After
<img width="1108" height="399" alt="Screenshot 2025-08-04 at 20 25 26" src="https://github.com/user-attachments/assets/3b5bcbc6-2b58-479e-9e2f-63493c1c57a1" />

<img width="1110" height="385" alt="Screenshot 2025-08-04 at 20 25 04" src="https://github.com/user-attachments/assets/1819adec-e3fc-4dd1-9f41-1619c955afce" />


## References
#13593


## Reviewer guidance
Navigate into a Kolibri channels that has longer names on the cards. 

