### PR TITLE
sorts class names in the dropdown menu alphabetically

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
@@ -24,7 +24,6 @@
 
   import { computed, toRefs } from 'vue';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
-
   import { ClassesActions } from '../../../../constants';
 
   const ALL_VALUE = 'ALL';
@@ -55,7 +54,7 @@
         }));
 
         classesOptions.unshift(allClassesOption.value);
-        return classesOptions;
+        return classesOptions.sort((a, b) => a.label.localeCompare(b.label));
       });
 
       const selectValue = computed({

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
@@ -24,6 +24,7 @@
 
   import { computed, toRefs } from 'vue';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+
   import { ClassesActions } from '../../../../constants';
 
   const ALL_VALUE = 'ALL';

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/ClassesSelect.vue
@@ -54,8 +54,9 @@
           value: classItem.id,
         }));
 
+        classesOptions.sort((a, b) => a.label.localeCompare(b.label));
         classesOptions.unshift(allClassesOption.value);
-        return classesOptions.sort((a, b) => a.label.localeCompare(b.label));
+        return classesOptions;
       });
 
       const selectValue = computed({


### PR DESCRIPTION

## Summary
This PR fixes sorting issue in the "enroll in class" dropdown menu when creating a new user.

#### Before

<img width="692" height="397" alt="Screenshot 2025-08-04 at 21 28 58" src="https://github.com/user-attachments/assets/7616e3b9-b2c2-45d2-bc79-f0f7fe3a20f3" />

#### After
<img width="691" height="388" alt="Screenshot 2025-08-04 at 21 28 13" src="https://github.com/user-attachments/assets/e0f16399-a730-42db-8f04-249f45efa0ff" />


## References
#13549

## Reviewer guidance
Go to Facility > Users
Add users and classes
Observe the order of the classes list in the "Enroll in class" dropdown.
