### PR TITLE
Remove class title in favour of class name in class copy form

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
@@ -15,7 +15,7 @@
           <KTextbox
             v-model="copiedClassName"
             type="text"
-            :label="className$()"
+            :label="coreString('classNameLabel')"
             :autofocus="true"
             :maxlength="100"
             :showInvalidText="true"
@@ -111,7 +111,6 @@
         classNameAlreadyExists$,
         copyClasslabel$,
         classCopiedSuccessfully$,
-        className$,
       } = bulkUserManagementStrings;
       const { createSnackbar } = useSnackbar();
 
@@ -132,7 +131,6 @@
         numCoachesSelected$,
         copyClasslabel$,
         classNameAlreadyExists$,
-        className$,
         classCopiedSuccessfully$,
         handleSelection,
         copiedClassName,

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/CopyClassSidePanel.vue
@@ -15,7 +15,7 @@
           <KTextbox
             v-model="copiedClassName"
             type="text"
-            :label="classTitleLabel$()"
+            :label="className$()"
             :autofocus="true"
             :maxlength="100"
             :showInvalidText="true"
@@ -106,12 +106,12 @@
 
       const {
         coachesAssignedToClassLabel$,
-        classTitleLabel$,
         selectAllLabel$,
         numCoachesSelected$,
         classNameAlreadyExists$,
         copyClasslabel$,
         classCopiedSuccessfully$,
+        className$,
       } = bulkUserManagementStrings;
       const { createSnackbar } = useSnackbar();
 
@@ -128,11 +128,11 @@
 
       return {
         coachesAssignedToClassLabel$,
-        classTitleLabel$,
         selectAllLabel$,
         numCoachesSelected$,
         copyClasslabel$,
         classNameAlreadyExists$,
+        className$,
         classCopiedSuccessfully$,
         handleSelection,
         copiedClassName,

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -270,6 +270,10 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Class name already exists',
     context: 'Error message shown when trying to copy a class with a name that already exists',
   },
+  className: {
+    message: ' Class name',
+    context: 'Label for the class name input field in the copy class modal',
+  },
 
   // User Creation
   newUsers: {
@@ -323,10 +327,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   copyOfClass: {
     message: 'Copy of {class}',
     context: 'Initial name of a class upon being copied',
-  },
-  classTitleLabel: {
-    message: 'Class title',
-    context: 'Label for the class title input field in the copy class modal',
   },
   // Error Handling
   defaultErrorMessage: {

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -270,10 +270,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Class name already exists',
     context: 'Error message shown when trying to copy a class with a name that already exists',
   },
-  className: {
-    message: ' Class name',
-    context: 'Label for the class name input field in the copy class modal',
-  },
 
   // User Creation
   newUsers: {


### PR DESCRIPTION

## Summary
This PR changes "Class title" to "Class name" in copy class sidepanel

#### Before
<img width="704" height="498" alt="Screenshot 2025-08-04 at 22 19 06" src="https://github.com/user-attachments/assets/6a88dc22-bf2b-416c-9580-ff3d1a2d2e88" />


#### After
<img width="698" height="414" alt="Screenshot 2025-08-04 at 22 18 35" src="https://github.com/user-attachments/assets/dd0c4522-f5cd-48bd-aec6-4bfe7e2b5498" />

Closes #13559

## References
#13559

## Reviewer guidance
Go to Facility > Classes and try to copy a class