### PR TITLE
Add user type column to csv logs export

### DIFF
--- a/kolibri/core/auth/constants/user_kinds.py
+++ b/kolibri/core/auth/constants/user_kinds.py
@@ -1,6 +1,8 @@
 """
 This module contains constants representing the kinds of user that can be logged in, based on their roles and permissions.
 """
+from django.utils.translation import gettext_lazy as _
+
 from .role_kinds import ADMIN  # noqa F401
 from .role_kinds import ASSIGNABLE_COACH  # noqa F401
 from .role_kinds import choices
@@ -17,3 +19,11 @@ choices = choices + (
     (ANONYMOUS, "Anonymous"),
     (CAN_MANAGE_CONTENT, "Can manage content"),
 )
+
+labels = {
+    ADMIN: _("Admin"),
+    SUPERUSER: _("Super admin"),
+    ASSIGNABLE_COACH: _("Class coach"),
+    COACH: _("Facility coach"),
+    LEARNER: _("Learner"),
+}


### PR DESCRIPTION
## Summary

* Adds user type column to csv logs export
* Adds a `labels` dictionary in the `user_kinds` module to store the translated user kind labels in the backend.

## References
Closes #12674.

## Reviewer guidance
* Generate a session log, and summary logs for different types of users.
* Go to Facility > Data and generate session and summary logs.
* Check that users have the correct user type
