### PR TITLE
Kolibri-Onboarding: Progress bar UI update  & tooltip additions for Learn-only device setup and first-time use

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -124,8 +124,8 @@
     mixins: [commonCoreStrings, taskNotificationMixin],
     setup() {
       useContentTasks();
-      const { isLearnerOnlyImport } = useUser();
-      return { isLearnerOnlyImport };
+      const { isLearnerOnlyImport, user_id } = useUser();
+      return { isLearnerOnlyImport, userId: user_id };
     },
     data() {
       return {
@@ -181,7 +181,7 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
+          window.localStorage.getItem(`${welcomeDismissalKey}-${this.userId}`) !== 'true' &&
           (!this.installedChannelsWithResources.length > 0) & !this.isLearnerOnlyImport
         );
       },
@@ -215,7 +215,7 @@
     methods: {
       ...mapActions('manageContent', ['refreshChannelList', 'startImportWorkflow']),
       hideWelcomeModal() {
-        window.localStorage.setItem(welcomeDismissalKey, true);
+        window.localStorage.setItem(`${welcomeDismissalKey}-${this.userId}`, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
       handleSelect({ value }) {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -2,7 +2,7 @@
 
   <div>
     <WelcomeModal
-      v-if="step === Steps.WELCOME && isUserLoggedIn && classesLoaded"
+      v-if="step === Steps.WELCOME && isUserLoggedIn && showWelcomeModal"
       :importedFacility="importedFacility"
       :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
@@ -69,7 +69,16 @@
     },
     mixins: [commonSyncElements],
     setup() {
-      const { isUserLoggedIn } = useUser();
+      const {
+        isUserLoggedIn,
+        isLearner,
+        isCoach,
+        isAdmin,
+        isSuperuser,
+        isClassCoach,
+        isFacilityCoach,
+        isFacilityAdmin,
+      } = useUser();
       const { createSnackbar } = useSnackbar();
       const { facilities } = useFacilities();
       const { classes } = useLearnerResources();
@@ -79,6 +88,13 @@
         createSnackbar,
         facilities,
         classes,
+        isLearner,
+        isCoach,
+        isAdmin,
+        isSuperuser,
+        isFacilityAdmin,
+        isClassCoach,
+        isFacilityCoach,
       };
     },
     props: {
@@ -104,7 +120,26 @@
         return null;
       },
       classesLoaded() {
-        return this.classes.length > 0;
+        return Array.isArray(this.classes) && this.classes.length > 0;
+      },
+      showWelcomeModal() {
+        if (
+          this.isSuperuser ||
+          this.isAdmin ||
+          this.isFacilityAdmin ||
+          this.isClassCoach ||
+          this.isFacilityCoach ||
+          this.isCoach
+        ) {
+          return true;
+        }
+        if (this.isLearner && !this.classesLoaded) {
+          return true;
+        }
+        if (this.isLearner && this.classesLoaded) {
+          return true;
+        }
+        return false;
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -2,7 +2,7 @@
 
   <div>
     <WelcomeModal
-      v-if="step === Steps.WELCOME && isUserLoggedIn && (showWelcomeModal || classesLoaded)"
+      v-if="step === Steps.WELCOME && isUserLoggedIn"
       :importedFacility="importedFacility"
       :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
@@ -45,7 +45,6 @@
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
-  import useLearnerResources from '../../../../learn/assets/src/composables/useLearnerResources';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
@@ -69,32 +68,14 @@
     },
     mixins: [commonSyncElements],
     setup() {
-      const {
-        isUserLoggedIn,
-        isLearner,
-        isCoach,
-        isAdmin,
-        isSuperuser,
-        isClassCoach,
-        isFacilityCoach,
-        isFacilityAdmin,
-      } = useUser();
+      const { isUserLoggedIn } = useUser();
       const { createSnackbar } = useSnackbar();
       const { facilities } = useFacilities();
-      const { classes } = useLearnerResources();
 
       return {
         isUserLoggedIn,
         createSnackbar,
         facilities,
-        classes,
-        isLearner,
-        isCoach,
-        isAdmin,
-        isSuperuser,
-        isFacilityAdmin,
-        isClassCoach,
-        isFacilityCoach,
       };
     },
     props: {
@@ -118,25 +99,6 @@
           return facility;
         }
         return null;
-      },
-      classesLoaded() {
-        return Array.isArray(this.classes) && this.classes.length > 0;
-      },
-      showWelcomeModal() {
-        if (
-          this.isSuperuser ||
-          this.isAdmin ||
-          this.isFacilityAdmin ||
-          this.isClassCoach ||
-          this.isFacilityCoach ||
-          this.isCoach
-        ) {
-          return true;
-        }
-        if (this.isLearner && !this.classesLoaded) {
-          return true;
-        }
-        return false;
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -104,7 +104,7 @@
         return null;
       },
       classesLoaded() {
-        return Array.isArray(this.classes);
+        return this.classes.length > 0;
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -2,7 +2,7 @@
 
   <div>
     <WelcomeModal
-      v-if="step === Steps.WELCOME && isUserLoggedIn"
+      v-if="step === Steps.WELCOME && isUserLoggedIn && classesLoaded"
       :importedFacility="importedFacility"
       :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
@@ -45,6 +45,7 @@
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useLearnerResources from '../../../../learn/assets/src/composables/useLearnerResources';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
@@ -71,11 +72,13 @@
       const { isUserLoggedIn } = useUser();
       const { createSnackbar } = useSnackbar();
       const { facilities } = useFacilities();
+      const { classes } = useLearnerResources();
 
       return {
         isUserLoggedIn,
         createSnackbar,
         facilities,
+        classes,
       };
     },
     props: {
@@ -99,6 +102,9 @@
           return facility;
         }
         return null;
+      },
+      classesLoaded() {
+        return Array.isArray(this.classes);
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -2,7 +2,7 @@
 
   <div>
     <WelcomeModal
-      v-if="step === Steps.WELCOME && isUserLoggedIn && showWelcomeModal"
+      v-if="step === Steps.WELCOME && isUserLoggedIn && (showWelcomeModal || classesLoaded)"
       :importedFacility="importedFacility"
       :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
@@ -134,9 +134,6 @@
           return true;
         }
         if (this.isLearner && !this.classesLoaded) {
-          return true;
-        }
-        if (this.isLearner && this.classesLoaded) {
           return true;
         }
         return false;

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -27,7 +27,6 @@
   import { kolibriOnboardingGuideStrings } from 'kolibri/uiText/kolibriOnboardingGuideStrings';
   import useUser from 'kolibri/composables/useUser';
   import useFacilities from 'kolibri-common/composables/useFacilities';
-  import useLearnerResources from '../../../../../../kolibri/plugins/learn/assets/src/composables/useLearnerResources';
 
   export default {
     name: 'WelcomeModal',
@@ -36,7 +35,6 @@
       const { isLearnerOnlyImport, isLearner } = useUser();
       const { facilities } = useFacilities();
       const { onMyOwnWelcomeMessage$, HomePageWelcomeMessage$ } = kolibriOnboardingGuideStrings;
-      const { classes } = useLearnerResources();
 
       return {
         isLearnerOnlyImport,
@@ -44,7 +42,6 @@
         isLearner,
         onMyOwnWelcomeMessage$,
         HomePageWelcomeMessage$,
-        classes,
       };
     },
     props: {
@@ -69,7 +66,7 @@
               : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
           return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
         }
-        if (this.isLearner && this.classes.length > 0) {
+        if (this.isLearner) {
           return [this.HomePageWelcomeMessage$({ facilityName: '' })];
         }
         if (this.isOnMyOwnUser) {

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -27,6 +27,7 @@
   import { kolibriOnboardingGuideStrings } from 'kolibri/uiText/kolibriOnboardingGuideStrings';
   import useUser from 'kolibri/composables/useUser';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useLearnerResources from '../../../../../../kolibri/plugins/learn/assets/src/composables/useLearnerResources';
 
   export default {
     name: 'WelcomeModal',
@@ -35,12 +36,15 @@
       const { isLearnerOnlyImport, isLearner } = useUser();
       const { facilities } = useFacilities();
       const { onMyOwnWelcomeMessage$, HomePageWelcomeMessage$ } = kolibriOnboardingGuideStrings;
+      const { classes } = useLearnerResources();
+
       return {
         isLearnerOnlyImport,
         facilities,
         isLearner,
         onMyOwnWelcomeMessage$,
         HomePageWelcomeMessage$,
+        classes,
       };
     },
     props: {
@@ -65,8 +69,8 @@
               : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
           return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
         }
-        if (this.isLearner) {
-          return [this.HomePageWelcomeMessage$()];
+        if (this.isLearner && this.classes.length > 0) {
+          return [this.HomePageWelcomeMessage$({ facilityName: '' })];
         }
         if (this.isOnMyOwnUser) {
           return [this.onMyOwnWelcomeMessage$()];

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -32,10 +32,16 @@
     name: 'WelcomeModal',
     mixins: [commonCoreStrings],
     setup() {
-      const { isLearnerOnlyImport } = useUser();
+      const { isLearnerOnlyImport, isLearner } = useUser();
       const { facilities } = useFacilities();
-      const { onMyOwnWelcomeMessage$ } = kolibriOnboardingGuideStrings;
-      return { isLearnerOnlyImport, facilities, onMyOwnWelcomeMessage$ };
+      const { onMyOwnWelcomeMessage$, HomePageWelcomeMessage$ } = kolibriOnboardingGuideStrings;
+      return {
+        isLearnerOnlyImport,
+        facilities,
+        isLearner,
+        onMyOwnWelcomeMessage$,
+        HomePageWelcomeMessage$,
+      };
     },
     props: {
       importedFacility: {
@@ -58,6 +64,9 @@
               ? this.$tr('learnOnlyDeviceWelcomeMessage2')
               : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
           return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
+        }
+        if (this.isLearner) {
+          return [this.HomePageWelcomeMessage$()];
         }
         if (this.isOnMyOwnUser) {
           return [this.onMyOwnWelcomeMessage$()];

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
@@ -185,7 +185,9 @@
         });
       },
       removeClassLearner(args) {
+        const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
         this.$store.dispatch('classEditManagement/removeClassLearner', args).then(() => {
+          localStorage.setItem(`${welcomeDismissalKey}-${args.userId}`, true);
           this.showSnackbarNotification('learnersRemovedNoCount', { count: 1 });
         });
       },

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
@@ -187,7 +187,7 @@
       removeClassLearner(args) {
         const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
         this.$store.dispatch('classEditManagement/removeClassLearner', args).then(() => {
-          localStorage.setItem(`${welcomeDismissalKey}-${args.userId}`, true);
+          window.localStorage.setItem(`${welcomeDismissalKey}-${args.userId}`, true);
           this.showSnackbarNotification('learnersRemovedNoCount', { count: 1 });
         });
       },

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -69,7 +69,7 @@
         this.formIsDisabled = true;
         const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
         selectedUsers.forEach(id => {
-          localStorage.setItem(`${welcomeDismissalKey}-${id}`, false);
+          window.localStorage.setItem(`${welcomeDismissalKey}-${id}`, false);
         });
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
           .then(() => {

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -67,6 +67,10 @@
       ...mapActions('classAssignMembers', ['enrollLearnersInClass']),
       enrollLearners(selectedUsers) {
         this.formIsDisabled = true;
+        const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+        selectedUsers.forEach(id => {
+          localStorage.setItem(`${welcomeDismissalKey}-${id}`, false);
+        });
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
           .then(() => {
             this.$router

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -91,7 +91,7 @@
       <p>{{ $tr('removeFromMyLibraryInfo') }}</p>
     </KModal>
     <TooltipTour
-      v-if="tourActive && isTourActive('ViewAndDownloadResources')"
+      v-if="tourActive && isTourActive('ViewAndDownloadResources') && !isLearner"
       page="ViewAndDownloadResources"
       :spotlightOpacity="0.12"
       @tourEnded="endTour('ViewAndDownloadResources')"

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -109,7 +109,10 @@
           :deviceId="deviceId"
         />
 
-        <TransitionGroup name="bar-actions">
+        <TransitionGroup
+          name="bar-actions"
+          data-onboarding-id="contentPageTopBar"
+        >
           <KIconButton
             v-for="action in barActions"
             :key="action.id"
@@ -171,6 +174,11 @@
         </span>
       </template>
     </KToolbar>
+    <TooltipTour
+      v-if="tourActive && isTourActive('LearningActivityBarPage') && isLearner"
+      page="LearningActivityBarPage"
+      @tourEnded="endTour()"
+    />
   </nav>
 
 </template>
@@ -191,8 +199,11 @@
   import SuggestedTime from 'kolibri-common/components/SuggestedTime';
   import get from 'lodash/get';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
-  import commonLearnStrings from './commonLearnStrings';
+  import TooltipTour from 'kolibri/components/onboarding/TooltipTour';
+  import useTour from 'kolibri/composables/useTour';
+  import useUser from 'kolibri/composables/useUser';
   import DeviceConnectionStatus from './DeviceConnectionStatus.vue';
+  import commonLearnStrings from './commonLearnStrings';
 
   export default {
     name: 'LearningActivityBar',
@@ -206,6 +217,7 @@
       TimeDuration,
       SuggestedTime,
       DeviceConnectionStatus,
+      TooltipTour,
     },
     filters: {
       truncateText(value, maxLength) {
@@ -218,8 +230,15 @@
     mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const { windowBreakpoint } = useKResponsiveWindow();
+      const { tourActive, isTourActive, startTour, endTour } = useTour();
+      const { isLearner } = useUser();
       return {
         windowBreakpoint,
+        tourActive,
+        isTourActive,
+        startTour,
+        endTour,
+        isLearner,
       };
     },
     /**
@@ -480,6 +499,11 @@
     },
     beforeDestroy() {
       window.removeEventListener('click', this.onWindowClick);
+    },
+    mounted() {
+      this.$nextTick(() => {
+        this.startTour('LearningActivityBarPage');
+      });
     },
     methods: {
       closeMenu({ focusMoreOptionsButton = true } = {}) {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -185,7 +185,7 @@
         />
       </SidePanelModal>
       <TooltipTour
-        v-if="tourActive && isTourActive('LibraryPage')"
+        v-if="tourActive && isTourActive('LibraryPage') && !isLearner"
         page="LibraryPage"
         @tourEnded="endTour('LibraryPage')"
       />
@@ -267,15 +267,8 @@
       const store = currentInstance.$store;
       const router = currentInstance.$router;
       const { tourActive, isTourActive, startTour, endTour, resumeTour } = useTour();
-      const {
-        isUserLoggedIn,
-        isCoach,
-        isAdmin,
-        isSuperuser,
-        user_id,
-        canManageContent,
-        isLearnerOnlyImport,
-      } = useUser();
+      const { isUserLoggedIn, isCoach, isAdmin, isSuperuser, isLearner, user_id } = useUser();
+
       const { allowDownloadOnMeteredConnection } = useDeviceSettings();
       const {
         searchTerms,
@@ -435,8 +428,7 @@
         rootNodesLoading,
         rootNodes,
         isUserLoggedIn,
-        canManageContent,
-        isLearnerOnlyImport,
+        isLearner,
         tourActive,
         isTourActive,
         startTour,
@@ -474,10 +466,7 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
-          !(this.rootNodes.length > 0) &&
-          this.canManageContent &&
-          !this.isLearnerOnlyImport
+          window.localStorage.getItem(`${welcomeDismissalKey}-${this.userId}`) !== 'true'
         );
       },
       showOtherLibraries() {
@@ -566,7 +555,7 @@
     created() {
       const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
-      if (window.localStorage.getItem(welcomeDismissalKey) !== 'true') {
+      if (window.sessionStorage.getItem(`${welcomeDismissalKey}-${this.userId}`) !== 'true') {
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', true);
       }
 
@@ -584,7 +573,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        window.localStorage.setItem(welcomeDismissalKey, true);
+        window.localStorage.setItem(`${welcomeDismissalKey}-${this.userId}`, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
         this.startTour('LibraryPage');
       },

--- a/packages/kolibri/components/onboarding/TooltipTour.vue
+++ b/packages/kolibri/components/onboarding/TooltipTour.vue
@@ -242,12 +242,12 @@
 
   .onboarding-tooltip-progress {
     display: flex;
-    gap: 6px;
+    gap: 8px;
   }
 
   .dot {
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     background: #cccccc;
     border-radius: 50%;
   }

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -248,7 +248,7 @@
       @cancel="languageModalShown = false"
     />
     <TooltipTour
-      v-if="tourActive && isTourActive('SideNavigation')"
+      v-if="tourActive && isTourActive('SideNavigation') && !isLearner"
       page="SideNavigation"
       @tourEnded="endTour('SideNavigation')"
     />

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -600,6 +600,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Refers to the sidebar menu in Kolibri that allows switching between main app sections like Learn, Coach, Facility, Device.',
   },
+  contentActionsLabel: {
+    message: 'Content actions',
+    context:
+      'Refers to the set of actions that can be performed on a resource, such as bookmarking, downloading, etc.',
+  },
 
   // Learning Activities
   all: {

--- a/packages/kolibri/uiText/kolibriOnboardingGuideStrings.js
+++ b/packages/kolibri/uiText/kolibriOnboardingGuideStrings.js
@@ -67,6 +67,10 @@ export const kolibriOnboardingGuideStrings = createTranslator('kolibriOnboarding
   onMyOwnWelcomeMessage: {
     message: 'The first thing you should do is add learning resources to your library.',
   },
+  HomePageWelcomeMessage: {
+    message:
+      'Welcome to your learning facility. Your class materials can be found on the home page.',
+  },
   onboardingStepDescription: {
     message: '{pageTitle} - Onboarding - step {currentStep} of {totalSteps}',
     context:

--- a/packages/kolibri/uiText/kolibriOnboardingGuideStrings.js
+++ b/packages/kolibri/uiText/kolibriOnboardingGuideStrings.js
@@ -77,6 +77,7 @@ export const kolibriOnboardingGuideStrings = createTranslator('kolibriOnboarding
       'Provides screen reader users with information about where they are in the onboarding process',
   },
 });
+
 export function onboardingGuideString(...args) {
   return kolibriOnboardingGuideStrings.$tr(...args);
 }

--- a/packages/kolibri/utils/onboardingSteps.js
+++ b/packages/kolibri/utils/onboardingSteps.js
@@ -36,6 +36,16 @@ export const onboardingSteps = {
       },
     ],
   },
+  LearningActivityBarPage: {
+    label: 'contentActionsLabel',
+    steps: [
+      {
+        key: 'contentPageTopBar',
+        content: () => onboardingGuideString('contentPageTopBarDescription'),
+        stepIndex: 0,
+      },
+    ],
+  },
   ExploreLibraries: {
     label: 'exploreGlobalLibrary',
     steps: [


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR increases the size of onboarding modal progress bar dots from 8px to 12px, enables the display of the Welcome Modal for learners on HomePage when user is enrolled in a class otherwise on LibraryPage and adds tooltips for the "first time use – content already on device" scenario.
Before :
<img width="750" height="414" alt="image" src="https://github.com/user-attachments/assets/0021d724-cc6e-4213-be52-62d5c97f26e6" />

After:
<img width="748" height="418" alt="image" src="https://github.com/user-attachments/assets/e05b1c8b-e10f-47c1-be6e-5c833ade6e67" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
It references issue #13627 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
On a full device setup as Learn-only:

- Create a new learner account
- Confirm Welcome Modal appears immediately
- Check that onboarding tooltips appear in correct order and match Figma styling
