### PR TITLE
Handle deletion of coach from the  assigned classes

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -990,35 +990,41 @@ class ClassroomViewSet(ValuesViewset):
                 ]
             )
         )
+        soft_deleted_user_ids = list(
+            FacilityUser.soft_deleted_objects.all().values_list("id", flat=True)
+        )
+        active_coach_ids = [
+            coach_id for coach_id in coach_ids if coach_id not in soft_deleted_user_ids
+        ]
         facility_roles = {
             obj.pop("user"): obj
             for obj in Role.objects.filter(
-                user_id__in=coach_ids, collection__kind=collection_kinds.FACILITY
+                user_id__in=active_coach_ids, collection__kind=collection_kinds.FACILITY
             ).values("user", "kind", "collection", "id")
         }
+
         for key, group in groupby(items, lambda x: x["id"]):
             coaches = []
             for item in group:
                 user_id = item.pop("role__user__id")
-                if (
-                    user_id in facility_roles
-                    and facility_roles[user_id]["collection"] == item["parent"]
-                ):
-                    roles = [facility_roles[user_id]]
-                else:
-                    roles = []
-                coach = {
-                    "id": user_id,
-                    "facility": item["parent"],
-                    # Coerce to bool if None
-                    "is_superuser": bool(
-                        item.pop("role__user__devicepermissions__is_superuser")
-                    ),
-                    "full_name": item.pop("role__user__full_name"),
-                    "username": item.pop("role__user__username"),
-                    "roles": roles,
-                }
-                if coach["id"]:
+                if user_id in active_coach_ids:
+                    if (
+                        user_id in facility_roles
+                        and facility_roles[user_id]["collection"] == item["parent"]
+                    ):
+                        roles = [facility_roles[user_id]]
+                    else:
+                        roles = []
+                    coach = {
+                        "id": user_id,
+                        "facility": item["parent"],
+                        "is_superuser": bool(
+                            item.pop("role__user__devicepermissions__is_superuser")
+                        ),
+                        "full_name": item.pop("role__user__full_name"),
+                        "username": item.pop("role__user__username"),
+                        "roles": roles,
+                    }
                     coaches.append(coach)
             item["coaches"] = coaches
             output.append(item)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1005,29 +1005,38 @@ class ClassroomViewSet(ValuesViewset):
 
         for key, group in groupby(items, lambda x: x["id"]):
             coaches = []
-            for item in group:
-                user_id = item.pop("role__user__id")
+            group_list = list(group)
+            base_item = group_list[0]
+
+            for item in group_list:
+                user_id = item.get("role__user__id")
                 if user_id in active_coach_ids:
-                    if (
-                        user_id in facility_roles
-                        and facility_roles[user_id]["collection"] == item["parent"]
-                    ):
-                        roles = [facility_roles[user_id]]
-                    else:
-                        roles = []
+                    roles = []
+                    if user_id in facility_roles and facility_roles[user_id][
+                        "collection"
+                    ] == item.get("parent"):
+                        roles.append(facility_roles[user_id])
+
                     coach = {
                         "id": user_id,
-                        "facility": item["parent"],
+                        "facility": item.get("parent"),
                         "is_superuser": bool(
-                            item.pop("role__user__devicepermissions__is_superuser")
+                            item.get("role__user__devicepermissions__is_superuser")
                         ),
-                        "full_name": item.pop("role__user__full_name"),
-                        "username": item.pop("role__user__username"),
+                        "full_name": item.get("role__user__full_name"),
+                        "username": item.get("role__user__username"),
                         "roles": roles,
                     }
                     coaches.append(coach)
-            item["coaches"] = coaches
-            output.append(item)
+            consolidated_item = {
+                "id": base_item.get("id"),
+                "name": base_item.get("name"),
+                "parent": base_item.get("parent"),
+                "learner_count": base_item.get("learner_count"),
+                "coaches": coaches,
+            }
+            output.append(consolidated_item)
+
         return output
 
 

--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -216,6 +216,7 @@
         // methods
         close,
         moveToTrash,
+        usersRemoved,
 
         // translation functions
         moveToTrashAction$,

--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -8,7 +8,7 @@
       :cancelText="coreStrings.dismissAction$()"
       :submitDisabled="loading"
       :cancelDisabled="loading"
-      @cancel="confimClosureOnDeleting"
+      @cancel="confimClosureOnDelete"
       @submit="undoMoveToTrash"
     >
       <KCircularLoader v-if="loading" />
@@ -129,23 +129,28 @@
         }
       };
 
-      const confimClosureOnDeleting = () => {
+      const confimClosureOnDelete = () => {
         ClassroomResource.fetchCollection({
           getParams: { parent: activeFacilityId },
           force: true,
         }).then(classrooms => {
-          classrooms.flatMap(classObj =>
-            classObj.coaches.map(coach => {
+          const removePromises = [];
+
+          classrooms.forEach(classObj => {
+            classObj.coaches.forEach(coach => {
               if (props.selectedUsers.has(coach.id)) {
-                $store.dispatch('classEditManagement/removeClassCoach', {
+                const promise = $store.dispatch('classEditManagement/removeClassCoach', {
                   classId: classObj.id,
                   userId: coach.id,
                 });
+                removePromises.push(promise);
               }
-            }),
-          );
-          emit('change', { resetSelection: true });
-          close();
+            });
+          });
+          return Promise.all(removePromises).then(() => {
+            emit('change', { resetSelection: true });
+            close();
+          });
         });
       };
 
@@ -217,7 +222,7 @@
         moveToTrashLabel$,
         numAdminsSelected$,
         moveToTrashWarning$,
-        confimClosureOnDeleting,
+        confimClosureOnDelete,
       };
     },
     props: {
@@ -242,8 +247,6 @@
 <style lang="scss" scoped>
 
   .fix-line-height {
-    // Override default global line-height of 1.15 which is not enough
-    // space for single lines content modal and makes scrollbar appear.
     line-height: 1.5;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -1,7 +1,28 @@
 <template>
 
   <div>
-    <KModal :title="moveToTrashLabel$({ num: selectedUsers.size })">
+    <KModal
+      v-if="usersRemoved"
+      :title="undoTrashHeading$({ num: usersRemoved.length })"
+      :submitText="undoAction$()"
+      :cancelText="coreStrings.dismissAction$()"
+      :submitDisabled="loading"
+      :cancelDisabled="loading"
+      @cancel="confimClosureOnDeleting"
+      @submit="undoMoveToTrash"
+    >
+      <KCircularLoader v-if="loading" />
+      <p>
+        {{ undoTrashMessageA$({ numUsers: usersRemoved.length }) }}
+      </p>
+      <p>
+        {{ undoTrashMessageB$() }}
+      </p>
+    </KModal>
+    <KModal
+      v-else
+      :title="moveToTrashLabel$({ num: selectedUsers.size })"
+    >
       <KCircularLoader v-if="loading" />
       <div
         v-else
@@ -48,7 +69,7 @@
 
 <script>
 
-  import { computed, ref } from 'vue';
+  import { computed, ref, getCurrentInstance } from 'vue';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
 
@@ -57,6 +78,7 @@
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+  import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import DeletedFacilityUserResource from 'kolibri-common/apiResources/DeletedFacilityUserResource';
 
@@ -72,6 +94,9 @@
       const loading = ref(false);
       const users = ref([]);
       const usersRemoved = ref(null);
+      const { $store, $router } = getCurrentInstance().proxy;
+      const activeFacilityId =
+        $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
 
       const {
         trashUndoneNotice$,
@@ -102,6 +127,26 @@
         } finally {
           loading.value = false;
         }
+      };
+
+      const confimClosureOnDeleting = () => {
+        ClassroomResource.fetchCollection({
+          getParams: { parent: activeFacilityId },
+          force: true,
+        }).then(classrooms => {
+          classrooms.flatMap(classObj =>
+            classObj.coaches.map(coach => {
+              if (props.selectedUsers.has(coach.id)) {
+                $store.dispatch('classEditManagement/removeClassCoach', {
+                  classId: classObj.id,
+                  userId: coach.id,
+                });
+              }
+            }),
+          );
+          emit('change', { resetSelection: true });
+          close();
+        });
       };
 
       const close = () => {
@@ -172,6 +217,7 @@
         moveToTrashLabel$,
         numAdminsSelected$,
         moveToTrashWarning$,
+        confimClosureOnDeleting,
       };
     },
     props: {


### PR DESCRIPTION
## Summary
Fixes coaches and admins that  remain assigned to a class after being deleted.


https://github.com/user-attachments/assets/93bb14d1-3249-44a2-addf-c013ada6d61c



## References

close [#13640](https://github.com/learningequality/kolibri/issues/13640)
## Reviewer guidance

Assign coaches, admins and super admins to a class or several classes and then delete them
Please note:  If you attempt to perform bulk delete, you will be hit by `503` which should be gracefully handled in https://github.com/learningequality/kolibri/pull/13614

