### PR TITLE
Fixes the deletion of super admin by admin user.

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -181,8 +181,8 @@
     setup() {
       usePreviousRoute();
       const route = useRoute();
-      const usersTableRef = ref(null);
       const { currentUserId, isSuperuser, isAdmin } = useUser();
+      const usersTableRef = ref(null);
       const isMoveToTrashModalOpen = ref(false);
 
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -154,6 +154,8 @@
   import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
   import { useRoute } from 'vue-router/composables';
+  import useUser from 'kolibri/composables/useUser';
+  import { UserKinds } from 'kolibri/constants';
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -161,7 +161,6 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
   import { UserKinds } from 'kolibri/constants';
-  import useUser from 'kolibri/composables/useUser';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
   import { PageNames } from '../../constants';
@@ -208,8 +207,6 @@
       });
 
       const selectedUsers = ref(new Set());
-      const { currentUserId } = useUser();
-
       const showUsersTable = computed(
         () =>
           facilityUsers.value.length > 0 ||

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -316,10 +316,7 @@
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
           .some(user => {
-            const isSuperuser =
-              user.kind === UserKinds.SUPERUSER ||
-              user.kind === 'superuser' ||
-              user.is_superuser === true;
+            const isSuperuser = user.kind === UserKinds.SUPERUSER || user.is_superuser === true;
             return isSuperuser;
           });
       },

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -48,13 +48,13 @@
                   name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
                 })
               "
-              :class="{ 'disabled-link': !canAssignCoaches }"
+              :class="{ 'disabled-link': !canAssignCoaches || !hasSelectedUsers }"
             >
               <KIconButton
                 icon="assignCoaches"
                 :ariaLabel="assignCoach$()"
                 :tooltip="assignCoach$()"
-                :disabled="!canAssignCoaches"
+                :disabled="!canAssignCoaches || !hasSelectedUsers"
               />
             </component>
             <component
@@ -64,13 +64,13 @@
                   name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
                 })
               "
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
             >
               <KIconButton
                 icon="add"
                 :ariaLabel="enrollToClass$()"
                 :tooltip="enrollToClass$()"
-                :disabled="!canEnrollOrRemoveFromClass"
+                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
               />
             </component>
             <component
@@ -86,14 +86,14 @@
                 icon="remove"
                 :ariaLabel="removeFromClass$()"
                 :tooltip="removeFromClass$()"
-                :disabled="!canEnrollOrRemoveFromClass"
+                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
               />
             </component>
             <KIconButton
               icon="trash"
               :ariaLabel="deleteSelection$()"
               :tooltip="deleteSelection$()"
-              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              :disabled="!canDeleteSelection || !hasSelectedUsers"
               @click="isMoveToTrashModalOpen = true"
             />
           </template>
@@ -155,7 +155,6 @@
   import { computed, onMounted, ref } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import useUser from 'kolibri/composables/useUser';
-  import { UserKinds } from 'kolibri/constants';
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
@@ -184,6 +183,7 @@
       usePreviousRoute();
       const route = useRoute();
       const usersTableRef = ref(null);
+      const { currentUserId, isSuperuser, isAdmin } = useUser();
       const isMoveToTrashModalOpen = ref(false);
 
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
@@ -274,6 +274,8 @@
         addNewUserLabel$,
         noNewUsersDescription$,
         currentUserId,
+        isSuperuser,
+        isAdmin,
       };
     },
     computed: {
@@ -287,7 +289,7 @@
         if (!this.hasSelectedUsers) return false;
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
-          .some(
+          .every(
             user =>
               user.kind.includes(UserKinds.COACH) ||
               user.kind === UserKinds.ADMIN ||
@@ -307,6 +309,30 @@
               user.kind === UserKinds.SUPERUSER ||
               user.is_superuser,
           );
+      },
+      hasSelectedSuperusers() {
+        if (!this.hasSelectedUsers || !this.facilityUsers) return false;
+
+        return this.facilityUsers
+          .filter(user => this.selectedUsers.has(user.id))
+          .some(user => {
+            const isSuperuser =
+              user.kind === UserKinds.SUPERUSER ||
+              user.kind === 'superuser' ||
+              user.is_superuser === true;
+            return isSuperuser;
+          });
+      },
+      canDeleteSelection() {
+        if (!this.hasSelectedUsers) return false;
+
+        if (this.listContainsLoggedInUser) return false;
+        if (this.isSuperuser) return true;
+        if (this.isAdmin) {
+          return !this.hasSelectedSuperusers;
+        }
+
+        return false;
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -57,44 +57,43 @@
             <component
               :is="canAssignCoaches ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canAssignCoaches }"
+              :class="{ 'disabled-link': !canAssignCoaches || !hasSelectedUsers }"
             >
               <KIconButton
                 icon="assignCoaches"
                 :ariaLabel="assignCoach$()"
                 :tooltip="assignCoach$()"
-                :disabled="!canAssignCoaches"
+                :disabled="!canAssignCoaches || !hasSelectedUsers"
               />
             </component>
             <component
               :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
             >
               <KIconButton
                 icon="add"
                 :ariaLabel="enrollToClass$()"
                 :tooltip="enrollToClass$()"
-                :disabled="!canEnrollOrRemoveFromClass"
+                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
               />
             </component>
             <component
               :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
             >
               <KIconButton
                 icon="remove"
                 :ariaLabel="removeFromClass$()"
                 :tooltip="removeFromClass$()"
-                :disabled="!canEnrollOrRemoveFromClass"
+                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
               />
             </component>
             <KIconButton
               icon="trash"
-              :ariaLabel="deleteSelection$()"
-              :tooltip="deleteSelection$()"
-              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              :tooltip="deleteSelectionTooltip"
+              :disabled="!canDeleteSelection || !hasSelectedUsers"
               @click="isMoveToTrashModalOpen = true"
             />
           </template>
@@ -283,7 +282,6 @@
       },
       hasSelectedSuperusers() {
         if (!this.hasSelectedUsers || !this.facilityUsers) return false;
-
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
           .some(user => {
@@ -296,14 +294,18 @@
       },
       canDeleteSelection() {
         if (!this.hasSelectedUsers) return false;
-
         if (this.listContainsLoggedInUser) return false;
         if (this.isSuperuser) return true;
         if (this.isAdmin) {
           return !this.hasSelectedSuperusers;
         }
-
         return false;
+      },
+      deleteSelectionTooltip() {
+        if (this.listContainsLoggedInUser) {
+          return this.canNotdeletSelfTooltip$();
+        }
+        return this.deleteSelection$();
       },
     },
     methods: {
@@ -315,12 +317,6 @@
             params: { facility_id: this.$store.getters.activeFacilityId },
           });
         }
-      },
-      deleteSelectionTooltip() {
-        if (this.listContainsLoggedInUser) {
-          return this.canNotdeletSelfTooltip$();
-        }
-        return this.deleteSelection$();
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -168,7 +168,7 @@
         enrollToClass$,
         removeFromClass$,
         deleteSelection$,
-        canNotdeletSelfTooltip$,
+        cannotDeleteSelfTooltip$,
       } = bulkUserManagementStrings;
 
       const { $store, $router } = getCurrentInstance().proxy;
@@ -227,7 +227,7 @@
         enrollToClass$,
         removeFromClass$,
         deleteSelection$,
-        canNotdeletSelfTooltip$,
+        cannotDeleteSelfTooltip$,
         selectedUsers,
         currentUserId,
         isSuperuser,
@@ -285,10 +285,7 @@
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
           .some(user => {
-            const isSuperuser =
-              user.kind === UserKinds.SUPERUSER ||
-              user.kind === 'superuser' ||
-              user.is_superuser === true;
+            const isSuperuser = user.kind === UserKinds.SUPERUSER || user.is_superuser === true;
             return isSuperuser;
           });
       },
@@ -303,7 +300,7 @@
       },
       deleteSelectionTooltip() {
         if (this.listContainsLoggedInUser) {
-          return this.canNotdeletSelfTooltip$();
+          return this.cannotDeleteSelfTooltip$();
         }
         return this.deleteSelection$();
       },

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -155,7 +155,7 @@
     mixins: [commonCoreStrings],
     setup() {
       usePreviousRoute();
-      const { currentUserId } = useUser();
+      const { currentUserId, isSuperuser, isAdmin } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
       const selectedUsers = ref(new Set());
       const isMoveToTrashModalOpen = ref(false);
@@ -169,6 +169,7 @@
         enrollToClass$,
         removeFromClass$,
         deleteSelection$,
+        canNotdeletSelfTooltip$,
       } = bulkUserManagementStrings;
 
       const { $store, $router } = getCurrentInstance().proxy;
@@ -227,8 +228,11 @@
         enrollToClass$,
         removeFromClass$,
         deleteSelection$,
+        canNotdeletSelfTooltip$,
         selectedUsers,
         currentUserId,
+        isSuperuser,
+        isAdmin,
       };
     },
     computed: {
@@ -277,6 +281,30 @@
               user.is_superuser,
           );
       },
+      hasSelectedSuperusers() {
+        if (!this.hasSelectedUsers || !this.facilityUsers) return false;
+
+        return this.facilityUsers
+          .filter(user => this.selectedUsers.has(user.id))
+          .some(user => {
+            const isSuperuser =
+              user.kind === UserKinds.SUPERUSER ||
+              user.kind === 'superuser' ||
+              user.is_superuser === true;
+            return isSuperuser;
+          });
+      },
+      canDeleteSelection() {
+        if (!this.hasSelectedUsers) return false;
+
+        if (this.listContainsLoggedInUser) return false;
+        if (this.isSuperuser) return true;
+        if (this.isAdmin) {
+          return !this.hasSelectedSuperusers;
+        }
+
+        return false;
+      },
     },
     methods: {
       overrideRoute,
@@ -287,6 +315,12 @@
             params: { facility_id: this.$store.getters.activeFacilityId },
           });
         }
+      },
+      deleteSelectionTooltip() {
+        if (this.listContainsLoggedInUser) {
+          return this.canNotdeletSelfTooltip$();
+        }
+        return this.deleteSelection$();
       },
     },
   };

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -124,7 +124,7 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     context: 'Label for bulk-action button that will allow user to delete selected users',
   },
   cannotDeleteSelfTooltip: {
-    message: 'You cannot delete your self.',
+    message: 'You cannot delete yourself.',
     context:
       'Tooltip text that appears when a admin and supper admin  attempts to delete their own account from the user management table.',
   },

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -123,7 +123,7 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Remove selected users',
     context: 'Label for bulk-action button that will allow user to delete selected users',
   },
-  canNotdeletSelfTooltip: {
+  cannotDeleteSelfTooltip: {
     message: 'You cannot delete your self.',
     context:
       'Tooltip text that appears when a admin and supper admin  attempts to delete their own account from the user management table.',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -123,6 +123,11 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Remove selected users',
     context: 'Label for bulk-action button that will allow user to delete selected users',
   },
+  canNotdeletSelfTooltip: {
+    message: 'You cannot delete your self.',
+    context:
+      'Tooltip text that appears when a admin and supper admin  attempts to delete their own account from the user management table.',
+  },
   selectAllLabel: {
     message: 'Select all',
     context: 'Label for bulk-action button that will select all users in the current view',


### PR DESCRIPTION
## Summary
This Pr fixes several usability and consistency issues related to the user management page. where user of type 'admin' is able to delete a user of type 'super admin' and the new user page  the 'Delete selection' button is enabled, along with the other buttons
## References
Fixes  #13635


## Reviewer guidance
 Navigate to user management page > Select one or more users. As an Admin or Superuser, select yourself along with other users. or log in as admin and try to delete super admin.
 Try creating new user and perform the same action above 
