### PR TITLE
Render MathML in QTI questions generated by Studio

### DIFF
--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -7,6 +7,7 @@ import SafeHtmlImage from './SafeHtmlImage.vue';
 const ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 const FORBID_TAGS = ['style', 'link'];
 const FORBID_ATTR = ['style', 'width', 'height'];
+const ADD_TAGS = ['semantics'];
 
 // Factory function to create SafeHTML with custom component support
 export function createSafeHTML(customComponents = {}) {
@@ -33,6 +34,7 @@ export function createSafeHTML(customComponents = {}) {
     },
     render(h, context) {
       const docFragment = DOMPurify.sanitize(context.props.html, {
+        ADD_TAGS,
         FORBID_TAGS,
         ALLOWED_URI_REGEXP,
         FORBID_ATTR,

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -180,3 +180,9 @@ img.safe-html {
 .expand-btn:focus {
   opacity: 1;
 }
+
+math.safe-html {
+  @include text-style(normal, 32px, 130%);
+
+  margin: 8px auto;
+}


### PR DESCRIPTION
## Summary
* In our QTI question generation on Studio for any formulae, we leverage the MathML `semantics` element to preserve the original LaTeX of the expression.
* Unfortunately, DOMPurify santiizes out `semantics` elements due to XSS vulnerabilities associated with its annotation elements.
* We allow the semantics element to be retained here, but don't allow the annotation elements to be preserved - this slightly messes with the point of preserving the LaTeX as an annotation, but if we do need it in future, we can do some more precise filtering to allow that through will still disallowing any other encoding.
* Adds some basic styling for MathML.


## References
Fixes https://github.com/learningequality/kolibri/issues/13667

## Reviewer guidance

<img width="1917" height="712" alt="image" src="https://github.com/user-attachments/assets/c71f866b-fce7-4464-8444-31e6947db164" />

Import a survey with a free response question and formula content into Kolibri and observe that the formula is now properly renderered.

Open question - the alternative here is to just remove the annotation completely from the Studio side - I don't think allowing semantics in this way opens us up to an XSS, but we would have to do some extra work to specifically allow the LaTeX annotation  to be retained during santization.