### PR TITLE
Improved mobile responsiveness of existing onboarding tour

### DIFF
--- a/packages/kolibri-common/components/onboarding/TooltipTour.vue
+++ b/packages/kolibri-common/components/onboarding/TooltipTour.vue
@@ -23,10 +23,17 @@
   import tippy from 'tippy.js';
   import Vue from 'vue';
   import { onboardingSteps } from 'kolibri-common/utils/onboardingSteps.js';
+  import useTour from 'kolibri-common/composables/useTour';
   import TooltipContent from './TooltipContent.vue';
 
   export default {
     name: 'TooltipTour',
+    setup() {
+      const { tourActive } = useTour();
+      return {
+        tourActive,
+      };
+    },
     props: {
       page: {
         type: String,
@@ -39,6 +46,7 @@
         tippyInstance: null,
         showOverlay: false,
         rect: {},
+        resizeHandler: null,
       };
     },
     computed: {
@@ -65,11 +73,29 @@
     mounted() {
       this.showTooltip();
       window.document.documentElement.style['overflow'] = 'hidden';
+      window.addEventListener('resize', () => {
+        if (this.tippyInstance) {
+          this.tippyInstance.destroy();
+          this.tippyInstance = null;
+        }
+        if (this.tourActive) this.showTooltip();
+      });
     },
     destroyed() {
+      window.removeEventListener('resize', this.resizeHandler);
+      if (this.tippyInstance) this.tippyInstance.destroy();
       window.document.documentElement.style['overflow'] = 'auto';
     },
     methods: {
+      getVisibleOnboardingElement(key) {
+        const all = Array.from(document.querySelectorAll(`[data-onboarding-id="${key}"]`));
+        return all.find(el => {
+          const style = window.getComputedStyle(el);
+          return (
+            style.opacity !== '0' && style.pointerEvents !== 'none' && el.offsetParent !== null
+          );
+        });
+      },
       showTooltip() {
         if (this.tippyInstance) {
           this.tippyInstance.destroy();
@@ -80,7 +106,7 @@
           const currentStep = this.steps[this.currentStepIndex];
           if (!currentStep) return;
 
-          const target = document.querySelector(`[data-onboarding-id="${currentStep.key}"]`);
+          const target = this.getVisibleOnboardingElement(currentStep.key);
 
           if (!target) {
             return;
@@ -103,12 +129,16 @@
           instance.$mount();
           this.updateOverlay();
           window.addEventListener('scroll', this.updateOverlay, true);
-          window.addEventListener('resize', this.updateOverlay);
+          window.addEventListener('resize', () => {
+            window.requestAnimationFrame(this.updateOverlay);
+          });
+          const placement = window.innerWidth < 680 ? 'bottom' : 'right-start';
+
           try {
             this.tippyInstance = tippy(target, {
               content: instance.$el,
               allowHTML: true,
-              placement: 'right-start',
+              placement: placement,
               interactive: true,
               trigger: 'manual',
               appendTo: document.body,
@@ -136,9 +166,9 @@
       },
       updateOverlay() {
         const currentStep = this.steps[this.currentStepIndex];
-        const target = document.querySelector(`[data-onboarding-id="${currentStep.key}"]`);
+        const target = this.getVisibleOnboardingElement(currentStep.key);
         if (!target) return;
-
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
         const rect = target.getBoundingClientRect();
         this.rect = rect;
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR addresses multiple responsiveness issues identified in the onboarding tour for the Learn > Library page:

- Spotlight misalignment on navbar :
   Fixed dynamic adjustment of spotlight when navbar items wrap into multiple lines on smaller screens.
   Before:
![WhatsApp Image 2025-08-24 at 17 04 05_a52a5472](https://github.com/user-attachments/assets/c643af18-9bef-44ce-8a9a-b2a26bd8ce73)

   After:
<img width="1846" height="877" alt="image" src="https://github.com/user-attachments/assets/409aa708-150e-4426-94f6-bbc1e18e28b3" />

- Target element not scrolled into view :
   Ensured that tour automatically scrolls the target element into view before rendering tooltips.
   Before:
![WhatsApp Image 2025-08-24 at 17 04 06_c74ed0cc](https://github.com/user-attachments/assets/59c450ca-275e-4a02-9f14-d1afd8394f21)

   After:
<img width="1846" height="877" alt="image" src="https://github.com/user-attachments/assets/7d4dc54d-5802-4f52-a516-e27aacf40030" />

- Tooltip overlapping spotlight area:
   Updated tooltip positioning logic so that tooltips no longer overlap the spotlighted region.
   Before:
![WhatsApp Image 2025-08-24 at 17 04 06_22f472a9](https://github.com/user-attachments/assets/e974b343-f41c-4cfe-a2aa-745f2ea3d5a5)

   After:
<img width="1846" height="877" alt="image" src="https://github.com/user-attachments/assets/ec3b7c97-d682-4a2e-b03f-14692db57cc7" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes issue: #13669 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Run the onboarding tour on the Learn > Library page.
- Test on smaller screen sizes (e.g., mobile widths in DevTools):
      1. Verify that when the navbar items wrap onto a second line (as happens on narrow screens), the spotlight still aligns    correctly with the Library tab.
     2.  Check that if a target element is initially outside the viewport, the page scrolls to bring it into view before showing the tooltip.
      3.  Confirm that tooltips do not overlap the highlighted (spotlighted) element, even for items like the channel cards.
- Also test on larger screen sizes to make sure the existing tour behavior is unchanged and no regressions are introduced.