### PR TITLE
Fix scroll users page

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -1,9 +1,11 @@
 <template>
 
   <AppBarPage :title="title">
-    <div style="max-width: 1000px; margin: 0 auto">
-      <slot></slot>
-    </div>
+    <template #default="{ pageContentHeight }">
+      <div style="max-width: 1000px; margin: 0 auto">
+        <slot :pageContentHeight="pageContentHeight"></slot>
+      </div>
+    </template>
   </AppBarPage>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -4,135 +4,140 @@
     :appBarTitle="newUsers$()"
     :route="$store.getters.facilityPageLinks.UserPage"
   >
-    <KPageContainer style="max-width: 1000px; margin: 24px auto">
-      <p>
-        <KRouterLink
-          :to="$store.getters.facilityPageLinks.UserPage"
-          icon="back"
-          :text="backToUsers$()"
-        />
-      </p>
-      <div class="new-users-page-header">
-        <h1>{{ newUsers$() }}</h1>
-        <div>
+    <template #default="{ pageContentHeight }">
+      <KPageContainer
+        class="page-container"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
+      >
+        <p>
+          <KRouterLink
+            :to="$store.getters.facilityPageLinks.UserPage"
+            icon="back"
+            :text="backToUsers$()"
+          />
+        </p>
+        <div class="new-users-page-header">
+          <h1>{{ newUsers$() }}</h1>
+          <div>
+            <KRouterLink
+              primary
+              appearance="raised-button"
+              :text="newUser$()"
+              :to="$store.getters.facilityPageLinks.UserCreatePage"
+            />
+          </div>
+        </div>
+        <UsersTable
+          v-if="showUsersTable"
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canAssignCoaches }"
+            >
+              <KIconButton
+                icon="assignCoaches"
+                :ariaLabel="assignCoach$()"
+                :tooltip="assignCoach$()"
+                :disabled="!canAssignCoaches"
+              />
+            </router-link>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="add"
+                :ariaLabel="enrollToClass$()"
+                :tooltip="enrollToClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="remove"
+                :ariaLabel="removeFromClass$()"
+                :tooltip="removeFromClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <KIconButton
+              icon="trash"
+              :ariaLabel="deleteSelection$()"
+              :tooltip="deleteSelection$()"
+              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              @click="isMoveToTrashModalOpen = true"
+            />
+          </template>
+        </UsersTable>
+        <div
+          v-else
+          class="empty-new-users"
+        >
+          <div class="empty-new-users-content">
+            <KImg
+              isDecorative
+              :src="emptyPlusCloudSvg"
+              backgroundColor="transparent"
+            />
+            <strong> {{ noNewUsersLabel$() }}</strong>
+            <p
+              :style="{
+                color: $themePalette.grey.v_700,
+              }"
+            >
+              {{ noNewUsersDescription$() }}
+            </p>
+          </div>
           <KRouterLink
             primary
             appearance="raised-button"
-            :text="newUser$()"
+            :text="addNewUserLabel$()"
             :to="$store.getters.facilityPageLinks.UserCreatePage"
           />
         </div>
-      </div>
-      <UsersTable
-        v-if="showUsersTable"
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
+      </KPageContainer>
+      <!-- For sidepanels -->
+      <router-view
+        :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
+        :classes="classes"
+        :selectedUsers="selectedUsers"
         @change="onUsersChange"
-      >
-        <template #userActions>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canAssignCoaches }"
-          >
-            <KIconButton
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :tooltip="assignCoach$()"
-              :disabled="!canAssignCoaches"
-            />
-          </router-link>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :tooltip="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :tooltip="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <KIconButton
-            icon="trash"
-            :ariaLabel="deleteSelection$()"
-            :tooltip="deleteSelection$()"
-            :disabled="!hasSelectedUsers || listContainsLoggedInUser"
-            @click="isMoveToTrashModalOpen = true"
-          />
-        </template>
-      </UsersTable>
-      <div
-        v-else
-        class="empty-new-users"
-      >
-        <div class="empty-new-users-content">
-          <KImg
-            isDecorative
-            :src="emptyPlusCloudSvg"
-            backgroundColor="transparent"
-          />
-          <strong> {{ noNewUsersLabel$() }}</strong>
-          <p
-            :style="{
-              color: $themePalette.grey.v_700,
-            }"
-          >
-            {{ noNewUsersDescription$() }}
-          </p>
-        </div>
-        <KRouterLink
-          primary
-          appearance="raised-button"
-          :text="addNewUserLabel$()"
-          :to="$store.getters.facilityPageLinks.UserCreatePage"
-        />
-      </div>
-    </KPageContainer>
-    <!-- For sidepanels -->
-    <router-view
-      :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
-      :classes="classes"
-      :selectedUsers="selectedUsers"
-      @change="onUsersChange"
-      @hook:beforeDestroy="selectedUsers = new Set()"
-    />
+        @hook:beforeDestroy="selectedUsers = new Set()"
+      />
 
-    <!-- Modals -->
-    <MoveToTrashModal
-      v-if="isMoveToTrashModalOpen"
-      :selectedUsers="selectedUsers"
-      @close="isMoveToTrashModalOpen = false"
-      @change="onUsersChange"
-    />
+      <!-- Modals -->
+      <MoveToTrashModal
+        v-if="isMoveToTrashModalOpen"
+        :selectedUsers="selectedUsers"
+        @close="isMoveToTrashModalOpen = false"
+        @change="onUsersChange"
+      />
+    </template>
   </ImmersivePage>
 
 </template>
@@ -292,6 +297,13 @@
 
 
 <style lang="scss" scoped>
+
+  .page-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 1000px;
+    margin: 24px auto;
+  }
 
   .new-users-page-header {
     display: flex;

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -1,113 +1,118 @@
 <template>
 
   <FacilityAppBarPage>
-    <KPageContainer>
-      <p>
-        <KRouterLink
-          v-if="userIsMultiFacilityAdmin"
-          :to="{
-            name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
-            params: { subtopicName: 'UserPage' },
-          }"
-          icon="back"
-          :text="coreString('changeLearningFacility')"
-        />
-      </p>
-      <div class="users-page-header">
-        <h1>{{ coreString('usersLabel') }}</h1>
-        <div class="users-page-header-actions">
-          <KButton
-            hasDropdown
-            :primary="false"
-            :text="coreString('optionsLabel')"
-          >
-            <template #menu>
-              <KDropdownMenu
-                :options="pageDropdownOptions"
-                @select="handlePageDropdownSelection"
-              />
-            </template>
-          </KButton>
-          <KRouterLink
-            primary
-            appearance="raised-button"
-            :text="newUser$()"
-            :to="$store.getters.facilityPageLinks.UserCreatePage"
-          />
-        </div>
-      </div>
-
-      <UsersTable
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
-        @change="onUsersChange"
+    <template #default="{ pageContentHeight }">
+      <!-- Adding 24 pixels to the max height to prevent having too much bottom padding space -->
+      <KPageContainer
+        class="flex-column"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
       >
-        <template #userActions>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canAssignCoaches }"
-          >
-            <KIconButton
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :tooltip="assignCoach$()"
-              :disabled="!canAssignCoaches"
-            />
-          </router-link>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :tooltip="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :tooltip="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <KIconButton
-            icon="trash"
-            :ariaLabel="deleteSelection$()"
-            :tooltip="deleteSelection$()"
-            :disabled="!hasSelectedUsers || listContainsLoggedInUser"
-            @click="isMoveToTrashModalOpen = true"
+        <p>
+          <KRouterLink
+            v-if="userIsMultiFacilityAdmin"
+            :to="{
+              name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
+              params: { subtopicName: 'UserPage' },
+            }"
+            icon="back"
+            :text="coreString('changeLearningFacility')"
           />
-        </template>
-      </UsersTable>
-      <!-- For sidepanels -->
-      <router-view
-        :selectedUsers="selectedUsers"
-        :classes="classes"
-        @change="onUsersChange"
-        @clearSelection="clearSelectedUsers"
-        @hook:beforeDestroy="selectedUsers = new Set()"
-      />
+        </p>
+        <div class="users-page-header">
+          <h1>{{ coreString('usersLabel') }}</h1>
+          <div class="users-page-header-actions">
+            <KButton
+              hasDropdown
+              :primary="false"
+              :text="coreString('optionsLabel')"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="pageDropdownOptions"
+                  @select="handlePageDropdownSelection"
+                />
+              </template>
+            </KButton>
+            <KRouterLink
+              primary
+              appearance="raised-button"
+              :text="newUser$()"
+              :to="$store.getters.facilityPageLinks.UserCreatePage"
+            />
+          </div>
+        </div>
+        <UsersTable
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canAssignCoaches }"
+            >
+              <KIconButton
+                icon="assignCoaches"
+                :ariaLabel="assignCoach$()"
+                :tooltip="assignCoach$()"
+                :disabled="!canAssignCoaches"
+              />
+            </router-link>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="add"
+                :ariaLabel="enrollToClass$()"
+                :tooltip="enrollToClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="remove"
+                :ariaLabel="removeFromClass$()"
+                :tooltip="removeFromClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <KIconButton
+              icon="trash"
+              :ariaLabel="deleteSelection$()"
+              :tooltip="deleteSelection$()"
+              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              @click="isMoveToTrashModalOpen = true"
+            />
+          </template>
+        </UsersTable>
+        <!-- For sidepanels -->
+        <router-view
+          :selectedUsers="selectedUsers"
+          :classes="classes"
+          @change="onUsersChange"
+          @clearSelection="clearSelectedUsers"
+          @hook:beforeDestroy="selectedUsers = new Set()"
+        />
 
-      <!-- Modals -->
-      <MoveToTrashModal
-        v-if="isMoveToTrashModalOpen"
-        :selectedUsers="selectedUsers"
-        @close="isMoveToTrashModalOpen = false"
-        @change="onUsersChange"
-      />
-    </KPageContainer>
+        <!-- Modals -->
+        <MoveToTrashModal
+          v-if="isMoveToTrashModalOpen"
+          :selectedUsers="selectedUsers"
+          @close="isMoveToTrashModalOpen = false"
+          @change="onUsersChange"
+        />
+      </KPageContainer>
+    </template>
   </FacilityAppBarPage>
 
 </template>
@@ -301,6 +306,11 @@
   .disabled-link {
     pointer-events: none;
     cursor: not-allowed;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -4,87 +4,92 @@
     :appBarTitle="removedUsersTitle$()"
     :route="$store.getters.facilityPageLinks.UserPage"
   >
-    <KPageContainer style="max-width: 1000px; margin: 24px auto">
-      <p>
-        <KRouterLink
-          :to="$store.getters.facilityPageLinks.UserPage"
-          icon="back"
-          :text="backToUsers$()"
-        />
-      </p>
-      <div class="removed-users-page-header">
-        <h1>{{ removedUsersTitle$() }}</h1>
-        <p v-if="showUsersTable">
-          {{ removedUsersPageDescription$() }}
+    <template #default="{ pageContentHeight }">
+      <KPageContainer
+        class="page-container"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
+      >
+        <p>
+          <KRouterLink
+            :to="$store.getters.facilityPageLinks.UserPage"
+            icon="back"
+            :text="backToUsers$()"
+          />
         </p>
-      </div>
-      <UsersTable
-        v-if="showUsersTable"
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
-        @change="onUsersChange"
-      >
-        <template #userActions>
-          <KIconButton
-            icon="refresh"
-            :disabled="!selectedUsers.size || loading"
-            :tooltip="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
-            @click="recoverUsers(selectedUsers)"
-          />
-          <KIconButton
-            icon="trash"
-            :disabled="!selectedUsers.size || loading"
-            :ariaLabel="deletePermanentlyLabel$()"
-            :tooltip="deletePermanentlyLabel$()"
-            @click="usersToDelete = selectedUsers"
-          />
-        </template>
-        <template #userDropdownMenu="{ user }">
-          <KDropdownMenu
-            :options="userDropdownMenuOptions"
-            @select="handleDropdownSelect($event, user)"
-          />
-        </template>
-      </UsersTable>
-      <div
-        v-else
-        class="empty-removed-users"
-      >
-        <div class="empty-removed-users-content">
-          <KImg
-            isDecorative
-            :src="emptyTrashCloudSvg"
-            backgroundColor="transparent"
-          />
-          <strong> {{ noRemovedUsersLabel$() }}</strong>
-          <p
-            :style="{
-              color: $themePalette.grey.v_700,
-            }"
-          >
-            {{ removedUsersNotice$() }}
+        <div class="removed-users-page-header">
+          <h1>{{ removedUsersTitle$() }}</h1>
+          <p v-if="showUsersTable">
+            {{ removedUsersPageDescription$() }}
           </p>
         </div>
-      </div>
-    </KPageContainer>
-    <router-view
-      :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
-      :classes="classes"
-      :selectedUsers="selectedUsers"
-      @change="onUsersChange"
-    />
-    <PermanentDeleteModal
-      v-if="usersToDelete"
-      :selectedUsers="usersToDelete"
-      @close="usersToDelete = null"
-      @change="onUsersChange"
-    />
+        <UsersTable
+          v-if="showUsersTable"
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <KIconButton
+              icon="refresh"
+              :disabled="!selectedUsers.size || loading"
+              :tooltip="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+              @click="recoverUsers(selectedUsers)"
+            />
+            <KIconButton
+              icon="trash"
+              :disabled="!selectedUsers.size || loading"
+              :ariaLabel="deletePermanentlyLabel$()"
+              :tooltip="deletePermanentlyLabel$()"
+              @click="usersToDelete = selectedUsers"
+            />
+          </template>
+          <template #userDropdownMenu="{ user }">
+            <KDropdownMenu
+              :options="userDropdownMenuOptions"
+              @select="handleDropdownSelect($event, user)"
+            />
+          </template>
+        </UsersTable>
+        <div
+          v-else
+          class="empty-removed-users"
+        >
+          <div class="empty-removed-users-content">
+            <KImg
+              isDecorative
+              :src="emptyTrashCloudSvg"
+              backgroundColor="transparent"
+            />
+            <strong> {{ noRemovedUsersLabel$() }}</strong>
+            <p
+              :style="{
+                color: $themePalette.grey.v_700,
+              }"
+            >
+              {{ removedUsersNotice$() }}
+            </p>
+          </div>
+        </div>
+      </KPageContainer>
+      <router-view
+        :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
+        :classes="classes"
+        :selectedUsers="selectedUsers"
+        @change="onUsersChange"
+      />
+      <PermanentDeleteModal
+        v-if="usersToDelete"
+        :selectedUsers="usersToDelete"
+        @close="usersToDelete = null"
+        @change="onUsersChange"
+      />
+    </template>
   </ImmersivePage>
 
 </template>
@@ -253,6 +258,13 @@
 
 
 <style lang="scss" scoped>
+
+  .page-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 1000px;
+    margin: 24px auto;
+  }
 
   .removed-users-page-header {
     margin-bottom: 16px;

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="flex-column">
     <PaginatedListContainerWithBackend
       v-model="currentPage"
       :itemsPerPage="itemsPerPage"
@@ -737,6 +737,13 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
+    // Min height is set to 0 to allow flex items to shrink
+    min-height: 0;
   }
 
 </style>

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="flex-column">
     <KGrid v-if="$slots.otherFilter || $slots.filter">
       <KGridItem :layout12="{ span: 7 }">
         <slot name="otherFilter"></slot>
@@ -13,7 +13,7 @@
       </KGridItem>
     </KGrid>
 
-    <div>
+    <div class="flex-column">
       <slot> </slot>
     </div>
 
@@ -137,6 +137,13 @@
     position: relative;
     top: -2px;
     display: inline;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
+    // Min height is set to 0 to allow flex items to shrink
+    min-height: 0;
   }
 
 </style>

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -38,7 +38,7 @@
       class="main-wrapper"
       :style="[wrapperStyles, paddingTop]"
     >
-      <slot></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
 
     <transition mode="out-in">
@@ -158,6 +158,17 @@
         return {
           paddingTop: `${totalPadding}px`,
         };
+      },
+      pageContentHeight() {
+        const paddingTop = parseInt(this.paddingTop.paddingTop) || 0;
+        const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
+
+        let height = window.innerHeight - paddingTop - paddingBottom - 1;
+        if (this.isAppContextAndTouchDevice) {
+          height -= 56; // Account for the Android bottom navigation bar
+        }
+
+        return height;
       },
       paddingLeftRight() {
         return this.isAppContext || this.windowIsSmall ? '8px' : '32px';

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -92,9 +92,10 @@
           }
         },
       });
-      const { windowIsSmall } = useKResponsiveWindow();
+      const { windowHeight, windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
       return {
+        windowHeight,
         windowIsSmall,
         isAppContext,
         swipeZone,
@@ -163,7 +164,7 @@
         const paddingTop = parseInt(this.paddingTop.paddingTop) || 0;
         const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
 
-        let height = window.innerHeight - paddingTop - paddingBottom - 1;
+        let height = this.windowHeight - paddingTop - paddingBottom - 1;
         if (this.isAppContextAndTouchDevice) {
           height -= 56; // Account for the Android bottom navigation bar
         }

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -25,7 +25,7 @@
       class="main-wrapper"
       :style="wrapperStyles"
     >
-      <slot></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
   </div>
 
@@ -91,6 +91,12 @@
             paddingBottom: '72px',
             paddingTop: this.appBarHeight + 16 + 'px',
           };
+      },
+      pageContentHeight() {
+        const paddingTop = parseInt(this.wrapperStyles.paddingTop) || 0;
+        const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
+        const height = window.innerHeight - paddingTop - paddingBottom - 1;
+        return height;
       },
     },
     mounted() {

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -35,12 +35,24 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import useUser from 'kolibri/composables/useUser';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+
   import ScrollingHeader from '../ScrollingHeader';
   import ImmersiveToolbar from './internal/ImmersiveToolbar';
 
   export default {
     name: 'ImmersivePage',
     components: { ImmersiveToolbar, ScrollingHeader },
+    setup() {
+      const { windowHeight, windowIsSmall } = useKResponsiveWindow();
+      const { isAppContext } = useUser();
+      return {
+        windowHeight,
+        windowIsSmall,
+        isAppContext,
+      };
+    },
     props: {
       appBarTitle: {
         type: String,
@@ -86,16 +98,19 @@
             width: '100%',
             display: 'inline-block',
             backgroundColor: this.$themePalette.grey.v_100,
-            paddingLeft: '32px',
-            paddingRight: '32px',
             paddingBottom: '72px',
+            paddingLeft: this.paddingLeftRight,
+            paddingRight: this.paddingLeftRight,
             paddingTop: this.appBarHeight + 16 + 'px',
           };
+      },
+      paddingLeftRight() {
+        return this.isAppContext || this.windowIsSmall ? '8px' : '32px';
       },
       pageContentHeight() {
         const paddingTop = parseInt(this.wrapperStyles.paddingTop) || 0;
         const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
-        const height = window.innerHeight - paddingTop - paddingBottom - 1;
+        const height = this.windowHeight - paddingTop - paddingBottom - 1;
         return height;
       },
     },


### PR DESCRIPTION
## Summary
* Set max-height style to the Users Page KPageContainer and set flex-containers in the page layout, so the users table wrapper can be shrink and show the whole table, the horizontal scrollbar, and page navigation arrows without scrolling the table ([slack thread](https://learningequality.slack.com/archives/CTG8XDTCL/p1755813530542509)).
* Add `pageContentHeight` calculation in AppBarPage and ImmersivePage.
* Reduce gutter size for immersive page blocks on mobile. Solve [this issue](https://github.com/learningequality/kolibri/issues/10530) but for immersive pages.

### Before


https://github.com/user-attachments/assets/b4275f43-e188-486d-9b15-d3059602c110



### After

https://github.com/user-attachments/assets/eb2cd6fb-d310-44b7-85a0-d43924116219



## Reviewer guidance
* Go to the users table, new users table, removed users table and play with the shrinked table. How does it feel? Does it feel better? Is there something else we can do?
* Take a brief look at the layout of other paginated tables in Kolibri, like the learner class enroll page in facility > classes, and my downloads module, to make sure this PR does not introduce any unwanted changes there.