### PR TITLE
Upgrade windows installer action usage to latest version.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.8
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.9
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.8
+      ref: v1.6.9
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -88,11 +88,11 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.8
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.9
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.8
+      ref: v1.6.9
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -296,14 +296,14 @@ class DeviceNameTestCase(APITestCase):
         response = self.client.get(reverse("kolibri:core:devicename"))
         self.assertEqual(
             response.data["name"],
-            InstanceIDModel.get_or_create_current_instance()[0].hostname,
+            InstanceIDModel.get_or_create_current_instance()[0].hostname[:50],
         )
 
     def test_patch(self):
         device_settings = DeviceSettings.objects.get()
         self.assertEqual(
             device_settings.name,
-            InstanceIDModel.get_or_create_current_instance()[0].hostname,
+            InstanceIDModel.get_or_create_current_instance()[0].hostname[:50],
         )
 
         response = self.client.patch(
@@ -315,7 +315,7 @@ class DeviceNameTestCase(APITestCase):
         self.assertEqual(device_settings.name, self.device_name["name"])
         self.assertNotEqual(
             device_settings.name,
-            InstanceIDModel.get_or_create_current_instance()[0].hostname,
+            InstanceIDModel.get_or_create_current_instance()[0].hostname[:50],
         )
 
     def test_device_name_max_length(self):


### PR DESCRIPTION
## Summary
* The default windows action runner as used by `windows-latest` will soon be upgraded from `windows-2022` to `windows-2025` - this may cause no issues, but as a precaution, I have pinned the soon to be replaced windows installer action to windows-2022 to avoid any work for us.

## References
Changelog here: https://github.com/learningequality/kolibri-installer-windows/compare/v1.6.8...v1.6.9

## Reviewer guidance
The windows installer should build without incident.
