### PR TITLE
Refactor undo actions + consistent go back and close confirmation guards

### DIFF
--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -1,6 +1,33 @@
 import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
 
+/**
+ *
+ * @param {Object} options
+ * @param {() => Promise<boolean>} options.action - Callback that executes the action to perform.
+ * Should return a boolean promise indicating whether the action was successful. If the action
+ * succeeds, the snackbar will display a success message and provide an undo option.
+ *
+ * @param {() => string} options.actionNotice$ - Function that returns the message to display on
+ * the snackbar when the action is successful.
+ *
+ * @param {() => Promise<void>} options.undoAction - Callback that executes the undo action.
+ * Be careful if this action is happening after the component that triggered the original action has
+ * been unmounted (e.g. you cannot emit events from an unmounted component). If the undoAction fails
+ * the function should throw an error, and a snackbar will be shown with a generic error message.
+ *
+ * @param {() => string} options.undoActionNotice$ - Function that returns the message to display on
+ * the snackbar when the undo action is successful.
+ *
+ * @param {() => void} [options.onBlur] - Optional callback that executes when the undo button in
+ * the snackbar loses focus.
+ *
+ * @typedef {Object} UseActionWithUndoObject
+ * @property {() => Promise<void>} performAction - A method to manually trigger the main action
+ * with all the undo machinery set up.
+ *
+ * @returns {UseActionWithUndoObject}
+ */
 export default function useActionWithUndo({
   action,
   actionNotice$,

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -6,6 +6,7 @@ export default function useActionWithUndo({
   actionNotice$,
   undoAction,
   undoActionNotice$,
+  onBlur,
 }) {
   const { undoAction$, defaultErrorMessage$ } = bulkUserManagementStrings;
   const { createSnackbar, clearSnackbar } = useSnackbar();
@@ -21,12 +22,18 @@ export default function useActionWithUndo({
   };
 
   const performAction = async () => {
-    await action();
+    const success = await action();
+    if (!success) {
+      return;
+    }
+
     createSnackbar({
       text: actionNotice$(),
+      autofocus: true,
       autoDismiss: true,
       duration: 6000,
       actionText: undoAction$(),
+      onBlur,
       actionCallback: performUndoAction,
     });
   };

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -1,0 +1,37 @@
+import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+import useSnackbar from 'kolibri/composables/useSnackbar';
+
+export default function useActionWithUndo({
+  action,
+  actionNotice$,
+  undoAction,
+  undoActionNotice$,
+}) {
+  const { undoAction$, defaultErrorMessage$ } = bulkUserManagementStrings;
+  const { createSnackbar, clearSnackbar } = useSnackbar();
+
+  const performUndoAction = async () => {
+    clearSnackbar();
+    try {
+      await undoAction();
+      createSnackbar(undoActionNotice$());
+    } catch (error) {
+      createSnackbar(defaultErrorMessage$());
+    }
+  };
+
+  const performAction = async () => {
+    await action();
+    createSnackbar({
+      text: actionNotice$(),
+      autoDismiss: true,
+      duration: 6000,
+      actionText: undoAction$(),
+      actionCallback: performUndoAction,
+    });
+  };
+
+  return {
+    performAction,
+  };
+}

--- a/kolibri/plugins/facility/assets/src/utils.js
+++ b/kolibri/plugins/facility/assets/src/utils.js
@@ -49,6 +49,9 @@ export function getRootRouteName(route) {
   if (route.name?.endsWith('__NEW_USERS')) {
     return PageNames.NEW_USERS_PAGE;
   }
+  if (route.name?.endsWith('__TRASH')) {
+    return PageNames.USERS_TRASH_PAGE;
+  }
   return PageNames.USER_MGMT_PAGE;
 }
 

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -1,9 +1,11 @@
 <template>
 
   <AppBarPage :title="title">
-    <div style="max-width: 1000px; margin: 0 auto">
-      <slot></slot>
-    </div>
+    <template #default="{ pageContentHeight }">
+      <div style="max-width: 1000px; margin: 0 auto">
+        <slot :pageContentHeight="pageContentHeight"></slot>
+      </div>
+    </template>
   </AppBarPage>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -41,7 +41,8 @@
           @change="onUsersChange"
         >
           <template #userActions>
-            <router-link
+            <component
+              :is="canAssignCoaches ? 'router-link' : 'span'"
               :to="
                 overrideRoute($route, {
                   name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
@@ -55,8 +56,9 @@
                 :tooltip="assignCoach$()"
                 :disabled="!canAssignCoaches"
               />
-            </router-link>
-            <router-link
+            </component>
+            <component
+              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="
                 overrideRoute($route, {
                   name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
@@ -70,8 +72,9 @@
                 :tooltip="enrollToClass$()"
                 :disabled="!canEnrollOrRemoveFromClass"
               />
-            </router-link>
-            <router-link
+            </component>
+            <component
+              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="
                 overrideRoute($route, {
                   name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
@@ -85,7 +88,7 @@
                 :tooltip="removeFromClass$()"
                 :disabled="!canEnrollOrRemoveFromClass"
               />
-            </router-link>
+            </component>
             <KIconButton
               icon="trash"
               :ariaLabel="deleteSelection$()"

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -29,6 +29,7 @@
         </div>
         <UsersTable
           v-if="showUsersTable"
+          ref="usersTableRef"
           :facilityUsers="facilityUsers"
           :usersCount="usersCount"
           :totalPages="totalPages"
@@ -126,7 +127,8 @@
         :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
         :classes="classes"
         :selectedUsers="selectedUsers"
-        @change="onUsersChange"
+        :onBlur="onModalBlur"
+        :onUsersChange="onUsersChange"
         @hook:beforeDestroy="selectedUsers = new Set()"
       />
 
@@ -134,8 +136,9 @@
       <MoveToTrashModal
         v-if="isMoveToTrashModalOpen"
         :selectedUsers="selectedUsers"
+        :onBlur="onModalBlur"
+        :onUsersChange="onUsersChange"
         @close="isMoveToTrashModalOpen = false"
-        @change="onUsersChange"
       />
     </template>
   </ImmersivePage>
@@ -174,6 +177,7 @@
     setup() {
       usePreviousRoute();
       const route = useRoute();
+      const usersTableRef = ref(null);
       const isMoveToTrashModalOpen = ref(false);
 
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
@@ -227,6 +231,10 @@
         noNewUsersDescription$,
       } = bulkUserManagementStrings;
 
+      function onModalBlur() {
+        usersTableRef.value?.focus();
+      }
+
       onMounted(() => {
         fetchClasses();
       });
@@ -238,11 +246,13 @@
         totalPages,
         usersCount,
         dataLoading,
+        usersTableRef,
         selectedUsers,
         showUsersTable,
         emptyPlusCloudSvg,
         numAppliedFilters,
         isMoveToTrashModalOpen,
+        onModalBlur,
         onUsersChange,
         overrideRoute,
         resetFilters,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -4,135 +4,140 @@
     :appBarTitle="newUsers$()"
     :route="$store.getters.facilityPageLinks.UserPage"
   >
-    <KPageContainer style="max-width: 1000px; margin: 24px auto">
-      <p>
-        <KRouterLink
-          :to="$store.getters.facilityPageLinks.UserPage"
-          icon="back"
-          :text="backToUsers$()"
-        />
-      </p>
-      <div class="new-users-page-header">
-        <h1>{{ newUsers$() }}</h1>
-        <div>
+    <template #default="{ pageContentHeight }">
+      <KPageContainer
+        class="page-container"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
+      >
+        <p>
+          <KRouterLink
+            :to="$store.getters.facilityPageLinks.UserPage"
+            icon="back"
+            :text="backToUsers$()"
+          />
+        </p>
+        <div class="new-users-page-header">
+          <h1>{{ newUsers$() }}</h1>
+          <div>
+            <KRouterLink
+              primary
+              appearance="raised-button"
+              :text="newUser$()"
+              :to="$store.getters.facilityPageLinks.UserCreatePage"
+            />
+          </div>
+        </div>
+        <UsersTable
+          v-if="showUsersTable"
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canAssignCoaches }"
+            >
+              <KIconButton
+                icon="assignCoaches"
+                :ariaLabel="assignCoach$()"
+                :tooltip="assignCoach$()"
+                :disabled="!canAssignCoaches"
+              />
+            </router-link>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="add"
+                :ariaLabel="enrollToClass$()"
+                :tooltip="enrollToClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <router-link
+              :to="
+                overrideRoute($route, {
+                  name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
+                })
+              "
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="remove"
+                :ariaLabel="removeFromClass$()"
+                :tooltip="removeFromClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <KIconButton
+              icon="trash"
+              :ariaLabel="deleteSelection$()"
+              :tooltip="deleteSelection$()"
+              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              @click="isMoveToTrashModalOpen = true"
+            />
+          </template>
+        </UsersTable>
+        <div
+          v-else
+          class="empty-new-users"
+        >
+          <div class="empty-new-users-content">
+            <KImg
+              isDecorative
+              :src="emptyPlusCloudSvg"
+              backgroundColor="transparent"
+            />
+            <strong> {{ noNewUsersLabel$() }}</strong>
+            <p
+              :style="{
+                color: $themePalette.grey.v_700,
+              }"
+            >
+              {{ noNewUsersDescription$() }}
+            </p>
+          </div>
           <KRouterLink
             primary
             appearance="raised-button"
-            :text="newUser$()"
+            :text="addNewUserLabel$()"
             :to="$store.getters.facilityPageLinks.UserCreatePage"
           />
         </div>
-      </div>
-      <UsersTable
-        v-if="showUsersTable"
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
+      </KPageContainer>
+      <!-- For sidepanels -->
+      <router-view
+        :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
+        :classes="classes"
+        :selectedUsers="selectedUsers"
         @change="onUsersChange"
-      >
-        <template #userActions>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canAssignCoaches }"
-          >
-            <KIconButton
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :tooltip="assignCoach$()"
-              :disabled="!canAssignCoaches"
-            />
-          </router-link>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :tooltip="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <router-link
-            :to="
-              overrideRoute($route, {
-                name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
-              })
-            "
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :tooltip="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <KIconButton
-            icon="trash"
-            :ariaLabel="deleteSelection$()"
-            :tooltip="deleteSelection$()"
-            :disabled="!hasSelectedUsers || listContainsLoggedInUser"
-            @click="isMoveToTrashModalOpen = true"
-          />
-        </template>
-      </UsersTable>
-      <div
-        v-else
-        class="empty-new-users"
-      >
-        <div class="empty-new-users-content">
-          <KImg
-            isDecorative
-            :src="emptyPlusCloudSvg"
-            backgroundColor="transparent"
-          />
-          <strong> {{ noNewUsersLabel$() }}</strong>
-          <p
-            :style="{
-              color: $themePalette.grey.v_700,
-            }"
-          >
-            {{ noNewUsersDescription$() }}
-          </p>
-        </div>
-        <KRouterLink
-          primary
-          appearance="raised-button"
-          :text="addNewUserLabel$()"
-          :to="$store.getters.facilityPageLinks.UserCreatePage"
-        />
-      </div>
-    </KPageContainer>
-    <!-- For sidepanels -->
-    <router-view
-      :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
-      :classes="classes"
-      :selectedUsers="selectedUsers"
-      @change="onUsersChange"
-      @hook:beforeDestroy="selectedUsers = new Set()"
-    />
+        @hook:beforeDestroy="selectedUsers = new Set()"
+      />
 
-    <!-- Modals -->
-    <MoveToTrashModal
-      v-if="isMoveToTrashModalOpen"
-      :selectedUsers="selectedUsers"
-      @close="isMoveToTrashModalOpen = false"
-      @change="onUsersChange"
-    />
+      <!-- Modals -->
+      <MoveToTrashModal
+        v-if="isMoveToTrashModalOpen"
+        :selectedUsers="selectedUsers"
+        @close="isMoveToTrashModalOpen = false"
+        @change="onUsersChange"
+      />
+    </template>
   </ImmersivePage>
 
 </template>
@@ -292,6 +297,13 @@
 
 
 <style lang="scss" scoped>
+
+  .page-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 1000px;
+    margin: 24px auto;
+  }
 
   .new-users-page-header {
     display: flex;

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -42,6 +42,7 @@
           </div>
         </div>
         <UsersTable
+          ref="usersTableRef"
           :facilityUsers="facilityUsers"
           :usersCount="usersCount"
           :totalPages="totalPages"
@@ -99,7 +100,8 @@
         <router-view
           :selectedUsers="selectedUsers"
           :classes="classes"
-          @change="onUsersChange"
+          :onBlur="onModalBlur"
+          :onUsersChange="onUsersChange"
           @clearSelection="clearSelectedUsers"
           @hook:beforeDestroy="selectedUsers = new Set()"
         />
@@ -108,8 +110,9 @@
         <MoveToTrashModal
           v-if="isMoveToTrashModalOpen"
           :selectedUsers="selectedUsers"
+          :onBlur="onModalBlur"
+          :onUsersChange="onUsersChange"
           @close="isMoveToTrashModalOpen = false"
-          @change="onUsersChange"
         />
       </KPageContainer>
     </template>
@@ -153,6 +156,7 @@
       const { userIsMultiFacilityAdmin } = useFacilities();
       const selectedUsers = ref(new Set());
       const isMoveToTrashModalOpen = ref(false);
+      const usersTableRef = ref(null);
 
       const {
         newUser$,
@@ -194,6 +198,10 @@
         selectedUsers.value = new Set();
       }
 
+      function onModalBlur() {
+        usersTableRef.value?.focus();
+      }
+
       return {
         PageNames,
         userIsMultiFacilityAdmin,
@@ -202,10 +210,13 @@
         usersCount,
         dataLoading,
         classes,
+        usersTableRef,
         numAppliedFilters,
         isMoveToTrashModalOpen,
+        onModalBlur,
         resetFilters,
         onUsersChange,
+        clearSelectedUsers,
         newUser$,
         viewTrash$,
         assignCoach$,
@@ -215,7 +226,6 @@
         deleteSelection$,
         selectedUsers,
         currentUserId,
-        clearSelectedUsers,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -54,7 +54,8 @@
           @change="onUsersChange"
         >
           <template #userActions>
-            <router-link
+            <component
+              :is="canAssignCoaches ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
               :class="{ 'disabled-link': !canAssignCoaches }"
             >
@@ -64,8 +65,9 @@
                 :tooltip="assignCoach$()"
                 :disabled="!canAssignCoaches"
               />
-            </router-link>
-            <router-link
+            </component>
+            <component
+              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
               :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
             >
@@ -75,8 +77,9 @@
                 :tooltip="enrollToClass$()"
                 :disabled="!canEnrollOrRemoveFromClass"
               />
-            </router-link>
-            <router-link
+            </component>
+            <component
+              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
               :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
               :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
             >
@@ -86,7 +89,7 @@
                 :tooltip="removeFromClass$()"
                 :disabled="!canEnrollOrRemoveFromClass"
               />
-            </router-link>
+            </component>
             <KIconButton
               icon="trash"
               :ariaLabel="deleteSelection$()"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -1,113 +1,118 @@
 <template>
 
   <FacilityAppBarPage>
-    <KPageContainer>
-      <p>
-        <KRouterLink
-          v-if="userIsMultiFacilityAdmin"
-          :to="{
-            name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
-            params: { subtopicName: 'UserPage' },
-          }"
-          icon="back"
-          :text="coreString('changeLearningFacility')"
-        />
-      </p>
-      <div class="users-page-header">
-        <h1>{{ coreString('usersLabel') }}</h1>
-        <div class="users-page-header-actions">
-          <KButton
-            hasDropdown
-            :primary="false"
-            :text="coreString('optionsLabel')"
-          >
-            <template #menu>
-              <KDropdownMenu
-                :options="pageDropdownOptions"
-                @select="handlePageDropdownSelection"
-              />
-            </template>
-          </KButton>
-          <KRouterLink
-            primary
-            appearance="raised-button"
-            :text="newUser$()"
-            :to="$store.getters.facilityPageLinks.UserCreatePage"
-          />
-        </div>
-      </div>
-
-      <UsersTable
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
-        @change="onUsersChange"
+    <template #default="{ pageContentHeight }">
+      <!-- Adding 24 pixels to the max height to prevent having too much bottom padding space -->
+      <KPageContainer
+        class="flex-column"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
       >
-        <template #userActions>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canAssignCoaches }"
-          >
-            <KIconButton
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :tooltip="assignCoach$()"
-              :disabled="!canAssignCoaches"
-            />
-          </router-link>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :tooltip="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <router-link
-            :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
-            :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-          >
-            <KIconButton
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :tooltip="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass"
-            />
-          </router-link>
-          <KIconButton
-            icon="trash"
-            :ariaLabel="deleteSelection$()"
-            :tooltip="deleteSelection$()"
-            :disabled="!hasSelectedUsers || listContainsLoggedInUser"
-            @click="isMoveToTrashModalOpen = true"
+        <p>
+          <KRouterLink
+            v-if="userIsMultiFacilityAdmin"
+            :to="{
+              name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
+              params: { subtopicName: 'UserPage' },
+            }"
+            icon="back"
+            :text="coreString('changeLearningFacility')"
           />
-        </template>
-      </UsersTable>
-      <!-- For sidepanels -->
-      <router-view
-        :selectedUsers="selectedUsers"
-        :classes="classes"
-        @change="onUsersChange"
-        @clearSelection="clearSelectedUsers"
-        @hook:beforeDestroy="selectedUsers = new Set()"
-      />
+        </p>
+        <div class="users-page-header">
+          <h1>{{ coreString('usersLabel') }}</h1>
+          <div class="users-page-header-actions">
+            <KButton
+              hasDropdown
+              :primary="false"
+              :text="coreString('optionsLabel')"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="pageDropdownOptions"
+                  @select="handlePageDropdownSelection"
+                />
+              </template>
+            </KButton>
+            <KRouterLink
+              primary
+              appearance="raised-button"
+              :text="newUser$()"
+              :to="$store.getters.facilityPageLinks.UserCreatePage"
+            />
+          </div>
+        </div>
+        <UsersTable
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canAssignCoaches }"
+            >
+              <KIconButton
+                icon="assignCoaches"
+                :ariaLabel="assignCoach$()"
+                :tooltip="assignCoach$()"
+                :disabled="!canAssignCoaches"
+              />
+            </router-link>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="add"
+                :ariaLabel="enrollToClass$()"
+                :tooltip="enrollToClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <router-link
+              :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
+              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
+            >
+              <KIconButton
+                icon="remove"
+                :ariaLabel="removeFromClass$()"
+                :tooltip="removeFromClass$()"
+                :disabled="!canEnrollOrRemoveFromClass"
+              />
+            </router-link>
+            <KIconButton
+              icon="trash"
+              :ariaLabel="deleteSelection$()"
+              :tooltip="deleteSelection$()"
+              :disabled="!hasSelectedUsers || listContainsLoggedInUser"
+              @click="isMoveToTrashModalOpen = true"
+            />
+          </template>
+        </UsersTable>
+        <!-- For sidepanels -->
+        <router-view
+          :selectedUsers="selectedUsers"
+          :classes="classes"
+          @change="onUsersChange"
+          @clearSelection="clearSelectedUsers"
+          @hook:beforeDestroy="selectedUsers = new Set()"
+        />
 
-      <!-- Modals -->
-      <MoveToTrashModal
-        v-if="isMoveToTrashModalOpen"
-        :selectedUsers="selectedUsers"
-        @close="isMoveToTrashModalOpen = false"
-        @change="onUsersChange"
-      />
-    </KPageContainer>
+        <!-- Modals -->
+        <MoveToTrashModal
+          v-if="isMoveToTrashModalOpen"
+          :selectedUsers="selectedUsers"
+          @close="isMoveToTrashModalOpen = false"
+          @change="onUsersChange"
+        />
+      </KPageContainer>
+    </template>
   </FacilityAppBarPage>
 
 </template>
@@ -301,6 +306,11 @@
   .disabled-link {
     pointer-events: none;
     cursor: not-allowed;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -4,87 +4,92 @@
     :appBarTitle="removedUsersTitle$()"
     :route="$store.getters.facilityPageLinks.UserPage"
   >
-    <KPageContainer style="max-width: 1000px; margin: 24px auto">
-      <p>
-        <KRouterLink
-          :to="$store.getters.facilityPageLinks.UserPage"
-          icon="back"
-          :text="backToUsers$()"
-        />
-      </p>
-      <div class="removed-users-page-header">
-        <h1>{{ removedUsersTitle$() }}</h1>
-        <p v-if="showUsersTable">
-          {{ removedUsersPageDescription$() }}
+    <template #default="{ pageContentHeight }">
+      <KPageContainer
+        class="page-container"
+        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
+      >
+        <p>
+          <KRouterLink
+            :to="$store.getters.facilityPageLinks.UserPage"
+            icon="back"
+            :text="backToUsers$()"
+          />
         </p>
-      </div>
-      <UsersTable
-        v-if="showUsersTable"
-        :facilityUsers="facilityUsers"
-        :usersCount="usersCount"
-        :totalPages="totalPages"
-        :dataLoading="dataLoading"
-        :selectedUsers.sync="selectedUsers"
-        :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
-        :numAppliedFilters="numAppliedFilters"
-        @clearFilters="resetFilters"
-        @change="onUsersChange"
-      >
-        <template #userActions>
-          <KIconButton
-            icon="refresh"
-            :disabled="!selectedUsers.size || loading"
-            :tooltip="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
-            @click="recoverUsers(selectedUsers)"
-          />
-          <KIconButton
-            icon="trash"
-            :disabled="!selectedUsers.size || loading"
-            :ariaLabel="deletePermanentlyLabel$()"
-            :tooltip="deletePermanentlyLabel$()"
-            @click="usersToDelete = selectedUsers"
-          />
-        </template>
-        <template #userDropdownMenu="{ user }">
-          <KDropdownMenu
-            :options="userDropdownMenuOptions"
-            @select="handleDropdownSelect($event, user)"
-          />
-        </template>
-      </UsersTable>
-      <div
-        v-else
-        class="empty-removed-users"
-      >
-        <div class="empty-removed-users-content">
-          <KImg
-            isDecorative
-            :src="emptyTrashCloudSvg"
-            backgroundColor="transparent"
-          />
-          <strong> {{ noRemovedUsersLabel$() }}</strong>
-          <p
-            :style="{
-              color: $themePalette.grey.v_700,
-            }"
-          >
-            {{ removedUsersNotice$() }}
+        <div class="removed-users-page-header">
+          <h1>{{ removedUsersTitle$() }}</h1>
+          <p v-if="showUsersTable">
+            {{ removedUsersPageDescription$() }}
           </p>
         </div>
-      </div>
-    </KPageContainer>
-    <router-view
-      :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
-      :classes="classes"
-      :selectedUsers="selectedUsers"
-      @change="onUsersChange"
-    />
-    <PermanentDeleteModal
-      v-if="usersToDelete"
-      :selectedUsers="usersToDelete"
-      @close="usersToDelete = null"
-      @change="onUsersChange"
-    />
+        <UsersTable
+          v-if="showUsersTable"
+          :facilityUsers="facilityUsers"
+          :usersCount="usersCount"
+          :totalPages="totalPages"
+          :dataLoading="dataLoading"
+          :selectedUsers.sync="selectedUsers"
+          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
+          :numAppliedFilters="numAppliedFilters"
+          @clearFilters="resetFilters"
+          @change="onUsersChange"
+        >
+          <template #userActions>
+            <KIconButton
+              icon="refresh"
+              :disabled="!selectedUsers.size || loading"
+              :tooltip="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+              @click="recoverUsers(selectedUsers)"
+            />
+            <KIconButton
+              icon="trash"
+              :disabled="!selectedUsers.size || loading"
+              :ariaLabel="deletePermanentlyLabel$()"
+              :tooltip="deletePermanentlyLabel$()"
+              @click="usersToDelete = selectedUsers"
+            />
+          </template>
+          <template #userDropdownMenu="{ user }">
+            <KDropdownMenu
+              :options="userDropdownMenuOptions"
+              @select="handleDropdownSelect($event, user)"
+            />
+          </template>
+        </UsersTable>
+        <div
+          v-else
+          class="empty-removed-users"
+        >
+          <div class="empty-removed-users-content">
+            <KImg
+              isDecorative
+              :src="emptyTrashCloudSvg"
+              backgroundColor="transparent"
+            />
+            <strong> {{ noRemovedUsersLabel$() }}</strong>
+            <p
+              :style="{
+                color: $themePalette.grey.v_700,
+              }"
+            >
+              {{ removedUsersNotice$() }}
+            </p>
+          </div>
+        </div>
+      </KPageContainer>
+      <router-view
+        :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
+        :classes="classes"
+        :selectedUsers="selectedUsers"
+        @change="onUsersChange"
+      />
+      <PermanentDeleteModal
+        v-if="usersToDelete"
+        :selectedUsers="usersToDelete"
+        @close="usersToDelete = null"
+        @change="onUsersChange"
+      />
+    </template>
   </ImmersivePage>
 
 </template>
@@ -253,6 +258,13 @@
 
 
 <style lang="scss" scoped>
+
+  .page-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 1000px;
+    margin: 24px auto;
+  }
 
   .removed-users-page-header {
     margin-bottom: 16px;

--- a/kolibri/plugins/facility/assets/src/views/users/common/CloseConfirmationGuard.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/CloseConfirmationGuard.vue
@@ -4,41 +4,31 @@
     <KModal
       v-if="isConfirmationModalOpen"
       appendToOverlay
-      :submitText="submitText"
-      :cancelText="cancelText"
-      :title="title"
+      :submitText="submitText || coreStrings.continueAction$()"
+      :cancelText="cancelText || coreStrings.cancelAction$()"
+      :title="title || coreStrings.closeConfirmationTitle$()"
       @cancel="onCancel"
       @submit="onClose"
     >
       <div class="fix-line-height">
-        <slot
-          v-if="$slots.content"
-          name="content"
-        >
+        <slot>
+          <span>
+            {{ closeConfirmationMessage$() }}
+          </span>
         </slot>
-        <span v-else>
-          {{ closeConfirmationMessage$() }}
-        </span>
       </div>
       <template
-        v-if="cancelTextStyle || submitTextStyle"
+        v-if="reverseActionsOrder"
         #actions
       >
         <KButtonGroup>
           <KButton
-            v-if="submitTextStyle"
+            primary
             :text="submitText"
-            :style="submitTextStyle"
-            :appearance="submitTextStyle.appearance || 'raised-button'"
-            :primary="submitTextStyle.primary || false"
             @click="onClose"
           />
           <KButton
-            v-if="cancelTextStyle"
-            :style="cancelTextStyle"
-            :appearance="cancelTextStyle.appearance || 'raised-button'"
             :text="cancelText"
-            :primary="cancelTextStyle.primary || false"
             @click="onCancel"
           />
         </KButtonGroup>
@@ -107,6 +97,7 @@
       };
 
       return {
+        coreStrings,
         isConfirmationModalOpen,
         onClose,
         onCancel,
@@ -128,23 +119,19 @@
       },
       title: {
         type: String,
-        default: coreStrings.closeConfirmationTitle$(),
+        default: null,
       },
       cancelText: {
         type: String,
-        default: coreStrings.cancelAction$(),
-      },
-      cancelTextStyle: {
-        type: Object,
         default: null,
       },
       submitText: {
         type: String,
-        default: coreStrings.continueAction$(),
-      },
-      submitTextStyle: {
-        type: Object,
         default: null,
+      },
+      reverseActionsOrder: {
+        type: Boolean,
+        default: false,
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -118,26 +118,22 @@
           createSnackbar(usersTrashedNotice$());
           loading.value = false;
           usersRemoved.value = Array.from(props.selectedUsers);
-          emit('change', { resetSelection: true });
+          props.onUsersChange({ resetSelection: true });
+          close();
+          return true;
         } catch (error) {
           createSnackbar(defaultErrorMessage$());
           loading.value = false;
+          return false;
         }
       };
 
       const undoMoveToTrash = async () => {
-        loading.value = true;
-        try {
-          await DeletedFacilityUserResource.restoreCollection({
-            by_ids: usersRemoved.value.join(','),
-          });
-          createSnackbar(trashUndoneNotice$());
-          emit('change');
-          close();
-        } catch (error) {
-          createSnackbar(defaultErrorMessage$());
-          loading.value = false;
-        }
+        await DeletedFacilityUserResource.restoreCollection({
+          by_ids: usersRemoved.value.join(','),
+        });
+        createSnackbar(trashUndoneNotice$());
+        props.onUsersChange();
       };
 
       const { performAction: moveToTrash } = useActionWithUndo({
@@ -145,6 +141,7 @@
         actionNotice$: usersTrashedNotice$,
         undoAction: undoMoveToTrash,
         undoActionNotice$: trashUndoneNotice$,
+        onBlur: props.onBlur,
       });
 
       const removeButtonStyles = {
@@ -181,6 +178,14 @@
       selectedUsers: {
         type: Set,
         default: () => new Set(),
+      },
+      onBlur: {
+        type: Function,
+        default: () => {},
+      },
+      onUsersChange: {
+        type: Function,
+        default: () => {},
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="flex-column">
     <PaginatedListContainerWithBackend
       v-model="currentPage"
       :itemsPerPage="itemsPerPage"
@@ -737,6 +737,13 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
+    // Min height is set to 0 to allow flex items to shrink
+    min-height: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -15,6 +15,7 @@
         >
           <div class="search-filter-section">
             <FilterTextbox
+              ref="filterTextboxRef"
               v-model="searchTerm"
               :placeholder="coreStrings.searchForUser$()"
               :aria-label="coreStrings.searchForUser$()"
@@ -230,7 +231,7 @@
       ResetUserPasswordModal,
       PaginatedListContainerWithBackend,
     },
-    setup(props, { emit }) {
+    setup(props, { emit, expose }) {
       const route = useRoute();
       const router = useRouter();
       const { isSuperuser, currentUserId } = useUser();
@@ -241,6 +242,7 @@
       const { facilityUsers } = toRefs(props);
       const modalShown = ref(null);
       const userToChange = ref(null);
+      const filterTextboxRef = ref(null);
 
       const { selectAllLabel$ } = enhancedQuizManagementStrings;
       const {
@@ -611,6 +613,14 @@
         }
       });
 
+      const focus = () => {
+        filterTextboxRef.value?.focus();
+      };
+
+      expose({
+        focus,
+      });
+
       return {
         // Computed Properties
         tableHeaders,
@@ -624,6 +634,7 @@
         modalShown,
         userToChange,
         userToChangeSet,
+        filterTextboxRef,
 
         // Methods
         handleSelectAllToggle,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -1,36 +1,7 @@
 <template>
 
   <div>
-    <KModal
-      v-if="showUndoModal"
-      :title="
-        undoAssignCoachHeading$({
-          numUsers: eligibleUsersCount,
-          numClasses: selectedClasses.length,
-        })
-      "
-      :submitText="undoAction$()"
-      :cancelText="dismissAction$()"
-      :submitDisabled="isLoading"
-      :cancelDisabled="isLoading"
-      @cancel="handleDismissConfirmation"
-      @submit="handleUndoAssignments"
-    >
-      <KCircularLoader v-if="isLoading" />
-      <span
-        v-else
-        class="adjust-line-height"
-      >
-        {{
-          undoAssignCoachMessage$({
-            numUsers: eligibleUsersCount,
-            numClasses: selectedClasses.length,
-          })
-        }}
-      </span>
-    </KModal>
     <SidePanelModal
-      v-else
       alignment="right"
       sidePanelWidth="700px"
       :addBottomBorder="false"
@@ -90,7 +61,7 @@
         <div class="bottom-nav-container">
           <KButtonGroup>
             <KButton
-              :text="coreString('cancelAction')"
+              :text="coreStrings.cancelAction$()"
               :disabled="isLoading"
               @click="closeSidePanel"
             />
@@ -123,22 +94,22 @@
 
 <script>
 
-  import { ref, computed, getCurrentInstance } from 'vue';
+  import { ref, computed } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import KIcon from 'kolibri-design-system/lib/KIcon';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import { UserKinds } from 'kolibri/constants';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
-  import useSnackbar from 'kolibri/composables/useSnackbar';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
-  import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import SelectableList from '../../common/SelectableList.vue';
   import { _userState } from '../../../modules/mappers';
+  import useActionWithUndo from '../../../composables/useActionWithUndo';
 
   export default {
     name: 'AssignCoachesSidePanel',
@@ -148,14 +119,11 @@
       SelectableList,
       CloseConfirmationGuard,
     },
-    mixins: [commonCoreStrings],
     setup(props) {
       const selectedClasses = ref([]); // Array of selected class IDs
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
-      const showUndoModal = ref(false);
       const createdRoles = ref([]);
-      const instance = getCurrentInstance();
       const facilityUsers = ref([]);
       const route = useRoute();
       const closeConfirmationGuardRef = ref(null);
@@ -169,11 +137,8 @@
       });
 
       const {
-        undoAssignCoachHeading$,
-        undoAssignCoachMessage$,
         coachesAssignedNotice$,
         assignCoachUndoneNotice$,
-        undoAction$,
         usersInClassNotAffected$,
         assignAction$,
         searchForAClass$,
@@ -187,8 +152,6 @@
         assignUsersHeading$,
         assignToAllClasses$,
       } = bulkUserManagementStrings;
-      const { createSnackbar } = useSnackbar();
-      const { dismissAction$ } = coreStrings;
 
       const loadUsers = async () => {
         isLoading.value = true;
@@ -232,24 +195,13 @@
       });
       const ineligibleUsersCount = computed(() => ineligibleUsers.value.length);
 
-      const eligibleUsersCount = computed(() => {
-        return eligibleUsers.value.length;
-      });
-
       // Methods
-      async function handleAssign() {
-        if (!hasSelectedClasses.value) {
-          return;
-        }
-
+      async function _handleAssign() {
         isLoading.value = true;
         showErrorWarning.value = false;
-        createdRoles.value = [];
 
         try {
           await assignCoachesToClasses();
-          createSnackbar(coachesAssignedNotice$());
-          showUndoModal.value = true;
         } catch (error) {
           showErrorWarning.value = true;
         } finally {
@@ -284,65 +236,43 @@
 
         // Only add roles that were actually created (have an id)
         const actuallyCreatedRoles = newRoles.filter(role => role.id);
-        createdRoles.value.push(...actuallyCreatedRoles);
-      }
-
-      function handleDismissConfirmation() {
-        showUndoModal.value = false;
-        selectedClasses.value = [];
-        instance.proxy.$emit('clearSelection');
-        instance.proxy.$router.back();
+        createdRoles.value = actuallyCreatedRoles;
       }
 
       async function handleUndoAssignments() {
-        isLoading.value = true;
-        try {
-          if (createdRoles.value.length > 0) {
-            const roleIds = createdRoles.value.filter(role => role.id).map(role => role.id);
-
-            if (roleIds.length > 0) {
-              await RoleResource.deleteCollection({ by_ids: roleIds });
-            }
-          }
-          createSnackbar(assignCoachUndoneNotice$());
-        } catch (error) {
-          createSnackbar(defaultErrorMessage$());
-        } finally {
-          showUndoModal.value = false;
-          isLoading.value = false;
-          selectedClasses.value = [];
-          instance.proxy.$emit('clearSelection');
-          goBack();
+        if (createdRoles.value.length > 0) {
+          const roleIds = createdRoles.value.map(role => role.id);
+          await RoleResource.deleteCollection({ by_ids: roleIds });
         }
       }
+
+      const { performAction: handleAssign } = useActionWithUndo({
+        action: _handleAssign,
+        actionNotice$: coachesAssignedNotice$,
+        undoAction: handleUndoAssignments,
+        undoActionNotice$: assignCoachUndoneNotice$,
+      });
 
       function closeSidePanel() {
         goBack();
       }
 
       return {
+        coreStrings,
         selectedClasses,
         isLoading,
         formattedClasses,
         selectedUsersCount,
         hasSelectedClasses,
         hasUnsavedChanges,
-        eligibleUsersCount,
         ineligibleUsersCount,
         showErrorWarning,
-        showUndoModal,
         defaultErrorMessage$,
         usersInClassNotAffected$,
         assignAction$,
         searchForAClass$,
         SelectClassesLabel$,
         handleAssign,
-        handleDismissConfirmation,
-        handleUndoAssignments,
-        undoAction$,
-        dismissAction$,
-        undoAssignCoachHeading$,
-        undoAssignCoachMessage$,
         closeSidePanel,
         discardAction$,
         discardWarning$,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -68,7 +68,7 @@
             <KButton
               primary
               :text="assignAction$()"
-              :disabled="!hasSelectedClasses || isLoading"
+              :disabled="!hasSelectedClasses || isLoading || !selectedUsers.size"
               @click="handleAssign"
             />
           </KButtonGroup>
@@ -213,10 +213,11 @@
         try {
           await assignCoachesToClasses();
           closeSidePanel();
+          return true;
         } catch (error) {
           showErrorWarning.value = true;
-        } finally {
           isLoading.value = false;
+          return false;
         }
       }
 
@@ -225,9 +226,6 @@
           selectedClasses.value.includes(cls.id),
         );
         const eligibleUserIds = eligibleUsers.value.map(user => user.id);
-        if (eligibleUserIds.length === 0) {
-          return;
-        }
 
         if (selectedClassObjects.length === 0) {
           throw new Error('No classes selected');
@@ -262,6 +260,7 @@
         actionNotice$: coachesAssignedNotice$,
         undoAction: handleUndoAssignments,
         undoActionNotice$: assignCoachUndoneNotice$,
+        onBlur: props.onBlur,
       });
 
       function closeSidePanel() {
@@ -305,6 +304,10 @@
       classes: {
         type: Array,
         default: () => [],
+      },
+      onBlur: {
+        type: Function,
+        default: () => {},
       },
     },
     beforeRouteLeave(to, from, next) {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -77,14 +77,19 @@
 
       <CloseConfirmationGuard
         ref="closeConfirmationGuardRef"
+        reverseActionsOrder
         :hasUnsavedChanges="hasUnsavedChanges"
-        :title="disgardChanges$()"
+        :title="discardChanges$()"
         :submitText="discardAction$()"
         :cancelText="keepEditingAction$()"
       >
-        <template #content>
-          <span class="adjust-line-height">{{ discardWarning$() }}</span>
-        </template>
+        <KIcon
+          icon="infoOutline"
+          :color="$themePalette.red.v_600"
+        />
+        <span :style="{ color: $themePalette.red.v_600 }">
+          {{ discardWarning$() }}
+        </span>
       </CloseConfirmationGuard>
     </SidePanelModal>
   </div>
@@ -123,7 +128,7 @@
       const selectedClasses = ref([]); // Array of selected class IDs
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
-      const createdRoles = ref([]);
+      const createdRoles = ref(null);
       const facilityUsers = ref([]);
       const route = useRoute();
       const closeConfirmationGuardRef = ref(null);
@@ -146,7 +151,7 @@
         discardAction$,
         discardWarning$,
         keepEditingAction$,
-        disgardChanges$,
+        discardChanges$,
         numUsersNotEligible$,
         SelectClassesLabel$,
         assignUsersHeading$,
@@ -176,7 +181,12 @@
 
       const hasSelectedClasses = computed(() => selectedClasses.value.length > 0);
 
-      const hasUnsavedChanges = computed(() => selectedClasses.value.length > 0);
+      const hasUnsavedChanges = computed(() => {
+        if (createdRoles.value) {
+          return false;
+        }
+        return selectedClasses.value.length > 0;
+      });
 
       // Filter eligible users (coaches, admins, superusers)
       const eligibleUsers = computed(() => {
@@ -202,6 +212,7 @@
 
         try {
           await assignCoachesToClasses();
+          closeSidePanel();
         } catch (error) {
           showErrorWarning.value = true;
         } finally {
@@ -277,7 +288,7 @@
         discardAction$,
         discardWarning$,
         keepEditingAction$,
-        disgardChanges$,
+        discardChanges$,
         numUsersNotEligible$,
         assignUsersHeading$,
         assignToAllClasses$,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -279,10 +279,11 @@
           removedLearnerMemberships.value = learnerMembershipsToRemove || [];
           removedCoachRoles.value = coachRolesToRemove || [];
           goBack();
+          return true;
         } catch (error) {
           showErrorWarning.value = true;
-        } finally {
           loading.value = false;
+          return false;
         }
       }
 
@@ -291,6 +292,7 @@
         actionNotice$: usersRemovedNotice$,
         undoAction: undoUserRemoval,
         undoActionNotice$: undoUsersRemovedMessage$,
+        onBlur: props.onBlur,
       });
 
       onMounted(() => {
@@ -334,6 +336,10 @@
       classes: {
         type: Array,
         default: () => [],
+      },
+      onBlur: {
+        type: Function,
+        default: () => {},
       },
     },
     beforeRouteLeave(to, from, next) {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -77,22 +77,19 @@
       </template>
       <CloseConfirmationGuard
         ref="closeConfirmationGuardRef"
-        :hasUnsavedChanges="selectedOptions.length > 0 ? true : false"
-        :title="disgardChanges$()"
+        reverseActionsOrder
+        :hasUnsavedChanges="hasUnsavedChanges"
+        :title="discardChanges$()"
         :submitText="discardAction$()"
-        :submitTextStyle="{ primary: true }"
         :cancelText="keepEditingAction$()"
-        :cancelTextStyle="{ primary: false }"
       >
-        <template #content>
-          <KIcon
-            icon="infoOutline"
-            :color="$themePalette.red.v_600"
-          />
-          <span :style="{ color: $themePalette.red.v_600 }">
-            {{ discardWarning$() }}
-          </span>
-        </template>
+        <KIcon
+          icon="infoOutline"
+          :color="$themePalette.red.v_600"
+        />
+        <span :style="{ color: $themePalette.red.v_600 }">
+          {{ discardWarning$() }}
+        </span>
       </CloseConfirmationGuard>
     </SidePanelModal>
   </div>
@@ -142,7 +139,7 @@
         discardAction$,
         discardWarning$,
         keepEditingAction$,
-        disgardChanges$,
+        discardChanges$,
         defaultErrorMessage$,
         removeUsersFromClassesHeading$,
         usersNotInClasses$,
@@ -193,6 +190,13 @@
 
       const hasRemovedCoaches = computed(() => {
         return removedCoachRoles.value.length > 0;
+      });
+
+      const hasUnsavedChanges = computed(() => {
+        if (hasRemovedLearners.value || hasRemovedCoaches.value) {
+          return false;
+        }
+        return selectedOptions.value.length > 0;
       });
 
       // methods
@@ -296,8 +300,7 @@
       return {
         // ref and computed properties
         closeConfirmationGuardRef,
-        hasRemovedLearners,
-        hasRemovedCoaches,
+        hasUnsavedChanges,
         showErrorWarning,
         selectedOptions,
         classCoaches,
@@ -312,7 +315,7 @@
         discardAction$,
         discardWarning$,
         keepEditingAction$,
-        disgardChanges$,
+        discardChanges$,
         usersNotInClasses$,
         removeFromAllClassesLabel$,
         SelectClassesLabel$,
@@ -334,11 +337,7 @@
       },
     },
     beforeRouteLeave(to, from, next) {
-      if (this.hasRemovedLearners || this.hasRemovedCoaches) {
-        next();
-      } else {
-        this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);
-      }
+      this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -183,7 +183,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props, { emit }) {
+    setup(props) {
       const formId = 'create-user-form';
       const route = useRoute();
       const router = useRouter();
@@ -318,7 +318,7 @@
 
       const handleSubmitSuccess = () => {
         createSnackbar(notificationStrings.userCreated$());
-        emit('change');
+        props.onUsersChange();
       };
 
       const handleSubmitFailure = error => {
@@ -488,6 +488,10 @@
       classes: {
         type: Array,
         default: () => [],
+      },
+      onUsersChange: {
+        type: Function,
+        default: () => {},
       },
     },
     beforeRouteLeave(to, from, next) {

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="flex-column">
     <KGrid v-if="$slots.otherFilter || $slots.filter">
       <KGridItem :layout12="{ span: 7 }">
         <slot name="otherFilter"></slot>
@@ -13,7 +13,7 @@
       </KGridItem>
     </KGrid>
 
-    <div>
+    <div class="flex-column">
       <slot> </slot>
     </div>
 
@@ -137,6 +137,13 @@
     position: relative;
     top: -2px;
     display: inline;
+  }
+
+  .flex-column {
+    display: flex;
+    flex-direction: column;
+    // Min height is set to 0 to allow flex items to shrink
+    min-height: 0;
   }
 
 </style>

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -189,16 +189,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   },
 
   // Assign coaches to class
-  undoAssignCoachHeading: {
-    message:
-      'You have successfully assigned {numUsers, number} {numUsers, plural, one {user} other {users}} to {numClasses, number} {numClasses, plural, one {class} other {classes}}. If this was a mistake, you can undo it.',
-    context: 'Confirmation heading that allows user to undo their action of assigning coaches',
-  },
-  undoAssignCoachMessage: {
-    message:
-      "You've successfully assigned {numUsers, number} {numUsers, plural, one {user} other {users}} from {numClasses, number} {numClasses, plural, one {class} other {classes}}. If this was a mistake, you can undo it.",
-    context: 'Snackbar notification message indicating success',
-  },
   coachesAssignedNotice: {
     message: 'Selected coaches have been assigned',
     context:
@@ -270,16 +260,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Users already in selected classes will not be affected',
     context: 'Warning message about users already in selected classes',
   },
-  undoUsersEnrolledHeading: {
-    message:
-      '{num, number} {num, plural, one {user has} other {users have}} been enrolled. Undo this?',
-    context: 'Heading for undo confirmation after enrolling users',
-  },
-  undoUsersEnrolledMessage: {
-    message:
-      "You've successfully enrolled {numUsers, number} {numUsers, plural, one {user} other {users}} to {numClasses, number} {numClasses, plural, one {class} other {classes}}. If this was a mistake, you can undo it.",
-    context: 'Detailed message for undo confirmation after enrolling users',
-  },
   usersEnrolledNotice: {
     message: 'Selected users have been enrolled',
     context: 'Confirmation message when users are enrolled in classes',
@@ -335,20 +315,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message:
       'Users will be removed from all classes and immediately deactivated. Deactivated users will be deleted permanently after 30 days.',
     context: 'Warning message about trash deletion timeline',
-  },
-  undoTrashHeading: {
-    message:
-      '{num, number} {num, plural, one {user has} other {users have}} been removed. Undo this?',
-    context: 'Confirmation heading asking if user wants to undo removing multiple users',
-  },
-  undoTrashMessageA: {
-    message:
-      "You've successfully removed {numUsers, number} {numUsers, plural, one {user} other {users}}.",
-    context: 'Success notification after users have been removed',
-  },
-  undoTrashMessageB: {
-    message: 'These users will be deleted in 30 days. If this was a mistake, you can undo it.',
-    context: 'Informational message about trash deletion timeline and undo option',
   },
   usersTrashedNotice: {
     message: 'Selected users have been removed',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -139,7 +139,7 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Undo',
     context: 'Label for the button that will undo the last action taken on the users',
   },
-  disgardChanges: {
+  discardChanges: {
     message: 'Discard changes?',
     context: 'Heading for the confirmation modal that asks user if they want to discard changes',
   },

--- a/packages/kolibri/components/FilterTextbox.vue
+++ b/packages/kolibri/components/FilterTextbox.vue
@@ -135,6 +135,12 @@
         this.model = '';
         this.$refs.searchinput.focus();
       },
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.searchinput.focus();
+      },
     },
   };
 

--- a/packages/kolibri/components/GlobalSnackbar/index.vue
+++ b/packages/kolibri/components/GlobalSnackbar/index.vue
@@ -30,6 +30,14 @@
       CoreSnackbar,
     },
     directives: {
+      /**
+       * Using directives here to have a cleaner control over DOM elements and the
+       * snackbar button element, if rendered.
+       *
+       * TODO: This could be managed directly with vue event handlers and KDS
+       * properties, but `CoreSnackbar` uses a keen component, and the snackbar
+       * handling should probably be refactored before extending more functionalities.
+       */
       autofocus: {
         async inserted(el, binding) {
           if (binding.value === false) {

--- a/packages/kolibri/components/GlobalSnackbar/index.vue
+++ b/packages/kolibri/components/GlobalSnackbar/index.vue
@@ -47,6 +47,7 @@
           if (!binding.value) {
             return;
           }
+          // Save blur methods on element, so we can remove them later
           el._onBlurHandler = binding.value;
           el._onKeydownHandler = event => {
             if (event.key === 'Tab') {

--- a/packages/kolibri/components/GlobalSnackbar/internal/CoreSnackbar.vue
+++ b/packages/kolibri/components/GlobalSnackbar/internal/CoreSnackbar.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div @keydown.esc="hideSnackbar">
     <template v-if="backdrop">
       <Backdrop class="snackbar-backdrop" />
       <!-- Prevent focus from leaving the this container -->

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -38,7 +38,7 @@
       class="main-wrapper"
       :style="[wrapperStyles, paddingTop]"
     >
-      <slot></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
 
     <transition mode="out-in">
@@ -158,6 +158,17 @@
         return {
           paddingTop: `${totalPadding}px`,
         };
+      },
+      pageContentHeight() {
+        const paddingTop = parseInt(this.paddingTop.paddingTop) || 0;
+        const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
+
+        let height = window.innerHeight - paddingTop - paddingBottom - 1;
+        if (this.isAppContextAndTouchDevice) {
+          height -= 56; // Account for the Android bottom navigation bar
+        }
+
+        return height;
       },
       paddingLeftRight() {
         return this.isAppContext || this.windowIsSmall ? '8px' : '32px';

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -92,9 +92,10 @@
           }
         },
       });
-      const { windowIsSmall } = useKResponsiveWindow();
+      const { windowHeight, windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
       return {
+        windowHeight,
         windowIsSmall,
         isAppContext,
         swipeZone,
@@ -163,7 +164,7 @@
         const paddingTop = parseInt(this.paddingTop.paddingTop) || 0;
         const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
 
-        let height = window.innerHeight - paddingTop - paddingBottom - 1;
+        let height = this.windowHeight - paddingTop - paddingBottom - 1;
         if (this.isAppContextAndTouchDevice) {
           height -= 56; // Account for the Android bottom navigation bar
         }

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -25,7 +25,7 @@
       class="main-wrapper"
       :style="wrapperStyles"
     >
-      <slot></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
   </div>
 
@@ -91,6 +91,12 @@
             paddingBottom: '72px',
             paddingTop: this.appBarHeight + 16 + 'px',
           };
+      },
+      pageContentHeight() {
+        const paddingTop = parseInt(this.wrapperStyles.paddingTop) || 0;
+        const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
+        const height = window.innerHeight - paddingTop - paddingBottom - 1;
+        return height;
       },
     },
     mounted() {

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -35,12 +35,24 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import useUser from 'kolibri/composables/useUser';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+
   import ScrollingHeader from '../ScrollingHeader';
   import ImmersiveToolbar from './internal/ImmersiveToolbar';
 
   export default {
     name: 'ImmersivePage',
     components: { ImmersiveToolbar, ScrollingHeader },
+    setup() {
+      const { windowHeight, windowIsSmall } = useKResponsiveWindow();
+      const { isAppContext } = useUser();
+      return {
+        windowHeight,
+        windowIsSmall,
+        isAppContext,
+      };
+    },
     props: {
       appBarTitle: {
         type: String,
@@ -86,16 +98,19 @@
             width: '100%',
             display: 'inline-block',
             backgroundColor: this.$themePalette.grey.v_100,
-            paddingLeft: '32px',
-            paddingRight: '32px',
             paddingBottom: '72px',
+            paddingLeft: this.paddingLeftRight,
+            paddingRight: this.paddingLeftRight,
             paddingTop: this.appBarHeight + 16 + 'px',
           };
+      },
+      paddingLeftRight() {
+        return this.isAppContext || this.windowIsSmall ? '8px' : '32px';
       },
       pageContentHeight() {
         const paddingTop = parseInt(this.wrapperStyles.paddingTop) || 0;
         const paddingBottom = parseInt(this.wrapperStyles.paddingBottom) || 0;
-        const height = window.innerHeight - paddingTop - paddingBottom - 1;
+        const height = this.windowHeight - paddingTop - paddingBottom - 1;
         return height;
       },
     },

--- a/packages/kolibri/composables/useSnackbar.js
+++ b/packages/kolibri/composables/useSnackbar.js
@@ -5,7 +5,9 @@ const snackbarIsVisible = ref(false);
 const snackbarOptions = ref({
   text: '',
   autoDismiss: true,
+  // Property to autofocus the snackbar action button if any.
   autofocus: false,
+  // Blur event handler for when the snackbar action button loses focus.
   onBlur: null,
 });
 

--- a/packages/kolibri/composables/useSnackbar.js
+++ b/packages/kolibri/composables/useSnackbar.js
@@ -5,6 +5,8 @@ const snackbarIsVisible = ref(false);
 const snackbarOptions = ref({
   text: '',
   autoDismiss: true,
+  autofocus: false,
+  onBlur: null,
 });
 
 export default function useSnackbar() {


### PR DESCRIPTION
The branch of this PR was created out of the https://github.com/learningequality/kolibri/pull/13671 branch to prevent future conflicts, so reviewers can ignore the first 5 commits.

## Summary
* Refactor undo actions across all side panels.
  * Create a `useActionWithUndo` composable to manage the common logic.
  * Turn the emit("change") events to directly call a callback passed as component props, to comply restrictions set by the undo snackbar. i.e. the undo action will happen after the side panel is unmounted, so we can't do emit('change') there since the component is already unmounted. 
* Use the `useGoBack` composable across all side panels.
* Use the `CloseConfirmationGuard` across all side panels.
  * Refactor the `CloseConfirmationGuard`component for it to have an API more similar to KModal, since it pretty much acts as a wrapper.
* Add close confirmation guard to the filters side panel.
* useSnackbar's createSnackbar method now receives two new arguments: `autofocus` to autofocus the action button in the snackbar, and `onBlur` a callback that will be called when the action button in the snackbar blurs.
* GlobalSnackbar now closes the snackbar if the user presses esc.
* Fix link icon buttons being focusable when disabled.
* Fix error when going back from the removed users page filters redirecting to the users root page.

### Screencast
https://github.com/user-attachments/assets/683a0159-9fda-40b6-ae00-b571c27ec726


## References

Closes https://github.com/learningequality/kolibri/issues/13609.

## Reviewer guidance
* Play with side panel flows for assigning coaches, enrolling learners, removing learners from classes and soft deleting users, play with the undo action shown in the snackbar.
* Make sure there isnt any regression with the close side panel behavior, and with the "are you sure you want to leave" guards.