### PR TITLE
Fix copy pasta error in management command argument help string

### DIFF
--- a/kolibri/core/logger/management/commands/exportlogs.py
+++ b/kolibri/core/logger/management/commands/exportlogs.py
@@ -63,7 +63,7 @@ class Command(AsyncCommand):
             "--facility",
             action="store",
             type=str,
-            help="Facility id to import the users into",
+            help="Facility id to export log data from",
         )
         parser.add_argument(
             "--locale",


### PR DESCRIPTION
## Summary
Noticed while checking management command
