### PR TITLE
Fix bug that was preventing more than one download thread being used ever

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1125,7 +1125,10 @@ class ImportContentTestCase(TestCase):
             2201062 + 336974,
         )
         get_free_space_mock.side_effect = [100000000000, 0, 0, 0, 0, 0, 0]
-        with self.assertRaises(InsufficientStorageSpaceError):
+        # Ensure single threaded operation for deterministic testing
+        with patch(
+            "kolibri.core.tasks.utils.get_fd_limit", return_value=1
+        ), self.assertRaises(InsufficientStorageSpaceError):
             manager = RemoteChannelResourceImportManager(self.the_channel_id)
             manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
@@ -1466,7 +1469,9 @@ class ImportContentTestCase(TestCase):
             10,
         )
         manager = RemoteChannelResourceImportManager(self.the_channel_id)
-        manager.run()
+        # Ensure single threaded operation for deterministic testing
+        with patch("kolibri.core.tasks.utils.get_fd_limit", return_value=1):
+            manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
             self.the_channel_id,
             [

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -381,7 +381,7 @@ def fd_safe_executor(fds_per_task=2):
         # this task by double this number which should give us leeway in case of unforeseen
         # descriptor use during the process.
         max_workers = min(
-            max_workers, min(1, max_descriptors_per_task // (fds_per_task * 2))
+            max_workers, max(1, max_descriptors_per_task // (fds_per_task * 2))
         )
 
     return executor(max_workers=max_workers)


### PR DESCRIPTION
## Summary
* Fixes a bug introduced while trying to prevent errors due to too many open file descriptors - the accidental second `min` meant that only one thread was ever being used for download

## References
This bug was introduced here: https://github.com/learningequality/kolibri/pull/9242

First fix for https://github.com/learningequality/kolibri/issues/13680

## Reviewer guidance
How much faster does KA En download with this change?
