### PR TITLE
Streamline download by enabling multiprocessing workers as default

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1125,7 +1125,10 @@ class ImportContentTestCase(TestCase):
             2201062 + 336974,
         )
         get_free_space_mock.side_effect = [100000000000, 0, 0, 0, 0, 0, 0]
-        with self.assertRaises(InsufficientStorageSpaceError):
+        # Ensure single threaded operation for deterministic testing
+        with patch(
+            "kolibri.core.tasks.utils.get_fd_limit", return_value=1
+        ), self.assertRaises(InsufficientStorageSpaceError):
             manager = RemoteChannelResourceImportManager(self.the_channel_id)
             manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
@@ -1466,7 +1469,9 @@ class ImportContentTestCase(TestCase):
             10,
         )
         manager = RemoteChannelResourceImportManager(self.the_channel_id)
-        manager.run()
+        # Ensure single threaded operation for deterministic testing
+        with patch("kolibri.core.tasks.utils.get_fd_limit", return_value=1):
+            manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
             self.the_channel_id,
             [

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -381,7 +381,7 @@ def fd_safe_executor(fds_per_task=2):
         # this task by double this number which should give us leeway in case of unforeseen
         # descriptor use during the process.
         max_workers = min(
-            max_workers, min(1, max_descriptors_per_task // (fds_per_task * 2))
+            max_workers, max(1, max_descriptors_per_task // (fds_per_task * 2))
         )
 
     return executor(max_workers=max_workers)

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -7,9 +7,17 @@ from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.utils import db_connection
 from kolibri.core.tasks.utils import InfiniteLoopThread
+from kolibri.utils.logger import setup_worker_logging
 from kolibri.utils.multiprocessing_compat import PoolExecutor
 
 logger = logging.getLogger(__name__)
+
+
+def _init_worker(log_queue):
+    """
+    Initialize worker process, setting up logging to use the given log queue.
+    """
+    setup_worker_logging(log_queue)
 
 
 def execute_job(
@@ -18,7 +26,6 @@ def execute_job(
     worker_process=None,
     worker_thread=None,
     worker_extra=None,
-    log_queue=None,
 ):
     """
     Call the function stored in the job.func.
@@ -41,7 +48,7 @@ def execute_job(
     django_connection.close()
 
 
-def execute_job_with_python_worker(job_id, log_queue=None):
+def execute_job_with_python_worker(job_id):
     """
     Call execute_job but additionally with the current host, process and thread information taken
     directly from python internals.
@@ -55,7 +62,6 @@ def execute_job_with_python_worker(job_id, log_queue=None):
         worker_host=socket.gethostname(),
         worker_process=str(os.getpid()),
         worker_thread=str(threading.get_ident()),
-        log_queue=log_queue,
     )
 
 
@@ -105,7 +111,11 @@ class Worker(object):
         self.workers.shutdown(wait=wait)
 
     def start_workers(self):
-        pool = PoolExecutor(max_workers=self.max_workers)
+        pool = PoolExecutor(
+            max_workers=self.max_workers,
+            initializer=_init_worker,
+            initargs=(self.log_queue,),
+        )
         return pool
 
     def handle_finished_future(self, future):
@@ -199,7 +209,6 @@ class Worker(object):
         future = self.workers.submit(
             execute_job_with_python_worker,
             job_id=job.job_id,
-            log_queue=self.log_queue,
         )
 
         # Check if the job ID already exists in the future_job_mapping dictionary

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -52,7 +52,15 @@ class LoggerAwareQueueHandler(QueueHandler):
                 )
                 record.exc_info = None
             if hasattr(record, "args"):
-                record.args = tuple(str(arg) for arg in record.args)
+                # Convert args to strings only if they aren't already pickle-safe
+                safe_args = []
+                for arg in record.args:
+                    # Keep numeric types as-is for format compatibility
+                    if isinstance(arg, (int, float, bool, type(None))):
+                        safe_args.append(arg)
+                    else:
+                        safe_args.append(str(arg))
+                record.args = tuple(safe_args)
 
         record = super().prepare(record)
         record._logger_name = self.logger_name

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -796,7 +796,7 @@ base_option_spec = {
     "Tasks": {
         "USE_WORKER_MULTIPROCESSING": {
             "type": "multiprocess_bool",
-            "default": False,
+            "default": True,
             "description": """
                 Whether to use Python multiprocessing for worker pools. If False, then it will use threading. This may be useful,
                 if running on a dedicated device with multiple cores, and a lot of asynchronous tasks get run.


### PR DESCRIPTION
## Summary
* We have had the capability to run our workers as separate processes (rather than as threads) for quite some time, and while in not exactly the same manner, this is how they run on Android
* This PR sets this mode as the default to allow more free file descriptors (as they are per process), meaning more threads can be used for simultaneous downloads

## References
Second fix for https://github.com/learningequality/kolibri/issues/13680
Depends on https://github.com/learningequality/kolibri/pull/13689

## Reviewer guidance
How much faster does KA En download with this change?
