### PR TITLE
Fix LOD user management server sync interruptions

### DIFF
--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2578,6 +2578,8 @@ class SetNonSpecifiedPasswordViewTestCase(APITestCase):
 
 
 class DeleteImportedUserTestCase(APITransactionTestCase):
+    databases = "__all__"
+
     def setUp(self):
         super().setUp()
         provision_device()

--- a/kolibri/core/auth/utils/delete.py
+++ b/kolibri/core/auth/utils/delete.py
@@ -29,6 +29,7 @@ from kolibri.core.auth.models import Role
 from kolibri.core.bookmarks.models import Bookmark
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import LearnerDeviceStatus
+from kolibri.core.device.models import SyncQueue
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.exams.models import IndividualSyncableExam
@@ -399,6 +400,7 @@ def _get_user_related_models(user):
             Role.objects.filter(user_id_filter),
             Membership.objects.filter(user_id_filter),
             Bookmark.objects.filter(user_id_filter),
+            SyncQueue.objects.filter(user_id_filter),
             FacilityUser.objects.filter(id=user.id),
         ],
     )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Previously when adding/removing users on the LOD, the syncing to the server would sometimes stop completely, with the error:
```
[python-devserver]   File "/Users/lianaharris/kolibri/kolibri/core/auth/tasks.py", line 450, in soud_sync_processing
[python-devserver]     execute_sync(Context(user_id, instance_id))
[python-devserver]   File "/Users/lianaharris/kolibri/kolibri/core/device/soud.py", line 389, in execute_sync
[python-devserver]     kwargs["facility"] = context.user.facility_id
[python-devserver]     raise self.model.DoesNotExist(
[python-devserver] kolibri.core.auth.models.FacilityUser.DoesNotExist: FacilityUser matching query does not exist.
```

Indicating that executing a sync for a user failed because the user did not exist. This occurred because, when an imported user was deleted, a server sync for that user was still queued. When the sync was executed, it failed, causing the syncing to stop. This issue has been resolved by removing the corresponding user SyncQueue object when deleting imported users.

- Remove users queued syncing tasks when deleting imported users 
- Update DeleteImportedUserTestCase to have full database access to ensure the SyncQueue device model can be queried during testing

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13543 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. On device 1 setup a server with learners
2. On device 2 setup a Learn-only device and import several learners
3. Start removing or adding learners for a period of time
4. The removed users syncing status on the full device should eventually say "Waiting to sync" and "Not recently synced"
