### PR TITLE
Streamline download skip chunked files

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -983,10 +983,14 @@ class ImportContentTestCase(TestCase):
         )
 
         node_id = [self.c2c1_node_id]
-        manager = RemoteChannelResourceImportManager(
-            self.the_channel_id, node_ids=node_id, renderable_only=False
-        )
-        manager.run()
+        with patch(
+            "kolibri.core.content.utils.resource_import.transfer.FileDownload.run",
+            side_effect=HTTPError("Not Found", response=MagicMock(status_code=404)),
+        ):
+            manager = RemoteChannelResourceImportManager(
+                self.the_channel_id, node_ids=node_id, renderable_only=False
+            )
+            manager.run()
         logger_mock.assert_called_once()
         self.assertIn("4 files are skipped", logger_mock.call_args_list[0][0][0])
         self.annotation_mock.set_content_visibility.assert_called_with(
@@ -1030,9 +1034,7 @@ class ImportContentTestCase(TestCase):
         )
 
     @patch("kolibri.core.content.utils.resource_import.get_free_space")
-    @patch(
-        "kolibri.core.content.utils.resource_import.transfer.FileDownload._move_tmp_to_dest"
-    )
+    @patch("kolibri.core.content.utils.resource_import.transfer.FileDownload.finalize")
     @patch(
         "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path"
     )
@@ -1078,9 +1080,7 @@ class ImportContentTestCase(TestCase):
             manager.run()
 
     @patch("kolibri.core.content.utils.resource_import.get_free_space")
-    @patch(
-        "kolibri.core.content.utils.resource_import.transfer.FileDownload._move_tmp_to_dest"
-    )
+    @patch("kolibri.core.content.utils.resource_import.transfer.FileDownload.finalize")
     @patch(
         "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path"
     )
@@ -1364,9 +1364,6 @@ class ImportContentTestCase(TestCase):
         mock_overall_progress.assert_any_call(expected_file_size)
 
     @patch(
-        "kolibri.core.content.utils.resource_import.transfer.FileDownload._move_tmp_to_dest"
-    )
-    @patch(
         "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path"
     )
     @patch(
@@ -1382,7 +1379,6 @@ class ImportContentTestCase(TestCase):
         _checksum_correct_mock,
         is_cancelled_mock,
         path_mock,
-        _move_tmp_to_dest_mock,
         get_import_export_mock,
         channel_list_status_mock,
     ):
@@ -1423,9 +1419,7 @@ class ImportContentTestCase(TestCase):
             admin_imported=True,
         )
 
-    @patch(
-        "kolibri.core.content.utils.resource_import.transfer.FileDownload._move_tmp_to_dest"
-    )
+    @patch("kolibri.core.content.utils.resource_import.transfer.FileDownload.finalize")
     @patch(
         "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path"
     )
@@ -1976,7 +1970,10 @@ class ImportContentTestCase(TestCase):
             10,
         )
 
-        with self.assertRaises(HTTPError):
+        with patch(
+            "kolibri.core.content.utils.resource_import.transfer.FileDownload.run",
+            side_effect=HTTPError,
+        ), self.assertRaises(HTTPError):
             manager = RemoteChannelResourceImportManager(
                 self.the_channel_id,
                 node_ids=[self.c2c1_node_id],

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1125,7 +1125,10 @@ class ImportContentTestCase(TestCase):
             2201062 + 336974,
         )
         get_free_space_mock.side_effect = [100000000000, 0, 0, 0, 0, 0, 0]
-        with self.assertRaises(InsufficientStorageSpaceError):
+        # Ensure single threaded operation for deterministic testing
+        with patch(
+            "kolibri.core.tasks.utils.get_fd_limit", return_value=1
+        ), self.assertRaises(InsufficientStorageSpaceError):
             manager = RemoteChannelResourceImportManager(self.the_channel_id)
             manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
@@ -1466,7 +1469,9 @@ class ImportContentTestCase(TestCase):
             10,
         )
         manager = RemoteChannelResourceImportManager(self.the_channel_id)
-        manager.run()
+        # Ensure single threaded operation for deterministic testing
+        with patch("kolibri.core.tasks.utils.get_fd_limit", return_value=1):
+            manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
             self.the_channel_id,
             [

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -381,7 +381,7 @@ def fd_safe_executor(fds_per_task=2):
         # this task by double this number which should give us leeway in case of unforeseen
         # descriptor use during the process.
         max_workers = min(
-            max_workers, min(1, max_descriptors_per_task // (fds_per_task * 2))
+            max_workers, max(1, max_descriptors_per_task // (fds_per_task * 2))
         )
 
     return executor(max_workers=max_workers)

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -119,6 +119,40 @@ class ChunkedFileDoesNotExist(Exception):
 CHUNK_SUFFIX = ".chunks"
 
 
+class TransferFileBase(BufferedIOBase, metaclass=ABCMeta):
+    """Abstract base class for file transfer destination objects."""
+
+    @property
+    @abstractmethod
+    def file_size(self):
+        pass
+
+    @file_size.setter
+    @abstractmethod
+    def file_size(self, value):
+        pass
+
+    @abstractmethod
+    def is_complete(self, start=None, end=None):
+        pass
+
+    @abstractmethod
+    def finalize_file(self):
+        pass
+
+    @abstractmethod
+    def delete(self):
+        pass
+
+    @abstractmethod
+    def md5_checksum(self):
+        pass
+
+    @abstractmethod
+    def ensure_writable(self):
+        pass
+
+
 class ChunkedFileDirectoryManager(object):
     """
     A class to manage all chunked files in a directory and all its descendant directories.
@@ -192,21 +226,35 @@ class ChunkedFileDirectoryManager(object):
         return self._do_file_eviction(chunked_file_stats, total_size - max_size)
 
 
-class ChunkedFile(BufferedIOBase):
+class ChunkedFile(TransferFileBase):
     # Set chunk size to 128KB
     chunk_size = 128 * 1024
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, raise_if_empty=False, raise_if_exists=False):
         self.filepath = filepath
         self.chunk_dir = filepath + CHUNK_SUFFIX
-        mkdirp(self.chunk_dir, exist_ok=True)
-        self.cache_dir = os.path.join(self.chunk_dir, ".cache")
+        if raise_if_empty and not os.path.exists(self.chunk_dir):
+            raise FileNotFoundError("Chunked file does not exist")
+        if raise_if_exists and os.path.exists(self.filepath):
+            raise FileExistsError("File already exists at {}".format(self.filepath))
+        self._initialize()
         self.position = 0
         self._file_size = None
 
     def _open_cache(self):
         self._check_for_chunk_dir()
         return Cache(self.cache_dir)
+
+    def _initialize(self):
+        mkdirp(self.chunk_dir, exist_ok=True)
+        self.cache_dir = os.path.join(self.chunk_dir, ".cache")
+        self.position = 0
+
+    def ensure_writable(self):
+        try:
+            self._check_for_chunk_dir()
+        except ChunkedFileDoesNotExist:
+            self._initialize()
 
     @property
     def chunks_count(self):
@@ -462,6 +510,148 @@ class ChunkedFile(BufferedIOBase):
         return True
 
 
+class TransferFile(TransferFileBase):
+    """Simple file transfer class that writes directly to disk without chunking."""
+
+    # Match ChunkedFile chunk size for compatibility
+    chunk_size = 128 * 1024
+
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self._file_size = None
+        self._file_obj = None
+        self._finalized = False
+        self._tmp_filepath = filepath + ".transfer"
+        self.hasher = hashlib.md5()
+        self._bytes_written = 0
+
+        # ensure the directories in the destination path exist
+        mkdirp(os.path.dirname(self.filepath), exist_ok=True)
+
+    @property
+    def file_size(self):
+        if self._file_size is None:
+            raise ValueError("file_size is not set")
+        return self._file_size
+
+    @file_size.setter
+    def file_size(self, value):
+        if not isinstance(value, int):
+            raise TypeError("file_size must be an integer")
+        self._file_size = value
+
+    def is_complete(self, start=None, end=None):
+        """For TransferFile, complete means we've written all expected bytes."""
+        if os.path.exists(self.filepath):
+            return True
+        if self._file_size is not None:
+            return self._bytes_written >= self._file_size
+        return False
+
+    def ensure_writable(self):
+        pass
+
+    def write(self, data):
+        """Write data to the transfer file."""
+        if self._file_obj is None:
+            self._file_obj = open(self._tmp_filepath, "wb")
+        self._file_obj.write(data)
+        self.hasher.update(data)
+        self._bytes_written += len(data)
+
+    def write_all(self, data_generator, progress_callback=None):
+        """Write all data from generator to file."""
+        for data in data_generator:
+            self.write(data)
+            if callable(progress_callback):
+                progress_callback(data)
+
+    def chunk_generator(self, data):
+        """Generate chunks from data (for compatibility with ChunkedFile interface)."""
+        return (
+            data[i : i + self.chunk_size] for i in range(0, len(data), self.chunk_size)
+        )
+
+    def finalize_file(self):
+        """Move temporary file to final destination."""
+        if self._finalized:
+            return
+        if self._file_obj:
+            self._file_obj.close()
+            self._file_obj = None
+        if os.path.exists(self._tmp_filepath):
+            replace(self._tmp_filepath, self.filepath)
+        self._finalized = True
+
+    def delete(self):
+        """Delete the transfer file and any temporary files."""
+        if self._file_obj:
+            self._file_obj.close()
+            self._file_obj = None
+        try:
+            os.remove(self._tmp_filepath)
+        except OSError:
+            pass
+        try:
+            os.remove(self.filepath)
+        except OSError:
+            pass
+
+    def md5_checksum(self):
+        """Return MD5 checksum from incremental hasher."""
+        return self.hasher.hexdigest()
+
+    def close(self):
+        """Close the file object."""
+        if self._file_obj:
+            self._file_obj.close()
+            self._file_obj = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def readable(self):
+        return False
+
+    def writable(self):
+        return True
+
+    def seekable(self):
+        return False
+
+    # Compatibility methods for ChunkedFile interface used by FileDownload
+    def get_next_missing_range(self, start=None, end=None, full_range=False):
+        """For TransferFile, if not complete, return the full range."""
+        if self.is_complete(start, end):
+            return None, None, None
+        # Return full file range as missing
+        range_start = start or 0
+        range_end = (
+            end if end is not None else (self._file_size - 1 if self._file_size else 0)
+        )
+        return (0,), range_start, range_end
+
+    @contextmanager
+    def lock_chunks(self, *chunk_indices):
+        """No-op context manager for compatibility."""
+        yield
+
+    def chunk_complete(self, chunk_index):
+        """For TransferFile, chunks don't exist - return based on file completion."""
+        return self.is_complete()
+
+    def all_chunks(self, *skip_chunks):
+        """Return empty generator since TransferFile doesn't use chunks."""
+        return iter([])
+
+    def write_chunks(self, chunks, data_generator, progress_callback=None):
+        """Write chunks - for TransferFile just write all data sequentially."""
+        self.write_all(data_generator, progress_callback)
+
+
 class Transfer(metaclass=ABCMeta):
     DEFAULT_TIMEOUT = 60
 
@@ -522,14 +712,6 @@ class Transfer(metaclass=ABCMeta):
     def run(self, progress_update=None):
         pass
 
-    @abstractmethod
-    def _move_tmp_to_dest(self):
-        pass
-
-    @abstractmethod
-    def delete(self):
-        pass
-
     def __enter__(self):
         self.start()
         return self
@@ -548,14 +730,13 @@ class Transfer(metaclass=ABCMeta):
         logger.info("Canceling import: {}".format(self.source))
         self.close()
         try:
-            self.delete()
+            self.dest_file_obj.delete()
         except OSError:
             pass
         self.canceled = True
 
-    @abstractmethod
     def _checksum_correct(self):
-        pass
+        return self.dest_file_obj.md5_checksum() == self.checksum
 
     def _verify_checksum(self):
         # If checksum of the destination file is different from the localfile
@@ -566,7 +747,7 @@ class Transfer(metaclass=ABCMeta):
             e = "File {} is corrupted.".format(self.source)
             logger.error("An error occurred during content import: {}".format(e))
             try:
-                self.delete()
+                self.dest_file_obj.delete()
             except OSError:
                 pass
             raise TransferFailed(
@@ -586,7 +767,7 @@ class Transfer(metaclass=ABCMeta):
             return
 
         self._verify_checksum()
-        self._move_tmp_to_dest()
+        self.dest_file_obj.finalize_file()
         self.finalized = True
 
     def close(self):
@@ -639,14 +820,24 @@ class FileDownload(Transfer):
             source, dest, checksum=checksum, cancel_check=cancel_check
         )
 
-        self._initialize_chunked_file()
+        self._initialize_dest_file()
 
-    def _initialize_chunked_file(self):
-        self.dest_file_obj = ChunkedFile(self.dest)
-
+    def _set_completed(self):
         self.completed = self.dest_file_obj.is_complete(
             start=self.range_start, end=self.range_end
         )
+
+    def _initialize_dest_file(self):
+        try:
+            self.dest_file_obj = ChunkedFile(
+                self.dest,
+                raise_if_empty=self.full_ranges,
+                raise_if_exists=self.full_ranges,
+            )
+        except FileNotFoundError:
+            # No chunked file exists, use TransferFile for direct download
+            self.dest_file_obj = TransferFile(self.dest)
+        self._set_completed()
 
     def set_range(self, range_start, range_end):
         if range_start is not None and not isinstance(range_start, int):
@@ -673,6 +864,10 @@ class FileDownload(Transfer):
             self.transfer_size = value
 
     @property
+    def chunked_file_download(self):
+        return isinstance(self.dest_file_obj, ChunkedFile)
+
+    @property
     def finalize_download(self):
         return (
             self._finalize_download
@@ -684,20 +879,6 @@ class FileDownload(Transfer):
         if not self.finalize_download:
             return
         return super(FileDownload, self).finalize()
-
-    def _move_tmp_to_dest(self):
-        try:
-            self.dest_file_obj.finalize_file()
-            self.dest_file_obj.delete()
-        except FileNotFoundError as e:
-            if not os.path.exists(self.dest):
-                raise e
-
-    def delete(self):
-        self.dest_file_obj.delete()
-
-    def _checksum_correct(self):
-        return self.dest_file_obj.md5_checksum() == self.checksum
 
     def _catch_exception_and_retry(func):
         def inner(self, *args, **kwargs):
@@ -717,7 +898,7 @@ class FileDownload(Transfer):
                         logger.error(
                             "Error writing to chunked file, retrying: {}".format(e)
                         )
-                        self._initialize_chunked_file()
+                        self._initialize_dest_file()
                         self._headers_set = False
                         self._set_headers()
                     logger.info(
@@ -733,10 +914,11 @@ class FileDownload(Transfer):
 
     @_catch_exception_and_retry
     def run(self, progress_update=None):
+        self._set_completed()
         if not self.completed:
             try:
                 self._run_download(progress_update=progress_update)
-            except ChunkedFileDoesNotExist:
+            except (ChunkedFileDoesNotExist, ValueError):
                 # If the chunked file does not exist, we need to start from the beginning
                 # unless a simultaneous download has already completed the file.
                 if not os.path.exists(self.dest):
@@ -759,19 +941,7 @@ class FileDownload(Transfer):
         self.transfer_size = header_info["transfer_size"]
         self._headers_set = True
 
-    def _set_headers(self):
-        if self._headers_set:
-            return
-
-        response = self.session.head(
-            self.source, timeout=self.timeout, allow_redirects=True
-        )
-        response.raise_for_status()
-
-        if response.url != self.source:
-            logger.debug("Redirected from {} to {}".format(self.source, response.url))
-            self.source = response.url
-
+    def _set_transfer_info_from_response(self, response):
         self.compressed = bool(response.headers.get("content-encoding", ""))
 
         self.content_length_header = "content-length" in response.headers
@@ -786,6 +956,21 @@ class FileDownload(Transfer):
             if gcs_content_length:
                 self.transfer_size = int(gcs_content_length)
         self._headers_set = True
+
+    def _set_headers(self):
+        if self._headers_set or not self.chunked_file_download:
+            return
+
+        response = self.session.head(
+            self.source, timeout=self.timeout, allow_redirects=True
+        )
+        response.raise_for_status()
+
+        if response.url != self.source:
+            logger.debug("Redirected from {} to {}".format(self.source, response.url))
+            self.source = response.url
+
+        self._set_transfer_info_from_response(response)
 
     @_catch_exception_and_retry
     def start(self):
@@ -821,6 +1006,7 @@ class FileDownload(Transfer):
                     data_generator = response.iter_content(
                         self.dest_file_obj.chunk_size
                     )
+                    self.dest_file_obj.ensure_writable()
                     if range_response_supported:
                         self.dest_file_obj.write_chunks(
                             chunk_indices,
@@ -848,22 +1034,21 @@ class FileDownload(Transfer):
                 )
 
     def _run_no_byte_range_download(self, progress_callback):
-        with self.dest_file_obj.lock_chunks(self.dest_file_obj.all_chunks()):
-            response = self.session.get(self.source, stream=True, timeout=self.timeout)
-            response.raise_for_status()
-            generator = response.iter_content(self.dest_file_obj.chunk_size)
-            self.dest_file_obj.write_all(generator, progress_callback=progress_callback)
-
-    def _run_no_byte_range_download_no_total_size(self, progress_callback):
         response = self.session.get(self.source, stream=True, timeout=self.timeout)
         response.raise_for_status()
-        # Doing this exhausts the iterator, so if we need to do this, we need
-        # to return the dummy iterator below, as the iterator will be empty,
-        # and all content is now stored in memory. So we should avoid doing this as much
-        # as we can, hence the total size check before this function is invoked.
-        self.total_size = len(response.content)
-        with self.dest_file_obj.lock_chunks(self.dest_file_obj.all_chunks()):
+        if not self._headers_set:
+            self._set_transfer_info_from_response(response)
+        if not self.total_size:
+            # Doing this exhausts the iterator, so if we need to do this, we need
+            # to return the dummy iterator below, as the iterator will be empty,
+            # and all content is now stored in memory. So we should avoid doing this as much
+            # as we can, hence the total size check before this function is invoked.
+            self.total_size = len(response.content)
             generator = self.dest_file_obj.chunk_generator(response.content)
+        else:
+            generator = response.iter_content(self.dest_file_obj.chunk_size)
+        self.dest_file_obj.ensure_writable()
+        with self.dest_file_obj.lock_chunks(self.dest_file_obj.all_chunks()):
             self.dest_file_obj.write_all(generator, progress_callback=progress_callback)
 
     def _run_download(self, progress_update=None):
@@ -879,12 +1064,18 @@ class FileDownload(Transfer):
         # from their Accept-Ranges header. So we need to check if the server supports range requests
         # by trying to make a range request, and if it fails, we need to fall back to the old
         # behavior of downloading the whole file.
-        if self.content_length_header and not self.compressed:
+        # We also only bother doing byte range downloads if we are writing to a ChunkedFile,
+        # as there is no point in doing byte range requests if we are downloading to a single
+        # file anyway.
+        byte_range_download = (
+            self.content_length_header
+            and not self.compressed
+            and isinstance(self.dest_file_obj, ChunkedFile)
+        )
+        if byte_range_download:
             self._run_byte_range_download(progress_callback)
-        elif self.total_size:
-            self._run_no_byte_range_download(progress_callback)
         else:
-            self._run_no_byte_range_download_no_total_size(progress_callback)
+            self._run_no_byte_range_download(progress_callback)
 
     def close(self):
         if hasattr(self, "response"):
@@ -898,30 +1089,12 @@ class FileCopy(Transfer):
             raise AssertionError(
                 "File copy has already been started, and cannot be started again"
             )
-        self.dest_tmp = self.dest + ".transfer"
-        if os.path.isfile(self.dest_tmp):
-            try:
-                os.remove(self.dest_tmp)
-            except OSError:
-                pass
-        self.dest_file_obj = open(self.dest_tmp, "wb")
+        self.dest_file_obj = TransferFile(self.dest)
         self.total_size = os.path.getsize(self.source)
         self.transfer_size = self.total_size
+        self.dest_file_obj.file_size = self.total_size
         self.source_file_obj = open(self.source, "rb")
         self.started = True
-        self.hasher = hashlib.md5()
-
-    def _move_tmp_to_dest(self):
-        replace(self.dest_tmp, self.dest)
-
-    def delete(self):
-        try:
-            os.remove(self.dest_tmp)
-        except OSError:
-            pass
-
-    def _checksum_correct(self):
-        return self.hasher.hexdigest() == self.checksum
 
     def run(self, progress_update=None):
         while True:
@@ -930,7 +1103,6 @@ class FileCopy(Transfer):
             if not block:
                 break
             self.dest_file_obj.write(block)
-            self.hasher.update(block)
             if callable(progress_update):
                 progress_update(len(block))
         self.complete_close_and_finalize()

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -4,7 +4,7 @@ import math
 import os
 import shutil
 import sys
-from abc import ABCMeta
+from abc import ABC
 from abc import abstractmethod
 from contextlib import contextmanager
 from io import BufferedIOBase
@@ -119,7 +119,7 @@ class ChunkedFileDoesNotExist(Exception):
 CHUNK_SUFFIX = ".chunks"
 
 
-class TransferFileBase(BufferedIOBase, metaclass=ABCMeta):
+class TransferFileBase(BufferedIOBase, ABC):
     """Abstract base class for file transfer destination objects."""
 
     @property
@@ -258,7 +258,7 @@ class ChunkedFile(TransferFileBase):
 
     @property
     def chunks_count(self):
-        return int(math.ceil(float(self.file_size) / float(self.chunk_size)))
+        return math.ceil(float(self.file_size) / float(self.chunk_size))
 
     @property
     def file_size(self):
@@ -525,8 +525,7 @@ class TransferFile(TransferFileBase):
         self.hasher = hashlib.md5()
         self._bytes_written = 0
 
-        # ensure the directories in the destination path exist
-        mkdirp(os.path.dirname(self.filepath), exist_ok=True)
+        self.ensure_writable()
 
     @property
     def file_size(self):
@@ -549,7 +548,8 @@ class TransferFile(TransferFileBase):
         return False
 
     def ensure_writable(self):
-        pass
+        # ensure the directories in the destination path exist
+        mkdirp(os.path.dirname(self.filepath), exist_ok=True)
 
     def write(self, data):
         """Write data to the transfer file."""
@@ -652,7 +652,7 @@ class TransferFile(TransferFileBase):
         self.write_all(data_generator, progress_callback)
 
 
-class Transfer(metaclass=ABCMeta):
+class Transfer(ABC):
     DEFAULT_TIMEOUT = 60
 
     def __init__(
@@ -914,6 +914,9 @@ class FileDownload(Transfer):
 
     @_catch_exception_and_retry
     def run(self, progress_update=None):
+        # The initial _set_completed call is done when the dest_file_obj is initialized
+        # we call this again in case in the meantime, another process has completed the file,
+        # or cleaned up the chunked file.
         self._set_completed()
         if not self.completed:
             try:

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -49,6 +49,7 @@ class TestChunkedFile(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
+        shutil.rmtree(self.file_path, ignore_errors=True)
 
     def test_read(self):
         # Read from the beginning
@@ -297,6 +298,16 @@ class TestChunkedFile(unittest.TestCase):
         with self.assertRaises(ChunkedFileDoesNotExist):
             with self.chunked_file.lock_chunks(0):
                 pass
+
+    def test_chunked_file_raise_if_empty(self):
+        with self.assertRaises(FileNotFoundError):
+            ChunkedFile("empty_file", raise_if_empty=True)
+
+    def test_chunked_file_raise_if_exists(self):
+        with open(self.file_path, "wb") as f:
+            f.write(b"data")
+        with self.assertRaises(FileExistsError):
+            ChunkedFile(self.file_path, raise_if_exists=True)
 
 
 # The expected number of bytes taken up by files used in the diskcache

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -180,7 +180,9 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
         self.source = "http://example.com/testfile"
         self.set_session_mock()
 
-    def _assert_request_calls(self, start_range=0, end_range=None):
+    def _assert_request_calls(
+        self, start_range=0, end_range=None, chunked_file_exists=True
+    ):
         end_range = end_range or self.file_size - 1
         first_download_chunk = start_range // ChunkedFile.chunk_size
         last_download_chunk = end_range // ChunkedFile.chunk_size
@@ -203,20 +205,34 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
                 collapsed_chunks.append((start, end))
             download_chunks = collapsed_chunks
 
-        calls = [
-            call(
-                self.source,
-                headers={
-                    "Range": "bytes={}-{}".format(
-                        i * ChunkedFile.chunk_size,
-                        min(j * ChunkedFile.chunk_size, self.file_size) - 1,
-                    )
-                },
-                stream=True,
-                timeout=60,
-            )
-            for i, j in download_chunks
-        ]
+        calls = []
+
+        unchunked_download = (
+            self.full_ranges
+            and len(download_chunks) == 1
+            and download_chunks[0] == (0, last_download_chunk + 1)
+        )
+
+        for i, j in download_chunks:
+            if unchunked_download and not chunked_file_exists:
+                download_call = call(
+                    self.source,
+                    stream=True,
+                    timeout=60,
+                )
+            else:
+                download_call = call(
+                    self.source,
+                    headers={
+                        "Range": "bytes={}-{}".format(
+                            i * ChunkedFile.chunk_size,
+                            min(j * ChunkedFile.chunk_size, self.file_size) - 1,
+                        )
+                    },
+                    stream=True,
+                    timeout=60,
+                )
+            calls.append(download_call)
 
         if not self.byte_range_support:
             if self.attempt_byte_range:
@@ -266,6 +282,32 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
         self._assert_downloaded_content()
         self.assertEqual(self.mock_session.head.call_count, 0)
         self.assertEqual(self.mock_session.get.call_count, 0)
+
+    def test_download_run_no_existing_chunked_file(self):
+        """Test downloading entire file when no chunked file exists"""
+        # Create a fresh destination without any chunked file setup
+        fresh_dest = self.destdir + "/fresh_file_{}".format(self.num_files + 100)
+
+        with FileDownload(
+            self.source,
+            fresh_dest,
+            self.checksum,
+            session=self.mock_session,
+            full_ranges=self.full_ranges,
+        ) as fd:
+            fd.run()
+
+        # Verify file was downloaded correctly
+        with open(fresh_dest, "rb") as f:
+            downloaded_content = f.read()
+        self.assertEqual(downloaded_content, self.content)
+
+        # For entire file download with no existing chunked file,
+        # and full ranges set should skip HEAD request and download directly
+        self.assertEqual(
+            self.mock_session.head.call_count, 0 if self.full_ranges else 1
+        )
+        self._assert_request_calls(chunked_file_exists=False)
 
     def test_download_checksum_validation(self):
         # Test FileDownload checksum validation
@@ -498,14 +540,23 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
                 session=self.mock_session,
                 full_ranges=self.full_ranges,
             ) as fd1:
+                chunked_file_download = fd1.chunked_file_download
                 fd1.run()
             fd2.run()
         self._assert_downloaded_content()
+        if self.byte_range_support and not self.full_ranges and chunked_file_download:
+            expected_calls = self.chunks_count
+        elif (
+            not self.byte_range_support
+            and self.full_ranges
+            and not chunked_file_download
+        ):
+            expected_calls = 2
+        else:
+            expected_calls = 1
         self.assertEqual(
             self.mock_session.get.call_count,
-            self.chunks_count
-            if self.byte_range_support and not self.full_ranges
-            else 1,
+            expected_calls,
         )
         self._assert_request_calls()
 
@@ -528,7 +579,7 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
             if self.byte_range_support and not self.full_ranges
             else 1,
         )
-        self._assert_request_calls()
+        self._assert_request_calls(chunked_file_exists=False)
 
 
 class TestTransferNoFullRangesDownloadByteRangeSupport(


### PR DESCRIPTION
## Summary
In 0.16 to accommodate remote file browsing, I changed all file downloading to use the ChunkedFile object to accommodate simultaneous remote browsing and file download. This created a lot more file overhead, always creating a cache database, chunked files etc. etc. even when it was a dedicated file download with no remote browsing needed.

This partially reverts some of that work to ensure that in the case where we are trying to download full files, and there is no simultaneous or previous partial file download still active, we skip the ChunkedFile overhead and just download with a straight forward GET request.

This has two performance advantages - it no longer creates directories, caches, and separate files, and it also reduces requests from a HEAD request and a GET request (using range headers for the full length of the file) to just a GET request with no range headers.

By a happy coincidence, we've been having some issues with range requests and Cloudflare recently, so reducing the number of range requests we have to handle, hopefully will make things smoother there too.

## References
4th fix for https://github.com/learningequality/kolibri/issues/13680

Depends on https://github.com/learningequality/kolibri/pull/13689

## Reviewer guidance
How much faster is this for downloading KA en?