### PR TITLE
Fixes the remove icon enabled when a super admin is selected

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -205,6 +205,7 @@
       });
 
       const selectedUsers = ref(new Set());
+      const currentUserId = store.getters.currentUserId;
 
       const showUsersTable = computed(
         () =>
@@ -269,6 +270,7 @@
         noNewUsersLabel$,
         addNewUserLabel$,
         noNewUsersDescription$,
+        currentUserId,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -160,6 +160,7 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
   import { UserKinds } from 'kolibri/constants';
+  import useUser from 'kolibri/composables/useUser';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
   import { PageNames } from '../../constants';
@@ -205,7 +206,7 @@
       });
 
       const selectedUsers = ref(new Set());
-      const currentUserId = store.getters.currentUserId;
+      const { currentUserId } = useUser();
 
       const showUsersTable = computed(
         () =>


### PR DESCRIPTION


## Summary
This PR fixes  issue in the New Users table where the Remove selected users (trash) icon became enabled when the currently loggedin super admin is selected. The button should remain disabled in this case to prevent accidental self-removal.
closes #13693

## References
#13693

## Reviewer guidance
Go to Facility > New users and attempt to remove the user that you are currently signed in with
