### PR TITLE
Fixes selected users clearing before  an action is completed

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -222,6 +222,7 @@
       } = bulkUserManagementStrings;
 
       function onModalBlur() {
+        selectedUsers.value.clear();
         usersTableRef.value?.focus();
       }
 

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -125,7 +125,6 @@
         :selectedUsers="selectedUsers"
         :onBlur="onModalBlur"
         :onChange="onChange"
-        @hook:beforeDestroy="selectedUsers = new Set()"
       />
 
       <!-- Modals -->

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -223,6 +223,7 @@
 
       function onModalBlur() {
         selectedUsers.value.clear();
+        selectedUsers.value = new Set(selectedUsers.value);
         usersTableRef.value?.focus();
       }
 

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -111,7 +111,6 @@
           :onBlur="onModalBlur"
           :onChange="onChange"
           @clearSelection="clearSelectedUsers"
-          @hook:beforeDestroy="selectedUsers = new Set()"
         />
 
         <!-- Modals -->

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -204,7 +204,7 @@
 
       function onModalBlur() {
         selectedUsers.value.clear();
-        usersTableRef.value?.focus();
+        selectedUsers.value = new Set(selectedUsers.value);
       }
 
       function navigateToSidePanel(sidePanelName) {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -203,6 +203,7 @@
       }
 
       function onModalBlur() {
+        selectedUsers.value.clear();
         usersTableRef.value?.focus();
       }
 

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -501,21 +501,24 @@
         const { checked } = selectAllState.value;
 
         if (checked) {
-          visibleUserIds.forEach(id => _selectedUsers.value.delete(id));
+          _selectedUsers.value = new Set(
+            [..._selectedUsers.value].filter(id => !visibleUserIds.includes(id)),
+          );
         } else {
-          visibleUserIds.forEach(id => _selectedUsers.value.add(id));
+          const newSet = new Set(_selectedUsers.value);
+          visibleUserIds.forEach(id => newSet.add(id));
+          _selectedUsers.value = newSet;
         }
-
-        _selectedUsers.value = new Set(_selectedUsers.value);
       };
 
       const handleUserSelectionToggle = user => {
-        if (_selectedUsers.value.has(user.id)) {
-          _selectedUsers.value.delete(user.id);
+        const newSet = new Set(_selectedUsers.value);
+        if (newSet.has(user.id)) {
+          newSet.delete(user.id);
         } else {
-          _selectedUsers.value.add(user.id);
+          newSet.add(user.id);
         }
-        _selectedUsers.value = new Set(_selectedUsers.value);
+        _selectedUsers.value = newSet;
       };
 
       const clearSelectedUsers = () => {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -215,6 +215,7 @@
           props.onChange({
             affectedClasses: selectedClasses.value,
           });
+          emit('clearSelection');
           closeSidePanel();
           return true;
         } catch (error) {
@@ -270,7 +271,6 @@
       });
 
       function closeSidePanel() {
-        emit('clearSelection');
         goBack();
       }
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -124,7 +124,7 @@
       SelectableList,
       CloseConfirmationGuard,
     },
-    setup(props) {
+    setup(props, { emit }) {
       const selectedClasses = ref([]); // Array of selected class IDs
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
@@ -270,6 +270,7 @@
       });
 
       function closeSidePanel() {
+        emit('clearSelection');
         goBack();
       }
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -124,7 +124,7 @@
       SelectableList,
       CloseConfirmationGuard,
     },
-    setup(props, { emit }) {
+    setup(props) {
       const selectedClasses = ref([]); // Array of selected class IDs
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
@@ -214,8 +214,8 @@
           await assignCoachesToClasses();
           props.onChange({
             affectedClasses: selectedClasses.value,
+            resetSelection: true,
           });
-          emit('clearSelection');
           closeSidePanel();
           return true;
         } catch (error) {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -123,7 +123,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props, { emit }) {
+    setup(props) {
       const loading = ref(false);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -220,8 +220,8 @@
         }
         props.onChange({
           affectedClasses: selectedOptions.value,
+          resetSelection: true,
         });
-        emit('clearSelection');
         goBack();
         return true;
       }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -123,7 +123,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props) {
+    setup(props, { emit }) {
       const loading = ref(false);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -221,6 +221,7 @@
         props.onChange({
           affectedClasses: selectedOptions.value,
         });
+        emit('clearSelection');
         goBack();
         return true;
       }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -125,7 +125,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props) {
+    setup(props, { emit }) {
       const closeConfirmationGuardRef = ref(null);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -287,6 +287,7 @@
           props.onChange({
             affectedClasses: selectedOptions.value,
           });
+          emit('clearSelection');
           goBack();
           return true;
         } catch (error) {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -125,7 +125,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props, { emit }) {
+    setup(props) {
       const closeConfirmationGuardRef = ref(null);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -257,6 +257,7 @@
         ]);
         props.onChange({
           affectedClasses: selectedOptions.value,
+          resetSelection: true,
         });
       }
 
@@ -287,7 +288,6 @@
           props.onChange({
             affectedClasses: selectedOptions.value,
           });
-          emit('clearSelection');
           goBack();
           return true;
         } catch (error) {


### PR DESCRIPTION


## Summary
This PR fixes the issue where selected users in the Users table were being cleared whenever a side panel (Assign Coach, Enroll in Class, Remove from Class) was opened and then closed.
fixes #13691
## References
#13691

## Reviewer guidance

- Go to Facility > Users and select several users
- Open any of the available options such as "Assign coach", "Enroll in class", "Remove from class" and then close the side panel
