### PR TITLE
Adds regression test and fixes issue where unavailable nodes are not flagged for import.

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -272,6 +272,35 @@ class GetImportExportNodesTestCase(TestCase):
             expected_content_nodes,
         )
 
+    def test_unavailable_node_with_available_files_included_when_available_false(self):
+        # Get a node that exists in the test data
+        test_node = ContentNode.objects.get(
+            pk=self.c2c1_node_id, channel_id=self.the_channel_id
+        )
+
+        # Mark the node as unavailable but ensure its files are available
+        test_node.available = False
+        test_node.save()
+
+        # Ensure all local files for this node are marked as available
+        for file_obj in test_node.files.all():
+            local_file = file_obj.local_file
+            local_file.available = True
+            local_file.save()
+
+        # When available=False, the node should be included in the result
+        # even though it's marked unavailable (because it has available files)
+        matched_nodes_queries_list = get_import_export_nodes(
+            self.the_channel_id, renderable_only=False, available=False
+        )
+
+        result_node_ids = [
+            node.pk
+            for node in itertools.chain.from_iterable(matched_nodes_queries_list)
+        ]
+
+        self.assertIn(self.c2c1_node_id, result_node_ids)
+
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
 class GetContentNodesDataTestCase(TestCase):

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -164,11 +164,14 @@ def get_import_export_nodes(  # noqa: C901
 
     # When exporting, only include available nodes. When importing, include any
     # nodes that are missing files in case they have missing supplementary
-    # files and would be considered available.
+    # files and would be considered available, or conversely, have all their files
+    # but are not currently marked as available.
     if available is True:
         nodes_to_include = nodes_to_include.filter(available=True)
     elif available is False:
-        nodes_to_include = nodes_to_include.filter(files__local_file__available=False)
+        nodes_to_include = nodes_to_include.filter(
+            Q(files__local_file__available=False) | Q(available=False)
+        )
 
     if check_file_availability:
         nodes_to_include = filter_by_file_availability(


### PR DESCRIPTION
## Summary
* Activation of the import button is dependent on the backend reporting that any resources need to be imported
* The backend was inadvertently excluding resources that were marked as not available, but for which all files were already available
* This adds a regression test for this, and fixes the issue by additionally including unavailable content nodes for import only

## References
Fixes [#13610](https://github.com/learningequality/kolibri/issues/13610)

## Reviewer guidance

* Import a resource in a Kolibri Library channel into your local Kolibri device
* Create a channel on Kolibri Studio that includes just that resource imported from the Kolibri Library into your Kolibri Studio channel
* Publish the channel
* Attempt to import it into Kolibri - see that this is now possible!
