### PR TITLE
Ensure lesson resources load correctly across users and roles

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -370,12 +370,32 @@
           node: this.content,
           lessonId: this.lessonId,
           repeat,
-        }).then(() => {
-          this.sessionReady = true;
-          this.wasComplete = this.progress >= 1;
-          // Set progress into the content node progress store in case it was not already loaded
-          this.cacheProgress();
-        });
+        })
+          .then(() => {
+            this.sessionReady = true;
+            this.wasComplete = this.progress >= 1;
+            // Set progress into the content node progress store in case it was not already loaded
+            this.cacheProgress();
+          })
+          .catch(error => {
+            if (
+              error.response &&
+              error.response.status === 400 &&
+              error.response.data &&
+              error.response.data.includes('Invalid lesson_id')
+            ) {
+              this.$router.replace({ ...this.$route, query: null });
+              return this.initContentSession({
+                node: this.content,
+                repeat,
+              }).then(() => {
+                this.sessionReady = true;
+                this.wasComplete = this.progress >= 1;
+                this.cacheProgress();
+              });
+            }
+            throw error;
+          });
       },
       repeat() {
         this.stopTracking().then(() => {


### PR DESCRIPTION

## Summary
- Handle invalid lesson_id errors by stripping query params for learners not assigned to the lesson

## References
closes #12061

## Reviewer guidance
- Create a class with two learners.
- Assign one of the learner a lesson with resource like a pdf.
- Open the resource from the assigned learner and copy the url.
- Check if you can preview the same resource using the URL from a newly created user and from the other user assigned to class. 