### PR TITLE
Update Learn > Library Sidepanel to give access to all the folder resources

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -70,6 +70,18 @@
           </div>
         </div>
       </KRouterLink>
+      <div
+        v-if="contentNodes.length && moreContentNodesAvailable"
+        class="view-more-container"
+      >
+        <KButton
+          v-if="!moreContentNodesLoading"
+          :text="coreString('viewMoreAction')"
+          appearance="basic-link"
+          @click="$emit('loadMoreContentNodes')"
+        />
+        <KCircularLoader v-else />
+      </div>
     </div>
 
     <KCircularLoader v-else-if="loading" />
@@ -115,6 +127,7 @@
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
   import { validateObject } from 'kolibri/utils/objectSpecs';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import useContentLink from '../composables/useContentLink';
   import ProgressBar from './ProgressBar';
@@ -127,6 +140,7 @@
       TimeDuration,
       MissingResourceAlert,
     },
+    mixins: [commonCoreStrings],
     setup() {
       const { contentNodeProgressMap } = useContentNodeProgress();
       const { genContentLinkKeepCurrentBackLink, genContentLinkKeepPreviousBackLink } =
@@ -160,6 +174,20 @@
             }),
           );
         },
+      },
+      /**
+       * The "more" object from the API response if additional content nodes
+       * are available; otherwise, null. If non-null, a "View More" button
+       * will be displayed at the bottom of the list of contentNodes.
+       */
+      moreContentNodesAvailable: {
+        type: Object,
+        required: false,
+        default: null,
+      },
+      moreContentNodesLoading: {
+        type: Boolean,
+        default: false,
       },
       nextFolder: {
         type: Object,
@@ -288,6 +316,15 @@
     width: 100%;
     min-height: 72px;
     padding: 20px 0;
+  }
+
+  .view-more-container {
+    position: relative;
+    left: 10px;
+    display: grid;
+    justify-content: flex-start;
+    width: 100%;
+    padding-bottom: 20px;
   }
 
   .activity-icon,

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -129,11 +129,14 @@
       <AlsoInThis
         style="margin-top: 8px"
         :contentNodes="viewResourcesContents"
+        :moreContentNodesAvailable="moreResourcesContentAvailable"
+        :moreContentNodesLoading="moreResourcesContentLoading"
         :nextFolder="nextFolder"
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
         :currentResourceId="currentResourceId"
         :missingLessonResources="missingLessonResources"
+        @loadMoreContentNodes="loadMoreResourcesContent"
       />
     </SidePanelModal>
     <KModal
@@ -248,6 +251,9 @@
       const channel = ref(null);
       const content = ref(null);
       const loading = ref(false);
+      const viewResourcesContents = ref([]);
+      const moreResourcesContentAvailable = ref(null);
+      const moreResourcesContentLoading = ref(false);
 
       function _loadTopicsContent(shouldResolve, baseurl) {
         const id = props.id;
@@ -309,6 +315,31 @@
         });
       }
 
+      function loadMoreResourcesContent() {
+        const more = moreResourcesContentAvailable.value;
+        if (!more) {
+          return Promise.resolve(viewResourcesContents.value);
+        }
+        moreResourcesContentLoading.value = true;
+        // Fetch progress data for logged in users on local content
+        const shouldFetchProgress = get(isUserLoggedIn) && !props.deviceId;
+        if (shouldFetchProgress) {
+          fetchContentNodeTreeProgress(more);
+        }
+        // Fetch additional content nodes
+        return ContentNodeResource.fetchTree(more)
+          .then(({ children }) => {
+            viewResourcesContents.value = [...viewResourcesContents.value, ...children.results];
+            moreResourcesContentAvailable.value = children.more;
+          })
+          .catch(error => {
+            store.dispatch('handleApiError', { error });
+          })
+          .finally(() => {
+            moreResourcesContentLoading.value = false;
+          });
+      }
+
       watch(() => props.id, showTopicsContent);
       showTopicsContent();
 
@@ -335,6 +366,10 @@
         isSuperuser,
         currentUserId,
         showCompletedDownloadSnackbar,
+        viewResourcesContents,
+        moreResourcesContentAvailable,
+        loadMoreResourcesContent,
+        moreResourcesContentLoading,
       };
     },
     props: {
@@ -365,7 +400,6 @@
         sidePanelContent: null,
         showViewResourcesSidePanel: false,
         nextFolder: null,
-        viewResourcesContents: [],
         resourcesSidePanelFetched: false,
         resourcesSidePanelLoading: false,
         contentPageMounted: false,
@@ -622,6 +656,7 @@
           }
           this.nextFolder = nextFolders.find(c => c.kind === ContentNodeKinds.TOPIC) || null;
           this.viewResourcesContents = parent.children.results.filter(n => n.id);
+          this.moreResourcesContentAvailable = parent.children.more || null;
         });
       },
       navigateBack() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds "View More" button at the bottom of the list of `contentNodes` to `AlsoInThis` component 
- Updates `TopicsContentPage` to fetch and load more folder resources for the side panel when "View More" button is clicked

Before:

<img width="1149" height="861" alt="before" src="https://github.com/user-attachments/assets/c5f94417-2eb6-4a1b-a5fd-0fb88a05fc81" />

After:

<img width="1964" height="1716" alt="after" src="https://github.com/user-attachments/assets/1ccd5ca9-d615-47e9-ac4b-23dc3f279714" />


https://github.com/user-attachments/assets/fb91f713-7763-4f47-a5d4-40af987efb10


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13574 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. On the Library page, under Other Libraries, select a library and a folder.
2. Open a resource where there is a view more button at the end of the display of folder resources.
<img width="2044" height="1684" alt="Screenshot" src="https://github.com/user-attachments/assets/0193482b-4d4c-479e-b20c-90cd48efb418" />

3. Select the View folder resources button to see the "View More" button at the end of the list of resources in the side panel.


**Note:** Although the side-panel was not designed for pagination, [this comment](https://github.com/learningequality/kolibri/blob/5511d32b6b4ad53a8b37f2bb25a2aa12e9395634/kolibri/core/content/api.py#L969) mentions that the max recursed page size should be under 25 because the query remains performant and retrieves most of the tree data in a single request, and results in at most 651 SQL query parameters, preventing SQL parameter limit issues. So I opted to keep the returned nodes at 12 because the resources include more than a list of titles: each is an object with id, title, duration, progress, and a topic flag, used for the visual display, `VueRouter` links, and navigation to the next folder or topic content page.