### PR TITLE
Fix: Prevent time desynchronization in survey report dropdowns

### DIFF
--- a/packages/kolibri-common/components/quizzes/QuizReport/index.vue
+++ b/packages/kolibri-common/components/quizzes/QuizReport/index.vue
@@ -201,7 +201,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import MasteryLogResource from 'kolibri-common/apiResources/MasteryLogResource';
-  import { now } from 'kolibri/utils/serverClock';
+  import useNow from 'kolibri/composables/useNow';
   import { annotateSections } from 'kolibri-common/quizzes/utils';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import { displaySectionTitle } from 'kolibri-common/strings/enhancedQuizManagementStrings';
@@ -226,8 +226,10 @@
     mixins: [commonCoreStrings],
     setup() {
       const { windowIsSmall } = useKResponsiveWindow();
+      const { now } = useNow();
       return {
         windowIsSmall,
+        now,
       };
     },
     props: {
@@ -353,7 +355,6 @@
     data() {
       return {
         showCorrectAnswer: false,
-        now: now(),
         pastTries: [],
         currentTry: null,
         loading: true,


### PR DESCRIPTION
## Summary
Modified component to include reactive `now` from `useNow()`

## References
closes #13632

## Reviewer guidance
- Coach: Assign a survey to learner -> Learner takes quiz 2-3 times
Access the report page
Coach: Go to survey report -> Verify dropdown with multiple attempts
- Test time synchronization, leave the report page open for 2 minutes and observe both the "Attempted" field and the dropdown options.