### PR TITLE
Disable Kolibri Onboarding feature in develop

### DIFF
--- a/packages/kolibri/composables/useTour.js
+++ b/packages/kolibri/composables/useTour.js
@@ -8,16 +8,19 @@ const tourActive = ref(false);
 const currentStepIndex = ref(0);
 const tourActiveMap = reactive({});
 
+// Temporarily disabling tour; uncomment lines 15-22 to re-enable
+// eslint-disable-next-line no-unused-vars
 function startTour(pageName) {
   // Small delay to let users see the page before tour darkens it
-  setTimeout(() => {
-    localStorage.setItem(TOUR_ACTIVE, 'true');
-    tourActive.value = true;
-    Object.keys(tourActiveMap).forEach(key => {
-      tourActiveMap[key] = false;
-    });
-    tourActiveMap[pageName] = true;
-  }, 400);
+  // setTimeout(() => {
+  //   localStorage.setItem(TOUR_ACTIVE, 'true');
+  //   tourActive.value = true;
+  //   Object.keys(tourActiveMap).forEach(key => {
+  //     tourActiveMap[key] = false;
+  //   });
+  //   tourActiveMap[pageName] = true;
+  // }, 400);
+  return;
 }
 
 function endTour(pageName) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Disables the Kolibri onboarding feature in order to postpone its usage until the Kolibri 0.20 release

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #13688 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Setup Kolibri using the On My Own workflow and ensure that the onboarding tour does not start on the Library page, when opening the side navigation, or when viewing the resources within another library.
