### PR TITLE
Fix long text input in free response questions

### DIFF
--- a/kolibri/plugins/qti_viewer/assets/src/components/interactions/TextEntryInteraction.vue
+++ b/kolibri/plugins/qti_viewer/assets/src/components/interactions/TextEntryInteraction.vue
@@ -3,7 +3,7 @@
   <input
     v-if="interactive"
     v-model="variable"
-    class="qti-text-entry-interaction qti-text-entry-interaction-interactive"
+    class="qti-text-entry-interaction"
     :placeholder="placeholder"
     :style="{
       minWidth: `${Math.min(expectedLength ?? 20, 20)}ch`,
@@ -75,14 +75,6 @@
 
 
 <style scoped>
-
-  .qti-text-entry-interaction-interactive {
-    padding: 8px;
-    font-family: inherit;
-    font-size: inherit;
-    border: 1px solid #cccccc;
-    border-radius: 4px;
-  }
 
   .qti-text-entry-interaction-report {
     box-sizing: border-box;

--- a/kolibri/plugins/qti_viewer/assets/src/components/interactions/TextEntryInteraction.vue
+++ b/kolibri/plugins/qti_viewer/assets/src/components/interactions/TextEntryInteraction.vue
@@ -1,15 +1,21 @@
 <template>
 
   <input
+    v-if="interactive"
     v-model="variable"
-    class="qti-text-entry-interaction"
+    class="qti-text-entry-interaction qti-text-entry-interaction-interactive"
     :placeholder="placeholder"
-    :disabled="!interactive"
     :style="{
-      minWidth: `${expectedLength ?? 20}ch`,
-      width: `${variable.length}ch`,
+      minWidth: `${Math.min(expectedLength ?? 20, 20)}ch`,
+      maxWidth: '90%',
     }"
   >
+  <div
+    v-else
+    class="qti-text-entry-interaction qti-text-entry-interaction-report"
+  >
+    {{ variable || placeholder }}
+  </div>
 
 </template>
 
@@ -66,3 +72,27 @@
   };
 
 </script>
+
+
+<style scoped>
+
+  .qti-text-entry-interaction-interactive {
+    padding: 8px;
+    font-family: inherit;
+    font-size: inherit;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+  }
+
+  .qti-text-entry-interaction-report {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 1.5em;
+    padding: 8px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    background-color: #f8f9fa;
+    border-radius: 4px;
+  }
+
+</style>


### PR DESCRIPTION
## Summary
- Added a div for text entry component when in non interactive mode. 
<img width="1863" height="952" alt="image" src="https://github.com/user-attachments/assets/c177943b-56ae-4f31-8fb4-182bb07cbdcf" />

## References
- closes #13630

## Reviewer guidance
- Build a survey type of resource on Studio Hotfixes, to be able to use the Free response type. 
- Publish that channel, import it into Kolibri, and complete the survey by writing a very long answer to the question (2 sentences). 
- When you open the survey report you will see that the answer is fully visible now.
