### PR TITLE
Fix users reload after soft-deleting a user

### DIFF
--- a/kolibri/plugins/facility/assets/src/composables/__mocks__/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/__mocks__/useUserManagement.js
@@ -31,9 +31,10 @@
  * useUserManagement.mockImplementation(() => useUserManagementMock())
  * ```
  */
-import { computed } from 'vue';
+import { ref, computed } from 'vue';
 
 const MOCK_DEFAULTS = {
+  selectedUsers: ref(new Set()),
   facilityUsers: computed(() => []),
   totalPages: computed(() => 0),
   usersCount: computed(() => 0),
@@ -45,8 +46,10 @@ const MOCK_DEFAULTS = {
   search: computed(() => null),
   userType: computed(() => null),
   classes: computed(() => []),
+  onChange: jest.fn(),
   fetchUsers: jest.fn(),
   fetchClasses: jest.fn(),
+  resetFilters: jest.fn(),
 };
 
 export function useUserManagementMock(overrides = {}) {

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -13,6 +13,7 @@ export default function useUserManagement({
   dateJoinedGt,
   softDeletedUsers = false,
 } = {}) {
+  const selectedUsers = ref(new Set());
   const facilityUsers = ref([]);
   const totalPages = ref(0);
   const usersCount = ref(0);
@@ -75,6 +76,20 @@ export default function useUserManagement({
     }
   };
 
+  function onChange({ resetSelection = false, affectedClasses = null } = {}) {
+    if (resetSelection) {
+      selectedUsers.value = new Set();
+    }
+    if (
+      // If there isn't any specific class affected, always refetch
+      affectedClasses === null ||
+      // If there are affected classes, only refetch if one of them is in the current filters
+      routeFilters.value.classes.some(classId => affectedClasses.includes(classId))
+    ) {
+      fetchUsers();
+    }
+  }
+
   // re-running fetchUsers whenever the relevant query params change
   watch(
     () => [
@@ -94,6 +109,7 @@ export default function useUserManagement({
   );
 
   return {
+    selectedUsers,
     facilityUsers,
     totalPages,
     usersCount,
@@ -106,6 +122,7 @@ export default function useUserManagement({
     classes,
     numAppliedFilters,
     // methods
+    onChange,
     fetchUsers,
     fetchClasses,
     resetFilters,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -38,7 +38,7 @@
           :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
           :numAppliedFilters="numAppliedFilters"
           @clearFilters="resetFilters"
-          @change="onUsersChange"
+          @change="onChange"
         >
           <template #userActions>
             <component
@@ -131,7 +131,7 @@
         :classes="classes"
         :selectedUsers="selectedUsers"
         :onBlur="onModalBlur"
-        :onUsersChange="onUsersChange"
+        :onChange="onChange"
         @hook:beforeDestroy="selectedUsers = new Set()"
       />
 
@@ -140,7 +140,7 @@
         v-if="isMoveToTrashModalOpen"
         :selectedUsers="selectedUsers"
         :onBlur="onModalBlur"
-        :onUsersChange="onUsersChange"
+        :onChange="onChange"
         @close="isMoveToTrashModalOpen = false"
       />
     </template>
@@ -191,6 +191,7 @@
       newUsersCreationTreshold.setDate(newUsersCreationTreshold.getDate() - MAX_NEW_USER_DAYS);
 
       const {
+        selectedUsers,
         facilityUsers,
         search,
         classes,
@@ -198,7 +199,7 @@
         usersCount,
         dataLoading,
         numAppliedFilters,
-        fetchUsers,
+        onChange,
         fetchClasses,
         resetFilters,
       } = useUserManagement({
@@ -206,7 +207,6 @@
         dateJoinedGt: newUsersCreationTreshold,
       });
 
-      const selectedUsers = ref(new Set());
       const showUsersTable = computed(
         () =>
           facilityUsers.value.length > 0 ||
@@ -214,13 +214,6 @@
           numAppliedFilters.value > 0 ||
           dataLoading.value,
       );
-
-      function onUsersChange({ resetSelection = false } = {}) {
-        fetchUsers();
-        if (resetSelection) {
-          selectedUsers.value.clear();
-        }
-      }
 
       const {
         newUser$,
@@ -256,8 +249,8 @@
         emptyPlusCloudSvg,
         numAppliedFilters,
         isMoveToTrashModalOpen,
+        onChange,
         onModalBlur,
-        onUsersChange,
         overrideRoute,
         resetFilters,
         newUser$,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -140,7 +140,7 @@
   import MoveToTrashModal from '../common/MoveToTrashModal.vue';
 
   export default {
-    name: 'UserPage',
+    name: 'UsersRootPage',
     metaInfo() {
       return {
         title: this.coreString('usersLabel'),

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -51,7 +51,7 @@
           :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
           :numAppliedFilters="numAppliedFilters"
           @clearFilters="resetFilters"
-          @change="onUsersChange"
+          @change="onChange"
         >
           <template #userActions>
             <component
@@ -103,7 +103,7 @@
           :selectedUsers="selectedUsers"
           :classes="classes"
           :onBlur="onModalBlur"
-          :onUsersChange="onUsersChange"
+          :onChange="onChange"
           @clearSelection="clearSelectedUsers"
           @hook:beforeDestroy="selectedUsers = new Set()"
         />
@@ -113,7 +113,7 @@
           v-if="isMoveToTrashModalOpen"
           :selectedUsers="selectedUsers"
           :onBlur="onModalBlur"
-          :onUsersChange="onUsersChange"
+          :onChange="onChange"
           @close="isMoveToTrashModalOpen = false"
         />
       </KPageContainer>
@@ -156,7 +156,6 @@
       usePreviousRoute();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
-      const selectedUsers = ref(new Set());
       const isMoveToTrashModalOpen = ref(false);
       const usersTableRef = ref(null);
 
@@ -175,23 +174,17 @@
       const activeFacilityId =
         $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
       const {
+        selectedUsers,
         facilityUsers,
         totalPages,
         usersCount,
         dataLoading,
         classes,
         numAppliedFilters,
-        fetchUsers,
+        onChange,
         fetchClasses,
         resetFilters,
       } = useUserManagement({ activeFacilityId });
-
-      const onUsersChange = ({ resetSelection = false } = {}) => {
-        fetchUsers();
-        if (resetSelection) {
-          selectedUsers.value = new Set();
-        }
-      };
 
       onMounted(() => {
         fetchClasses();
@@ -216,9 +209,9 @@
         usersTableRef,
         numAppliedFilters,
         isMoveToTrashModalOpen,
+        onChange,
         onModalBlur,
         resetFilters,
-        onUsersChange,
         clearSelectedUsers,
         newUser$,
         viewTrash$,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -32,7 +32,7 @@
           :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
           :numAppliedFilters="numAppliedFilters"
           @clearFilters="resetFilters"
-          @change="onUsersChange"
+          @change="onChange"
         >
           <template #userActions>
             <KIconButton
@@ -81,13 +81,13 @@
         :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
         :classes="classes"
         :selectedUsers="selectedUsers"
-        @change="onUsersChange"
+        @change="onChange"
       />
       <PermanentDeleteModal
         v-if="usersToDelete"
         :selectedUsers="usersToDelete"
         @close="usersToDelete = null"
-        @change="onUsersChange"
+        @change="onChange"
       />
     </template>
   </ImmersivePage>
@@ -131,6 +131,7 @@
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
 
       const {
+        selectedUsers,
         facilityUsers,
         search,
         classes,
@@ -138,15 +139,13 @@
         usersCount,
         dataLoading,
         numAppliedFilters,
-        fetchUsers,
+        onChange,
         fetchClasses,
         resetFilters,
       } = useUserManagement({
         activeFacilityId,
         softDeletedUsers: true,
       });
-
-      const selectedUsers = ref(new Set());
 
       const showUsersTable = computed(
         () =>
@@ -155,13 +154,6 @@
           numAppliedFilters.value > 0 ||
           dataLoading.value,
       );
-
-      function onUsersChange({ resetSelection = false } = {}) {
-        fetchUsers();
-        if (resetSelection) {
-          selectedUsers.value.clear();
-        }
-      }
 
       const {
         backToUsers$,
@@ -182,7 +174,7 @@
             by_ids: Array.from(users).join(','),
           });
           createSnackbar(usersRecoveredNotice$({ num: users.size }));
-          onUsersChange({ resetSelection: true });
+          onChange({ resetSelection: true });
           loading.value = false;
         } catch (error) {
           loading.value = false;
@@ -235,8 +227,8 @@
         userDropdownMenuOptions,
 
         // Methods
+        onChange,
         recoverUsers,
-        onUsersChange,
         overrideRoute,
         resetFilters,
         handleDropdownSelect,

--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -118,7 +118,7 @@
           createSnackbar(usersTrashedNotice$());
           loading.value = false;
           usersRemoved.value = Array.from(props.selectedUsers);
-          props.onUsersChange({ resetSelection: true });
+          props.onChange({ resetSelection: true });
           close();
           return true;
         } catch (error) {
@@ -133,7 +133,7 @@
           by_ids: usersRemoved.value.join(','),
         });
         createSnackbar(trashUndoneNotice$());
-        props.onUsersChange();
+        props.onChange();
       };
 
       const { performAction: moveToTrash } = useActionWithUndo({
@@ -183,7 +183,7 @@
         type: Function,
         default: () => {},
       },
-      onUsersChange: {
+      onChange: {
         type: Function,
         default: () => {},
       },

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -175,8 +175,8 @@
     <MoveToTrashModal
       v-if="modalShown === Modals.DELETE_USER"
       :selectedUsers="userToChangeSet"
+      :onUsersChange="event => $emit('change', event)"
       @close="closeModal"
-      @change="$emit('change', { resetSelection: true })"
     />
   </div>
 

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -175,7 +175,7 @@
     <MoveToTrashModal
       v-if="modalShown === Modals.DELETE_USER"
       :selectedUsers="userToChangeSet"
-      :onUsersChange="event => $emit('change', event)"
+      :onChange="event => $emit('change', event)"
       @close="closeModal"
     />
   </div>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -212,6 +212,9 @@
 
         try {
           await assignCoachesToClasses();
+          props.onChange({
+            affectedClasses: selectedClasses.value,
+          });
           closeSidePanel();
           return true;
         } catch (error) {
@@ -252,6 +255,9 @@
         if (createdRoles.value.length > 0) {
           const roleIds = createdRoles.value.map(role => role.id);
           await RoleResource.deleteCollection({ by_ids: roleIds });
+          props.onChange({
+            affectedClasses: selectedClasses.value,
+          });
         }
       }
 
@@ -295,17 +301,19 @@
       };
     },
     props: {
-      /* eslint-disable vue/no-unused-properties */
       selectedUsers: {
         type: Set,
         default: () => new Set(),
       },
-      /* eslint-enable vue/no-unused-properties */
       classes: {
         type: Array,
         default: () => [],
       },
       onBlur: {
+        type: Function,
+        default: () => {},
+      },
+      onChange: {
         type: Function,
         default: () => {},
       },

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -218,6 +218,9 @@
           // were enrolled
           createdMemberships.value = [];
         }
+        props.onChange({
+          affectedClasses: selectedOptions.value,
+        });
         goBack();
         return true;
       }
@@ -238,6 +241,9 @@
         if (createdMemberships.value?.length > 0) {
           const ids = createdMemberships.value.map(m => m.id).join(',');
           await MembershipResource.deleteCollection({ by_ids: ids });
+          props.onChange({
+            affectedClasses: selectedOptions.value,
+          });
         }
       }
 
@@ -279,6 +285,10 @@
         required: true,
       },
       onBlur: {
+        type: Function,
+        default: () => {},
+      },
+      onChange: {
         type: Function,
         default: () => {},
       },

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -255,6 +255,9 @@
             ? RoleResource.saveCollection({ data: assignments })
             : Promise.resolve(),
         ]);
+        props.onChange({
+          affectedClasses: selectedOptions.value,
+        });
       }
 
       function getItemsToRemove(byUser, selectedSet) {
@@ -281,6 +284,9 @@
           await removeItems(RoleResource, coachRolesToRemove);
           removedLearnerMemberships.value = learnerMembershipsToRemove || [];
           removedCoachRoles.value = coachRolesToRemove || [];
+          props.onChange({
+            affectedClasses: selectedOptions.value,
+          });
           goBack();
           return true;
         } catch (error) {
@@ -341,6 +347,10 @@
         default: () => [],
       },
       onBlur: {
+        type: Function,
+        default: () => {},
+      },
+      onChange: {
         type: Function,
         default: () => {},
       },

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -318,7 +318,7 @@
 
       const handleSubmitSuccess = () => {
         createSnackbar(notificationStrings.userCreated$());
-        props.onUsersChange();
+        props.onChange();
       };
 
       const handleSubmitFailure = error => {
@@ -489,7 +489,7 @@
         type: Array,
         default: () => [],
       },
-      onUsersChange: {
+      onChange: {
         type: Function,
         default: () => {},
       },


### PR DESCRIPTION
## Summary

* Reloads users table after soft-deleting a user using the user dropdown.
* Reload users table if there was an active filter filtering by classes, and the side panel operations modifies the filtered list.
  * Moved the `onChange` logic to the `useUserManagement` composable to prevent code duplication.

https://github.com/user-attachments/assets/24d2f1b3-6b27-48c4-92f9-13f1e863db1b


## References

Closes #13685.

## Reviewer guidance

Replicate steps taken in #13685. Check that error does not happen anymore.
