### PR TITLE
Update to latest kolibri-installer-android release.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -55,10 +55,10 @@ jobs:
   apk:
     name: Build APK file
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.5
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.6
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
-      ref: v0.1.5
+      ref: v0.1.6
   zip:
     name: Build Raspberry Pi Image
     needs: deb

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -119,11 +119,11 @@ jobs:
   apk:
     name: Build Android APK
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.5
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.6
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
       release: true
-      ref: v0.1.5
+      ref: v0.1.6
     secrets:
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE }}
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD }}
@@ -273,9 +273,9 @@ jobs:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}
     needs: [apk, block_release_step]
-    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.1.5
+    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.1.6
     with:
       version-code: ${{ needs.apk.outputs.version-code }}
-      ref: v0.1.5
+      ref: v0.1.6
     secrets:
       KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON: ${{ secrets.KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
* Upgrades Android to allow building with API 35 target - required for Google Play Store releases since the end of August

## References
Primarily brings work from this PR: https://github.com/learningequality/kolibri-installer-android/pull/236 into Kolibri

## Reviewer guidance
Android app should build fine - and work on Android 7 through 16.