### PR TITLE
Update bulk action icons to need only one TAB press for keyboard navigation

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -41,60 +41,53 @@
           @change="onChange"
         >
           <template #userActions>
-            <component
-              :is="canAssignCoaches ? 'router-link' : 'span'"
-              :to="
-                overrideRoute($route, {
-                  name: PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS,
-                })
-              "
-              :class="{ 'disabled-link': !canAssignCoaches || !hasSelectedUsers }"
-            >
-              <KIconButton
-                icon="assignCoaches"
-                :ariaLabel="assignCoach$()"
-                :tooltip="assignCoach$()"
-                :disabled="!canAssignCoaches || !hasSelectedUsers"
-              />
-            </component>
-            <component
-              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
-              :to="
-                overrideRoute($route, {
-                  name: PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS,
-                })
-              "
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
-            >
-              <KIconButton
-                icon="add"
-                :ariaLabel="enrollToClass$()"
-                :tooltip="enrollToClass$()"
-                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              />
-            </component>
-            <component
-              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
-              :to="
-                overrideRoute($route, {
-                  name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS,
-                })
-              "
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass }"
-            >
-              <KIconButton
-                icon="remove"
-                :ariaLabel="removeFromClass$()"
-                :tooltip="removeFromClass$()"
-                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              />
-            </component>
             <KIconButton
+              ref="assignButton"
+              icon="assignCoaches"
+              :ariaLabel="assignCoach$()"
+              :disabled="!canAssignCoaches || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS)"
+            />
+            <KTooltip
+              reference="assignButton"
+              :refs="$refs"
+              :text="assignCoach$()"
+            />
+            <KIconButton
+              ref="enrollButton"
+              icon="add"
+              :ariaLabel="enrollToClass$()"
+              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS)"
+            />
+            <KTooltip
+              reference="enrollButton"
+              :refs="$refs"
+              :text="enrollToClass$()"
+            />
+            <KIconButton
+              ref="removeButton"
+              icon="remove"
+              :ariaLabel="removeFromClass$()"
+              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS)"
+            />
+            <KTooltip
+              reference="removeButton"
+              :refs="$refs"
+              :text="removeFromClass$()"
+            />
+            <KIconButton
+              ref="trashButton"
               icon="trash"
               :ariaLabel="deleteSelection$()"
-              :tooltip="deleteSelection$()"
               :disabled="!canDeleteSelection || !hasSelectedUsers"
               @click="isMoveToTrashModalOpen = true"
+            />
+            <KTooltip
+              reference="trashButton"
+              :refs="$refs"
+              :text="deleteSelection$()"
             />
           </template>
         </UsersTable>
@@ -153,7 +146,7 @@
 
   import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
-  import { useRoute } from 'vue-router/composables';
+  import { useRoute, useRouter } from 'vue-router/composables';
   import useUser from 'kolibri/composables/useUser';
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
@@ -181,6 +174,7 @@
     setup() {
       usePreviousRoute();
       const route = useRoute();
+      const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
       const usersTableRef = ref(null);
       const isMoveToTrashModalOpen = ref(false);
@@ -232,6 +226,11 @@
         usersTableRef.value?.focus();
       }
 
+      function navigateToSidePanel(sidePanelName) {
+        const newRoute = overrideRoute(route, { name: sidePanelName });
+        router.push(newRoute);
+      }
+
       onMounted(() => {
         fetchClasses();
       });
@@ -252,6 +251,7 @@
         onChange,
         onModalBlur,
         overrideRoute,
+        navigateToSidePanel,
         resetFilters,
         newUser$,
         newUsers$,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -132,6 +132,7 @@
 <script>
 
   import { ref, getCurrentInstance, onMounted } from 'vue';
+  import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
@@ -160,6 +161,8 @@
     mixins: [commonCoreStrings],
     setup() {
       usePreviousRoute();
+      const route = useRoute();
+      const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
       const isMoveToTrashModalOpen = ref(false);
@@ -204,6 +207,11 @@
         usersTableRef.value?.focus();
       }
 
+      function navigateToSidePanel(sidePanelName) {
+        const newRoute = overrideRoute(route, { name: sidePanelName });
+        router.push(newRoute);
+      }
+
       return {
         PageNames,
         userIsMultiFacilityAdmin,
@@ -231,6 +239,7 @@
         currentUserId,
         isSuperuser,
         isAdmin,
+        navigateToSidePanel,
       };
     },
     computed: {
@@ -305,11 +314,6 @@
       },
     },
     methods: {
-      overrideRoute,
-      navigateToSidePanel(sidePanelName) {
-        const newRoute = this.overrideRoute(this.$route, { name: sidePanelName });
-        this.$router.push(newRoute);
-      },
       handlePageDropdownSelection(option) {
         if (option.value) {
           this.$router.push({

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -54,47 +54,53 @@
           @change="onChange"
         >
           <template #userActions>
-            <component
-              :is="canAssignCoaches ? 'router-link' : 'span'"
-              :to="overrideRoute($route, { name: PageNames.ASSIGN_COACHES_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canAssignCoaches || !hasSelectedUsers }"
-            >
-              <KIconButton
-                icon="assignCoaches"
-                :ariaLabel="assignCoach$()"
-                :tooltip="assignCoach$()"
-                :disabled="!canAssignCoaches || !hasSelectedUsers"
-              />
-            </component>
-            <component
-              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
-              :to="overrideRoute($route, { name: PageNames.ENROLL_LEARNERS_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
-            >
-              <KIconButton
-                icon="add"
-                :ariaLabel="enrollToClass$()"
-                :tooltip="enrollToClass$()"
-                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              />
-            </component>
-            <component
-              :is="canEnrollOrRemoveFromClass ? 'router-link' : 'span'"
-              :to="overrideRoute($route, { name: PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL })"
-              :class="{ 'disabled-link': !canEnrollOrRemoveFromClass || !hasSelectedUsers }"
-            >
-              <KIconButton
-                icon="remove"
-                :ariaLabel="removeFromClass$()"
-                :tooltip="removeFromClass$()"
-                :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              />
-            </component>
             <KIconButton
+              ref="assignButton"
+              icon="assignCoaches"
+              :ariaLabel="assignCoach$()"
+              :disabled="!canAssignCoaches || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL)"
+            />
+            <KTooltip
+              reference="assignButton"
+              :refs="$refs"
+              :text="assignCoach$()"
+            />
+            <KIconButton
+              ref="enrollButton"
+              icon="add"
+              :ariaLabel="enrollToClass$()"
+              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL)"
+            />
+            <KTooltip
+              reference="enrollButton"
+              :refs="$refs"
+              :text="enrollToClass$()"
+            />
+            <KIconButton
+              ref="removeButton"
+              icon="remove"
+              :ariaLabel="removeFromClass$()"
+              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+              @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL)"
+            />
+            <KTooltip
+              reference="removeButton"
+              :refs="$refs"
+              :text="removeFromClass$()"
+            />
+            <KIconButton
+              ref="trashButton"
               icon="trash"
-              :tooltip="deleteSelectionTooltip"
+              :ariaLabel="deleteSelectionTooltip"
               :disabled="!canDeleteSelection || !hasSelectedUsers"
               @click="isMoveToTrashModalOpen = true"
+            />
+            <KTooltip
+              reference="trashButton"
+              :refs="$refs"
+              :text="deleteSelectionTooltip"
             />
           </template>
         </UsersTable>
@@ -300,6 +306,10 @@
     },
     methods: {
       overrideRoute,
+      navigateToSidePanel(sidePanelName) {
+        const newRoute = this.overrideRoute(this.$route, { name: sidePanelName });
+        this.$router.push(newRoute);
+      },
       handlePageDropdownSelection(option) {
         if (option.value) {
           this.$router.push({
@@ -334,11 +344,6 @@
       align-items: center;
       justify-content: flex-end;
     }
-  }
-
-  .disabled-link {
-    pointer-events: none;
-    cursor: not-allowed;
   }
 
   .flex-column {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -36,17 +36,28 @@
         >
           <template #userActions>
             <KIconButton
+              ref="recoverButton"
               icon="refresh"
               :disabled="!selectedUsers.size || loading"
-              :tooltip="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+              :ariaLabel="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
               @click="recoverUsers(selectedUsers)"
             />
+            <KTooltip
+              reference="recoverButton"
+              :refs="$refs"
+              :text="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+            />
             <KIconButton
+              ref="deleteButton"
               icon="trash"
               :disabled="!selectedUsers.size || loading"
               :ariaLabel="deletePermanentlyLabel$()"
-              :tooltip="deletePermanentlyLabel$()"
               @click="usersToDelete = selectedUsers"
+            />
+            <KTooltip
+              reference="deleteButton"
+              :refs="$refs"
+              :text="deletePermanentlyLabel$()"
             />
           </template>
           <template #userDropdownMenu="{ user }">


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates bulk action icon buttons to use `navigateToSidePanel()` to open side panels instead of `KRouterLink`, allowing the buttons to need only one tab when keyboard navigating.
- Adds separate `KTooltip` component for each bulk action icon button to ensure the tooltip text displays when keyboard navigating through the buttons within the Facility Users, New Users, and Trash pages.

Before:

https://github.com/user-attachments/assets/56dc686e-c70c-4bce-991d-29d3719aab19


After:

https://github.com/user-attachments/assets/9f044fc2-4cdb-44a1-a550-c0133c78b289


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #13734 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Use the keyboard to navigate the bulk action icon buttons above the users table, each icon button should only need one TAB press.
2. Ensure each icon button properly opens the corresponding side panel or bulk action on the Facility > Users, New Users, and Trash pages.

