### PR TITLE
Remove unneeded post-approval BCK upload

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -181,8 +181,8 @@ jobs:
         path: 'dist/${{ matrix.filename }}'
         destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}'
         process_gcloudignore: false
-  bck_prerelease_gcs_upload:
-    name: Upload WHL file to Google Cloud Storage for BCK Pre-release
+  bck_gcs_upload:
+    name: Upload WHL file to Google Cloud Storage for BCK
     runs-on: ubuntu-latest
     needs: [whl]
     steps:
@@ -244,31 +244,6 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  bck_gcs_upload:
-    name: Upload WHL file to Google Cloud Storage for BCK
-    needs: [block_release_step, whl, latest_release]
-    if: ${{ !github.event.release.prerelease && needs.latest_release.outputs.is_latest_release == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download WHL artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ needs.whl.outputs.whl-file-name }}
-        path: dist
-    - name: Zip whl file
-      run: zip -j dist/kolibri.zip dist/${{ needs.whl.outputs.whl-file-name }}
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        credentials_json: '${{ secrets.GH_UPLOADER_GCP_SA_CREDENTIALS }}'
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
-    - name: Upload to BCK bucket
-      uses: 'google-github-actions/upload-cloud-storage@v2'
-      with:
-        path: 'dist/kolibri.zip'
-        destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}'
-        parent: false
-        process_gcloudignore: false
   android_release:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}


### PR DESCRIPTION
## Summary
* Removes no longer needed second BCK GCS upload step
* All BCK assets are now handled through a single bucket, and deployment to production is handled via build approval in Google Cloud