### PR TITLE
Check unusable device on user_auth plugin

### DIFF
--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -11,7 +11,8 @@ from morango.models import Store
 from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
+from kolibri.core.auth.utils.deprovision import deprovision
+from kolibri.core.auth.utils.deprovision import get_deprovision_progress_total
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.logger.models import AttemptLog
@@ -57,12 +58,10 @@ class Command(AsyncCommand):
         )
 
     def deprovision(self):
-        with DisablePostDeleteSignal(), self.start_progress(
-            total=len(MODELS_TO_DELETE)
+        with self.start_progress(
+            total=get_deprovision_progress_total()
         ) as progress_update:
-            for Model in MODELS_TO_DELETE:
-                Model.objects.all().delete()
-                progress_update(1)
+            deprovision(progress_update=progress_update)
 
     def handle_async(self, *args, **options):
 

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -449,10 +449,12 @@ class MorangoSyncCommand(AsyncCommand):
 
             if not no_provision:
                 with self._lock():
-                    if user_id:
-                        provision_single_user_device(
-                            FacilityUser.objects.get(id=user_id)
-                        )
+                    try:
+                        user = FacilityUser.all_objects.get(id=user_id)
+                    except FacilityUser.DoesNotExist:
+                        user = None
+                    if user:
+                        provision_single_user_device(user)
                     else:
                         create_superuser_and_provision_device(
                             username, dataset_id, noninteractive=noninteractive

--- a/kolibri/core/auth/utils/deprovision.py
+++ b/kolibri/core/auth/utils/deprovision.py
@@ -10,7 +10,6 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
-from kolibri.core.device.utils import reset_device_provisioned_flag
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
@@ -38,7 +37,6 @@ def deprovision(progress_update=None):
             Model.objects.all().delete()
             if progress_update:
                 progress_update(1)
-    reset_device_provisioned_flag()
 
 
 def get_deprovision_progress_total():

--- a/kolibri/core/auth/utils/deprovision.py
+++ b/kolibri/core/auth/utils/deprovision.py
@@ -1,0 +1,45 @@
+from morango.models import Certificate
+from morango.models import DatabaseIDModel
+from morango.models import DatabaseMaxCounter
+from morango.models import DeletedModels
+from morango.models import HardDeletedModels
+from morango.models import Store
+
+from kolibri.core.auth.models import FacilityDataset
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.models import DeviceSettings
+from kolibri.core.device.utils import reset_device_provisioned_flag
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+
+MODELS_TO_DELETE = [
+    AttemptLog,
+    ContentSessionLog,
+    ContentSummaryLog,
+    FacilityUser,
+    FacilityDataset,
+    HardDeletedModels,
+    Certificate,
+    DatabaseIDModel,
+    Store,
+    DevicePermissions,
+    DeletedModels,
+    DeviceSettings,
+    DatabaseMaxCounter,
+]
+
+
+def deprovision(progress_update=None):
+    with DisablePostDeleteSignal():
+        for Model in MODELS_TO_DELETE:
+            Model.objects.all().delete()
+            if progress_update:
+                progress_update(1)
+    reset_device_provisioned_flag()
+
+
+def get_deprovision_progress_total():
+    return len(MODELS_TO_DELETE)

--- a/kolibri/core/auth/utils/deprovision.py
+++ b/kolibri/core/auth/utils/deprovision.py
@@ -13,6 +13,7 @@ from kolibri.core.device.models import DeviceSettings
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.tasks.main import job_storage
 
 MODELS_TO_DELETE = [
     AttemptLog,
@@ -37,6 +38,9 @@ def deprovision(progress_update=None):
             Model.objects.all().delete()
             if progress_update:
                 progress_update(1)
+
+        # Clear all completed, failed or cancelled jobs
+        job_storage.clear()
 
 
 def get_deprovision_progress_total():

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -18,6 +18,7 @@ from rest_framework import status
 
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
+from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import SyncQueue
@@ -49,7 +50,10 @@ class Context(object):
 
     @cached_property
     def user(self):
-        return FacilityUser.objects.get(id=self.user_id)
+        try:
+            return FacilityUser.all_objects.get(id=self.user_id)
+        except FacilityUser.DoesNotExist:
+            return None
 
     @property
     def has_sync_queue(self):
@@ -388,7 +392,11 @@ def execute_sync(context):
         command = "resumesync"
         kwargs["id"] = sync_session_id
     else:
-        kwargs["facility"] = context.user.facility_id
+        kwargs["facility"] = (
+            context.user.facility_id
+            if context.user
+            else Facility.get_default_facility().id
+        )
 
     sync_queue.status = SyncQueueStatus.Syncing
     sync_queue.save()

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -386,6 +386,7 @@ def execute_sync(context):
         baseurl=context.network_location.base_url,
         keep_alive=True,
         noninteractive=True,
+        no_provision=True,
     )
 
     if sync_session_id:

--- a/kolibri/core/device/tasks.py
+++ b/kolibri/core/device/tasks.py
@@ -247,6 +247,7 @@ def provisiondevice(**data):  # noqa C901
 
             job.update_metadata(**updates)
 
+
 @register_task(
     permission_classes=[IsDeviceUnusable],
     cancellable=False,

--- a/kolibri/core/device/tasks.py
+++ b/kolibri/core/device/tasks.py
@@ -10,6 +10,7 @@ from kolibri.core.auth.constants.facility_presets import choices
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.serializers import FacilitySerializer
+from kolibri.core.auth.utils.deprovision import deprovision
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import OSUser
 from kolibri.core.device.serializers import DeviceSerializerMixin
@@ -20,6 +21,7 @@ from kolibri.core.device.utils import provision_single_user_device
 from kolibri.core.device.utils import valid_app_key_on_request
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.permissions import FirstProvisioning
+from kolibri.core.tasks.permissions import IsDeviceUnusable
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.tasks.validation import JobValidator
 from kolibri.core.utils.token_generator import TokenGenerator
@@ -29,6 +31,7 @@ from kolibri.plugins.app.utils import interface
 logger = logging.getLogger(__name__)
 
 PROVISION_TASK_QUEUE = "device_provision"
+DEPROVISION_TASK_QUEUE = "device_deprovision"
 
 
 class DeviceProvisionValidator(DeviceSerializerMixin, JobValidator):
@@ -243,3 +246,14 @@ def provisiondevice(**data):  # noqa C901
                 updates["auth_token"] = TokenGenerator().make_token(superuser.id)
 
             job.update_metadata(**updates)
+
+@register_task(
+    permission_classes=[IsDeviceUnusable],
+    cancellable=False,
+    queue=DEPROVISION_TASK_QUEUE,
+)
+def deprovisiondevice():
+    """
+    Task for deprovisioning a device.
+    """
+    deprovision()

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -499,21 +499,6 @@ def is_full_facility_import(dataset_id):
     )
 
 
-device_is_provisioned = False
-
-
-def is_provisioned():
-    # First check if the device has been provisioned
-    global device_is_provisioned
-    device_is_provisioned = device_is_provisioned or device_provisioned()
-    return device_is_provisioned
-
-
-def reset_device_provisioned_flag():
-    global device_is_provisioned
-    device_is_provisioned = False
-
-
 def get_device_unusable_reason():
     from kolibri.core.auth.models import FacilityUser
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -29,6 +29,9 @@ LANDING_PAGE_LEARN = "learn"
 APP_KEY_COOKIE_NAME = "app_key_cookie"
 APP_AUTH_TOKEN_COOKIE_NAME = "app_auth_token_cookie"
 
+DEVICE_UNUSABLE_NO_SUPERUSERS = "NO_SUPERUSERS"
+DEVICE_UNUSABLE_SUPERUSERS_SOFT_DELETED = "SUPERUSERS_SOFT_DELETED"
+
 
 class DeviceNotProvisioned(Exception):
     pass
@@ -494,3 +497,37 @@ def is_full_facility_import(dataset_id):
         .filter(scope_definition_id=ScopeDefinitions.FULL_FACILITY)
         .exists()
     )
+
+
+device_is_provisioned = False
+
+
+def is_provisioned():
+    # First check if the device has been provisioned
+    global device_is_provisioned
+    device_is_provisioned = device_is_provisioned or device_provisioned()
+    return device_is_provisioned
+
+
+def reset_device_provisioned_flag():
+    global device_is_provisioned
+    device_is_provisioned = False
+
+
+def get_device_unusable_reason():
+    from kolibri.core.auth.models import FacilityUser
+
+    is_soud = get_device_setting("subset_of_users_device")
+    if not is_soud:
+        return None
+
+    superadmins = FacilityUser.all_objects.filter(devicepermissions__is_superuser=True)
+    if not superadmins.exists():
+        return DEVICE_UNUSABLE_NO_SUPERUSERS
+
+    non_soft_deleted_superadmins = FacilityUser.objects.filter(
+        devicepermissions__is_superuser=True
+    )
+    if not non_soft_deleted_superadmins.exists():
+        return DEVICE_UNUSABLE_SUPERUSERS_SOFT_DELETED
+    return None

--- a/kolibri/core/tasks/permissions.py
+++ b/kolibri/core/tasks/permissions.py
@@ -197,3 +197,13 @@ class FirstProvisioning(BasePermission):
 
     def user_can_read_job(self, user, job):
         return True
+
+
+class IsDeviceUnusable(BasePermission):
+    def user_can_run_job(self, user, job):
+        from kolibri.core.device.utils import get_device_unusable_reason
+
+        return get_device_unusable_reason() is not None
+
+    def user_can_read_job(self, user, job):
+        return True

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -28,7 +28,7 @@ from kolibri.core.device.translation import get_accept_headers_language
 from kolibri.core.device.translation import get_device_language
 from kolibri.core.device.translation import get_settings_language
 from kolibri.core.device.utils import allow_guest_access
-from kolibri.core.device.utils import device_provisioned
+from kolibri.core.device.utils import is_provisioned
 from kolibri.core.hooks import LogoutRedirectHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.theme_hook import ThemeHook
@@ -126,16 +126,6 @@ class GuestRedirectView(View):
         if allow_guest_access():
             return HttpResponseRedirect(get_url_by_role(user_kinds.LEARNER))
         return RootURLRedirectView.as_view()(request)
-
-
-device_is_provisioned = False
-
-
-def is_provisioned():
-    # First check if the device has been provisioned
-    global device_is_provisioned
-    device_is_provisioned = device_is_provisioned or device_provisioned()
-    return device_is_provisioned
 
 
 class RootURLRedirectView(View):

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -28,7 +28,7 @@ from kolibri.core.device.translation import get_accept_headers_language
 from kolibri.core.device.translation import get_device_language
 from kolibri.core.device.translation import get_settings_language
 from kolibri.core.device.utils import allow_guest_access
-from kolibri.core.device.utils import is_provisioned
+from kolibri.core.device.utils import device_provisioned
 from kolibri.core.hooks import LogoutRedirectHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.theme_hook import ThemeHook
@@ -134,7 +134,7 @@ class RootURLRedirectView(View):
         Redirects user based on the highest role they have for which a redirect is defined.
         """
         # If it has not been provisioned and we have something that can handle setup, redirect there.
-        if not is_provisioned() and SetupHook.provision_url:
+        if not device_provisioned() and SetupHook.provision_url:
             return redirect(SetupHook.provision_url())
 
         if request.user.is_authenticated:

--- a/kolibri/plugins/user_auth/assets/src/constants.js
+++ b/kolibri/plugins/user_auth/assets/src/constants.js
@@ -9,3 +9,8 @@ export const ComponentMap = {
 export const pageNameToModuleMap = {
   [ComponentMap.SIGN_IN]: 'signIn',
 };
+
+export const DeviceUnusableReason = {
+  NO_SUPERUSERS: 'NO_SUPERUSERS',
+  SUPERUSERS_SOFT_DELETED: 'SUPERUSERS_SOFT_DELETED',
+};

--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -6,7 +6,7 @@
         <div class="main-cell table-cell">
           <!-- remote access disabled -->
           <div
-            v-if="!$store.getters.allowAccess"
+            v-if="!$store.getters.allowAccess || deviceUnusableReason"
             class="box"
             :style="{ backgroundColor: $themeTokens.surface }"
           >
@@ -24,10 +24,16 @@
             >
               {{ logoText }}
             </h1>
-            <p data-test="restrictedAccess">
-              {{ $tr('restrictedAccess') }}
-            </p>
-            <p>{{ $tr('restrictedAccessDescription') }}</p>
+            <template v-if="!$store.getters.allowAccess">
+              <p data-test="restrictedAccess">
+                {{ $tr('restrictedAccess') }}
+              </p>
+              <p>{{ $tr('restrictedAccessDescription') }}</p>
+            </template>
+            <DeviceUnusableMessage
+              v-else
+              :reason="deviceUnusableReason"
+            />
           </div>
           <!-- remote access enabled -->
           <div
@@ -193,10 +199,11 @@
   import LanguageSwitcherFooter from '../views/LanguageSwitcherFooter';
   import commonUserStrings from './commonUserStrings';
   import getUrlParameter from './getUrlParameter';
+  import DeviceUnusableMessage from './DeviceUnusableMessage.vue';
 
   export default {
     name: 'AuthBase',
-    components: { CoreLogo, LanguageSwitcherFooter, PrivacyInfoModal },
+    components: { CoreLogo, LanguageSwitcherFooter, PrivacyInfoModal, DeviceUnusableMessage },
     mixins: [commonCoreStrings, commonUserStrings],
     setup() {
       const { facilityConfig } = useFacilities();
@@ -272,6 +279,9 @@
       },
       showGuestAccess() {
         return plugin_data.allowGuestAccess && !this.oidcProviderFlow;
+      },
+      deviceUnusableReason() {
+        return plugin_data.deviceUnusableReason;
       },
       versionMsg() {
         return this.$tr('poweredBy', { version: __version });

--- a/kolibri/plugins/user_auth/assets/src/views/DeviceUnusableMessage.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/DeviceUnusableMessage.vue
@@ -1,0 +1,135 @@
+<template>
+
+  <div>
+    <template v-if="reason === DeviceUnusableReason.NO_SUPERUSERS">
+      <p>{{ strings.noSuperusersNotice$() }}</p>
+      <p>{{ strings.noSuperuserCallToAction$() }}</p>
+    </template>
+    <template v-else-if="reason === DeviceUnusableReason.SUPERUSERS_SOFT_DELETED">
+      <p>
+        {{ strings.superusersSoftDeletedNotice$() }}
+      </p>
+      <p>
+        {{ strings.superusersSoftDeletedCallToAction$() }}
+      </p>
+    </template>
+    <p v-else>{{ strings.unknownIssueNotice$() }}</p>
+    <KButton
+      :disabled="taskLoading"
+      style="margin-top: 16px"
+      primary
+      :text="strings.reinstallKolibriAction$()"
+      @click="deprovision"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import TaskResource from 'kolibri/apiResources/TaskResource';
+  import useTaskPolling from 'kolibri-common/composables/useTaskPolling';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { TaskStatuses, TaskTypes } from 'kolibri-common/utils/syncTaskUtils';
+  import redirectBrowser from 'kolibri/utils/redirectBrowser';
+  import { createTranslator } from 'kolibri/utils/i18n';
+
+  import { computed, ref, watch } from 'vue';
+  import { DeviceUnusableReason } from '../constants';
+
+  const DEPROVISION_TASK_QUEUE = 'device_deprovision';
+
+  const strings = createTranslator('DeviceUnusableStrings', {
+    noSuperusersNotice: {
+      message: 'This device is unusable because there are no superuser accounts on this device.',
+      context: 'Notice that there are no superuser accounts on the device',
+    },
+    noSuperuserCallToAction: {
+      message: 'Please reinstall Kolibri to create a superuser account.',
+      context: 'Call to action to reinstall Kolibri to create a superuser account',
+    },
+    superusersSoftDeletedNotice: {
+      message:
+        'This device is unusable because all superuser accounts on this device have been deleted on the server.',
+      context: 'Notice that all superuser accounts have been deleted on the server',
+    },
+    superusersSoftDeletedCallToAction: {
+      message:
+        'Please contact your system administrator to restore your account or reinstall Kolibri to create a new superuser account.',
+      context:
+        'Call to action to contact system administrator or reinstall Kolibri to create a new superuser account',
+    },
+    unknownIssueNotice: {
+      message: 'This device is unusable due to an unknown reason. Please contact support.',
+      context: 'Notice that the device is unusable due to an unknown reason',
+    },
+    reinstallKolibriAction: {
+      message: 'Reinstall Kolibri',
+      context: 'Button text to reinstall Kolibri',
+    },
+    deprovisioningError: {
+      message: 'An error occurred while trying to reinstall Kolibri. Please try again.',
+      context: 'Error message when there is an error deprovisioning the device',
+    },
+  });
+
+  export default {
+    name: 'DeviceUnusableMessage',
+    setup() {
+      const taskLoading = ref(false);
+      const { tasks } = useTaskPolling(DEPROVISION_TASK_QUEUE);
+      const { createSnackbar } = useSnackbar();
+      const deprovisionTask = computed(() => tasks.value[tasks.value.length - 1]);
+
+      const deprovision = async () => {
+        try {
+          taskLoading.value = true;
+          await TaskResource.startTask({
+            type: TaskTypes.DEPROVISIONDEVICE,
+          });
+        } catch (e) {
+          createSnackbar(strings.deprovisioningError$());
+        }
+      };
+
+      const clearTasks = async () => {
+        try {
+          await TaskResource.clearAll(DEPROVISION_TASK_QUEUE);
+        } catch (e) {
+          return;
+        }
+      };
+
+      watch(deprovisionTask, task => {
+        if (!task) return;
+        taskLoading.value = true;
+        if (task.status === TaskStatuses.FAILED) {
+          taskLoading.value = false;
+          createSnackbar(strings.deprovisioningError$());
+          clearTasks();
+          return;
+        }
+        if (task.status === TaskStatuses.COMPLETED) {
+          clearTasks();
+          redirectBrowser();
+        }
+      });
+
+      return {
+        strings,
+        taskLoading,
+        DeviceUnusableReason,
+        deprovision,
+      };
+    },
+    props: {
+      reason: {
+        type: String,
+        required: true,
+        validator: value => Object.values(DeviceUnusableReason).includes(value),
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_auth/kolibri_plugin.py
+++ b/kolibri/plugins/user_auth/kolibri_plugin.py
@@ -1,5 +1,6 @@
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.device.utils import get_device_setting
+from kolibri.core.device.utils import get_device_unusable_reason
 from kolibri.core.device.utils import is_landing_page
 from kolibri.core.device.utils import LANDING_PAGE_LEARN
 from kolibri.core.hooks import NavigationHook
@@ -28,6 +29,7 @@ class UserAuthAsset(webpack_hooks.WebpackBundleHook):
         return {
             "oidcProviderEnabled": OIDCProviderHook.is_enabled(),
             "allowGuestAccess": get_device_setting("allow_guest_access"),
+            "deviceUnusableReason": get_device_unusable_reason(),
         }
 
 

--- a/packages/kolibri-common/utils/syncTaskUtils.js
+++ b/packages/kolibri-common/utils/syncTaskUtils.js
@@ -25,6 +25,7 @@ export const TaskTypes = {
   EXPORTUSERSTOCSV: 'kolibri.core.auth.tasks.exportuserstocsv',
   IMPORTLODUSER: 'kolibri.core.auth.tasks.peeruserimport',
   PROVISIONDEVICE: 'kolibri.core.device.tasks.provisiondevice',
+  DEPROVISIONDEVICE: 'kolibri.core.device.tasks.deprovisiondevice',
 };
 
 // identical to facility constants.js


### PR DESCRIPTION
## Summary
* Check unusable device on user_auth plugin.
* Move `deprovision` command logic to be a utils module so it can be reused in the command and in an async task.
* Clear the job store when deprovisioning the device.
* Fixes several places in the soud sync process that were relying on `FacilityUsers.objects.get` to support soft-deleted and hard-deleted syncs.

https://github.com/user-attachments/assets/2d57cd8b-167a-4612-aa24-4163d7b74d59



## References
Closes #13397

## Notes

* When a soft-deleted or hard-deleted user is synced to the LOD device, the session is not yet removed, so it won't be logged out automatically. This will be fixed in http://github.com/learningequality/kolibri/pull/13757