### PR TITLE
Standarize side panels styles

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/index.vue
@@ -3,10 +3,10 @@
   <SidePanelModal
     v-if="showSidePanel"
     ref="resourcePanel"
+    hideHeaderBorder
     alignment="right"
     sidePanelWidth="700px"
     closeButtonIconType="close"
-    :addBottomBorder="false"
     @closePanel="handleClosePanel"
     @shouldFocusFirstEl="findFirstEl()"
   >

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -2,13 +2,15 @@
 
   <div>
     <SidePanelModal
+      hideHeaderBorder
       alignment="right"
       sidePanelWidth="700px"
-      :addBottomBorder="false"
+      :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
+      :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="closeSidePanel"
     >
       <template #header>
-        <h1>{{ assignUsersHeading$({ num: selectedUsersCount }) }}</h1>
+        <h1 class="side-panel-title">{{ assignUsersHeading$({ num: selectedUsersCount }) }}</h1>
       </template>
 
       <div class="assign-coaches-content">
@@ -23,7 +25,7 @@
           </div>
 
           <div
-            class="top-info-box"
+            class="info-box"
             :style="{ backgroundColor: $themePalette.grey.v_100 }"
           >
             <template v-if="ineligibleUsersCount > 0">
@@ -47,11 +49,16 @@
             </template>
           </div>
 
-          <h2>{{ selectClassesLabel$() }}</h2>
+          <h2
+            id="assign-coaches-selected-classes"
+            class="side-panel-subtitle"
+          >
+            {{ selectClassesLabel$() }}
+          </h2>
           <SelectableList
             v-model="selectedClasses"
             :options="formattedClasses"
-            aria-labelledby="classes-heading"
+            aria-labelledby="assign-coaches-selected-classes"
             :selectAllLabel="assignToAllClasses$()"
             :searchLabel="searchForAClass$()"
           />
@@ -102,7 +109,6 @@
   import { ref, computed } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
-  import KIcon from 'kolibri-design-system/lib/KIcon';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import { UserKinds } from 'kolibri/constants';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
@@ -120,7 +126,6 @@
     name: 'AssignCoachesSidePanel',
     components: {
       SidePanelModal,
-      KIcon,
       SelectableList,
       CloseConfirmationGuard,
     },
@@ -328,8 +333,14 @@
 
 <style scoped>
 
-  .assign-coaches-content {
-    position: relative;
+  .side-panel-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .side-panel-subtitle {
+    font-size: 16px;
+    font-weight: 600;
   }
 
   .assign-warning-label {
@@ -348,19 +359,10 @@
     line-height: 1.5;
   }
 
-  .top-info-box {
-    padding: 12px;
-    margin-bottom: 16px;
-    border-radius: 8px;
-  }
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-content) {
-    padding-top: 0 !important ;
-  }
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-header) {
-    padding-right: 32px !important ;
-    padding-left: 32px !important ;
+  .info-box {
+    padding: 8px;
+    margin-bottom: 24px;
+    border-radius: 4px;
   }
 
   .info-flex {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -18,7 +18,7 @@
         <div v-else>
           <div
             v-if="showErrorWarning"
-            class="assign-warning-label"
+            class="warning-text"
             :style="{ color: $themeTokens.error }"
           >
             <span>{{ defaultErrorMessage$() }}</span>
@@ -28,25 +28,21 @@
             class="info-box"
             :style="{ backgroundColor: $themePalette.grey.v_100 }"
           >
-            <template v-if="ineligibleUsersCount > 0">
-              <div class="info-flex">
-                <KIcon
-                  icon="infoOutline"
-                  class="info-icon"
-                />
-                <div class="info-lines">
-                  <div class="info-line">
+            <div style="display: flex">
+              <KIcon
+                icon="infoOutline"
+                class="info-icon"
+              />
+              <div class="info-wrapper">
+                <template v-if="ineligibleUsersCount > 0">
+                  <span>
                     {{ numUsersNotEligible$({ num: ineligibleUsersCount }) }}
-                  </div>
-                  <div class="info-line">{{ usersInClassNotAffected$() }}</div>
-                </div>
+                  </span>
+                  <span>{{ usersInClassNotAffected$() }}</span>
+                </template>
+                <span v-else>{{ usersInClassNotAffected$() }}</span>
               </div>
-            </template>
-            <template v-else>
-              <div class="info-lines">
-                <div class="info-line">{{ usersInClassNotAffected$() }}</div>
-              </div>
-            </template>
+            </div>
           </div>
 
           <h2
@@ -164,6 +160,10 @@
       } = bulkUserManagementStrings;
 
       const loadUsers = async () => {
+        if (!props.selectedUsers || props.selectedUsers.size === 0) {
+          facilityUsers.value = [];
+          return;
+        }
         isLoading.value = true;
         const users = await FacilityUserResource.fetchCollection({
           getParams: {
@@ -333,62 +333,6 @@
 
 <style scoped>
 
-  .side-panel-title {
-    font-size: 18px;
-    font-weight: 600;
-  }
-
-  .side-panel-subtitle {
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .assign-warning-label {
-    margin-bottom: 10px;
-  }
-
-  .bottom-nav-container {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
-
-  .adjust-line-height {
-    /* Override default global line-height of 1.15 to prevent
-       scrollbars in KModal and add space for single-line content */
-    line-height: 1.5;
-  }
-
-  .info-box {
-    padding: 8px;
-    margin-bottom: 24px;
-    border-radius: 4px;
-  }
-
-  .info-flex {
-    display: flex;
-    align-items: flex-start;
-  }
-
-  .info-icon {
-    flex: 0 0 24px;
-    width: 24px;
-    height: 24px;
-    margin-right: 4px;
-  }
-
-  .info-lines {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .info-line {
-    line-height: 1.4;
-  }
-
-  .info-line:last-child {
-    margin-bottom: 0;
-  }
+  @import './common';
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -5,6 +5,7 @@
       hideHeaderBorder
       alignment="right"
       sidePanelWidth="700px"
+      class="bum-side-panel"
       :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
       :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="closeSidePanel"
@@ -331,8 +332,12 @@
 </script>
 
 
-<style scoped>
+<style lang="scss" scoped>
 
   @import './common';
+
+  .bum-side-panel {
+    @include bum-side-panel;
+  }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -6,6 +6,7 @@
       alignment="right"
       sidePanelWidth="700px"
       :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
+      class="bum-side-panel"
       :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="closeSidePanel"
     >
@@ -306,5 +307,9 @@
 <style lang="scss" scoped>
 
   @import './common';
+
+  .bum-side-panel {
+    @include bum-side-panel;
+  }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -31,7 +31,7 @@
             <div style="display: flex">
               <KIcon
                 icon="infoOutline"
-                class="enroll-info-icon"
+                class="info-icon"
               />
               <template v-if="usersNotEnrolled > 0">
                 <div class="info-wrapper">
@@ -305,46 +305,6 @@
 
 <style lang="scss" scoped>
 
-  .side-panel-title {
-    font-size: 18px;
-    font-weight: 600;
-  }
-
-  .side-panel-subtitle {
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .info-box {
-    padding: 8px;
-    margin-bottom: 24px;
-    border-radius: 4px;
-  }
-
-  .enroll-info-icon {
-    flex: 0 0 22px;
-    width: 22px;
-    height: 22px;
-    margin-right: 4px;
-  }
-
-  .info-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-top: 2px;
-    line-height: 1.4;
-  }
-
-  .warning-text {
-    margin-bottom: 10px;
-    margin-left: 5px;
-  }
-
-  .bottom-nav-container {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
+  @import './common';
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -2,13 +2,15 @@
 
   <div>
     <SidePanelModal
+      hideHeaderBorder
       alignment="right"
       sidePanelWidth="700px"
-      :addBottomBorder="false"
+      :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
+      :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="closeSidePanel"
     >
       <template #header>
-        <h1 style="font-size: 20px">
+        <h1 class="side-panel-title">
           {{ enrollUsersInClasses$({ num: selectedUsers.size }) }}
         </h1>
       </template>
@@ -48,7 +50,7 @@
           </div>
           <h2
             id="enroll-in-selected-classes"
-            style="font-size: 16px"
+            class="side-panel-subtitle"
           >
             {{ selectClassesLabel$() }}
           </h2>
@@ -303,23 +305,19 @@
 
 <style lang="scss" scoped>
 
-  .side-panel-content {
-    position: relative;
+  .side-panel-title {
+    font-size: 18px;
+    font-weight: 600;
   }
 
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-content) {
-    padding-top: 0 !important ;
-  }
-
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-header) {
-    padding-right: 32px !important ;
-    padding-left: 32px !important ;
+  .side-panel-subtitle {
+    font-size: 16px;
+    font-weight: 600;
   }
 
   .info-box {
     padding: 8px;
+    margin-bottom: 24px;
     border-radius: 4px;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
@@ -248,10 +248,7 @@
 
 <style lang="scss" scoped>
 
-  .side-panel-title {
-    font-size: 18px;
-    font-weight: 600;
-  }
+  @import '../common';
 
   .filter-section {
     margin-bottom: 24px;
@@ -271,13 +268,6 @@
 
   .birth-year-range-select {
     max-width: 316px;
-  }
-
-  .bottom-nav-container {
-    display: flex;
-    gap: 16px;
-    justify-content: flex-end;
-    width: 100%;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
@@ -3,6 +3,7 @@
   <SidePanelModal
     hideHeaderBorder
     alignment="right"
+    class="bum-side-panel"
     sidePanelWidth="700px"
     :contentContainerStyleOverrides="{ padding: '12px 24px 24px' }"
     :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
@@ -249,6 +250,10 @@
 <style lang="scss" scoped>
 
   @import '../common';
+
+  .bum-side-panel {
+    @include bum-side-panel;
+  }
 
   .filter-section {
     margin-bottom: 24px;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/FilterUsersSidePanel/index.vue
@@ -1,8 +1,11 @@
 <template>
 
   <SidePanelModal
+    hideHeaderBorder
     alignment="right"
     sidePanelWidth="700px"
+    :contentContainerStyleOverrides="{ padding: '12px 24px 24px' }"
+    :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
     @closePanel="goBack"
   >
     <template #header>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -5,6 +5,7 @@
       hideHeaderBorder
       alignment="right"
       sidePanelWidth="700px"
+      class="bum-side-panel"
       :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
       :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="goBack"
@@ -368,5 +369,9 @@
 <style lang="scss" scoped>
 
   @import './common';
+
+  .bum-side-panel {
+    @include bum-side-panel;
+  }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -2,13 +2,15 @@
 
   <div>
     <SidePanelModal
+      hideHeaderBorder
       alignment="right"
       sidePanelWidth="700px"
-      :addBottomBorder="false"
+      :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
+      :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
       @closePanel="goBack"
     >
       <template #header>
-        <h1 style="font-size: 20px">
+        <h1 class="side-panel-title">
           {{ removeUsersFromClassesHeading$({ numUsers: selectedUsers.size }) }}
         </h1>
       </template>
@@ -48,7 +50,7 @@
           </div>
           <h2
             id="remove-from-selected-classes"
-            style="font-size: 16px"
+            class="side-panel-subtitle"
           >
             {{ selectClassesLabel$() }}
           </h2>
@@ -365,23 +367,23 @@
 
 <style lang="scss" scoped>
 
+  .side-panel-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .side-panel-subtitle {
+    font-size: 16px;
+    font-weight: 600;
+  }
+
   .side-panel-content {
     position: relative;
   }
 
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-content) {
-    padding-top: 0 !important ;
-  }
-
-  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-  ::v-deep(.side-panel-header) {
-    padding-right: 32px !important ;
-    padding-left: 32px !important ;
-  }
-
   .info-box {
     padding: 8px;
+    margin-bottom: 24px;
     border-radius: 4px;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -31,7 +31,7 @@
             <div style="display: flex">
               <KIcon
                 icon="infoOutline"
-                class="remove-info-icon"
+                class="info-icon"
               />
               <template v-if="selectedUsers.size > 0 && classCoaches.length > 0">
                 <div class="info-wrapper">
@@ -367,50 +367,6 @@
 
 <style lang="scss" scoped>
 
-  .side-panel-title {
-    font-size: 18px;
-    font-weight: 600;
-  }
-
-  .side-panel-subtitle {
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .side-panel-content {
-    position: relative;
-  }
-
-  .info-box {
-    padding: 8px;
-    margin-bottom: 24px;
-    border-radius: 4px;
-  }
-
-  .remove-info-icon {
-    flex: 0 0 22px;
-    width: 22px;
-    height: 22px;
-    margin-right: 4px;
-  }
-
-  .info-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-top: 2px;
-    line-height: 1.4;
-  }
-
-  .warning-text {
-    margin-bottom: 10px;
-    margin-left: 5px;
-  }
-
-  .bottom-nav-container {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  }
+  @import './common';
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -1,9 +1,12 @@
 <template>
 
   <SidePanelModal
+    hideHeaderBorder
     alignment="right"
     sidePanelWidth="700px"
     closeButtonIconType="close"
+    :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
+    :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
     @closePanel="close"
   >
     <template #header>
@@ -12,6 +15,13 @@
       </h1>
     </template>
     <template #default>
+      <div
+        v-if="showErrorWarning"
+        :style="{ color: $themeTokens.error }"
+        class="warning-text"
+      >
+        <span>{{ defaultErrorMessage$() }}</span>
+      </div>
       <form
         v-if="!loading"
         :id="formId"
@@ -226,6 +236,8 @@
       const formSubmitted = ref(false);
       const caughtErrors = ref([]);
 
+      const showErrorWarning = ref(false);
+
       const resetForm = () => {
         fullName.value = '';
         username.value = '';
@@ -327,7 +339,7 @@
         if (caughtErrors.value.length > 0) {
           focusOnInvalidField();
         } else {
-          store.dispatch('handleApiError', { error });
+          showErrorWarning.value = true;
         }
       };
 
@@ -445,7 +457,7 @@
       });
 
       const { saveAndClose$ } = coreStrings;
-      const { saveAndAddAnother$ } = bulkUserManagementStrings;
+      const { saveAndAddAnother$, defaultErrorMessage$ } = bulkUserManagementStrings;
       return {
         classesAction,
         fullName,
@@ -478,6 +490,7 @@
         facilityConfig,
         saveAndClose$,
         saveAndAddAnother$,
+        defaultErrorMessage$,
       };
     },
     props: {
@@ -541,6 +554,11 @@
     gap: 16px;
     justify-content: flex-end;
     width: 100%;
+  }
+
+  .warning-text {
+    margin-bottom: 10px;
+    margin-left: 5px;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -524,6 +524,8 @@
 
 <style lang="scss" scoped>
 
+  @import '../common';
+
   .coach-selector {
     padding: 0;
     margin: 0;
@@ -539,21 +541,8 @@
     width: 100%;
   }
 
-  .side-panel-title {
-    font-size: 18px;
-    font-weight: 600;
-  }
-
   /deep/ .textbox {
     max-width: 100% !important;
-  }
-
-  .bottom-nav-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    justify-content: flex-end;
-    width: 100%;
   }
 
   .warning-text {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -4,6 +4,7 @@
     hideHeaderBorder
     alignment="right"
     sidePanelWidth="700px"
+    class="bum-side-panel"
     closeButtonIconType="close"
     :contentContainerStyleOverrides="{ padding: '0px 24px 24px' }"
     :headerContainerStyleOverrides="{ paddingLeft: '24px', paddingRight: '24px' }"
@@ -525,6 +526,10 @@
 <style lang="scss" scoped>
 
   @import '../common';
+
+  .bum-side-panel {
+    @include bum-side-panel;
+  }
 
   .coach-selector {
     padding: 0;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
@@ -1,48 +1,50 @@
-.side-panel-title {
-  font-size: 18px;
-  font-weight: 600;
-}
+@mixin bum-side-panel {
+  .side-panel-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
 
-.side-panel-subtitle {
-  font-size: 16px;
-  font-weight: 600;
-}
+  .side-panel-subtitle {
+    font-size: 16px;
+    font-weight: 600;
+  }
 
-.bottom-nav-container {
-  display: flex;
-  gap: 16px;
-  justify-content: flex-end;
-  width: 100%;
-}
+  .bottom-nav-container {
+    display: flex;
+    gap: 16px;
+    justify-content: flex-end;
+    width: 100%;
+  }
 
-.adjust-line-height {
-  /* Override default global line-height of 1.15 to prevent
+  .adjust-line-height {
+    /* Override default global line-height of 1.15 to prevent
        scrollbars in KModal and add space for single-line content */
-  line-height: 1.5;
-}
+    line-height: 1.5;
+  }
 
-.info-box {
-  padding: 8px;
-  margin-bottom: 24px;
-  border-radius: 4px;
-}
+  .info-box {
+    padding: 8px;
+    margin-bottom: 24px;
+    border-radius: 4px;
+  }
 
-.info-icon {
-  flex: 0 0 22px;
-  width: 22px !important;
-  height: 22px !important;
-  margin-right: 4px;
-}
+  .info-icon {
+    flex: 0 0 22px;
+    width: 22px !important;
+    height: 22px !important;
+    margin-right: 4px;
+  }
 
-.info-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 2px;
-  line-height: 1.4;
-}
+  .info-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 2px;
+    line-height: 1.4;
+  }
 
-.warning-text {
-  margin-bottom: 10px;
-  margin-left: 5px;
+  .warning-text {
+    margin-bottom: 10px;
+    margin-left: 5px;
+  }
 }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
@@ -1,0 +1,48 @@
+.side-panel-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.side-panel-subtitle {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.bottom-nav-container {
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.adjust-line-height {
+  /* Override default global line-height of 1.15 to prevent
+       scrollbars in KModal and add space for single-line content */
+  line-height: 1.5;
+}
+
+.info-box {
+  padding: 8px;
+  margin-bottom: 24px;
+  border-radius: 4px;
+}
+
+.info-icon {
+  flex: 0 0 22px;
+  width: 22px !important;
+  height: 22px !important;
+  margin-right: 4px;
+}
+
+.info-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.warning-text {
+  margin-bottom: 10px;
+  margin-left: 5px;
+}

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -106,10 +106,10 @@
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
         // @type {RefImpl<number>}
-        handleScroll,
         windowBreakpoint,
         lastFocus: null,
         isScrolled,
+        handleScroll,
       };
     },
     props: {

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -20,8 +20,12 @@
           <!-- Fixed header -->
           <div
             ref="fixedHeader"
-            :class="{ 'side-panel-header': true, immersive: immersive }"
-            :style="headerStyles"
+            :class="{
+              'side-panel-header': true,
+              immersive: immersive,
+              'floating-shadow': isScrolled && hideHeaderBorder,
+            }"
+            :style="[headerStyles, headerContainerStyleOverrides]"
           >
             <div
               class="header-content"
@@ -46,7 +50,8 @@
           <!-- Default slot for inserting content which will scroll on overflow -->
           <div
             class="side-panel-content"
-            @scroll="isScrolled = $event.target.scrollTop > 0"
+            :style="contentContainerStyleOverrides"
+            @scroll="handleScroll"
           >
             <slot :isScrolled="isScrolled"></slot>
           </div>
@@ -74,8 +79,9 @@
 
 <script>
 
-  import { ref } from 'vue';
+  import { computed, ref } from 'vue';
   import { get } from '@vueuse/core';
+  import throttle from 'lodash/throttle';
   import Backdrop from 'kolibri/components/Backdrop';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
@@ -88,12 +94,22 @@
     mixins: [commonCoreStrings],
     setup() {
       const { windowBreakpoint } = useKResponsiveWindow();
+
+      const isScrolled = ref(false);
+
+      const _handleScroll = event => {
+        isScrolled.value = event.target.scrollTop > 0;
+      };
+
+      const handleScroll = computed(() => throttle(_handleScroll, 100));
+
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
         // @type {RefImpl<number>}
+        handleScroll,
         windowBreakpoint,
         lastFocus: null,
-        isScrolled: ref(false),
+        isScrolled,
       };
     },
     props: {
@@ -130,10 +146,20 @@
         required: false,
         default: false,
       },
-      addBottomBorder: {
+      hideHeaderBorder: {
         type: Boolean,
         required: false,
-        default: true,
+        default: false,
+      },
+      headerContainerStyleOverrides: {
+        type: Object,
+        required: false,
+        default: null,
+      },
+      contentContainerStyleOverrides: {
+        type: Object,
+        required: false,
+        default: null,
       },
     },
     computed: {
@@ -165,9 +191,9 @@
       headerStyles() {
         return {
           backgroundColor: this.immersive ? this.$themeTokens.appBar : this.$themeTokens.surface,
-          borderBottom: this.addBottomBorder
-            ? `1px solid ${this.$themePalette.grey.v_400}`
-            : 'none',
+          borderBottom: this.hideHeaderBorder
+            ? 'none'
+            : `1px solid ${this.$themePalette.grey.v_400}`,
         };
       },
       sidePanelStyles() {
@@ -266,6 +292,10 @@
       padding: 24px 32px 16px;
       overflow-x: hidden;
       overflow-y: auto;
+    }
+
+    .floating-shadow {
+      @extend %dropshadow-1dp;
     }
 
     .bottom-navigation {


### PR DESCRIPTION
## Summary
* Standarize header bottom box shadow shown just on scroll.
* Standarize side panel titles and subtitles font-size and font-weight.
* Standarize info-box styles.
* Standarize padding of header and content side panel containers.
  * Removed side panels deep selectors to prevent unnoticed regressions.

| | |
| --- | --- |
| <img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/9093de37-bd6a-4af5-b09b-804617633788" /> | <img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/492be56a-0a81-48e6-87a5-ed718f5bdb75" /> |
| <img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/55bf8d24-7a04-4834-b24e-cae4056de56c" /> | <img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/6fe7b3f6-57b3-4421-b4ad-0f8104450082" /> |
| <img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/5aed70ca-1492-44ec-8321-c91a55032ba1" /> | |

All of them now shows a box shadow when the content is scrolled:

<img width="1048" height="1325" alt="image" src="https://github.com/user-attachments/assets/e93a5a2c-4610-448e-bb4c-4c651012d6bb" />


## References
Closes #13731.

## Reviewer guidance
* Go to every side panel in faciliy > users
* Are all of them consistent styling-wise?
