### PR TITLE
[Bugfix]: Remove breaking h1 w/ previously removed string in quiz section editor

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionEditor.vue
@@ -4,9 +4,6 @@
     v-if="activeSection"
     class="section-settings-content"
   >
-    <h1 :style="{ color: $themeTokens.text }">
-      {{ sectionSettings$() }}
-    </h1>
     <div>
       <MissingResourceAlert v-if="exam.missing_resource" />
     </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I went to test accordions while testing #13753 locally and ran into this bug that borked the section settings editor side panel altogether.

I looked and see that the `sectionSettings$` string was removed - so perhaps this slipped through some rebase cracks or something. In any case - I'm assuming this is the expected and intended layout (cc @tomiwaoLE @marcellamaki)

Before:

<img width="696" height="413" alt="image" src="https://github.com/user-attachments/assets/36ef9a40-8b32-4258-9623-6d499bdedbb8" />

After:

<img width="697" height="339" alt="image" src="https://github.com/user-attachments/assets/bc428f94-ee5f-481f-a740-e36c7ba1a47c" />


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does it look right now - or should there actually have been an H1 tag there w/ something in it?
