### PR TITLE
[Bulk User]: Handle bad-data errors w/ `handleApiError` (+ better side panel refresh handling)

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -111,7 +111,7 @@
 
 <script>
 
-  import { ref, computed } from 'vue';
+  import { onMounted, ref, computed } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
@@ -149,6 +149,13 @@
             name: getRootRouteName(route),
           });
         },
+      });
+
+      onMounted(() => {
+        // Answering the question "what happens when we refresh?"
+        if (props.selectedUsers.size === 0) {
+          goBack();
+        }
       });
 
       const {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -111,7 +111,7 @@
 
 <script>
 
-  import { onMounted, ref, computed } from 'vue';
+  import { ref, computed } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
@@ -122,6 +122,7 @@
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
+  import { PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import SelectableList from '../../common/SelectableList.vue';
   import { _userState } from '../../../modules/mappers';
@@ -149,13 +150,6 @@
             name: getRootRouteName(route),
           });
         },
-      });
-
-      onMounted(() => {
-        // Answering the question "what happens when we refresh?"
-        if (props.selectedUsers.size === 0) {
-          goBack();
-        }
       });
 
       const {
@@ -341,6 +335,19 @@
         type: Function,
         default: () => {},
       },
+    },
+    beforeRouteEnter(to, from, next) {
+      // We can't land here without having navigated to here from the users root page - we can't
+      // have selected any users if we load into this page, so go to the users table.
+      if (from.name === null) {
+        next(
+          // Override to to keep params like facility_id in place
+          overrideRoute(to, {
+            name: PageNames.USER_MGMT_PAGE,
+          }),
+        );
+      }
+      next();
     },
     beforeRouteLeave(to, from, next) {
       this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -234,7 +234,6 @@
             const newMemberships = await MembershipResource.saveCollection({ data: enrollments });
             createdMemberships.value = newMemberships;
           } catch (error) {
-            // Why doesn't this ever get run here?
             store.dispatch('handleApiError', { error });
             loading.value = false;
             return false;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -172,15 +172,6 @@
 
       const { classesLabel$ } = coreStrings;
 
-      const route = useRoute();
-      const goBack = useGoBack({
-        getFallbackRoute: () => {
-          return overrideRoute(route, {
-            name: getRootRouteName(route),
-          });
-        },
-      });
-
       // Computed properties
       const classList = computed(() =>
         props.classes

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -114,7 +114,7 @@
 <script>
 
   import { useRoute } from 'vue-router/composables';
-  import { onMounted, getCurrentInstance, ref, computed } from 'vue';
+  import { getCurrentInstance, ref, computed } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
@@ -123,6 +123,7 @@
   import groupBy from 'lodash/groupBy';
   import SelectableList from '../../common/SelectableList.vue';
   import useActionWithUndo from '../../../composables/useActionWithUndo';
+  import { PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
 
@@ -143,13 +144,6 @@
             name: getRootRouteName(route),
           });
         },
-      });
-
-      onMounted(() => {
-        // Answering the question "what happens when we refresh?"
-        if (props.selectedUsers.size === 0) {
-          goBack();
-        }
       });
 
       const loading = ref(false);
@@ -327,6 +321,19 @@
         type: Function,
         default: () => {},
       },
+    },
+    beforeRouteEnter(to, from, next) {
+      // We can't land here without having navigated to here from the users root page - we can't
+      // have selected any users if we load into this page, so go to the users table.
+      if (from.name === null) {
+        next(
+          // Override to to keep params like facility_id in place
+          overrideRoute(to, {
+            name: PageNames.USER_MGMT_PAGE,
+          }),
+        );
+      }
+      next();
     },
     beforeRouteLeave(to, from, next) {
       this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -114,7 +114,7 @@
 <script>
 
   import { useRoute } from 'vue-router/composables';
-  import { ref, computed } from 'vue';
+  import { onMounted, getCurrentInstance, ref, computed } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
@@ -135,6 +135,23 @@
     },
     mixins: [commonCoreStrings],
     setup(props) {
+      const store = getCurrentInstance().proxy.$store;
+      const route = useRoute();
+      const goBack = useGoBack({
+        getFallbackRoute: () => {
+          return overrideRoute(route, {
+            name: getRootRouteName(route),
+          });
+        },
+      });
+
+      onMounted(() => {
+        // Answering the question "what happens when we refresh?"
+        if (props.selectedUsers.size === 0) {
+          goBack();
+        }
+      });
+
       const loading = ref(false);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -223,7 +240,8 @@
             const newMemberships = await MembershipResource.saveCollection({ data: enrollments });
             createdMemberships.value = newMemberships;
           } catch (error) {
-            showErrorWarning.value = true;
+            // Why doesn't this ever get run here?
+            store.dispatch('handleApiError', { error });
             loading.value = false;
             return false;
           }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -326,6 +326,10 @@
       });
 
       onMounted(() => {
+        // Answering the question "what happens when we refresh?"
+        if (props.selectedUsers.size === 0) {
+          goBack();
+        }
         setClassUsers();
       });
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -119,6 +119,7 @@
 <script>
 
   import { ref, computed, onMounted } from 'vue';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
@@ -173,6 +174,8 @@
       } = bulkUserManagementStrings;
 
       const { classesLabel$ } = coreStrings;
+
+      const { createSnackbar } = useSnackbar();
 
       const goBack = useGoBack({
         getFallbackRoute: () => {
@@ -268,6 +271,7 @@
             kind: UserKinds.COACH,
           }))
           : [];
+
         try {
           await Promise.all([
             enrollments.length
@@ -278,10 +282,9 @@
               : Promise.resolve(),
           ]);
         } catch (_) {
-          showErrorWarning.value = true;
-        } finally {
-          loading.value = false;
+          createSnackbar(defaultErrorMessage$());
         }
+
         props.onChange({
           affectedClasses: selectedOptions.value,
           resetSelection: true,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -128,6 +128,7 @@
   import { UserKinds } from 'kolibri/constants';
   import groupBy from 'lodash/groupBy';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
+  import { PageNames } from '../../../constants.js';
   import SelectableList from '../../common/SelectableList.vue';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import useActionWithUndo from '../../../composables/useActionWithUndo';
@@ -326,10 +327,6 @@
       });
 
       onMounted(() => {
-        // Answering the question "what happens when we refresh?"
-        if (props.selectedUsers.size === 0) {
-          goBack();
-        }
         setClassUsers();
       });
 
@@ -382,6 +379,19 @@
         type: Function,
         default: () => {},
       },
+    },
+    beforeRouteEnter(to, from, next) {
+      // We can't land here without having navigated to here from the users root page - we can't
+      // have selected any users if we load into this page, so go to the users table.
+      if (from.name === null) {
+        next(
+          // Override to to keep params like facility_id in place
+          overrideRoute(to, {
+            name: PageNames.USER_MGMT_PAGE,
+          }),
+        );
+      }
+      next();
     },
     beforeRouteLeave(to, from, next) {
       this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -268,14 +268,20 @@
             kind: UserKinds.COACH,
           }))
           : [];
-        await Promise.all([
-          enrollments.length
-            ? MembershipResource.saveCollection({ data: enrollments })
-            : Promise.resolve(),
-          assignments.length
-            ? RoleResource.saveCollection({ data: assignments })
-            : Promise.resolve(),
-        ]);
+        try {
+          await Promise.all([
+            enrollments.length
+              ? MembershipResource.saveCollection({ data: enrollments })
+              : Promise.resolve(),
+            assignments.length
+              ? RoleResource.saveCollection({ data: assignments })
+              : Promise.resolve(),
+          ]);
+        } catch (_) {
+          showErrorWarning.value = true;
+        } finally {
+          loading.value = false;
+        }
         props.onChange({
           affectedClasses: selectedOptions.value,
           resetSelection: true,

--- a/packages/kolibri/apiResource.js
+++ b/packages/kolibri/apiResource.js
@@ -1054,7 +1054,7 @@ export class Resource {
       }
       console.groupEnd();
     }
-    if (Object.keys(err.config.params).length) {
+    if (err.config?.params && Object.keys(err.config.params).length) {
       console.group('Query parameters');
       for (const [k, v] of Object.entries(err.config.params)) {
         console.log(`${k}: ${v}`);
@@ -1073,7 +1073,7 @@ export class Resource {
         }
       } catch (e) {} // eslint-disable-line no-empty
     }
-    if (Object.keys(err.config.headers).length) {
+    if (err.config?.headers && Object.keys(err.config.headers).length) {
       console.group('Headers');
       for (const [k, v] of Object.entries(err.config.headers)) {
         console.log(`${k}: ${v}`);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- In the `apiResource.js` file, the `logError` function expected an error object to have a particular shape - but the error that this issue fixes was getting swallowed up by the errors thrown when the error object in `logError` wasn't the shape expected. I added some existence checks to ensure errors don't get annihilated.
- I noticed that refreshing w/ a side panel open would load the page w/ the side panel visible. I added checks in `onMounted` hooks to redirect to the root page (using the `goBack` module function) whenever there are no users selected.

This will give the user the ability to refresh the page, which will remove stale data.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13550 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Refresh the page on each of the side panels
- Perform the replication steps noted in #13550 and see that when you get a bad-data error there, you are shown the API error page and that when you click "Refresh" you are taken to a fresh users table.
