### PR TITLE
Fix inconsistent table width for New Users and Users Trash views

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -332,7 +332,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    max-width: 1000px;
+    max-width: 1440px;
     margin: 0 auto auto;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -265,7 +265,7 @@
   .page-container {
     display: flex;
     flex-direction: column;
-    max-width: 1000px;
+    max-width: 1440px;
     margin: 24px auto;
   }
 


### PR DESCRIPTION
- Change max-width from 1000px to 1440px in NewUsersPage.vue
- Change max-width from 1000px to 1440px in UsersTrashPage/index.vue
- Ensures consistent table width across all user management pages
- Matches the width used in the main Facility > Users table

Fixes table width inconsistency where New Users and Users Trash tables appeared narrower than the main Users table, improving visual consistency and user experience.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

