### PR TITLE
Unwrapped strings rule

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/CoachPrompts/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachPrompts/index.vue
@@ -1,5 +1,6 @@
 <template>
 
+  <!-- eslint-disable vue/no-bare-strings-in-template -->
   <!-- eslint-disable max-len -->
   <div :style="{ padding: '32px', backgroundColor: $themeTokens.surface }">
     <h1>Prompts while "Planning a lesson"</h1>

--- a/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/StatusTestPage.vue
@@ -1,5 +1,6 @@
 <template>
 
+  <!-- eslint-disable vue/no-bare-strings-in-template -->
   <div
     class="overview"
     :style="{ backgroundColor: $themeTokens.surface }"

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -249,7 +249,7 @@
                 class="slider-section"
                 :class="$computedClass(sliderSectionStyle)"
               >
-                <p class="slider-min-max">0</p>
+                <p class="slider-min-max">{{ $formatNumber(0) }}</p>
                 <input
                   id="slider"
                   v-model="limitForAutodownload"

--- a/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/CsvInfoModal.vue
@@ -19,6 +19,7 @@
         </tr>
       </thead>
       <tbody>
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('uuid') }}<br >
@@ -30,6 +31,8 @@
           <td><code>UUID</code></td>
           <td>{{ $tr('uuidInfo') }}</td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('username') }}<br >
@@ -63,6 +66,8 @@
           <td><code>FULL_NAME</code></td>
           <td>{{ $tr('fullNameInfo') }}</td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('userType') }}<br >
@@ -82,6 +87,8 @@
             </ul>
           </td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('identifier') }}<br >
@@ -104,6 +111,8 @@
           <td><code>BIRTH_YEAR</code></td>
           <td>{{ $tr('yearInfo') }}</td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('gender') }}<br >
@@ -122,6 +131,8 @@
             </ul>
           </td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('enrolled') }}<br >
@@ -140,6 +151,8 @@
             </ul>
           </td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <tr>
           <td>
             {{ $tr('assigned') }}<br >
@@ -158,6 +171,7 @@
             </ul>
           </td>
         </tr>
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
       </tbody>
     </table>
   </KModal>

--- a/kolibri/plugins/policies/assets/src/views/CookiePolicy.vue
+++ b/kolibri/plugins/policies/assets/src/views/CookiePolicy.vue
@@ -25,6 +25,7 @@
             <th>{{ $tr('cookiePurposeTableHeader') }}</th>
             <th>{{ $tr('cookieExpiryTableHeader') }}</th>
           </tr>
+          <!-- eslint-disable vue/no-bare-strings-in-template -->
           <tr>
             <td>kolibri_csrftoken</td>
             <td>{{ $tr('csrftokenCookiePurpose') }}</td>
@@ -40,6 +41,7 @@
             <td>{{ $tr('kolibriCookieConsentPurpose') }}</td>
             <td>{{ $tr('twoYearExpiry') }}</td>
           </tr>
+          <!-- eslint-enable vue/no-bare-strings-in-template -->
         </table>
       </section>
 
@@ -52,11 +54,13 @@
             <th>{{ $tr('cookiePurposeTableHeader') }}</th>
             <th>{{ $tr('cookieExpiryTableHeader') }}</th>
           </tr>
+          <!-- eslint-disable vue/no-bare-strings-in-template -->
           <tr>
             <td>visitor_id</td>
             <td>{{ $tr('visitorIdPurpose') }}</td>
             <td>{{ $tr('twoYearExpiry') }}</td>
           </tr>
+          <!-- eslint-enable vue/no-bare-strings-in-template -->
         </table>
       </section>
       <section>

--- a/kolibri/plugins/policies/assets/src/views/UsageAndPrivacy.vue
+++ b/kolibri/plugins/policies/assets/src/views/UsageAndPrivacy.vue
@@ -34,11 +34,13 @@
       <h2>{{ $tr('kolibriAboutTitle') }}</h2>
       <p>{{ $tr('kolibriAboutP1') }}</p>
       <p>
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <KExternalLink
           text="https://learningequality.org"
           href="https://learningequality.org"
           :openInNewTab="true"
         />
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
       </p>
       <p>{{ $tr('kolibriAboutP2') }}</p>
       <p>{{ $tr('kolibriAboutP3') }}</p>

--- a/kolibri/plugins/qti_viewer/assets/src/components/QTISandboxPage.vue
+++ b/kolibri/plugins/qti_viewer/assets/src/components/QTISandboxPage.vue
@@ -1,5 +1,6 @@
 <template>
 
+  <!-- eslint-disable vue/no-bare-strings-in-template -->
   <div class="qti-sandbox">
     <div class="qti-sandbox-header">
       <h1>QTI Sandbox</h1>

--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -163,6 +163,7 @@
     >
       <p>{{ $tr('oidcGenericExplanation') }}</p>
       <p>
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <KExternalLink
           text="https://learningequality.org/kolibri"
           :primary="true"
@@ -170,6 +171,7 @@
           :openInNewTab="true"
           appearance="basic-link"
         />
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
       </p>
     </KModal>
   </div>

--- a/packages/kolibri-format/.eslintrc.js
+++ b/packages/kolibri-format/.eslintrc.js
@@ -228,6 +228,18 @@ module.exports = {
     'vue/match-component-file-name': ERROR,
     'vue/component-options-name-casing': [ERROR, 'PascalCase'],
     'vue/no-unused-properties': [ERROR, { groups: ['props', 'data', 'computed', 'methods', 'setup'], deepData: true, ignorePublicMembers: true }],
+    // Prevent unwrapped strings in templates to ensure we are doing i18n properly
+    "vue/no-bare-strings-in-template": [ERROR, {
+      "allowlist": [
+        "(", ")", ",", ".", "&", "+", "-", "=", "*", "/", "#", "%", "!", "?", ":", "[", "]", "{", "}", "<", ">", "\u00b7", "\u2022", "\u2010", "\u2013", "\u2014", "\u2212", "|"
+      ],
+      "attributes": {
+        "/.+/": ["title", "aria-label", "aria-placeholder", "aria-roledescription", "aria-valuetext", "ariaLabel", "ariaPlaceholder", "ariaRoledescription", "ariaValuetext", "label", "text", "description", "tooltip", "submitText", "cancelText", "errorMessage"],
+        "input": ["placeholder"],
+        "img": ["alt"]
+      },
+      "directives": ["v-text"]
+    }],
 
     'import/first': ERROR,
     'import/no-duplicates': ERROR,

--- a/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context01.vue
+++ b/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context01.vue
@@ -1,5 +1,6 @@
 <template>
 
+  <!-- eslint-disable vue/no-bare-strings-in-template -->
   <div>Context01</div>
 
 </template>

--- a/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context02.vue
+++ b/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context02.vue
@@ -1,5 +1,6 @@
 <template>
 
+  <!-- eslint-disable vue/no-bare-strings-in-template -->
   <div>Context02</div>
 
 </template>

--- a/packages/kolibri/components/PrivacyInfoModal.vue
+++ b/packages/kolibri/components/PrivacyInfoModal.vue
@@ -35,11 +35,13 @@
       <h2>{{ $tr('kolibriAboutTitle') }}</h2>
       <p>{{ $tr('kolibriAboutP1') }}</p>
       <p>
+        <!-- eslint-disable vue/no-bare-strings-in-template -->
         <KExternalLink
           text="https://learningequality.org/kolibri-privacy-policy/"
           href="https://learningequality.org/kolibri-privacy-policy/"
           :openInNewTab="true"
         />
+        <!-- eslint-enable vue/no-bare-strings-in-template -->
       </p>
       <p>{{ $tr('kolibriAboutP2') }}</p>
       <p>{{ $tr('kolibriAboutP3') }}</p>

--- a/packages/kolibri/components/onboarding/TooltipContent.vue
+++ b/packages/kolibri/components/onboarding/TooltipContent.vue
@@ -52,7 +52,7 @@
           appearance="flat-button"
           @click="$emit('back')"
         >
-          Back
+          {{ coreString('backAction') }}
         </KButton>
 
         <KButton

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -178,7 +178,9 @@
               <div class="side-nav-scrollable-area-footer-info">
                 <p>{{ footerMsg }}</p>
                 <!-- Not translated -->
+                <!-- eslint-disable vue/no-bare-strings-in-template -->
                 <p>© {{ copyrightYear }} Learning Equality</p>
+                <!-- eslint-enable vue/no-bare-strings-in-template -->
                 <p>
                   <KButton
                     ref="privacyLink"


### PR DESCRIPTION
## Summary
Adds unwrapped strings rule linting for Vue templates
Fixes all instances, or ignores as appropriate

## References
Fixes #10257

## Reviewer guidance
Are all the ignored instances actually things that should be ignored?

To do this, I took the output of the linting failures and passed them to Claude Code and used manual approval of each change to ensure the correct fix was applied.

Note that one of the changes here is redundant with a change to wrap the same string here: https://github.com/learningequality/kolibri/pull/13639 but at most this will just cause a minor merge conflict, and was required for linting to pass.