### PR TITLE
Remove unused modal

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/MoveToTrashModal.vue
@@ -1,28 +1,7 @@
 <template>
 
   <div>
-    <KModal
-      v-if="usersRemoved"
-      :title="undoTrashHeading$({ num: usersRemoved.length })"
-      :submitText="undoAction$()"
-      :cancelText="coreStrings.dismissAction$()"
-      :submitDisabled="loading"
-      :cancelDisabled="loading"
-      @cancel="confimClosureOnDelete"
-      @submit="undoMoveToTrash"
-    >
-      <KCircularLoader v-if="loading" />
-      <p>
-        {{ undoTrashMessageA$({ numUsers: usersRemoved.length }) }}
-      </p>
-      <p>
-        {{ undoTrashMessageB$() }}
-      </p>
-    </KModal>
-    <KModal
-      v-else
-      :title="moveToTrashLabel$({ num: selectedUsers.size })"
-    >
+    <KModal :title="moveToTrashLabel$({ num: selectedUsers.size })">
       <KCircularLoader v-if="loading" />
       <div
         v-else
@@ -69,7 +48,7 @@
 
 <script>
 
-  import { computed, ref, getCurrentInstance } from 'vue';
+  import { computed, ref } from 'vue';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
 
@@ -78,7 +57,6 @@
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
-  import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import DeletedFacilityUserResource from 'kolibri-common/apiResources/DeletedFacilityUserResource';
 
@@ -94,9 +72,6 @@
       const loading = ref(false);
       const users = ref([]);
       const usersRemoved = ref(null);
-      const { $store, $router } = getCurrentInstance().proxy;
-      const activeFacilityId =
-        $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
 
       const {
         trashUndoneNotice$,
@@ -127,31 +102,6 @@
         } finally {
           loading.value = false;
         }
-      };
-
-      const confimClosureOnDelete = () => {
-        ClassroomResource.fetchCollection({
-          getParams: { parent: activeFacilityId },
-          force: true,
-        }).then(classrooms => {
-          const removePromises = [];
-
-          classrooms.forEach(classObj => {
-            classObj.coaches.forEach(coach => {
-              if (props.selectedUsers.has(coach.id)) {
-                const promise = $store.dispatch('classEditManagement/removeClassCoach', {
-                  classId: classObj.id,
-                  userId: coach.id,
-                });
-                removePromises.push(promise);
-              }
-            });
-          });
-          return Promise.all(removePromises).then(() => {
-            emit('change', { resetSelection: true });
-            close();
-          });
-        });
       };
 
       const close = () => {
@@ -216,14 +166,12 @@
         // methods
         close,
         moveToTrash,
-        usersRemoved,
 
         // translation functions
         moveToTrashAction$,
         moveToTrashLabel$,
         numAdminsSelected$,
         moveToTrashWarning$,
-        confimClosureOnDelete,
       };
     },
     props: {


### PR DESCRIPTION
## Summary

While working on #13785, I noticed that this confirmation modal was present in the move to trash modal, but never actually executed. This PR removes it.

## Reviewer guidance

* Check that this modal was actually not being executed.
* Check that no regressions have been introduced in the users removal flow.
