### PR TITLE
Prototyping User Table Design Updates

### DIFF
--- a/kolibri/plugins/facility/assets/src/composables/usePagination.js
+++ b/kolibri/plugins/facility/assets/src/composables/usePagination.js
@@ -1,0 +1,112 @@
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router/composables';
+import pickBy from 'lodash/pickBy';
+import clamp from 'lodash/clamp';
+
+/**
+ * Composable for managing pagination state and navigation
+ * Handles page changes, items per page, and URL query synchronization
+ */
+export default function usePagination({ usersCount, totalPages } = {}) {
+  const route = useRoute();
+  const router = useRouter();
+
+  // Current page from URL query params
+  const currentPage = computed({
+    get() {
+      return Number(route.query.page) || 1;
+    },
+    set(value) {
+      router.push({
+        ...route,
+        query: pickBy({
+          ...route.query,
+          page: value > 1 ? value : null, // Don't include page=1 in URL
+        }),
+      });
+    },
+  });
+
+  // Items per page from URL query params
+  const itemsPerPage = computed({
+    get() {
+      return Number(route.query.page_size) || 30;
+    },
+    set(value) {
+      router.push({
+        ...route,
+        query: pickBy({
+          ...route.query,
+          page_size: value !== 30 ? value : null, // Don't include default size in URL
+          page: null, // Reset to first page when changing page size
+        }),
+      });
+    },
+  });
+
+  // Calculate visible range for pagination display
+  const startRange = computed(() => {
+    return (currentPage.value - 1) * itemsPerPage.value;
+  });
+
+  const visibleStartRange = computed(() => {
+    const count = usersCount?.value || 0;
+    return Math.min(startRange.value + 1, count);
+  });
+
+  const endRange = computed(() => {
+    return currentPage.value * itemsPerPage.value;
+  });
+
+  const visibleEndRange = computed(() => {
+    const count = usersCount?.value || 0;
+    return Math.min(endRange.value, count);
+  });
+
+  // Button states
+  const previousButtonDisabled = computed(() => {
+    const count = usersCount?.value || 0;
+    return currentPage.value === 1 || count === 0;
+  });
+
+  const nextButtonDisabled = computed(() => {
+    const count = usersCount?.value || 0;
+    const total = totalPages?.value || 1;
+    return total === 1 || currentPage.value === total || count === 0;
+  });
+
+  // Method to change page with bounds checking
+  const changePage = change => {
+    const total = totalPages?.value || 1;
+    const newPage = clamp(currentPage.value + change, 1, total);
+    currentPage.value = newPage;
+  };
+
+  // Method to go to specific page
+  const goToPage = pageNumber => {
+    const total = totalPages?.value || 1;
+    currentPage.value = clamp(pageNumber, 1, total);
+  };
+
+  // Method to reset to first page
+  const resetToFirstPage = () => {
+    currentPage.value = 1;
+  };
+
+  return {
+    // State
+    currentPage,
+    itemsPerPage,
+
+    // Computed properties for display
+    visibleStartRange,
+    visibleEndRange,
+    previousButtonDisabled,
+    nextButtonDisabled,
+
+    // Methods
+    changePage,
+    goToPage,
+    resetToFirstPage,
+  };
+}

--- a/kolibri/plugins/facility/assets/src/composables/useUsersTableSearch.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUsersTableSearch.js
@@ -1,0 +1,60 @@
+import { ref, computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router/composables';
+import pickBy from 'lodash/pickBy';
+import debounce from 'lodash/debounce';
+
+/**
+ * Composable for managing search functionality in the Users table
+ * Handles search term state and URL query parameter synchronization
+ */
+export default function useUsersTableSearch() {
+  const route = useRoute();
+  const router = useRouter();
+  const filterTextboxRef = ref(null);
+
+  // Create debounced function for updating search in URL
+  const updateSearchInUrl = value => {
+    if (value === '') {
+      value = null;
+    }
+    router.push({
+      ...route,
+      query: pickBy({
+        ...route.query,
+        search: value,
+        page: null, // Reset to first page when searching
+      }),
+    });
+  };
+
+  const debouncedSearchTerm = debounce(updateSearchInUrl, 300);
+
+  // Computed property for search term with getter/setter
+  const searchTerm = computed({
+    get() {
+      return route.query.search || '';
+    },
+    set(value) {
+      debouncedSearchTerm(value);
+    },
+  });
+
+  // Method to focus the search textbox
+  const focusSearchBox = () => {
+    if (filterTextboxRef.value?.focus) {
+      filterTextboxRef.value.focus();
+    }
+  };
+
+  // Method to clear search
+  const clearSearch = () => {
+    searchTerm.value = '';
+  };
+
+  return {
+    searchTerm,
+    filterTextboxRef,
+    focusSearchBox,
+    clearSearch,
+  };
+}

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -1,18 +1,20 @@
 <template>
 
   <form>
-    <PaginatedListContainerWithBackend
-      v-model="currentPage"
-      :items="facilityUsers"
-      :itemsPerPage="itemsPerPage"
-      :totalPageNumber="totalPages"
-      :numFilteredItems="totalLearners"
-    >
-      <template #filter>
-        <FilterTextbox
-          v-model="search"
-          :placeholder="coreString('searchForUser')"
-        />
+    <PaginatedListContainerWithBackend>
+      <template #topActions>
+        <div class="flex-row">
+          <FilterTextbox
+            v-model="search"
+            :placeholder="coreString('searchForUser')"
+          />
+          <PaginationActions
+            v-model="currentPage"
+            :itemsPerPage="itemsPerPage"
+            :totalPageNumber="totalPages"
+            :numFilteredItems="totalLearners"
+          />
+        </div>
       </template>
       <template>
         <UserTable
@@ -24,6 +26,14 @@
         />
       </template>
     </PaginatedListContainerWithBackend>
+    <PaginationActions
+      v-if="totalPages > 1"
+      v-model="currentPage"
+      style="text-align: right"
+      :itemsPerPage="itemsPerPage"
+      :totalPageNumber="totalPages"
+      :numFilteredItems="totalLearners"
+    />
     <SelectionBottomBar
       :count="selectedUsers.length"
       :disabled="disabled || selectedUsers.length === 0"
@@ -44,6 +54,7 @@
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import UserTable from 'kolibri-common/components/UserTable';
   import PaginatedListContainerWithBackend from 'kolibri-common/components/PaginatedListContainerWithBackend';
+  import PaginationActions from 'kolibri-common/components/PaginationActions';
   import SelectionBottomBar from './SelectionBottomBar';
 
   export default {
@@ -51,6 +62,7 @@
     components: {
       SelectionBottomBar,
       PaginatedListContainerWithBackend,
+      PaginationActions,
       UserTable,
       FilterTextbox,
     },
@@ -166,6 +178,13 @@
   .footer {
     display: flex;
     justify-content: flex-end;
+  }
+
+  .flex-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1em 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityAppBarPage.vue
@@ -4,8 +4,11 @@
     :title="title"
     :appearanceOverrides="appearanceOverrides"
   >
-    <template #default="{ pageContentHeight }">
-      <slot :pageContentHeight="pageContentHeight"></slot>
+    <template #default="{ pageContentHeight, appBarHeight }">
+      <slot
+        :pageContentHeight="pageContentHeight"
+        :appBarHeight="appBarHeight"
+      ></slot>
     </template>
   </AppBarPage>
 

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -40,7 +40,7 @@
               <div class="top-row-left">
                 <h1>{{ newUsers$() }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -48,7 +48,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -3,92 +3,142 @@
   <ImmersivePage
     :appBarTitle="newUsers$()"
     :route="$store.getters.facilityPageLinks.UserPage"
+    :appearanceOverrides="{
+      width: '100%',
+      height: '100vh',
+      margin: '0px',
+      padding: '0px',
+    }"
   >
-    <template #default="{ pageContentHeight }">
-      <KPageContainer
-        class="page-container"
-        :style="{ maxHeight: pageContentHeight + 24 + 'px', padding: '2em 2em 1em' }"
-      >
-        <KRouterLink
-          :to="$store.getters.facilityPageLinks.UserPage"
-          icon="back"
-          :text="backToUsers$()"
-        />
-        <div class="new-users-page-header">
-          <h1>{{ newUsers$() }}</h1>
-          <div>
-            <KRouterLink
-              primary
-              appearance="raised-button"
-              :text="newUser$()"
-              :to="$store.getters.facilityPageLinks.UserCreatePage"
-            />
-          </div>
+    <template>
+      <div :style="containerStyles">
+        <div
+          class="header-shadow"
+          :style="headerStyles"
+        >
+          <KRouterLink
+            :to="$store.getters.facilityPageLinks.UserPage"
+            icon="back"
+            style="margin: 0.5em 0 1em"
+            :text="backToUsers$()"
+          />
+
+          <UsersTableToolbar>
+            <template #topRow>
+              <div class="top-row-left">
+                <h1>{{ newUsers$() }}</h1>
+                <FilterTextbox
+                  ref="filterTextboxRef"
+                  v-model="searchTerm"
+                  class="search-box"
+                  :placeholder="coreString('searchForUser')"
+                  :aria-label="coreString('searchForUser')"
+                />
+                <KRouterLink
+                  appearance="basic-link"
+                  :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
+                  class="filter-button"
+                  :to="
+                    overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS })
+                  "
+                />
+                <KButton
+                  v-if="numAppliedFilters > 0"
+                  appearance="basic-link"
+                  :appearanceOverrides="{ color: $themeTokens.error }"
+                  :text="clearFiltersLabel$()"
+                  @click="resetFilters"
+                />
+              </div>
+              <div class="users-page-header-actions">
+                <KRouterLink
+                  primary
+                  appearance="raised-button"
+                  :text="newUser$()"
+                  :to="$store.getters.facilityPageLinks.UserCreatePage"
+                />
+              </div>
+            </template>
+            <template #bottomRow>
+              <div class="bottom-row-left">
+                <KIconButton
+                  ref="assignButton"
+                  icon="assignCoaches"
+                  :ariaLabel="assignCoach$()"
+                  :disabled="!canAssignCoaches || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS)"
+                />
+                <KTooltip
+                  reference="assignButton"
+                  :refs="$refs"
+                  :text="assignCoach$()"
+                />
+                <KIconButton
+                  ref="enrollButton"
+                  icon="add"
+                  :ariaLabel="enrollToClass$()"
+                  :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS)"
+                />
+                <KTooltip
+                  reference="enrollButton"
+                  :refs="$refs"
+                  :text="enrollToClass$()"
+                />
+                <KIconButton
+                  ref="removeButton"
+                  icon="remove"
+                  :ariaLabel="removeFromClass$()"
+                  :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS)"
+                />
+                <KTooltip
+                  reference="removeButton"
+                  :refs="$refs"
+                  :text="removeFromClass$()"
+                />
+                <KIconButton
+                  ref="trashButton"
+                  icon="trash"
+                  :ariaLabel="deleteSelection$()"
+                  :disabled="!canDeleteSelection || !hasSelectedUsers"
+                  @click="isMoveToTrashModalOpen = true"
+                />
+                <KTooltip
+                  reference="trashButton"
+                  :refs="$refs"
+                  :text="deleteSelection$()"
+                />
+                <div
+                  v-if="hasSelectedUsers"
+                  class="selection-status"
+                >
+                  <span>{{ numUsersSelected$({ n: selectedUsers.size }) }}</span>
+                  <KButton
+                    appearance="basic-link"
+                    :text="coreString('clearAction')"
+                    @click="clearSelectedUsers"
+                  />
+                </div>
+              </div>
+              <PaginationActions
+                v-model="currentPage"
+                :itemsPerPage="itemsPerPage"
+                :totalPageNumber="totalPages"
+                :numFilteredItems="usersCount"
+              />
+            </template>
+          </UsersTableToolbar>
         </div>
         <UsersTable
           v-if="showUsersTable"
-          ref="usersTableRef"
+          class="users-table"
           :facilityUsers="facilityUsers"
-          :usersCount="usersCount"
-          :totalPages="totalPages"
           :dataLoading="dataLoading"
           :selectedUsers.sync="selectedUsers"
-          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__NEW_USERS"
-          :numAppliedFilters="numAppliedFilters"
-          @clearFilters="resetFilters"
+          @clearSelectedUsers="clearSelectedUsers"
           @change="onChange"
-        >
-          <template #userActions>
-            <KIconButton
-              ref="assignButton"
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :disabled="!canAssignCoaches || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL__NEW_USERS)"
-            />
-            <KTooltip
-              reference="assignButton"
-              :refs="$refs"
-              :text="assignCoach$()"
-            />
-            <KIconButton
-              ref="enrollButton"
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS)"
-            />
-            <KTooltip
-              reference="enrollButton"
-              :refs="$refs"
-              :text="enrollToClass$()"
-            />
-            <KIconButton
-              ref="removeButton"
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL__NEW_USERS)"
-            />
-            <KTooltip
-              reference="removeButton"
-              :refs="$refs"
-              :text="removeFromClass$()"
-            />
-            <KIconButton
-              ref="trashButton"
-              icon="trash"
-              :ariaLabel="deleteSelection$()"
-              :disabled="!canDeleteSelection || !hasSelectedUsers"
-              @click="isMoveToTrashModalOpen = true"
-            />
-            <KTooltip
-              reference="trashButton"
-              :refs="$refs"
-              :text="deleteSelection$()"
-            />
-          </template>
-        </UsersTable>
+        />
         <div
           v-else
           class="empty-new-users"
@@ -115,7 +165,7 @@
             :to="$store.getters.facilityPageLinks.UserCreatePage"
           />
         </div>
-      </KPageContainer>
+      </div>
       <!-- For sidepanels -->
       <router-view
         :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
@@ -141,9 +191,13 @@
 
 <script>
 
+  import FilterTextbox from 'kolibri/components/FilterTextbox';
+  import PaginationActions from 'kolibri-common/components/PaginationActions';
   import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useUser from 'kolibri/composables/useUser';
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
@@ -151,11 +205,14 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
   import { UserKinds } from 'kolibri/constants';
+  import useUsersTableSearch from '../../composables/useUsersTableSearch';
+  import usePagination from '../../composables/usePagination';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
   import { PageNames } from '../../constants';
   import { overrideRoute } from '../../utils';
   import UsersTable from './common/UsersTable.vue';
+  import UsersTableToolbar from './common/UsersTableToolbar';
   import MoveToTrashModal from './common/MoveToTrashModal.vue';
 
   // Constant for the maximum number of days to consider a user as a "new user"
@@ -165,15 +222,18 @@
     name: 'NewUsersPage',
     components: {
       UsersTable,
+      UsersTableToolbar,
       ImmersivePage,
       MoveToTrashModal,
+      FilterTextbox,
+      PaginationActions,
     },
+    mixins: [commonCoreStrings],
     setup() {
       usePreviousRoute();
       const route = useRoute();
       const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
-      const usersTableRef = ref(null);
       const isMoveToTrashModalOpen = ref(false);
 
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
@@ -206,6 +266,10 @@
           dataLoading.value,
       );
 
+      // Use our new composables
+      const { searchTerm, filterTextboxRef } = useUsersTableSearch();
+      const { currentPage, itemsPerPage } = usePagination({ usersCount, totalPages });
+
       const {
         newUser$,
         newUsers$,
@@ -217,12 +281,19 @@
         noNewUsersLabel$,
         addNewUserLabel$,
         noNewUsersDescription$,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
       } = bulkUserManagementStrings;
+
+      function clearSelectedUsers() {
+        selectedUsers.value = new Set();
+      }
 
       function onModalBlur() {
         selectedUsers.value.clear();
         selectedUsers.value = new Set(selectedUsers.value);
-        usersTableRef.value?.focus();
       }
 
       function navigateToSidePanel(sidePanelName) {
@@ -234,24 +305,42 @@
         fetchClasses();
       });
 
+      const { windowIsSmall } = useKResponsiveWindow();
+
       return {
+        windowIsSmall,
+        // Route utilities
+        overrideRoute,
         PageNames,
+
+        // Table data
         classes,
         facilityUsers,
         totalPages,
         usersCount,
         dataLoading,
-        usersTableRef,
         selectedUsers,
         showUsersTable,
         emptyPlusCloudSvg,
         numAppliedFilters,
         isMoveToTrashModalOpen,
+
+        // Search functionality from composable
+        searchTerm,
+        filterTextboxRef,
+
+        // Pagination from composable
+        currentPage,
+        itemsPerPage,
+
+        // Methods
         onChange,
         onModalBlur,
-        overrideRoute,
+        clearSelectedUsers,
         navigateToSidePanel,
         resetFilters,
+
+        // Strings
         newUser$,
         newUsers$,
         backToUsers$,
@@ -262,6 +351,12 @@
         noNewUsersLabel$,
         addNewUserLabel$,
         noNewUsersDescription$,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
+
+        // User info
         currentUserId,
         isSuperuser,
         isAdmin,
@@ -278,7 +373,7 @@
         if (!this.hasSelectedUsers) return false;
         return this.facilityUsers
           .filter(user => this.selectedUsers.has(user.id))
-          .every(
+          .some(
             user =>
               user.kind.includes(UserKinds.COACH) ||
               user.kind === UserKinds.ADMIN ||
@@ -311,14 +406,26 @@
       },
       canDeleteSelection() {
         if (!this.hasSelectedUsers) return false;
-
         if (this.listContainsLoggedInUser) return false;
         if (this.isSuperuser) return true;
         if (this.isAdmin) {
           return !this.hasSelectedSuperusers;
         }
-
         return false;
+      },
+      headerStyles() {
+        return {
+          padding: '16px',
+        };
+      },
+      containerStyles() {
+        return {
+          paddingTop: this.windowIsSmall ? '108px' : '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          backgroundColor: 'white',
+        };
       },
     },
   };
@@ -328,23 +435,50 @@
 
 <style lang="scss" scoped>
 
-  .page-container {
-    position: relative;
+  .users-page-header-actions {
     display: flex;
-    flex-direction: column;
-    max-width: 1000px;
-    margin: 0 auto auto;
-  }
-
-  .new-users-page-header {
-    display: flex;
+    flex-wrap: wrap;
     gap: 16px;
     align-items: center;
-    justify-content: space-between;
-    margin: 1em 0 1.5em;
+    justify-content: flex-end;
+  }
+
+  .header-shadow {
+    z-index: 8;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
+  }
+
+  .top-row-left {
+    display: flex;
+    flex: 1;
+    gap: 1em;
+    align-items: center;
 
     h1 {
       margin: 0;
+      white-space: nowrap;
+    }
+  }
+
+  .search-box {
+    flex: 1;
+    width: 100% !important;
+    max-width: 400px;
+  }
+
+  .filter-button {
+    white-space: nowrap;
+  }
+
+  .bottom-row-left {
+    display: flex;
+    gap: 0.25em;
+    align-items: center;
+
+    .selection-status {
+      display: flex;
+      gap: 0.5em;
+      align-items: center;
     }
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -40,7 +40,7 @@
               <div class="top-row-left">
                 <h1>{{ newUsers$() }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -48,7 +48,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -18,7 +18,7 @@
           display: 'flex',
           flexDirection: 'column',
           height: '100%',
-          backgroundColor: 'white',
+          backgroundColor: '$themeTokens.surface',
         }"
       >
         <div

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -13,12 +13,12 @@
     <template #default="{ appBarHeight, pageContentHeight }">
       <div
         :style="{
-          paddingTop: appBarHeight + 'px',
-          maxHeight: pageContentHeight,
           display: 'flex',
           flexDirection: 'column',
-          height: '100%',
-          backgroundColor: '$themeTokens.surface',
+          maxWidth: '1440px',
+          margin: appBarHeight + 'px auto 0',
+          maxHeight: pageContentHeight + 'px',
+          backgroundColor: $themeTokens.surface,
         }"
       >
         <div

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -24,8 +24,6 @@
         <div
           class="header-shadow"
           :style="{
-            top: 0,
-            position: 'sticky',
             padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
           }"

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -6,18 +6,23 @@
     :appearanceOverrides="{
       width: '100%',
       height: '100%',
-      margin: '0px',
-      padding: windowIsSmall ? '0 0.25em' : '0 1em',
+      padding: windowIsSmall ? '0 0.5em' : '0 1em',
     }"
   >
-    <template #default="{ appBarHeight, pageContentHeight }">
+    <template #default="{ pageContentHeight }">
+      <!--
+      There's some wonky looking math here for styles that basically:
+      Center the content & pad it appropriately against the screen & appbar.
+      This works for the ImmersivePage specifically and sets the content
+      container at ~0.5em padding on small screens and 1em otherwise
+      -->
       <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: pageContentHeight - appBarHeight - 48 + 'px',
+          margin: (windowIsSmall ? 64 : 80) + 'px auto 0',
+          maxHeight: pageContentHeight - (windowIsSmall ? 64 : 96) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -10,10 +10,11 @@
       padding: '0px',
     }"
   >
-    <template #default="{ appBarHeight }">
+    <template #default="{ appBarHeight, pageContentHeight }">
       <div
         :style="{
-          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
+          paddingTop: appBarHeight + 'px',
+          maxHeight: pageContentHeight,
           display: 'flex',
           flexDirection: 'column',
           height: '100%',
@@ -205,7 +206,6 @@
   import { computed, onMounted, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useUser from 'kolibri/composables/useUser';
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
@@ -313,10 +313,7 @@
         fetchClasses();
       });
 
-      const { windowIsSmall } = useKResponsiveWindow();
-
       return {
-        windowIsSmall,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -11,19 +11,24 @@
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
-      <div
+      <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
           margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: pageContentHeight - appBarHeight - 24 + 'px',
+          maxHeight: pageContentHeight - appBarHeight - 48 + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
         <div
           class="header-shadow"
-          :style="headerStyles"
+          :style="{
+            top: 0,
+            position: 'sticky',
+            padding: '1em 1em 0 1em',
+            backgroundColor: $themeTokens.surface,
+          }"
         >
           <KRouterLink
             :to="$store.getters.facilityPageLinks.UserPage"
@@ -176,7 +181,7 @@
             :to="$store.getters.facilityPageLinks.UserCreatePage"
           />
         </div>
-      </div>
+      </KPageContainer>
       <!-- For sidepanels -->
       <router-view
         :backRoute="overrideRoute($route, { name: PageNames.NEW_USERS_PAGE })"
@@ -420,11 +425,6 @@
         }
         return false;
       },
-      headerStyles() {
-        return {
-          padding: '16px',
-        };
-      },
     },
   };
 
@@ -442,7 +442,6 @@
   }
 
   .header-shadow {
-    z-index: 8;
     box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
@@ -514,6 +513,13 @@
     // the purpose of our maxHeight style on the KPageContainer.
     // Uses !important because the overridden style is inline
     padding-bottom: 0 !important;
+  }
+
+  /deep/ thead {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -7,7 +7,7 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: '0px',
+      padding: '0 1em',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
@@ -16,8 +16,8 @@
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 'px auto 0',
-          maxHeight: pageContentHeight + 'px',
+          margin: appBarHeight + 24 + 'px auto 0',
+          maxHeight: pageContentHeight - appBarHeight - 24 + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
@@ -37,6 +37,7 @@
               <div class="top-row-left">
                 <h1>{{ newUsers$() }}</h1>
                 <FilterTextbox
+                  v-if="facilityUsers.length"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -44,6 +45,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
+                  v-if="facilityUsers.length"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -22,7 +22,7 @@
           flexDirection: 'column',
           maxWidth: '1440px',
           margin: (windowIsSmall ? 64 : 80) + 'px auto 0',
-          maxHeight: pageContentHeight - (windowIsSmall ? 64 : 96) + 'px',
+          maxHeight: pageContentHeight - (windowIsSmall ? 70 : 96) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -5,13 +5,21 @@
     :route="$store.getters.facilityPageLinks.UserPage"
     :appearanceOverrides="{
       width: '100%',
-      height: '100vh',
+      height: '100%',
       margin: '0px',
       padding: '0px',
     }"
   >
-    <template>
-      <div :style="containerStyles">
+    <template #default="{ appBarHeight }">
+      <div
+        :style="{
+          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          backgroundColor: 'white',
+        }"
+      >
         <div
           class="header-shadow"
           :style="headerStyles"
@@ -416,15 +424,6 @@
       headerStyles() {
         return {
           padding: '16px',
-        };
-      },
-      containerStyles() {
-        return {
-          paddingTop: this.windowIsSmall ? '108px' : '64px',
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          backgroundColor: 'white',
         };
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -7,7 +7,7 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: '0 1em',
+      padding: windowIsSmall ? '0 0.25em' : '0 1em',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
@@ -64,7 +64,10 @@
                   @click="resetFilters"
                 />
               </div>
-              <div class="users-page-header-actions">
+              <div
+                v-if="!windowIsSmall"
+                class="users-page-header-actions"
+              >
                 <KRouterLink
                   primary
                   appearance="raised-button"
@@ -134,6 +137,17 @@
                     @click="clearSelectedUsers"
                   />
                 </div>
+              </div>
+              <div
+                v-if="windowIsSmall"
+                class="users-page-header-actions"
+              >
+                <KRouterLink
+                  primary
+                  appearance="raised-button"
+                  :text="newUser$()"
+                  :to="$store.getters.facilityPageLinks.UserCreatePage"
+                />
               </div>
               <PaginationActions
                 v-model="currentPage"
@@ -218,6 +232,7 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
   import { UserKinds } from 'kolibri/constants';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useUsersTableSearch from '../../composables/useUsersTableSearch';
   import usePagination from '../../composables/usePagination';
   import useUserManagement from '../../composables/useUserManagement';
@@ -318,6 +333,8 @@
         fetchClasses();
       });
 
+      const { windowIsSmall } = useKResponsiveWindow();
+
       return {
         // Route utilities
         overrideRoute,
@@ -370,6 +387,8 @@
         currentUserId,
         isSuperuser,
         isAdmin,
+
+        windowIsSmall,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -27,7 +27,6 @@
         }"
       >
         <div
-          class="header-shadow"
           :style="{
             padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
@@ -461,10 +460,6 @@
     gap: 16px;
     align-items: center;
     justify-content: flex-end;
-  }
-
-  .header-shadow {
-    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
   .top-row-left {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -9,11 +9,12 @@
       padding: '0px',
     }"
   >
-    <template #default="{ pageContentHeight }">
-      <div
-        :style="containerStyles"
-      >
-        <div class='header-shadow' :style="headerStyles">
+    <template>
+      <div :style="containerStyles">
+        <div
+          class="header-shadow"
+          :style="headerStyles"
+        >
           <KRouterLink
             v-if="userIsMultiFacilityAdmin"
             :to="{
@@ -108,7 +109,6 @@
         </div>
         <UsersTable
           class="users-table"
-          ref="usersTableRef"
           :facilityUsers="facilityUsers"
           :usersCount="usersCount"
           :totalPages="totalPages"
@@ -148,14 +148,13 @@
 
   import { ref, getCurrentInstance, onMounted } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
-  import UsersTableToolbar from '../common/UsersTableToolbar';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useUser from 'kolibri/composables/useUser';
   import { UserKinds } from 'kolibri/constants';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
+  import UsersTableToolbar from '../common/UsersTableToolbar';
   import useUserManagement from '../../../composables/useUserManagement';
   import FacilityAppBarPage from '../../FacilityAppBarPage';
   import { PageNames } from '../../../constants';
@@ -184,7 +183,6 @@
       const { currentUserId, isSuperuser, isAdmin } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
       const isMoveToTrashModalOpen = ref(false);
-      const usersTableRef = ref(null);
 
       const {
         newUser$,
@@ -231,10 +229,7 @@
         router.push(newRoute);
       }
 
-      const { windowIsSmall } = useKResponsiveWindow();
-
       return {
-        windowIsSmall,
         PageNames,
         userIsMultiFacilityAdmin,
         facilityUsers,
@@ -242,7 +237,6 @@
         usersCount,
         dataLoading,
         classes,
-        usersTableRef,
         numAppliedFilters,
         isMoveToTrashModalOpen,
         onChange,
@@ -336,24 +330,15 @@
       },
       headerStyles() {
         return {
-          position: 'fixed',
-          top: this.windowIsSmall ? '6em' : '4em',
-          left: 0,
-          right: 0,
-          backgroundColor: 'white',
-          padding: '1em 1em 0.5em',
-          zIndex: 8,
+          padding: '16px',
         };
       },
       containerStyles() {
-        const paddings = {
-          paddingTop: this.windowIsSmall ? '15.25em!important' : '11.25em!important',
-          paddingBottom: '4em',
-          paddingLeft: 0,
-          paddingRight: 0,
-        };
         return {
-          ...paddings,
+          paddingTop: '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
           backgroundColor: 'white',
         };
       },
@@ -396,14 +381,14 @@
   }
 
   .users-container {
-    height: 100%;
-    background-color: white;
     display: flex;
     flex-direction: column;
-    // !important to override
-    margin: 0!important;
+    height: 100%;
     // top: 4em (app bar) + 2em (internal padding)
     padding: 6em 2em 1em;
+    // !important to override
+    margin: 0 !important;
+    background-color: white;
   }
 
   /deep/ .main-wrapper {
@@ -412,17 +397,12 @@
     // Uses !important because the overridden style is inline
     padding-bottom: 0 !important;
   }
+
   .header-shadow {
+    z-index: 4;
     box-shadow:
       0 0 2px rgba(0, 0, 0, 0.12),
       0 2px 2px rgba(0, 0, 0, 0.2);
-  }
-
-  /deep/ .users-table thead {
-    position: static;
-    width: 100%;
-    background-color: white;
-    z-index: 8;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -23,8 +23,6 @@
         <div
           class="header-shadow"
           :style="{
-            top: 0,
-            position: 'sticky',
             padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
           }"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -3,50 +3,111 @@
   <FacilityAppBarPage
     class="wrapper"
     :appearanceOverrides="{
-      maxWidth: '1440px',
-      margin: '0 auto',
-      padding: '2em',
+      width: '100%',
+      height: '100vh',
+      margin: '0px',
+      padding: '0px',
     }"
   >
     <template #default="{ pageContentHeight }">
-      <!-- Adding 24 pixels to the max height to prevent having too much bottom padding space -->
-      <KPageContainer
-        class="flex-column"
-        :style="{ maxHeight: pageContentHeight - 48 + 'px', padding: '2em 2em 1em' }"
+      <div
+        :style="containerStyles"
       >
-        <KRouterLink
-          v-if="userIsMultiFacilityAdmin"
-          :to="{
-            name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
-            params: { subtopicName: 'UserPage' },
-          }"
-          icon="back"
-          :text="coreString('changeLearningFacility')"
-        />
-        <div class="users-page-header">
-          <h1>{{ coreString('usersLabel') }}</h1>
-          <div class="users-page-header-actions">
-            <KButton
-              hasDropdown
-              :primary="false"
-              :text="coreString('optionsLabel')"
-            >
-              <template #menu>
-                <KDropdownMenu
-                  :options="pageDropdownOptions"
-                  @select="handlePageDropdownSelection"
-                />
-              </template>
-            </KButton>
-            <KRouterLink
-              primary
-              appearance="raised-button"
-              :text="newUser$()"
-              :to="$store.getters.facilityPageLinks.UserCreatePage"
-            />
+        <div class='header-shadow' :style="headerStyles">
+          <KRouterLink
+            v-if="userIsMultiFacilityAdmin"
+            :to="{
+              name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
+              params: { subtopicName: 'UserPage' },
+            }"
+            icon="back"
+            :text="coreString('changeLearningFacility')"
+          />
+          <div class="users-page-header">
+            <h1>{{ coreString('usersLabel') }}</h1>
+            <div class="users-page-header-actions">
+              <KButton
+                hasDropdown
+                :primary="false"
+                :text="coreString('optionsLabel')"
+              >
+                <template #menu>
+                  <KDropdownMenu
+                    :options="pageDropdownOptions"
+                    @select="handlePageDropdownSelection"
+                  />
+                </template>
+              </KButton>
+              <KRouterLink
+                primary
+                appearance="raised-button"
+                :text="newUser$()"
+                :to="$store.getters.facilityPageLinks.UserCreatePage"
+              />
+            </div>
           </div>
+
+          <UsersTableToolbar
+            :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
+            :selectedUsers="selectedUsers"
+            :numAppliedFilters="numAppliedFilters"
+          >
+            <template #userActions>
+              <div>
+                <KIconButton
+                  ref="assignButton"
+                  icon="assignCoaches"
+                  :ariaLabel="assignCoach$()"
+                  :disabled="!canAssignCoaches || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL)"
+                />
+                <KTooltip
+                  reference="assignButton"
+                  :refs="$refs"
+                  :text="assignCoach$()"
+                />
+                <KIconButton
+                  ref="enrollButton"
+                  icon="add"
+                  :ariaLabel="enrollToClass$()"
+                  :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL)"
+                />
+                <KTooltip
+                  reference="enrollButton"
+                  :refs="$refs"
+                  :text="enrollToClass$()"
+                />
+                <KIconButton
+                  ref="removeButton"
+                  icon="remove"
+                  :ariaLabel="removeFromClass$()"
+                  :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
+                  @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL)"
+                />
+                <KTooltip
+                  reference="removeButton"
+                  :refs="$refs"
+                  :text="removeFromClass$()"
+                />
+                <KIconButton
+                  ref="trashButton"
+                  icon="trash"
+                  :ariaLabel="deleteSelectionTooltip"
+                  :disabled="!canDeleteSelection || !hasSelectedUsers"
+                  @click="isMoveToTrashModalOpen = true"
+                />
+                <KTooltip
+                  reference="trashButton"
+                  :refs="$refs"
+                  :text="deleteSelectionTooltip"
+                />
+              </div>
+            </template>
+          </UsersTableToolbar>
         </div>
         <UsersTable
+          class="users-table"
           ref="usersTableRef"
           :facilityUsers="facilityUsers"
           :usersCount="usersCount"
@@ -55,60 +116,10 @@
           :selectedUsers.sync="selectedUsers"
           :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
           :numAppliedFilters="numAppliedFilters"
+          @clearSelectedUsers="clearSelectedUsers"
           @clearFilters="resetFilters"
           @change="onChange"
-        >
-          <template #userActions>
-            <KIconButton
-              ref="assignButton"
-              icon="assignCoaches"
-              :ariaLabel="assignCoach$()"
-              :disabled="!canAssignCoaches || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.ASSIGN_COACHES_SIDE_PANEL)"
-            />
-            <KTooltip
-              reference="assignButton"
-              :refs="$refs"
-              :text="assignCoach$()"
-            />
-            <KIconButton
-              ref="enrollButton"
-              icon="add"
-              :ariaLabel="enrollToClass$()"
-              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.ENROLL_LEARNERS_SIDE_PANEL)"
-            />
-            <KTooltip
-              reference="enrollButton"
-              :refs="$refs"
-              :text="enrollToClass$()"
-            />
-            <KIconButton
-              ref="removeButton"
-              icon="remove"
-              :ariaLabel="removeFromClass$()"
-              :disabled="!canEnrollOrRemoveFromClass || !hasSelectedUsers"
-              @click="navigateToSidePanel(PageNames.REMOVE_FROM_CLASSES_SIDE_PANEL)"
-            />
-            <KTooltip
-              reference="removeButton"
-              :refs="$refs"
-              :text="removeFromClass$()"
-            />
-            <KIconButton
-              ref="trashButton"
-              icon="trash"
-              :ariaLabel="deleteSelectionTooltip"
-              :disabled="!canDeleteSelection || !hasSelectedUsers"
-              @click="isMoveToTrashModalOpen = true"
-            />
-            <KTooltip
-              reference="trashButton"
-              :refs="$refs"
-              :text="deleteSelectionTooltip"
-            />
-          </template>
-        </UsersTable>
+        />
         <!-- For sidepanels -->
         <router-view
           :selectedUsers="selectedUsers"
@@ -126,7 +137,7 @@
           :onChange="onChange"
           @close="isMoveToTrashModalOpen = false"
         />
-      </KPageContainer>
+      </div>
     </template>
   </FacilityAppBarPage>
 
@@ -137,8 +148,10 @@
 
   import { ref, getCurrentInstance, onMounted } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
+  import UsersTableToolbar from '../common/UsersTableToolbar';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useUser from 'kolibri/composables/useUser';
   import { UserKinds } from 'kolibri/constants';
@@ -159,6 +172,7 @@
     },
     components: {
       UsersTable,
+      UsersTableToolbar,
       MoveToTrashModal,
       FacilityAppBarPage,
     },
@@ -217,7 +231,10 @@
         router.push(newRoute);
       }
 
+      const { windowIsSmall } = useKResponsiveWindow();
+
       return {
+        windowIsSmall,
         PageNames,
         userIsMultiFacilityAdmin,
         facilityUsers,
@@ -317,6 +334,29 @@
         }
         return this.deleteSelection$();
       },
+      headerStyles() {
+        return {
+          position: 'fixed',
+          top: this.windowIsSmall ? '6em' : '4em',
+          left: 0,
+          right: 0,
+          backgroundColor: 'white',
+          padding: '1em 1em 0.5em',
+          zIndex: 8,
+        };
+      },
+      containerStyles() {
+        const paddings = {
+          paddingTop: this.windowIsSmall ? '15.25em!important' : '11.25em!important',
+          paddingBottom: '4em',
+          paddingLeft: 0,
+          paddingRight: 0,
+        };
+        return {
+          ...paddings,
+          backgroundColor: 'white',
+        };
+      },
     },
     methods: {
       handlePageDropdownSelection(option) {
@@ -340,7 +380,7 @@
     gap: 16px;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 1.5em;
+    margin-bottom: 0.5em;
 
     h1 {
       margin: 0;
@@ -355,9 +395,15 @@
     }
   }
 
-  .flex-column {
+  .users-container {
+    height: 100%;
+    background-color: white;
     display: flex;
     flex-direction: column;
+    // !important to override
+    margin: 0!important;
+    // top: 4em (app bar) + 2em (internal padding)
+    padding: 6em 2em 1em;
   }
 
   /deep/ .main-wrapper {
@@ -365,6 +411,18 @@
     // the purpose of our maxHeight style on the KPageContainer.
     // Uses !important because the overridden style is inline
     padding-bottom: 0 !important;
+  }
+  .header-shadow {
+    box-shadow:
+      0 0 2px rgba(0, 0, 0, 0.12),
+      0 2px 2px rgba(0, 0, 0, 0.2);
+  }
+
+  /deep/ .users-table thead {
+    position: static;
+    width: 100%;
+    background-color: white;
+    z-index: 8;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -6,23 +6,29 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: '0px',
+      padding: windowIsSmall ? '1em' : '0px',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
       <div
         :style="{
-          paddingTop: appBarHeight + 'px',
           display: 'flex',
           flexDirection: 'column',
-          height: '100%',
-          maxHeight: pageContentHeight,
+          maxWidth: '1440px',
+          margin: appBarHeight + 'px auto 0',
+          maxHeight: pageContentHeight + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
         <div
           class="header-shadow"
-          :style="headerStyles"
+          :style="{
+            top: appBarHeight + 'px',
+            position: 'sticky',
+            padding: '1em',
+            zIndex: 12,
+            backgroundColor: $themeTokens.surface,
+          }"
         >
           <KRouterLink
             v-if="userIsMultiFacilityAdmin"
@@ -48,9 +54,9 @@
                 />
                 <KRouterLink
                   appearance="basic-link"
-                  :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"
                   :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"
+                  :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                 />
                 <KButton
                   v-if="numAppliedFilters > 0"
@@ -419,11 +425,6 @@
           return this.cannotDeleteSelfTooltip$();
         }
         return this.deleteSelection$();
-      },
-      headerStyles() {
-        return {
-          padding: '16px',
-        };
       },
     },
     methods: {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -32,9 +32,9 @@
                 <FilterTextbox
                   ref="filterTextboxRef"
                   v-model="searchTerm"
+                  class="search-box"
                   :placeholder="coreString('searchForUser')"
                   :aria-label="coreString('searchForUser')"
-                  class="search-box"
                 />
                 <KRouterLink
                   appearance="basic-link"
@@ -57,6 +57,7 @@
                   </template>
                 </KButton>
                 <KRouterLink
+                  v-if="!windowIsSmall"
                   primary
                   appearance="raised-button"
                   :text="newUser$()"
@@ -66,17 +67,6 @@
             </template>
             <template #bottomRow>
               <div class="bottom-row-left">
-                <div
-                  v-if="hasSelectedUsers"
-                  class="selection-status"
-                >
-                  <span>{{ numUsersSelected$({ n: selectedUsers.size }) }}</span>
-                  <KButton
-                    appearance="basic-link"
-                    :text="coreString('clearAction')"
-                    @click="clearSelectedUsers"
-                  />
-                </div>
                 <KIconButton
                   ref="assignButton"
                   icon="assignCoaches"
@@ -125,6 +115,17 @@
                   :refs="$refs"
                   :text="deleteSelectionTooltip"
                 />
+                <div
+                  v-if="hasSelectedUsers"
+                  class="selection-status"
+                >
+                  <span>{{ numUsersSelected$({ n: selectedUsers.size }) }}</span>
+                  <KButton
+                    appearance="basic-link"
+                    :text="coreString('clearAction')"
+                    @click="clearSelectedUsers"
+                  />
+                </div>
               </div>
               <PaginationActions
                 v-model="currentPage"
@@ -174,6 +175,7 @@
   import { ref, computed, getCurrentInstance, onMounted } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useUser from 'kolibri/composables/useUser';
@@ -225,7 +227,6 @@
         numFilters$,
         filterLabel$,
         numUsersSelected$,
-        clearFiltersLabel$,
       } = bulkUserManagementStrings;
 
       const { $store, $router } = getCurrentInstance().proxy;
@@ -241,7 +242,6 @@
         numAppliedFilters,
         onChange,
         fetchClasses,
-        resetFilters,
       } = useUserManagement({ activeFacilityId });
 
       // Use our new composables
@@ -270,7 +270,9 @@
         return selectedUsers.value && selectedUsers.value.size > 0;
       });
 
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
+        windowIsSmall,
         // Route utilities
         overrideRoute,
         PageNames,
@@ -305,7 +307,6 @@
         // Methods
         onChange,
         onModalBlur,
-        resetFilters,
         clearSelectedUsers,
         navigateToSidePanel,
 
@@ -325,7 +326,7 @@
     },
     computed: {
       pageDropdownOptions() {
-        return [
+        const opts = [
           {
             label: this.viewNewUsers$(),
             id: 'view_new_users',
@@ -337,6 +338,14 @@
             value: PageNames.USERS_TRASH_PAGE,
           },
         ];
+        if (this.windowIsSmall) {
+          opts.unshift({
+            label: this.newUser$(),
+            id: 'new_user',
+            value: PageNames.ADD_NEW_USER_SIDE_PANEL__NEW_USERS,
+          });
+        }
+        return opts;
       },
       listContainsLoggedInUser() {
         return this.selectedUsers.has(this.currentUserId);
@@ -397,7 +406,7 @@
       },
       containerStyles() {
         return {
-          paddingTop: '64px',
+          paddingTop: this.windowIsSmall ? '108px' : '64px',
           display: 'flex',
           flexDirection: 'column',
           height: '100%',
@@ -408,10 +417,12 @@
     methods: {
       handlePageDropdownSelection(option) {
         if (option.value) {
-          this.$router.push({
-            name: option.value,
-            params: { facility_id: this.$store.getters.activeFacilityId },
-          });
+          if (option.id === 'new_user') {
+            this.$router.push({
+              name: option.value,
+              params: { facility_id: this.$store.getters.activeFacilityId },
+            });
+          }
         }
       },
     },
@@ -449,10 +460,8 @@
   }
 
   .header-shadow {
-    z-index: 4;
-    box-shadow:
-      0 0 2px rgba(0, 0, 0, 0.12),
-      0 2px 2px rgba(0, 0, 0, 0.2);
+    z-index: 8;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
   .top-row-left {
@@ -469,6 +478,7 @@
 
   .search-box {
     flex: 1;
+    width: 100% !important;
     max-width: 400px;
   }
 
@@ -478,7 +488,7 @@
 
   .bottom-row-left {
     display: flex;
-    gap: 1em;
+    gap: 0.25em;
     align-items: center;
 
     .selection-status {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -24,37 +24,59 @@
             icon="back"
             :text="coreString('changeLearningFacility')"
           />
-          <div class="users-page-header">
-            <h1>{{ coreString('usersLabel') }}</h1>
-            <div class="users-page-header-actions">
-              <KButton
-                hasDropdown
-                :primary="false"
-                :text="coreString('optionsLabel')"
-              >
-                <template #menu>
-                  <KDropdownMenu
-                    :options="pageDropdownOptions"
-                    @select="handlePageDropdownSelection"
-                  />
-                </template>
-              </KButton>
-              <KRouterLink
-                primary
-                appearance="raised-button"
-                :text="newUser$()"
-                :to="$store.getters.facilityPageLinks.UserCreatePage"
-              />
-            </div>
-          </div>
 
-          <UsersTableToolbar
-            :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
-            :selectedUsers="selectedUsers"
-            :numAppliedFilters="numAppliedFilters"
-          >
-            <template #userActions>
-              <div>
+          <UsersTableToolbar>
+            <template #topRow>
+              <div class="top-row-left">
+                <h1>{{ coreString('usersLabel') }}</h1>
+                <FilterTextbox
+                  ref="filterTextboxRef"
+                  v-model="searchTerm"
+                  :placeholder="coreString('searchForUser')"
+                  :aria-label="coreString('searchForUser')"
+                  class="search-box"
+                />
+                <KRouterLink
+                  appearance="basic-link"
+                  :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
+                  class="filter-button"
+                  :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"
+                />
+              </div>
+              <div class="users-page-header-actions">
+                <KButton
+                  hasDropdown
+                  :primary="false"
+                  :text="coreString('optionsLabel')"
+                >
+                  <template #menu>
+                    <KDropdownMenu
+                      :options="pageDropdownOptions"
+                      @select="handlePageDropdownSelection"
+                    />
+                  </template>
+                </KButton>
+                <KRouterLink
+                  primary
+                  appearance="raised-button"
+                  :text="newUser$()"
+                  :to="$store.getters.facilityPageLinks.UserCreatePage"
+                />
+              </div>
+            </template>
+            <template #bottomRow>
+              <div class="bottom-row-left">
+                <div
+                  v-if="hasSelectedUsers"
+                  class="selection-status"
+                >
+                  <span>{{ numUsersSelected$({ n: selectedUsers.size }) }}</span>
+                  <KButton
+                    appearance="basic-link"
+                    :text="coreString('clearAction')"
+                    @click="clearSelectedUsers"
+                  />
+                </div>
                 <KIconButton
                   ref="assignButton"
                   icon="assignCoaches"
@@ -104,20 +126,21 @@
                   :text="deleteSelectionTooltip"
                 />
               </div>
+              <PaginationActions
+                v-model="currentPage"
+                :itemsPerPage="itemsPerPage"
+                :totalPageNumber="totalPages"
+                :numFilteredItems="usersCount"
+              />
             </template>
           </UsersTableToolbar>
         </div>
         <UsersTable
           class="users-table"
           :facilityUsers="facilityUsers"
-          :usersCount="usersCount"
-          :totalPages="totalPages"
           :dataLoading="dataLoading"
           :selectedUsers.sync="selectedUsers"
-          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL"
-          :numAppliedFilters="numAppliedFilters"
           @clearSelectedUsers="clearSelectedUsers"
-          @clearFilters="resetFilters"
           @change="onChange"
         />
         <!-- For sidepanels -->
@@ -146,7 +169,9 @@
 
 <script>
 
-  import { ref, getCurrentInstance, onMounted } from 'vue';
+  import FilterTextbox from 'kolibri/components/FilterTextbox';
+  import PaginationActions from 'kolibri-common/components/PaginationActions';
+  import { ref, computed, getCurrentInstance, onMounted } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
@@ -161,6 +186,8 @@
   import UsersTable from '../common/UsersTable.vue';
   import { overrideRoute } from '../../../utils';
   import MoveToTrashModal from '../common/MoveToTrashModal.vue';
+  import useUsersTableSearch from '../../../composables/useUsersTableSearch';
+  import usePagination from '../../../composables/usePagination';
 
   export default {
     name: 'UsersRootPage',
@@ -174,6 +201,8 @@
       UsersTableToolbar,
       MoveToTrashModal,
       FacilityAppBarPage,
+      FilterTextbox,
+      PaginationActions,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -193,6 +222,10 @@
         removeFromClass$,
         deleteSelection$,
         cannotDeleteSelfTooltip$,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
       } = bulkUserManagementStrings;
 
       const { $store, $router } = getCurrentInstance().proxy;
@@ -210,6 +243,10 @@
         fetchClasses,
         resetFilters,
       } = useUserManagement({ activeFacilityId });
+
+      // Use our new composables
+      const { searchTerm, filterTextboxRef } = useUsersTableSearch();
+      const { currentPage, itemsPerPage } = usePagination({ usersCount, totalPages });
 
       onMounted(() => {
         fetchClasses();
@@ -229,20 +266,50 @@
         router.push(newRoute);
       }
 
+      const hasSelectedUsers = computed(() => {
+        return selectedUsers.value && selectedUsers.value.size > 0;
+      });
+
       return {
+        // Route utilities
+        overrideRoute,
         PageNames,
+
+        // User and facility info
         userIsMultiFacilityAdmin,
+        currentUserId,
+        isSuperuser,
+        isAdmin,
+
+        // Table data
         facilityUsers,
         totalPages,
         usersCount,
         dataLoading,
         classes,
+        selectedUsers,
         numAppliedFilters,
+        hasSelectedUsers,
+
+        // Search functionality from composable
+        searchTerm,
+        filterTextboxRef,
+
+        // Pagination from composable
+        currentPage,
+        itemsPerPage,
+
+        // Modal state
         isMoveToTrashModalOpen,
+
+        // Methods
         onChange,
         onModalBlur,
         resetFilters,
         clearSelectedUsers,
+        navigateToSidePanel,
+
+        // Strings
         newUser$,
         viewTrash$,
         assignCoach$,
@@ -251,11 +318,9 @@
         removeFromClass$,
         deleteSelection$,
         cannotDeleteSelfTooltip$,
-        selectedUsers,
-        currentUserId,
-        isSuperuser,
-        isAdmin,
-        navigateToSidePanel,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
       };
     },
     computed: {
@@ -272,9 +337,6 @@
             value: PageNames.USERS_TRASH_PAGE,
           },
         ];
-      },
-      hasSelectedUsers() {
-        return this.selectedUsers && this.selectedUsers.size > 0;
       },
       listContainsLoggedInUser() {
         return this.selectedUsers.has(this.currentUserId);
@@ -360,24 +422,12 @@
 
 <style lang="scss" scoped>
 
-  .users-page-header {
+  .users-page-header-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 16px;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.5em;
-
-    h1 {
-      margin: 0;
-    }
-
-    .users-page-header-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 16px;
-      align-items: center;
-      justify-content: flex-end;
-    }
+    justify-content: flex-end;
   }
 
   .users-container {
@@ -403,6 +453,39 @@
     box-shadow:
       0 0 2px rgba(0, 0, 0, 0.12),
       0 2px 2px rgba(0, 0, 0, 0.2);
+  }
+
+  .top-row-left {
+    display: flex;
+    flex: 1;
+    gap: 1em;
+    align-items: center;
+
+    h1 {
+      margin: 0;
+      white-space: nowrap;
+    }
+  }
+
+  .search-box {
+    flex: 1;
+    max-width: 400px;
+  }
+
+  .filter-button {
+    white-space: nowrap;
+  }
+
+  .bottom-row-left {
+    display: flex;
+    gap: 1em;
+    align-items: center;
+
+    .selection-status {
+      display: flex;
+      gap: 0.5em;
+      align-items: center;
+    }
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -43,7 +43,7 @@
               <div class="top-row-left">
                 <h1>{{ coreString('usersLabel') }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -51,7 +51,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   appearance="basic-link"
                   class="filter-button"
                   :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -4,13 +4,21 @@
     class="wrapper"
     :appearanceOverrides="{
       width: '100%',
-      height: '100vh',
+      height: '100%',
       margin: '0px',
       padding: '0px',
     }"
   >
-    <template>
-      <div :style="containerStyles">
+    <template #default="{ appBarHeight }">
+      <div
+        :style="{
+          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          backgroundColor: 'white',
+        }"
+      >
         <div
           class="header-shadow"
           :style="headerStyles"
@@ -414,15 +422,6 @@
       headerStyles() {
         return {
           padding: '16px',
-        };
-      },
-      containerStyles() {
-        return {
-          paddingTop: this.windowIsSmall ? '108px' : '64px',
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          backgroundColor: 'white',
         };
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -5,7 +5,7 @@
     :appearanceOverrides="{
       width: '100%',
       height: '100%',
-      padding: windowIsSmall ? '0 0.5em' : '0 1em',
+      padding: windowIsSmallNoApp ? '0 0.5em' : '0 1em',
     }"
   >
     <template #default="{ pageContentHeight }">
@@ -20,8 +20,8 @@
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: (windowIsSmall ? 112 : 80) + 'px auto 0',
-          maxHeight: pageContentHeight - (windowIsSmall ? 16 : 24) + 'px',
+          margin: topMargin + 'px auto 0',
+          maxHeight: pageContentHeight - (windowIsSmallNoApp ? 16 : 24) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
@@ -153,6 +153,7 @@
                   <KButton
                     appearance="basic-link"
                     :text="coreString('clearAction')"
+                    style="display: inline-block"
                     @click="clearSelectedUsers"
                   />
                 </div>
@@ -265,7 +266,7 @@
       usePreviousRoute();
       const route = useRoute();
       const router = useRouter();
-      const { currentUserId, isSuperuser, isAdmin } = useUser();
+      const { currentUserId, isSuperuser, isAdmin, isAppContext } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
       const isMoveToTrashModalOpen = ref(false);
 
@@ -327,7 +328,19 @@
       });
 
       const { windowIsSmall } = useKResponsiveWindow();
+
+      const topMargin = computed(() => {
+        if (windowIsSmall.value) {
+          if (isAppContext.value) {
+            return 72;
+          }
+          return 112;
+        }
+        return 80;
+      });
+
       return {
+        topMargin,
         windowIsSmall,
         // Route utilities
         overrideRoute,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -26,7 +26,6 @@
         }"
       >
         <div
-          class="header-shadow"
           :style="{
             padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
@@ -496,30 +495,12 @@
     justify-content: flex-end;
   }
 
-  .users-container {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    // top: 4em (app bar) + 2em (internal padding)
-    padding: 6em 2em 1em;
-    // !important to override
-    margin: 0 !important;
-    background-color: white;
-  }
-
   /deep/ .main-wrapper {
     // The default padding causes root scroll which defeats
     // the purpose of our maxHeight style on the KPageContainer.
     // Uses !important because the overridden style is inline
     padding-bottom: 0 !important;
   }
-
-  /*
-  .header-shadow {
-    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
-    z-index: 4;
-  }
-*/
 
   /deep/ thead {
     position: sticky;

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -16,7 +16,7 @@
           flexDirection: 'column',
           maxWidth: '1440px',
           margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: 16 + (pageContentHeight - appBarHeight) + 'px',
+          maxHeight: 24 + (pageContentHeight - appBarHeight) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
@@ -25,7 +25,7 @@
           :style="{
             top: 0,
             position: 'sticky',
-            padding: '1em',
+            padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
           }"
         >
@@ -471,8 +471,17 @@
     padding-bottom: 0 !important;
   }
 
+  /*
   .header-shadow {
-    z-index: 8;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
+    z-index: 4;
+  }
+*/
+
+  /deep/ thead {
+    position: sticky;
+    top: 0;
+    z-index: 4;
     box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -21,6 +21,7 @@
               name: $store.getters.facilityPageLinks.AllFacilitiesPage.name,
               params: { subtopicName: 'UserPage' },
             }"
+            style="margin: 0.5em 0 1em"
             icon="back"
             :text="coreString('changeLearningFacility')"
           />
@@ -428,12 +429,10 @@
     methods: {
       handlePageDropdownSelection(option) {
         if (option.value) {
-          if (option.id === 'new_user') {
-            this.$router.push({
-              name: option.value,
-              params: { facility_id: this.$store.getters.activeFacilityId },
-            });
-          }
+          this.$router.push({
+            name: option.value,
+            params: { facility_id: this.$store.getters.activeFacilityId },
+          });
         }
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -43,7 +43,7 @@
               <div class="top-row-left">
                 <h1>{{ coreString('usersLabel') }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -51,7 +51,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   appearance="basic-link"
                   class="filter-button"
                   :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -17,7 +17,7 @@
           flexDirection: 'column',
           height: '100%',
           maxHeight: pageContentHeight,
-          backgroundColor: 'white',
+          backgroundColor: $themeTokens.surface,
         }"
       >
         <div

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -42,6 +42,13 @@
                   class="filter-button"
                   :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"
                 />
+                <KButton
+                  v-if="numAppliedFilters > 0"
+                  appearance="basic-link"
+                  :appearanceOverrides="{ color: $themeTokens.error }"
+                  :text="clearFiltersLabel$()"
+                  @click="resetFilters"
+                />
               </div>
               <div class="users-page-header-actions">
                 <KButton
@@ -227,6 +234,7 @@
         numFilters$,
         filterLabel$,
         numUsersSelected$,
+        clearFiltersLabel$,
       } = bulkUserManagementStrings;
 
       const { $store, $router } = getCurrentInstance().proxy;
@@ -242,6 +250,7 @@
         numAppliedFilters,
         onChange,
         fetchClasses,
+        resetFilters,
       } = useUserManagement({ activeFacilityId });
 
       // Use our new composables
@@ -309,6 +318,7 @@
         onModalBlur,
         clearSelectedUsers,
         navigateToSidePanel,
+        resetFilters,
 
         // Strings
         newUser$,
@@ -322,6 +332,7 @@
         numFilters$,
         filterLabel$,
         numUsersSelected$,
+        clearFiltersLabel$,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -9,13 +9,14 @@
       padding: '0px',
     }"
   >
-    <template #default="{ appBarHeight }">
+    <template #default="{ appBarHeight, pageContentHeight }">
       <div
         :style="{
-          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
+          paddingTop: appBarHeight + 'px',
           display: 'flex',
           flexDirection: 'column',
           height: '100%',
+          maxHeight: pageContentHeight,
           backgroundColor: 'white',
         }"
       >

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -6,7 +6,7 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: '0 1em',
+      padding: windowIsSmall ? '0 0.25em' : '0 1em',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
@@ -65,7 +65,10 @@
                   @click="resetFilters"
                 />
               </div>
-              <div class="users-page-header-actions">
+              <div
+                v-if="!windowIsSmall"
+                class="users-page-header-actions"
+              >
                 <KButton
                   hasDropdown
                   :primary="false"
@@ -148,6 +151,30 @@
                     @click="clearSelectedUsers"
                   />
                 </div>
+              </div>
+              <div
+                v-if="windowIsSmall"
+                class="users-page-header-actions"
+              >
+                <KButton
+                  hasDropdown
+                  :primary="false"
+                  :text="coreString('optionsLabel')"
+                >
+                  <template #menu>
+                    <KDropdownMenu
+                      :options="pageDropdownOptions"
+                      @select="handlePageDropdownSelection"
+                    />
+                  </template>
+                </KButton>
+                <KRouterLink
+                  v-if="!windowIsSmall"
+                  primary
+                  appearance="raised-button"
+                  :text="newUser$()"
+                  :to="$store.getters.facilityPageLinks.UserCreatePage"
+                />
               </div>
               <PaginationActions
                 v-model="currentPage"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -6,27 +6,26 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: windowIsSmall ? '1em' : '0px',
+      padding: '0 1em',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
-      <div
+      <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 'px auto 0',
-          maxHeight: pageContentHeight + 'px',
+          margin: appBarHeight + 24 + 'px auto 0',
+          maxHeight: 16 + (pageContentHeight - appBarHeight) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
         <div
           class="header-shadow"
           :style="{
-            top: appBarHeight + 'px',
+            top: 0,
             position: 'sticky',
             padding: '1em',
-            zIndex: 12,
             backgroundColor: $themeTokens.surface,
           }"
         >
@@ -46,6 +45,7 @@
               <div class="top-row-left">
                 <h1>{{ coreString('usersLabel') }}</h1>
                 <FilterTextbox
+                  v-if="facilityUsers.length"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -53,6 +53,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
+                  v-if="facilityUsers.length"
                   appearance="basic-link"
                   class="filter-button"
                   :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL })"
@@ -184,7 +185,7 @@
           :onChange="onChange"
           @close="isMoveToTrashModalOpen = false"
         />
-      </div>
+      </KPageContainer>
     </template>
   </FacilityAppBarPage>
 

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -5,18 +5,23 @@
     :appearanceOverrides="{
       width: '100%',
       height: '100%',
-      margin: '0px',
-      padding: windowIsSmall ? '0 0.25em' : '0 1em',
+      padding: windowIsSmall ? '0 0.5em' : '0 1em',
     }"
   >
-    <template #default="{ appBarHeight, pageContentHeight }">
+    <template #default="{ pageContentHeight }">
+      <!--
+      There's some wonky looking math here for styles that basically:
+      Center the content & pad it appropriately against the screen & appbar.
+      This works specifically for the AppBarPage ancestry and sets the content
+      container at ~0.5em padding on small screens and 1em otherwise
+      -->
       <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: 24 + (pageContentHeight - appBarHeight) + 'px',
+          margin: (windowIsSmall ? 112 : 80) + 'px auto 0',
+          maxHeight: pageContentHeight - (windowIsSmall ? 16 : 24) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -27,7 +27,6 @@
         }"
       >
         <div
-          class="header-shadow"
           :style="{
             padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
@@ -386,10 +385,6 @@
 
 
 <style lang="scss" scoped>
-
-  .header-shadow {
-    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
-  }
 
   .top-row-left {
     display: flex;

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -17,7 +17,7 @@
           display: 'flex',
           flexDirection: 'column',
           height: '100%',
-          backgroundColor: 'white',
+          backgroundColor: $themeTokens.surface,
         }"
       >
         <div

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -11,19 +11,24 @@
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
-      <div
+      <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
           margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: pageContentHeight - appBarHeight - 24 + 'px',
+          maxHeight: pageContentHeight - appBarHeight - 48 + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
         <div
           class="header-shadow"
-          :style="headerStyles"
+          :style="{
+            top: 0,
+            position: 'sticky',
+            padding: '1em',
+            backgroundColor: $themeTokens.surface,
+          }"
         >
           <KRouterLink
             :to="$store.getters.facilityPageLinks.UserPage"
@@ -149,7 +154,7 @@
             </p>
           </div>
         </div>
-      </div>
+      </KPageContainer>
       <!-- For sidepanels -->
       <router-view
         :selectedUsers="selectedUsers"
@@ -367,13 +372,6 @@
         clearFiltersLabel$,
       };
     },
-    computed: {
-      headerStyles() {
-        return {
-          padding: '16px',
-        };
-      },
-    },
   };
 
 </script>
@@ -382,13 +380,13 @@
 <style lang="scss" scoped>
 
   .header-shadow {
-    z-index: 8;
     box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
   .top-row-left {
     display: flex;
     flex: 1;
+    flex-wrap: wrap;
     gap: 1em;
     align-items: center;
 
@@ -422,7 +420,8 @@
 
   .page-description {
     flex-grow: 1;
-    text-align: right;
+    margin: 0 !important;
+    text-align: center;
   }
 
   .empty-removed-users {
@@ -452,6 +451,13 @@
         font-size: 14px;
       }
     }
+  }
+
+  /deep/ thead {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -13,10 +13,11 @@
     <template #default="{ appBarHeight }">
       <div
         :style="{
-          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
           display: 'flex',
           flexDirection: 'column',
-          height: '100%',
+          maxWidth: '1440px',
+          margin: appBarHeight + 'px auto 0',
+          maxHeight: pageContentHeight + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
@@ -175,7 +176,6 @@
   import { computed, onMounted, ref } from 'vue';
   import { useRoute } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
@@ -314,10 +314,7 @@
         fetchClasses();
       });
 
-      const { windowIsSmall } = useKResponsiveWindow();
-
       return {
-        windowIsSmall,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -6,25 +6,30 @@
     :appearanceOverrides="{
       width: '100%',
       height: '100%',
-      margin: '0px',
-      padding: windowIsSmall ? '0 0.25em' : '0 1em',
+      padding: windowIsSmall ? '0 0.5em' : '0 1em',
     }"
   >
-    <template #default="{ appBarHeight, pageContentHeight }">
+    <template #default="{ pageContentHeight }">
+      <!--
+      There's some wonky looking math here for styles that basically:
+      Center the content & pad it appropriately against the screen & appbar.
+      This works for the ImmersivePage specifically and sets the content
+      container at ~0.5em padding on small screens and 1em otherwise
+      -->
       <KPageContainer
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 24 + 'px auto 0',
-          maxHeight: pageContentHeight - appBarHeight - 48 + 'px',
+          margin: (windowIsSmall ? 64 : 80) + 'px auto 0',
+          maxHeight: pageContentHeight - (windowIsSmall ? 64 : 96) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
         <div
           class="header-shadow"
           :style="{
-            padding: '1em',
+            padding: '1em 1em 0 1em',
             backgroundColor: $themeTokens.surface,
           }"
         >

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -7,7 +7,7 @@
       width: '100%',
       height: '100%',
       margin: '0px',
-      padding: '0 1em',
+      padding: windowIsSmall ? '0 0.25em' : '0 1em',
     }"
   >
     <template #default="{ appBarHeight, pageContentHeight }">
@@ -188,6 +188,7 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import DeletedFacilityUserResource from 'kolibri-common/apiResources/DeletedFacilityUserResource';
 
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useUserManagement from '../../../composables/useUserManagement';
   import { PageNames } from '../../../constants';
   import { overrideRoute } from '../../../utils';
@@ -319,7 +320,11 @@
         fetchClasses();
       });
 
+      const { windowIsSmall } = useKResponsiveWindow();
+
       return {
+        windowIsSmall,
+
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -24,8 +24,6 @@
         <div
           class="header-shadow"
           :style="{
-            top: 0,
-            position: 'sticky',
             padding: '1em',
             backgroundColor: $themeTokens.surface,
           }"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -22,7 +22,7 @@
           flexDirection: 'column',
           maxWidth: '1440px',
           margin: (windowIsSmall ? 64 : 80) + 'px auto 0',
-          maxHeight: pageContentHeight - (windowIsSmall ? 64 : 96) + 'px',
+          maxHeight: pageContentHeight - (windowIsSmall ? 70 : 96) + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -5,13 +5,21 @@
     :route="$store.getters.facilityPageLinks.UserPage"
     :appearanceOverrides="{
       width: '100%',
-      height: '100vh',
+      height: '100ersh',
       margin: '0px',
       padding: '0px',
     }"
   >
-    <template>
-      <div :style="containerStyles">
+    <template #default="{ appBarHeight }">
+      <div
+        :style="{
+          paddingTop: windowIsSmall ? 64 + appBarHeight + 'px' : '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          backgroundColor: 'white',
+        }"
+      >
         <div
           class="header-shadow"
           :style="headerStyles"
@@ -364,15 +372,6 @@
       headerStyles() {
         return {
           padding: '16px',
-        };
-      },
-      containerStyles() {
-        return {
-          paddingTop: this.windowIsSmall ? '108px' : '64px',
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          backgroundColor: 'white',
         };
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -40,7 +40,7 @@
               <div class="top-row-left">
                 <h1>{{ removedUsersTitle$() }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -48,7 +48,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length || searchTerm"
+                  v-if="facilityUsers.length || searchTerm || numAppliedFilters > 0"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -3,63 +3,114 @@
   <ImmersivePage
     :appBarTitle="removedUsersTitle$()"
     :route="$store.getters.facilityPageLinks.UserPage"
+    :appearanceOverrides="{
+      width: '100%',
+      height: '100vh',
+      margin: '0px',
+      padding: '0px',
+    }"
   >
-    <template #default="{ pageContentHeight }">
-      <KPageContainer
-        class="page-container"
-        :style="{ maxHeight: pageContentHeight + 24 + 'px' }"
-      >
-        <p>
+    <template>
+      <div :style="containerStyles">
+        <div
+          class="header-shadow"
+          :style="headerStyles"
+        >
           <KRouterLink
             :to="$store.getters.facilityPageLinks.UserPage"
             icon="back"
+            style="margin: 0.5em 0 1em"
             :text="backToUsers$()"
           />
-        </p>
-        <div class="removed-users-page-header">
-          <h1>{{ removedUsersTitle$() }}</h1>
-          <p v-if="showUsersTable">
-            {{ removedUsersPageDescription$() }}
-          </p>
+
+          <UsersTableToolbar>
+            <template #topRow>
+              <div class="top-row-left">
+                <h1>{{ removedUsersTitle$() }}</h1>
+                <FilterTextbox
+                  ref="filterTextboxRef"
+                  v-model="searchTerm"
+                  class="search-box"
+                  :placeholder="coreString('searchForUser')"
+                  :aria-label="coreString('searchForUser')"
+                />
+                <KRouterLink
+                  appearance="basic-link"
+                  :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
+                  class="filter-button"
+                  :to="overrideRoute($route, { name: PageNames.FILTER_USERS_SIDE_PANEL__TRASH })"
+                />
+                <KButton
+                  v-if="numAppliedFilters > 0"
+                  appearance="basic-link"
+                  :appearanceOverrides="{ color: $themeTokens.error }"
+                  :text="clearFiltersLabel$()"
+                  @click="resetFilters"
+                />
+                <p
+                  v-if="showUsersTable"
+                  class="page-description"
+                >
+                  {{ removedUsersPageDescription$() }}
+                </p>
+              </div>
+            </template>
+            <template #bottomRow>
+              <div class="bottom-row-left">
+                <KIconButton
+                  ref="recoverButton"
+                  icon="refresh"
+                  :disabled="!hasSelectedUsers || loading"
+                  :ariaLabel="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+                  @click="recoverUsers(selectedUsers)"
+                />
+                <KTooltip
+                  reference="recoverButton"
+                  :refs="$refs"
+                  :text="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
+                />
+                <KIconButton
+                  ref="deleteButton"
+                  icon="trash"
+                  :disabled="!hasSelectedUsers || loading"
+                  :ariaLabel="deletePermanentlyLabel$()"
+                  @click="usersToDelete = selectedUsers"
+                />
+                <KTooltip
+                  reference="deleteButton"
+                  :refs="$refs"
+                  :text="deletePermanentlyLabel$()"
+                />
+                <div
+                  v-if="hasSelectedUsers"
+                  class="selection-status"
+                >
+                  <span>{{ numUsersSelected$({ n: selectedUsers.size }) }}</span>
+                  <KButton
+                    appearance="basic-link"
+                    :text="coreString('clearAction')"
+                    @click="clearSelectedUsers"
+                  />
+                </div>
+              </div>
+              <PaginationActions
+                v-model="currentPage"
+                :itemsPerPage="itemsPerPage"
+                :totalPageNumber="totalPages"
+                :numFilteredItems="usersCount"
+              />
+            </template>
+          </UsersTableToolbar>
         </div>
         <UsersTable
           v-if="showUsersTable"
+          class="users-table"
           :facilityUsers="facilityUsers"
-          :usersCount="usersCount"
-          :totalPages="totalPages"
           :dataLoading="dataLoading"
           :selectedUsers.sync="selectedUsers"
-          :filterPageName="PageNames.FILTER_USERS_SIDE_PANEL__TRASH"
-          :numAppliedFilters="numAppliedFilters"
-          @clearFilters="resetFilters"
+          @clearSelectedUsers="clearSelectedUsers"
           @change="onChange"
         >
-          <template #userActions>
-            <KIconButton
-              ref="recoverButton"
-              icon="refresh"
-              :disabled="!selectedUsers.size || loading"
-              :ariaLabel="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
-              @click="recoverUsers(selectedUsers)"
-            />
-            <KTooltip
-              reference="recoverButton"
-              :refs="$refs"
-              :text="selectedUsers.size > 1 ? recoverSelectionLabel$() : recoverLabel$()"
-            />
-            <KIconButton
-              ref="deleteButton"
-              icon="trash"
-              :disabled="!selectedUsers.size || loading"
-              :ariaLabel="deletePermanentlyLabel$()"
-              @click="usersToDelete = selectedUsers"
-            />
-            <KTooltip
-              reference="deleteButton"
-              :refs="$refs"
-              :text="deletePermanentlyLabel$()"
-            />
-          </template>
           <template #userDropdownMenu="{ user }">
             <KDropdownMenu
               :options="userDropdownMenuOptions"
@@ -87,12 +138,14 @@
             </p>
           </div>
         </div>
-      </KPageContainer>
+      </div>
+      <!-- For sidepanels -->
       <router-view
-        :backRoute="overrideRoute($route, { name: PageNames.USERS_TRASH_PAGE })"
-        :classes="classes"
         :selectedUsers="selectedUsers"
-        @change="onChange"
+        :classes="classes"
+        :onBlur="onModalBlur"
+        :onChange="onChange"
+        @clearSelection="clearSelectedUsers"
       />
       <PermanentDeleteModal
         v-if="usersToDelete"
@@ -108,9 +161,13 @@
 
 <script>
 
+  import FilterTextbox from 'kolibri/components/FilterTextbox';
+  import PaginationActions from 'kolibri-common/components/PaginationActions';
   import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
   import { useRoute } from 'vue-router/composables';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
@@ -122,16 +179,23 @@
   import { PageNames } from '../../../constants';
   import { overrideRoute } from '../../../utils';
   import UsersTable from '../common/UsersTable.vue';
+  import UsersTableToolbar from '../common/UsersTableToolbar';
   import emptyTrashCloudSvg from '../../../images/empty_trash_cloud.svg';
+  import useUsersTableSearch from '../../../composables/useUsersTableSearch';
+  import usePagination from '../../../composables/usePagination';
   import PermanentDeleteModal from './PermanentDeleteModal.vue';
 
   export default {
     name: 'UsersTrashPage',
     components: {
       UsersTable,
+      UsersTableToolbar,
       ImmersivePage,
       PermanentDeleteModal,
+      FilterTextbox,
+      PaginationActions,
     },
+    mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
       usePreviousRoute();
@@ -166,6 +230,14 @@
           dataLoading.value,
       );
 
+      const hasSelectedUsers = computed(() => {
+        return selectedUsers.value && selectedUsers.value.size > 0;
+      });
+
+      // Use our new composables
+      const { searchTerm, filterTextboxRef } = useUsersTableSearch();
+      const { currentPage, itemsPerPage } = usePagination({ usersCount, totalPages });
+
       const {
         backToUsers$,
         recoverLabel$,
@@ -176,7 +248,20 @@
         recoverSelectionLabel$,
         deletePermanentlyLabel$,
         removedUsersPageDescription$,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
       } = bulkUserManagementStrings;
+
+      function clearSelectedUsers() {
+        selectedUsers.value = new Set();
+      }
+
+      function onModalBlur() {
+        selectedUsers.value.clear();
+        selectedUsers.value = new Set(selectedUsers.value);
+      }
 
       const recoverUsers = async users => {
         try {
@@ -221,11 +306,17 @@
         fetchClasses();
       });
 
+      const { windowIsSmall } = useKResponsiveWindow();
+
       return {
+        windowIsSmall,
+        // Route utilities
+        overrideRoute,
+        PageNames,
+
         // ref and computed properties
         loading,
         classes,
-        PageNames,
         totalPages,
         usersCount,
         dataLoading,
@@ -233,14 +324,24 @@
         usersToDelete,
         selectedUsers,
         showUsersTable,
+        hasSelectedUsers,
         emptyTrashCloudSvg,
         numAppliedFilters,
         userDropdownMenuOptions,
 
+        // Search functionality from composable
+        searchTerm,
+        filterTextboxRef,
+
+        // Pagination from composable
+        currentPage,
+        itemsPerPage,
+
         // Methods
         onChange,
+        onModalBlur,
+        clearSelectedUsers,
         recoverUsers,
-        overrideRoute,
         resetFilters,
         handleDropdownSelect,
 
@@ -253,7 +354,27 @@
         removedUsersNotice$,
         noRemovedUsersLabel$,
         removedUsersPageDescription$,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
       };
+    },
+    computed: {
+      headerStyles() {
+        return {
+          padding: '16px',
+        };
+      },
+      containerStyles() {
+        return {
+          paddingTop: this.windowIsSmall ? '108px' : '64px',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          backgroundColor: 'white',
+        };
+      },
     },
   };
 
@@ -262,15 +383,48 @@
 
 <style lang="scss" scoped>
 
-  .page-container {
-    display: flex;
-    flex-direction: column;
-    max-width: 1000px;
-    margin: 24px auto;
+  .header-shadow {
+    z-index: 8;
+    box-shadow: 0 4px 4px -4px rgba(0, 0, 0, 0.8);
   }
 
-  .removed-users-page-header {
-    margin-bottom: 16px;
+  .top-row-left {
+    display: flex;
+    flex: 1;
+    gap: 1em;
+    align-items: center;
+
+    h1 {
+      margin: 0;
+      white-space: nowrap;
+    }
+  }
+
+  .search-box {
+    flex: 1;
+    width: 100% !important;
+    max-width: 400px;
+  }
+
+  .filter-button {
+    white-space: nowrap;
+  }
+
+  .bottom-row-left {
+    display: flex;
+    gap: 0.25em;
+    align-items: center;
+
+    .selection-status {
+      display: flex;
+      gap: 0.5em;
+      align-items: center;
+    }
+  }
+
+  .page-description {
+    flex-grow: 1;
+    text-align: right;
   }
 
   .empty-removed-users {

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -40,7 +40,7 @@
               <div class="top-row-left">
                 <h1>{{ removedUsersTitle$() }}</h1>
                 <FilterTextbox
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -48,7 +48,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
-                  v-if="facilityUsers.length"
+                  v-if="facilityUsers.length || searchTerm"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersTrashPage/index.vue
@@ -5,19 +5,19 @@
     :route="$store.getters.facilityPageLinks.UserPage"
     :appearanceOverrides="{
       width: '100%',
-      height: '100ersh',
+      height: '100%',
       margin: '0px',
-      padding: '0px',
+      padding: '0 1em',
     }"
   >
-    <template #default="{ appBarHeight }">
+    <template #default="{ appBarHeight, pageContentHeight }">
       <div
         :style="{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: '1440px',
-          margin: appBarHeight + 'px auto 0',
-          maxHeight: pageContentHeight + 'px',
+          margin: appBarHeight + 24 + 'px auto 0',
+          maxHeight: pageContentHeight - appBarHeight - 24 + 'px',
           backgroundColor: $themeTokens.surface,
         }"
       >
@@ -37,6 +37,7 @@
               <div class="top-row-left">
                 <h1>{{ removedUsersTitle$() }}</h1>
                 <FilterTextbox
+                  v-if="facilityUsers.length"
                   ref="filterTextboxRef"
                   v-model="searchTerm"
                   class="search-box"
@@ -44,6 +45,7 @@
                   :aria-label="coreString('searchForUser')"
                 />
                 <KRouterLink
+                  v-if="facilityUsers.length"
                   appearance="basic-link"
                   :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
                   class="filter-button"

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -1,13 +1,7 @@
 <template>
 
   <div class="flex-column">
-    <PaginatedListContainerWithBackend
-      v-model="currentPage"
-      class="paginated-wrapper"
-      :itemsPerPage="itemsPerPage"
-      :totalPageNumber="totalPages"
-      :numFilteredItems="usersCount"
-    >
+    <PaginatedListContainerWithBackend class="paginated-wrapper">
       <KTable
         class="move-down user-roster"
         :stickyColumns="stickyColumns"
@@ -111,21 +105,6 @@
           </span>
         </template>
       </KTable>
-      <template #paginationFooter>
-        <div>
-          <div v-if="selectedUsers.size > 0">
-            <span style="margin: 0 1em">
-              {{ numUsersSelected$({ n: selectedUsers.size }) }}
-            </span>
-
-            <KButton
-              appearance="basic-link"
-              :text="coreStrings.clearAction$()"
-              @click="$emit('clearSelectedUsers')"
-            />
-          </div>
-        </div>
-      </template>
     </PaginatedListContainerWithBackend>
     <ResetUserPasswordModal
       v-if="modalShown === Modals.RESET_USER_PASSWORD"
@@ -150,10 +129,8 @@
   import store from 'kolibri/store';
   import cloneDeep from 'lodash/cloneDeep';
   import useNow from 'kolibri/composables/useNow';
-  import { toRefs, ref, computed, onBeforeUnmount, getCurrentInstance } from 'vue';
+  import { toRefs, ref, computed, getCurrentInstance } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
-  import pickBy from 'lodash/pickBy';
-  import debounce from 'lodash/debounce';
   import { UserKinds } from 'kolibri/constants';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { getUserKindDisplayMap } from 'kolibri-common/uiText/userKinds';
@@ -172,7 +149,6 @@
   import MoveToTrashModal from './MoveToTrashModal.vue';
   import ResetUserPasswordModal from './ResetUserPasswordModal';
 
-  const ALL_FILTER = 'all';
   const SELECTION_COLUMN_ID = 'selection';
 
   // Constant for the number of days until the user is permanently deleted
@@ -191,7 +167,7 @@
       ResetUserPasswordModal,
       PaginatedListContainerWithBackend,
     },
-    setup(props, { emit, expose }) {
+    setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
       const { isSuperuser, currentUserId } = useUser();
@@ -202,7 +178,6 @@
       const { facilityUsers } = toRefs(props);
       const modalShown = ref(null);
       const userToChange = ref(null);
-      const filterTextboxRef = ref(null);
 
       const { selectAllLabel$ } = enhancedQuizManagementStrings;
       const {
@@ -350,15 +325,6 @@
         return { checked: isChecked, indeterminate: isIndeterminate };
       });
 
-      const userKinds = computed(() => {
-        return [
-          { label: coreStrings.allLabel$(), value: ALL_FILTER },
-          { label: coreStrings.learnersLabel$(), value: UserKinds.LEARNER },
-          { label: coreStrings.coachesLabel$(), value: UserKinds.COACH },
-          { label: coreStrings.adminsLabel$(), value: UserKinds.ADMIN },
-          { label: coreStrings.superAdminsLabel$(), value: UserKinds.SUPERUSER },
-        ];
-      });
 
       const userRoleBadgeStyle = computed(() => {
         const $themeTokens = themeTokens();
@@ -369,81 +335,6 @@
             color: $themeTokens.text,
           },
         };
-      });
-
-      const roleFilter = computed({
-        get() {
-          return userKinds.value.find(k => k.value === route.query.user_type) || userKinds.value[0];
-        },
-        set(value) {
-          value = value.value;
-          if (value === ALL_FILTER) {
-            value = null;
-          }
-          router.push({
-            ...route,
-            query: pickBy({
-              ...route.query,
-              user_type: value,
-              page: null,
-            }),
-          });
-        },
-      });
-
-      const emitSearchTerm = value => {
-        if (value === '') {
-          value = null;
-        }
-        router.push({
-          ...route,
-          query: pickBy({
-            ...route.query,
-            search: value,
-            page: null,
-          }),
-        });
-      };
-      const debouncedSearchTerm = debounce(emitSearchTerm, 300);
-
-      const searchTerm = computed({
-        get() {
-          return route.query.search || '';
-        },
-        set(value) {
-          debouncedSearchTerm(value);
-        },
-      });
-
-      const currentPage = computed({
-        get() {
-          return Number(route.query.page) || 1;
-        },
-        set(value) {
-          router.push({
-            ...route,
-            query: pickBy({
-              ...route.query,
-              page: value,
-            }),
-          });
-        },
-      });
-
-      const itemsPerPage = computed({
-        get() {
-          return Number(route.query.page_size) || 30;
-        },
-        set(value) {
-          router.push({
-            ...route,
-            query: pickBy({
-              ...route.query,
-              page_size: value,
-              page: null,
-            }),
-          });
-        },
       });
 
       const userToChangeSet = computed(() => {
@@ -497,7 +388,7 @@
         query.page = 1;
         router.push({
           path: route.path,
-          query: pickBy(query),
+          query: query,
         });
       };
 
@@ -513,10 +404,13 @@
       };
 
       const getEmptyMessageForItems = items => {
+        const search = route.query.search || '';
+        const roleType = route.query.user_type;
+
         if (facilityUsers.value.length === 0) {
           return coreStrings.noUsersExistLabel$();
-        } else if (roleFilter.value && searchTerm.value === '') {
-          switch (roleFilter.value.value) {
+        } else if (roleType && search === '') {
+          switch (roleType) {
             case UserKinds.LEARNER:
               return noLearnersExist$();
             case UserKinds.COACH:
@@ -529,7 +423,7 @@
               return '';
           }
         } else if (items.length === 0) {
-          return allUsersFilteredOut$({ filterText: searchTerm.value });
+          return allUsersFilteredOut$({ filterText: search });
         }
         return '';
       };
@@ -562,21 +456,6 @@
         }
       };
 
-      onBeforeUnmount(() => {
-        const { query } = route;
-        if (query.ordering || query.order || query.page) {
-          router.replace({ query: null });
-        }
-      });
-
-      const focus = () => {
-        filterTextboxRef.value?.focus();
-      };
-
-      expose({
-        focus,
-      });
-
       const { windowBreakpoint } = useKResponsiveWindow();
       const stickyColumns = computed(() => [
         windowBreakpoint.value <= 2 ? 'first' : 'firstTwo',
@@ -589,8 +468,6 @@
         tableRows,
         selectAllState,
         userRoleBadgeStyle,
-        currentPage,
-        itemsPerPage,
         Modals,
         modalShown,
         userToChange,
@@ -613,20 +490,11 @@
         coreStrings,
         selectLabel$,
         selectAllLabel$,
-        numUsersSelected$,
       };
     },
     props: {
       facilityUsers: {
         type: Array,
-        required: true,
-      },
-      usersCount: {
-        type: Number,
-        required: true,
-      },
-      totalPages: {
-        type: Number,
         required: true,
       },
       dataLoading: {

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -553,33 +553,6 @@
     min-height: 0;
   }
 
-  /deep/ .pagination-nav {
-    /deep/ .pagination-nav {
-      z-index: 2;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: space-between;
-      width: 100%;
-      padding: 1em 0;
-      margin-top: 0;
-      background-color: white;
-      box-shadow:
-        0 0 4px rgba(0, 0, 0, 0.42),
-        0 4px 2px rgba(0, 0, 0, 0.82);
-
-      .pagination-actions {
-        margin: 0 1em;
-      }
-    }
-
-    .paginated-wrapper /deep/ .table-content {
-      display: block;
-      padding: 0 1em;
-      overflow: auto;
-    }
-  }
-
   /deep/ .k-table-wrapper {
     // Ensure space enough for swipe zone on mobile
     tr td:first-child,

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -7,61 +7,6 @@
       :totalPageNumber="totalPages"
       :numFilteredItems="usersCount"
     >
-      <KGrid>
-        <KGridItem
-          :layout="{ alignment: 'right' }"
-          :layout8="{ span: 5 }"
-          :layout12="{ span: 7 }"
-        >
-          <div class="search-filter-section">
-            <FilterTextbox
-              ref="filterTextboxRef"
-              v-model="searchTerm"
-              :placeholder="coreStrings.searchForUser$()"
-              :aria-label="coreStrings.searchForUser$()"
-              class="move-down search-box"
-            />
-            <KRouterLink
-              appearance="basic-link"
-              :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
-              class="filter-button move-down"
-              :to="overrideRoute($route, { name: filterPageName })"
-            />
-            <KButton
-              v-if="numAppliedFilters > 0"
-              appearance="basic-link"
-              :text="clearFiltersLabel$()"
-              class="filter-button move-down"
-              :style="{
-                color: $themePalette.red.v_600 + ' !important',
-              }"
-              @click="$emit('clearFilters')"
-            />
-          </div>
-        </KGridItem>
-        <KGridItem
-          :layout="{ alignment: 'right' }"
-          :layout8="{ span: 3 }"
-          :layout12="{ span: 5 }"
-          class="move-down"
-        >
-          <span
-            v-if="selectedUsers.size > 0"
-            class="mr-8"
-          >
-            <span class="selected-count">
-              {{ numUsersSelected$({ n: selectedUsers.size }) }}
-            </span>
-
-            <KButton
-              appearance="basic-link"
-              :text="coreStrings.clearAction$()"
-              @click="clearSelectedUsers"
-            />
-          </span>
-          <slot name="userActions"></slot>
-        </KGridItem>
-      </KGrid>
       <KTable
         class="move-down user-roster"
         :stickyColumns="stickyColumns"
@@ -165,6 +110,23 @@
           </span>
         </template>
       </KTable>
+      <template #paginationFooter>
+        <div>
+          <div
+            v-if="selectedUsers.size > 0"
+          >
+            <span style="margin: 0 1em;">
+              {{ numUsersSelected$({ n: selectedUsers.size }) }}
+            </span>
+
+            <KButton
+              appearance="basic-link"
+              :text="coreStrings.clearAction$()"
+              @click="$emit('clearSelectedUsers')"
+            />
+          </div>
+        </div>
+      </template>
     </PaginatedListContainerWithBackend>
     <ResetUserPasswordModal
       v-if="modalShown === Modals.RESET_USER_PASSWORD"
@@ -212,6 +174,7 @@
   import { overrideRoute } from '../../../utils';
   import MoveToTrashModal from './MoveToTrashModal.vue';
   import ResetUserPasswordModal from './ResetUserPasswordModal';
+  import UsersTableToolbar from './UsersTableToolbar';
 
   const ALL_FILTER = 'all';
   const SELECTION_COLUMN_ID = 'selection';
@@ -232,6 +195,7 @@
       BirthYearDisplayText,
       ResetUserPasswordModal,
       PaginatedListContainerWithBackend,
+      UsersTableToolbar,
     },
     setup(props, { emit, expose }) {
       const route = useRoute();
@@ -727,28 +691,8 @@
     overflow-x: auto;
   }
 
-  .search-filter-section {
-    display: flex;
-    justify-content: start;
-    // Ensure space enough for keyboard nav outline before table content
-    padding-bottom: 0.5em;
-  }
-
   .user-type-icon {
     width: auto;
-  }
-
-  .search-box {
-    width: 294px;
-  }
-
-  .filter-button {
-    padding-top: 10px;
-    margin-left: 1em;
-  }
-
-  .mr-8 {
-    margin-right: 8px;
   }
 
   .screen-reader-only {
@@ -769,5 +713,28 @@
     // Min height is set to 0 to allow flex items to shrink
     min-height: 0;
   }
+
+/deep/ .pagination-nav {
+  position: fixed;
+  box-shadow:
+    0 0 4px rgba(0, 0, 0, 0.42),
+    0 4px 2px rgba(0, 0, 0, 0.82);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  padding: 1em 0;
+  background-color: white;
+  z-index: 8;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+
+.pagination-actions {
+margin: 0 1em;
+}
+
+}
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -9,7 +9,7 @@
         :caption="coreStrings.usersLabel$()"
         :rows="tableRows"
         :dataLoading="dataLoading"
-        :emptyMessage="getEmptyMessageForItems(facilityUsers)"
+        :emptyMessage="getEmptyMessage"
         sortable
         disableBuiltinSorting
         @changeSort="changeSortHandler"
@@ -401,32 +401,31 @@
         return selectLabel$() + ' ' + user.full_name + ', ' + userKindMap[user.kind];
       };
 
-      const getEmptyMessageForItems = items => {
+      const getEmptyMessage = computed(() => {
         const search = route.query.search || '';
-        const roleTypes = route.query.user_types;
+        const roleTypes = route.query.user_types?.split(',') || [];
 
         if (facilityUsers.value.length === 0) {
-          return coreStrings.noUsersExistLabel$();
-        } else if (roleTypes && search === '') {
-          // TODO The language here will likely change - note that there is no
-          if (roleTypes.includes(UserKinds.LEARNER)) {
-            return noLearnersExist$();
+          if (!roleTypes.length) {
+            return coreStrings.noUsersExistLabel$();
+          } else if (search === '') {
+            // TODO The language here will likely change - note that there is no
+            if (roleTypes.includes(UserKinds.LEARNER)) {
+              return noLearnersExist$();
+            }
+            if (roleTypes.includes(UserKinds.COACH)) {
+              return noCoachesExist$();
+            }
+            if (roleTypes.includes(UserKinds.ADMIN)) {
+              return noAdminsExist$();
+            }
+            if (roleTypes.includes(UserKinds.SUPERUSER)) {
+              return noSuperAdminsExist$();
+            }
           }
-          if (roleTypes.includes(UserKinds.COACH)) {
-            return noCoachesExist$();
-          }
-          if (roleTypes.includes(UserKinds.ADMIN)) {
-            return noAdminsExist$();
-          }
-          if (roleTypes.includes(UserKinds.SUPERUSER)) {
-            return noSuperAdminsExist$();
-          }
-          return '';
-        } else if (items.length === 0) {
-          return allUsersFilteredOut$({ filterText: search });
         }
-        return '';
-      };
+        return allUsersFilteredOut$({ filterText: search });
+      });
 
       const closeModal = () => {
         modalShown.value = null;
@@ -481,7 +480,7 @@
         changeSortHandler,
         userCanBeEdited,
         getTranslatedSelectedArialabel,
-        getEmptyMessageForItems,
+        getEmptyMessage,
         closeModal,
         getManageUserOptions,
         handleManageUserAction,

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -575,15 +575,25 @@
 
     .paginated-wrapper /deep/ .table-content {
       display: block;
+      padding: 0 1em;
       overflow: auto;
     }
   }
 
   /deep/ .k-table-wrapper {
+    // Ensure space enough for swipe zone on mobile
+    tr td:first-child,
+    tr th:first-child {
+      padding-left: 2em;
+    }
+
     // Applying the padding here avoids the scrollbar having padding
     // between itself and the window's edge and floating. This way
     // it looks like a root-level scrollbar (even though there isn't one)
-    padding: 0 1em;
+    tr td:last-child,
+    tr th:last-child {
+      padding-right: 1em;
+    }
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -187,7 +187,6 @@
         resetPassword$,
         noCoachesExist$,
         noLearnersExist$,
-        numUsersSelected$,
         noSuperAdminsExist$,
         allUsersFilteredOut$,
         permanentDeletion$,
@@ -324,7 +323,6 @@
 
         return { checked: isChecked, indeterminate: isIndeterminate };
       });
-
 
       const userRoleBadgeStyle = computed(() => {
         const $themeTokens = themeTokens();
@@ -578,6 +576,13 @@
       display: block;
       overflow: auto;
     }
+  }
+
+  /deep/ .k-table-wrapper {
+    // Applying the padding here avoids the scrollbar having padding
+    // between itself and the window's edge and floating. This way
+    // it looks like a root-level scrollbar (even though there isn't one)
+    padding: 0 1em;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -3,6 +3,7 @@
   <div class="flex-column">
     <PaginatedListContainerWithBackend
       v-model="currentPage"
+      class="paginated-wrapper"
       :itemsPerPage="itemsPerPage"
       :totalPageNumber="totalPages"
       :numFilteredItems="usersCount"
@@ -112,10 +113,8 @@
       </KTable>
       <template #paginationFooter>
         <div>
-          <div
-            v-if="selectedUsers.size > 0"
-          >
-            <span style="margin: 0 1em;">
+          <div v-if="selectedUsers.size > 0">
+            <span style="margin: 0 1em">
               {{ numUsersSelected$({ n: selectedUsers.size }) }}
             </span>
 
@@ -156,7 +155,6 @@
   import pickBy from 'lodash/pickBy';
   import debounce from 'lodash/debounce';
   import { UserKinds } from 'kolibri/constants';
-  import FilterTextbox from 'kolibri/components/FilterTextbox';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { getUserKindDisplayMap } from 'kolibri-common/uiText/userKinds';
   import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
@@ -171,10 +169,8 @@
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
 
   import { Modals } from '../../../constants';
-  import { overrideRoute } from '../../../utils';
   import MoveToTrashModal from './MoveToTrashModal.vue';
   import ResetUserPasswordModal from './ResetUserPasswordModal';
-  import UsersTableToolbar from './UsersTableToolbar';
 
   const ALL_FILTER = 'all';
   const SELECTION_COLUMN_ID = 'selection';
@@ -188,14 +184,12 @@
     name: 'UsersTable',
     components: {
       CoreInfoIcon,
-      FilterTextbox,
       UserTypeDisplay,
       MoveToTrashModal,
       GenderDisplayText,
       BirthYearDisplayText,
       ResetUserPasswordModal,
       PaginatedListContainerWithBackend,
-      UsersTableToolbar,
     },
     setup(props, { emit, expose }) {
       const route = useRoute();
@@ -213,15 +207,12 @@
       const { selectAllLabel$ } = enhancedQuizManagementStrings;
       const {
         createdAt$,
-        numFilters$,
         selectLabel$,
-        filterLabel$,
         noAdminsExist$,
         resetPassword$,
         noCoachesExist$,
         noLearnersExist$,
         numUsersSelected$,
-        clearFiltersLabel$,
         noSuperAdminsExist$,
         allUsersFilteredOut$,
         permanentDeletion$,
@@ -487,10 +478,6 @@
         _selectedUsers.value = newSet;
       };
 
-      const clearSelectedUsers = () => {
-        _selectedUsers.value = new Set();
-      };
-
       const isUserSelected = user => {
         return _selectedUsers.value.has(user.id);
       };
@@ -602,23 +589,19 @@
         tableRows,
         selectAllState,
         userRoleBadgeStyle,
-        searchTerm,
         currentPage,
         itemsPerPage,
         Modals,
         modalShown,
         userToChange,
         userToChangeSet,
-        filterTextboxRef,
         stickyColumns,
 
         // Methods
         handleSelectAllToggle,
         handleUserSelectionToggle,
-        clearSelectedUsers,
         isUserSelected,
         changeSortHandler,
-        overrideRoute,
         userCanBeEdited,
         getTranslatedSelectedArialabel,
         getEmptyMessageForItems,
@@ -628,12 +611,9 @@
 
         // Strings
         coreStrings,
-        numFilters$,
         selectLabel$,
-        filterLabel$,
         selectAllLabel$,
         numUsersSelected$,
-        clearFiltersLabel$,
       };
     },
     props: {
@@ -652,14 +632,6 @@
       dataLoading: {
         type: Boolean,
         default: false,
-      },
-      filterPageName: {
-        type: String,
-        required: true,
-      },
-      numAppliedFilters: {
-        type: Number,
-        default: 0,
       },
       selectedUsers: {
         type: Set,
@@ -714,27 +686,30 @@
     min-height: 0;
   }
 
-/deep/ .pagination-nav {
-  position: fixed;
-  box-shadow:
-    0 0 4px rgba(0, 0, 0, 0.42),
-    0 4px 2px rgba(0, 0, 0, 0.82);
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  padding: 1em 0;
-  background-color: white;
-  z-index: 8;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  /deep/ .pagination-nav {
+    /deep/ .pagination-nav {
+      z-index: 2;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      padding: 1em 0;
+      margin-top: 0;
+      background-color: white;
+      box-shadow:
+        0 0 4px rgba(0, 0, 0, 0.42),
+        0 4px 2px rgba(0, 0, 0, 0.82);
 
-.pagination-actions {
-margin: 0 1em;
-}
+      .pagination-actions {
+        margin: 0 1em;
+      }
+    }
 
-}
+    .paginated-wrapper /deep/ .table-content {
+      display: block;
+      overflow: auto;
+    }
+  }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -403,23 +403,25 @@
 
       const getEmptyMessageForItems = items => {
         const search = route.query.search || '';
-        const roleType = route.query.user_type;
+        const roleTypes = route.query.user_types;
 
         if (facilityUsers.value.length === 0) {
           return coreStrings.noUsersExistLabel$();
-        } else if (roleType && search === '') {
-          switch (roleType) {
-            case UserKinds.LEARNER:
-              return noLearnersExist$();
-            case UserKinds.COACH:
-              return noCoachesExist$();
-            case UserKinds.ADMIN:
-              return noAdminsExist$();
-            case UserKinds.SUPERUSER:
-              return noSuperAdminsExist$();
-            default:
-              return '';
+        } else if (roleTypes && search === '') {
+          // TODO The language here will likely change - note that there is no
+          if (roleTypes.includes(UserKinds.LEARNER)) {
+            return noLearnersExist$();
           }
+          if (roleTypes.includes(UserKinds.COACH)) {
+            return noCoachesExist$();
+          }
+          if (roleTypes.includes(UserKinds.ADMIN)) {
+            return noAdminsExist$();
+          }
+          if (roleTypes.includes(UserKinds.SUPERUSER)) {
+            return noSuperAdminsExist$();
+          }
+          return '';
         } else if (items.length === 0) {
           return allUsersFilteredOut$({ filterText: search });
         }

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -554,18 +554,14 @@
   }
 
   /deep/ .k-table-wrapper {
-    // Ensure space enough for swipe zone on mobile
     tr td:first-child,
     tr th:first-child {
-      padding-left: 2em;
+      padding: 0.675em 1em;
     }
 
-    // Applying the padding here avoids the scrollbar having padding
-    // between itself and the window's edge and floating. This way
-    // it looks like a root-level scrollbar (even though there isn't one)
     tr td:last-child,
     tr th:last-child {
-      padding-right: 1em;
+      padding: 0.675em 1em;
     }
   }
 

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
@@ -32,7 +32,6 @@
     display: flex;
     flex-direction: column;
     gap: 1em;
-    margin-bottom: 1em;
   }
 
   .top-row {

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
@@ -1,0 +1,164 @@
+<template>
+
+  <div style='display: flex; justify-content: space-between; flex-wrap: wrap;'>
+    <div class="search-filter-section">
+      <FilterTextbox
+        ref="filterTextboxRef"
+        v-model="searchTerm"
+        :placeholder="coreStrings.searchForUser$()"
+        :aria-label="coreStrings.searchForUser$()"
+        class="move-down search-box"
+      />
+      <KRouterLink
+        appearance="basic-link"
+        :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
+        class="filter-button move-down"
+        :to="overrideRoute($route, { name: filterPageName })"
+      />
+      <KButton
+        v-if="numAppliedFilters > 0"
+        appearance="basic-link"
+        :text="clearFiltersLabel$()"
+        class="filter-button move-down"
+        :style="{
+          color: $themePalette.red.v_600 + ' !important',
+        }"
+        @click="$emit('clearFilters')"
+      />
+    </div>
+
+    <div style="display: flex;">
+      <slot name="userActions">
+      </slot>
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, computed, onBeforeUnmount } from 'vue';
+  import pickBy from 'lodash/pickBy';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import debounce from 'lodash/debounce';
+  import FilterTextbox from 'kolibri/components/FilterTextbox';
+  import { useRoute, useRouter } from 'vue-router/composables';
+  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import { overrideRoute } from '../../../utils';
+
+
+  export default {
+    name: "UsersTableToolbar",
+    components: {
+      FilterTextbox
+    },
+    setup(_, { expose }) {
+      const route = useRoute();
+      const router = useRouter();
+      const filterTextboxRef = ref(null);
+
+      const {
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
+      } = bulkUserManagementStrings;
+
+      const emitSearchTerm = value => {
+        if (value === '') {
+          value = null;
+        }
+        router.push({
+          ...route,
+          query: pickBy({
+            ...route.query,
+            search: value,
+            page: null,
+          }),
+        });
+      };
+      const debouncedSearchTerm = debounce(emitSearchTerm, 300);
+
+      const searchTerm = computed({
+        get() {
+          return route.query.search || '';
+        },
+        set(value) {
+          debouncedSearchTerm(value);
+        },
+      });
+
+      onBeforeUnmount(() => {
+        const { query } = route;
+        if (query.ordering || query.order || query.page) {
+          router.replace({ query: null });
+        }
+      });
+
+      const focus = () => {
+        filterTextboxRef.value?.focus();
+      };
+
+      expose({
+        focus,
+      });
+
+      return {
+        overrideRoute,
+        // Computed Properties
+        searchTerm,
+        filterTextboxRef,
+
+        // Strings
+        coreStrings,
+        numFilters$,
+        filterLabel$,
+        numUsersSelected$,
+        clearFiltersLabel$,
+      };
+    },
+    props: {
+      selectedUsers: {
+        type: Set,
+        required: true,
+      },
+      numAppliedFilters: {
+        type: Number,
+        default: 0,
+      },
+      filterPageName: {
+        type: String,
+        required: true,
+      },
+    },
+  }
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .search-filter-section {
+    display: flex;
+    justify-content: start;
+    // Ensure space enough for keyboard nav outline before table content
+    padding-bottom: 0.5em;
+  }
+
+  .filter-button {
+    padding-top: 10px;
+    margin-left: 1em;
+  }
+
+  .move-down {
+    position: relative;
+  }
+
+  .search-box {
+    width: 100%;
+  }
+
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
@@ -34,14 +34,7 @@
     gap: 1em;
   }
 
-  .top-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1em;
-    align-items: center;
-    justify-content: space-between;
-  }
-
+  .top-row,
   .bottom-row {
     display: flex;
     flex-wrap: wrap;

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar.vue
@@ -1,37 +1,12 @@
 <template>
 
-  <div style='display: flex; justify-content: space-between; flex-wrap: wrap;'>
-    <div class="search-filter-section">
-      <FilterTextbox
-        ref="filterTextboxRef"
-        v-model="searchTerm"
-        :placeholder="coreStrings.searchForUser$()"
-        :aria-label="coreStrings.searchForUser$()"
-        class="move-down search-box"
-      />
-      <KRouterLink
-        appearance="basic-link"
-        :text="numAppliedFilters ? numFilters$({ n: numAppliedFilters }) : filterLabel$()"
-        class="filter-button move-down"
-        :to="overrideRoute($route, { name: filterPageName })"
-      />
-      <KButton
-        v-if="numAppliedFilters > 0"
-        appearance="basic-link"
-        :text="clearFiltersLabel$()"
-        class="filter-button move-down"
-        :style="{
-          color: $themePalette.red.v_600 + ' !important',
-        }"
-        @click="$emit('clearFilters')"
-      />
+  <div class="toolbar-container">
+    <div class="top-row">
+      <slot name="topRow"></slot>
     </div>
-
-    <div style="display: flex;">
-      <slot name="userActions">
-      </slot>
+    <div class="bottom-row">
+      <slot name="bottomRow"></slot>
     </div>
-
   </div>
 
 </template>
@@ -39,126 +14,41 @@
 
 <script>
 
-  import { ref, computed, onBeforeUnmount } from 'vue';
-  import pickBy from 'lodash/pickBy';
-  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-  import debounce from 'lodash/debounce';
-  import FilterTextbox from 'kolibri/components/FilterTextbox';
-  import { useRoute, useRouter } from 'vue-router/composables';
-  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
-  import { overrideRoute } from '../../../utils';
-
-
+  /**
+   * UsersTableToolbar - A layout component for the users table toolbar
+   * Provides two rows for flexible arrangement of toolbar actions
+   * All logic for search, filtering, and pagination should be handled by parent components
+   */
   export default {
-    name: "UsersTableToolbar",
-    components: {
-      FilterTextbox
-    },
-    setup(_, { expose }) {
-      const route = useRoute();
-      const router = useRouter();
-      const filterTextboxRef = ref(null);
-
-      const {
-        numFilters$,
-        filterLabel$,
-        numUsersSelected$,
-        clearFiltersLabel$,
-      } = bulkUserManagementStrings;
-
-      const emitSearchTerm = value => {
-        if (value === '') {
-          value = null;
-        }
-        router.push({
-          ...route,
-          query: pickBy({
-            ...route.query,
-            search: value,
-            page: null,
-          }),
-        });
-      };
-      const debouncedSearchTerm = debounce(emitSearchTerm, 300);
-
-      const searchTerm = computed({
-        get() {
-          return route.query.search || '';
-        },
-        set(value) {
-          debouncedSearchTerm(value);
-        },
-      });
-
-      onBeforeUnmount(() => {
-        const { query } = route;
-        if (query.ordering || query.order || query.page) {
-          router.replace({ query: null });
-        }
-      });
-
-      const focus = () => {
-        filterTextboxRef.value?.focus();
-      };
-
-      expose({
-        focus,
-      });
-
-      return {
-        overrideRoute,
-        // Computed Properties
-        searchTerm,
-        filterTextboxRef,
-
-        // Strings
-        coreStrings,
-        numFilters$,
-        filterLabel$,
-        numUsersSelected$,
-        clearFiltersLabel$,
-      };
-    },
-    props: {
-      selectedUsers: {
-        type: Set,
-        required: true,
-      },
-      numAppliedFilters: {
-        type: Number,
-        default: 0,
-      },
-      filterPageName: {
-        type: String,
-        required: true,
-      },
-    },
-  }
+    name: 'UsersTableToolbar',
+  };
 
 </script>
 
 
 <style lang="scss" scoped>
 
-  .search-filter-section {
+  .toolbar-container {
     display: flex;
-    justify-content: start;
-    // Ensure space enough for keyboard nav outline before table content
-    padding-bottom: 0.5em;
+    flex-direction: column;
+    gap: 1em;
+    margin-bottom: 1em;
   }
 
-  .filter-button {
-    padding-top: 10px;
-    margin-left: 1em;
+  .top-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    align-items: center;
+    justify-content: space-between;
   }
 
-  .move-down {
-    position: relative;
+  .bottom-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    align-items: center;
+    justify-content: space-between;
   }
-
-  .search-box {
-    width: 100%;
-  }
-
 
 </style>

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -1,12 +1,14 @@
 <template>
 
   <form>
-    <PaginatedListContainerWithBackend
+    <PaginationActions
       v-model="currentPage"
+      class="top-pagination-actions"
       :itemsPerPage="itemsPerPage"
       :totalPageNumber="totalPageNumber"
       :numFilteredItems="downloadItemListLength"
-    >
+    />
+    <PaginatedListContainerWithBackend>
       <CoreTable>
         <template #headers>
           <th>
@@ -141,6 +143,13 @@
       @cancel="resourcesToDelete = []"
       @success="emitCurrentlySelectedResourcesForRemoval"
     />
+    <PaginationActions
+      v-model="currentPage"
+      class="bottom-pagination-actions"
+      :itemsPerPage="itemsPerPage"
+      :totalPageNumber="totalPageNumber"
+      :numFilteredItems="downloadItemListLength"
+    />
   </form>
 
 </template>
@@ -154,6 +163,7 @@
   import CoreTable from 'kolibri/components/CoreTable';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import PaginatedListContainerWithBackend from 'kolibri-common/components/PaginatedListContainerWithBackend';
+  import PaginationActions from 'kolibri-common/components/PaginationActions';
   import { computed, getCurrentInstance } from 'vue';
   import { get } from '@vueuse/core';
   import { createTranslator } from 'kolibri/utils/i18n';
@@ -179,6 +189,7 @@
       SelectionBottomBar,
       ConfirmationDeleteModal,
       PaginatedListContainerWithBackend,
+      PaginationActions,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -446,6 +457,17 @@
     display: inline-block;
     margin-left: 0;
     vertical-align: bottom;
+  }
+
+  .top-pagination-actions {
+    margin-top: 1em;
+    margin-bottom: -2em;
+    text-align: right;
+  }
+
+  .bottom-pagination-actions {
+    margin-top: 1em;
+    text-align: right;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -1,13 +1,6 @@
 <template>
 
   <form>
-    <PaginationActions
-      v-model="currentPage"
-      class="top-pagination-actions"
-      :itemsPerPage="itemsPerPage"
-      :totalPageNumber="totalPageNumber"
-      :numFilteredItems="downloadItemListLength"
-    />
     <PaginatedListContainerWithBackend>
       <CoreTable>
         <template #headers>
@@ -457,12 +450,6 @@
     display: inline-block;
     margin-left: 0;
     vertical-align: bottom;
-  }
-
-  .top-pagination-actions {
-    margin-top: 1em;
-    margin-bottom: -2em;
-    text-align: right;
   }
 
   .bottom-pagination-actions {

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -125,6 +125,8 @@
 
   .container {
     min-height: 450px;
+    // Ensure we can scroll to where there is space beneath container
+    margin-bottom: 2em;
   }
 
   .selector {

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -13,13 +13,13 @@
       </KGridItem>
     </KGrid>
 
-    <div class="flex-column">
+    <div class="flex-column table-content">
       <slot> </slot>
     </div>
 
     <nav class="pagination-nav">
       <slot name="paginationFooter"></slot>
-      <div class='pagination-actions'>
+      <div class="pagination-actions">
         <span
           dir="auto"
           class="pagination-label"

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -36,20 +36,8 @@
 
 <style lang="scss" scoped>
 
-  .pagination-nav {
-    /* Ensure space for pagination buttons on touch devices */
-    margin-top: 1em;
-    text-align: right;
-  }
-
   .text-filter {
     margin-top: 14px;
-  }
-
-  .pagination-label {
-    position: relative;
-    top: -2px;
-    display: inline;
   }
 
   .flex-column {

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -1,6 +1,9 @@
 <template>
 
   <div class="flex-column">
+
+    <slot name="topActions"></slot>
+
     <KGrid v-if="$slots.otherFilter || $slots.filter">
       <KGridItem :layout12="{ span: 7 }">
         <slot name="otherFilter"></slot>
@@ -17,33 +20,8 @@
       <slot> </slot>
     </div>
 
-    <nav class="pagination-nav">
-      <slot name="paginationFooter"></slot>
-      <div class="pagination-actions">
-        <span
-          dir="auto"
-          class="pagination-label"
-        >
-          {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
-        </span>
-        <KButtonGroup>
-          <KIconButton
-            :ariaLabel="$tr('previousResults')"
-            :disabled="previousButtonDisabled"
-            size="small"
-            icon="back"
-            @click="changePage(-1)"
-          />
-          <KIconButton
-            :ariaLabel="$tr('nextResults')"
-            :disabled="nextButtonDisabled"
-            size="small"
-            icon="forward"
-            @click="changePage(+1)"
-          />
-        </KButtonGroup>
-      </div>
-    </nav>
+    <slot name="bottomActions"></slot>
+
   </div>
 
 </template>
@@ -51,75 +29,9 @@
 
 <script>
 
-  import clamp from 'lodash/clamp';
 
   export default {
     name: 'PaginatedListContainerWithBackend',
-    props: {
-      itemsPerPage: {
-        type: Number,
-        required: true,
-      },
-      totalPageNumber: {
-        type: Number,
-        required: true,
-      },
-      value: {
-        type: Number,
-        required: true,
-      },
-      numFilteredItems: {
-        type: Number,
-        required: true,
-      },
-    },
-    computed: {
-      startRange() {
-        return (this.value - 1) * this.itemsPerPage;
-      },
-      visibleStartRange() {
-        return Math.min(this.startRange + 1, this.numFilteredItems);
-      },
-      endRange() {
-        return this.value * this.itemsPerPage;
-      },
-      visibleEndRange() {
-        return Math.min(this.endRange, this.numFilteredItems);
-      },
-      previousButtonDisabled() {
-        return this.value === 1 || this.numFilteredItems === 0;
-      },
-      nextButtonDisabled() {
-        return (
-          this.totalPageNumber === 1 ||
-          this.value === this.totalPageNumber ||
-          this.numFilteredItems === 0
-        );
-      },
-    },
-    methods: {
-      changePage(change) {
-        // Clamp the newPage number between the bounds if browser doesn't correctly
-        // disable buttons (see #6454 issue with old versions of MS Edge)
-        this.$emit('input', clamp(this.value + change, 1, this.totalPageNumber));
-      },
-    },
-    $trs: {
-      previousResults: {
-        message: 'Previous results',
-        context:
-          'Text which indicates the previous page of results when a user makes a search query.\n',
-      },
-      nextResults: {
-        message: 'Next results',
-        context: 'Text which indicates the next page of results when a user makes a search query.',
-      },
-      pagination: {
-        message:
-          '{ visibleStartRange, number } - { visibleEndRange, number } of { numFilteredItems, number }',
-        context: "Refers to pagination. Only translate the word \"of''.",
-      },
-    },
   };
 
 </script>

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -18,28 +18,31 @@
     </div>
 
     <nav class="pagination-nav">
-      <span
-        dir="auto"
-        class="pagination-label"
-      >
-        {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
-      </span>
-      <KButtonGroup>
-        <KIconButton
-          :ariaLabel="$tr('previousResults')"
-          :disabled="previousButtonDisabled"
-          size="small"
-          icon="back"
-          @click="changePage(-1)"
-        />
-        <KIconButton
-          :ariaLabel="$tr('nextResults')"
-          :disabled="nextButtonDisabled"
-          size="small"
-          icon="forward"
-          @click="changePage(+1)"
-        />
-      </KButtonGroup>
+      <slot name="paginationFooter"></slot>
+      <div class='pagination-actions'>
+        <span
+          dir="auto"
+          class="pagination-label"
+        >
+          {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
+        </span>
+        <KButtonGroup>
+          <KIconButton
+            :ariaLabel="$tr('previousResults')"
+            :disabled="previousButtonDisabled"
+            size="small"
+            icon="back"
+            @click="changePage(-1)"
+          />
+          <KIconButton
+            :ariaLabel="$tr('nextResults')"
+            :disabled="nextButtonDisabled"
+            size="small"
+            icon="forward"
+            @click="changePage(+1)"
+          />
+        </KButtonGroup>
+      </div>
     </nav>
   </div>
 

--- a/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
+++ b/packages/kolibri-common/components/PaginatedListContainerWithBackend.vue
@@ -1,7 +1,6 @@
 <template>
 
   <div class="flex-column">
-
     <slot name="topActions"></slot>
 
     <KGrid v-if="$slots.otherFilter || $slots.filter">
@@ -21,14 +20,12 @@
     </div>
 
     <slot name="bottomActions"></slot>
-
   </div>
 
 </template>
 
 
 <script>
-
 
   export default {
     name: 'PaginatedListContainerWithBackend',

--- a/packages/kolibri-common/components/PaginationActions.vue
+++ b/packages/kolibri-common/components/PaginationActions.vue
@@ -1,0 +1,113 @@
+<template>
+
+  <nav>
+    <div class="pagination-actions">
+      <span
+        dir="auto"
+        class="pagination-label"
+      >
+        {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
+      </span>
+      <KButtonGroup>
+        <KIconButton
+          :ariaLabel="$tr('previousResults')"
+          :disabled="previousButtonDisabled"
+          size="small"
+          icon="back"
+          @click="changePage(-1)"
+        />
+        <KIconButton
+          :ariaLabel="$tr('nextResults')"
+          :disabled="nextButtonDisabled"
+          size="small"
+          icon="forward"
+          @click="changePage(+1)"
+        />
+      </KButtonGroup>
+    </div>
+  </nav>
+
+</template>
+
+
+<script>
+
+  import clamp from 'lodash/clamp';
+
+  export default {
+    name: 'PaginationActions',
+    props: {
+      itemsPerPage: {
+        type: Number,
+        required: true,
+      },
+      totalPageNumber: {
+        type: Number,
+        required: true,
+      },
+      value: {
+        type: Number,
+        required: true,
+      },
+      numFilteredItems: {
+        type: Number,
+        required: true,
+      },
+    },
+    computed: {
+      startRange() {
+        return (this.value - 1) * this.itemsPerPage;
+      },
+      visibleStartRange() {
+        return Math.min(this.startRange + 1, this.numFilteredItems);
+      },
+      endRange() {
+        return this.value * this.itemsPerPage;
+      },
+      visibleEndRange() {
+        return Math.min(this.endRange, this.numFilteredItems);
+      },
+      previousButtonDisabled() {
+        return this.value === 1 || this.numFilteredItems === 0;
+      },
+      nextButtonDisabled() {
+        return (
+          this.totalPageNumber === 1 ||
+          this.value === this.totalPageNumber ||
+          this.numFilteredItems === 0
+        );
+      },
+    },
+    methods: {
+      changePage(change) {
+        // Clamp the newPage number between the bounds if browser doesn't correctly
+        // disable buttons (see #6454 issue with old versions of MS Edge)
+        this.$emit('input', clamp(this.value + change, 1, this.totalPageNumber));
+      },
+    },
+    methods: {
+      changePage(change) {
+        // Clamp the newPage number between the bounds if browser doesn't correctly
+        // disable buttons (see #6454 issue with old versions of MS Edge)
+        this.$emit('input', clamp(this.value + change, 1, this.totalPageNumber));
+      },
+    },
+    $trs: {
+      previousResults: {
+        message: 'Previous results',
+        context:
+          'Text which indicates the previous page of results when a user makes a search query.\n',
+      },
+      nextResults: {
+        message: 'Next results',
+        context: 'Text which indicates the next page of results when a user makes a search query.',
+      },
+      pagination: {
+        message:
+          '{ visibleStartRange, number } - { visibleEndRange, number } of { numFilteredItems, number }',
+        context: "Refers to pagination. Only translate the word \"of''.",
+      },
+    },
+  };
+
+</script>

--- a/packages/kolibri-common/components/PaginationActions.vue
+++ b/packages/kolibri-common/components/PaginationActions.vue
@@ -85,13 +85,6 @@
         this.$emit('input', clamp(this.value + change, 1, this.totalPageNumber));
       },
     },
-    methods: {
-      changePage(change) {
-        // Clamp the newPage number between the bounds if browser doesn't correctly
-        // disable buttons (see #6454 issue with old versions of MS Edge)
-        this.$emit('input', clamp(this.value + change, 1, this.totalPageNumber));
-      },
-    },
     $trs: {
       previousResults: {
         message: 'Previous results',

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -142,7 +142,7 @@
       },
       wrapperStyles() {
         return this.appearanceOverrides
-          ? {...this.paddingTop, ...this.appearanceOverrides }
+          ? { ...this.paddingTop, ...this.appearanceOverrides }
           : {
             width: '100%',
             maxWidth: '1064px',

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -38,7 +38,10 @@
       class="main-wrapper"
       :style="[wrapperStyles]"
     >
-      <slot :pageContentHeight="pageContentHeight"></slot>
+      <slot
+        :pageContentHeight="pageContentHeight"
+        :appBarHeight="appBarHeight"
+      ></slot>
     </div>
 
     <transition mode="out-in">

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -38,10 +38,7 @@
       class="main-wrapper"
       :style="[wrapperStyles]"
     >
-      <slot
-        :pageContentHeight="pageContentHeight"
-        :appBarHeight="appBarHeight"
-      ></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
 
     <transition mode="out-in">

--- a/packages/kolibri/components/pages/AppBarPage/index.vue
+++ b/packages/kolibri/components/pages/AppBarPage/index.vue
@@ -36,7 +36,7 @@
     <div
       id="main"
       class="main-wrapper"
-      :style="[wrapperStyles, paddingTop]"
+      :style="[wrapperStyles]"
     >
       <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
@@ -142,7 +142,7 @@
       },
       wrapperStyles() {
         return this.appearanceOverrides
-          ? this.appearanceOverrides
+          ? {...this.paddingTop, ...this.appearanceOverrides }
           : {
             width: '100%',
             maxWidth: '1064px',
@@ -152,6 +152,7 @@
             paddingRight: this.paddingLeftRight,
             paddingBottom: '72px',
             marginTop: 0,
+            ...this.paddingTop,
           };
       },
       paddingTop() {

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -25,10 +25,7 @@
       class="main-wrapper"
       :style="wrapperStyles"
     >
-      <slot
-        :pageContentHeight="pageContentHeight"
-        :appBarHeight="appBarHeight"
-      ></slot>
+      <slot :pageContentHeight="pageContentHeight"></slot>
     </div>
   </div>
 

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -25,7 +25,10 @@
       class="main-wrapper"
       :style="wrapperStyles"
     >
-      <slot :pageContentHeight="pageContentHeight"></slot>
+      <slot
+        :pageContentHeight="pageContentHeight"
+        :appBarHeight="appBarHeight"
+      ></slot>
     </div>
   </div>
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

### Major Changes 

- New UI/UX layout & spacing applied across all NewUsers, UsersRoot and UsersTrash pages.
- Consistency of search/filtering options across pages
- Some changes have been made that impact other parts of the application (see the PaginationActions component & PaginatedListContainerWithBackend component updates and their related changes outside of Facility).


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Touches #13782 , follows up from #13743

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### QA

There are no specific Figma references for these updates to reference.

#### Users Root Table, New Users Table, Deleted Users Table

All of these pages have had similar changes performed on them and there is significant change for regression - so please check the following:

- All bulk actions available and functioning on each of these pages
- Do/undo behaviour
- All filters/search combinations
- Validate messaging for empty table states

**Root Table Specific**
- Test across screen sizes with a focus on the table heading/actions being positioned correctly beneath the top "App bar"
- When the screen shrinks, the "New user" button folds into the "Options" dropdown now - be sure all dropdown options work as expected
- Also note that as you shrink the page, the AppBar's buttons might overflow to another row for about 40px at one point in a way that is different than the proper mobile view - be sure that at all screen widths, the heading is positioned correctly

#### Android & App mode

Test that all content and data is visible when in app mode (where there is a bottom actions bar).

#### My Downloads

Check this page for regressions, particularly around pagination.

#### Classes -> Class Details -> Enroll learners

This page also has had some updates to the pagination and should be tested for regressions with a focus on pagination