### PR TITLE
options button remain active after selection

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTable.vue
@@ -89,6 +89,8 @@
             <KIconButton
               icon="optionsVertical"
               :disabled="!userCanBeEdited(content)"
+              :style="activeRowId === row[0].id ? { backgroundColor: 'rgba(0,0,0,.1)' } : {}"
+              @click="handleSelectedButtonState(row[0].id)"
             >
               <template #menu>
                 <slot
@@ -98,6 +100,7 @@
                   <KDropdownMenu
                     :options="getManageUserOptions(content.id)"
                     @select="handleManageUserAction($event, content)"
+                    @close="activeRowId = null"
                   />
                 </slot>
               </template>
@@ -178,6 +181,7 @@
       const { facilityUsers } = toRefs(props);
       const modalShown = ref(null);
       const userToChange = ref(null);
+      const activeRowId = ref(null);
 
       const { selectAllLabel$ } = enhancedQuizManagementStrings;
       const {
@@ -443,6 +447,9 @@
           },
         ];
       };
+      const handleSelectedButtonState = id => {
+        activeRowId.value = id;
+      };
 
       const handleManageUserAction = (action, user) => {
         if (action.value === Modals.EDIT_USER) {
@@ -472,8 +479,10 @@
         userToChange,
         userToChangeSet,
         stickyColumns,
+        activeRowId,
 
         // Methods
+        handleSelectedButtonState,
         handleSelectAllToggle,
         handleUserSelectionToggle,
         isUserSelected,


### PR DESCRIPTION


## Summary
Fixes Options button's focus lost when navigating dropdown.

###  Before
https://private-user-images.githubusercontent.com/79847249/491656158-a762a3cc-5dd5-4daf-9e79-ca334375cc50.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjA3MTY1MjIsIm5iZiI6MTc2MDcxNjIyMiwicGF0aCI6Ii83OTg0NzI0OS80OTE2NTYxNTgtYTc2MmEzY2MtNWRkNS00ZGFmLTllNzktY2EzMzQzNzVjYzUwLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMTclMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDE3VDE1NTAyMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNhMjJjZTY3MzU0M2U3ZTFiZTQzZDIzZGEyMWU4NWZmOWJmM2RmYTM4ODg4YTgwYTQ1NTYzZGU4M2I3YjRkOGImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.bq_u72nUY698CDdmMkQqV339hdK8VvfNl_dPYtAX1xY

###  After
https://github.com/user-attachments/assets/3dacd197-1ba4-4288-a5ab-02feec7efd50


## References
[#13764](https://github.com/learningequality/kolibri/issues/13764)

## Reviewer guidance

Navigate to Facility > Users  and click on the options icon and observe.