### PR TITLE
[BUM Side Panel]: Fix hidden android side panels

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/common.scss
@@ -1,4 +1,8 @@
 @mixin bum-side-panel {
+  position: relative;
+  // Ensures we are above the app-mode bottom bar when present
+  z-index: 21;
+
   .side-panel-title {
     font-size: 18px;
     font-weight: 600;


### PR DESCRIPTION
## Summary

Adds position:relative & z-index:21 to the bum-side-panel sass mixin.

## References

Fixes #13784 

## Reviewer guidance

Aside from the bug in the related issue being fixed, please verify that the "Are you sure you will lose your changes" KModals work as expected as well (ie, they're properly visible on all screen sizes).

