### PR TITLE
Add load testing framework for learner lesson interactions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+__pycache__
 
 # Host directory where `make dockerbuild` outputs .pex and .whl files
 # same directory is mounted under /docker/mnt inside containers and

--- a/docs/manual_testing/index.rst
+++ b/docs/manual_testing/index.rst
@@ -10,3 +10,4 @@ Manual testing & QA
    testing_with_vms/index
    app_plugin/index
    a11y_resources/index
+   performance_testing/load_testing

--- a/docs/manual_testing/performance_testing/load_testing.rst
+++ b/docs/manual_testing/performance_testing/load_testing.rst
@@ -1,0 +1,104 @@
+
+Kolibri Load‑Testing CLI — Quick Start
+======================================
+
+Run from ``integration_testing/load_testing/``; entrypoint is ``loadtest.py``.
+
+Prerequisites
+-------------
+Before running load tests:
+
+1. **Install dependencies**:
+
+   .. code-block:: bash
+
+      pip install -r requirements/load_test.txt
+
+2. **Start Kolibri server** (NOT development server):
+
+   .. code-block:: bash
+
+      # Use port 8080 for production-like server
+      kolibri start --port=8080
+
+   **Server state**: The server can be either:
+
+   - **New KOLIBRI_HOME/unprovisioned** - the tool will provision it for you
+   - **Existing KOLIBRI_HOME** - the tool will use existing setup
+
+   **Important**: Do NOT use ``yarn run devserver`` - load tests must run against a
+   production-like server to get accurate performance measurements. The development
+   server has additional overhead that will skew results.
+
+Help
+----
+.. code-block:: bash
+
+   python loadtest.py --help
+   python loadtest.py --help
+   python loadtest.py run --help
+
+See the help for available flags (e.g., users, spawn rate, duration, headless, retries).
+
+Full provision → manual capture → test
+--------------------------------------
+Runs the whole flow against a Kolibri server (provisioned or unprovisioned):
+
+* **Fresh server**: Provisions device → creates facility/users/class → imports QA channel → creates lesson
+* **Existing server**: Uses existing setup where possible, creates missing components
+
+The tool prompts for admin credentials which are used to either:
+
+* Create a NEW admin account (if provisioning a fresh server)
+* Authenticate with EXISTING admin account (if server already provisioned)
+
+Then opens a browser for **manual capture** → saves a versioned HAR → executes the Locust test.
+
+.. code-block:: bash
+
+   python loadtest.py
+
+Full run using an existing HAR (skip capture)
+---------------------------------------------
+Use a pre-recorded HAR to skip the manual capture step. With a file in ``har_files/lesson_flow_kolibri_testing_high_latency.har``, for example:
+
+.. code-block:: bash
+
+   python loadtest.py --har har_files/lesson_flow_kolibri_testing_high_latency.har
+
+Other flags
+-----------
+
+Non-interactive server and credentials:
+
+.. code-block:: bash
+
+   python loadtest.py --server http://127.0.0.1:8080 --username admin --password sosecure
+
+Headless 10‑minute run at modest scale:
+
+.. code-block:: bash
+
+   python loadtest.py --headless -u 100 -r 50 -t 10m run
+
+HAR Files
+---------
+HAR files capture the exact sequence of HTTP requests made during a learner lesson interaction.
+
+**When to use existing HAR files**:
+
+* The committed HAR file's version is ≥ your Kolibri version AND there have been no
+  frontend request pattern changes since that version
+* Example: ``lesson_flow_kolibri_0.18.4.har`` can be used for testing 0.18.4, 0.18.5,
+  0.18.6, etc., as long as no frontend changes affected learner request patterns
+
+**When to create new HAR files**:
+
+* Frontend code changes that modify the pattern of HTTP requests during learner interactions
+* New Kolibri version where request patterns have changed
+* Adding new content types or interaction flows to test
+
+**Versioning**: HAR files are named with the Kolibri version where they were captured
+(e.g., ``lesson_flow_kolibri_0.18.4.har``). This version acts as a "valid from" marker -
+the HAR can be used for that version and later versions until request patterns change.
+Committed HAR files for released versions are preserved in version control.

--- a/integration_testing/load_testing/.gitignore
+++ b/integration_testing/load_testing/.gitignore
@@ -1,0 +1,5 @@
+# Generated files from load testing
+generated/
+har_files/*.*
+# Allow committing of HAR files that are for released versions
+!har_files/*_kolibri_[0-9]*.[0-9]*.[0-9].har

--- a/integration_testing/load_testing/kolibri_client.py
+++ b/integration_testing/load_testing/kolibri_client.py
@@ -1,0 +1,525 @@
+"""
+HTTP client for interacting with Kolibri APIs.
+Provides methods for device provisioning, user management, content import, and lesson creation.
+"""
+import io
+import os
+import time
+
+import requests
+from logger import info
+from logger import plain
+from logger import success
+from requests.adapters import HTTPAdapter
+from requests.exceptions import RequestException
+from utils import generate_users_csv
+from utils import get_or_generate_lesson_resources
+
+
+TASKS_API_PATH = "/api/tasks/tasks/"
+LESSON_TITLE = "Load Test Lesson"
+LESSON_DESCRIPTION = "Load test lesson with comprehensive content types"
+
+
+class CSRFAdapter(HTTPAdapter):
+    """
+    Adapter that automatically adds CSRF token header to mutating requests.
+
+    Django requires CSRF token in X-CSRFToken header for POST/PUT/PATCH/DELETE requests.
+    This adapter extracts the token from cookies and adds it to the request headers.
+    """
+
+    def add_headers(self, request, **kwargs):
+        """Add CSRF token header for mutating HTTP methods"""
+        super().add_headers(request, **kwargs)
+
+        # Only add CSRF token for mutating requests
+        if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+            # Extract CSRF token from cookies
+            csrf_token = request._cookies.get("kolibri_csrftoken")
+            if csrf_token:
+                request.headers["X-CSRFToken"] = csrf_token
+
+
+class KolibriClient:
+    """Client for interacting with Kolibri REST APIs"""
+
+    def __init__(self, base_url, username=None, password=None):
+        """
+        Initialize Kolibri client.
+
+        Args:
+            base_url: Base URL of Kolibri server (e.g., 'http://localhost:8000')
+            username: Optional admin username for authentication
+            password: Optional admin password for authentication
+        """
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+
+        # Mount CSRF adapter for all HTTP/HTTPS requests
+        csrf_adapter = CSRFAdapter()
+        self.session.mount("http://", csrf_adapter)
+        self.session.mount("https://", csrf_adapter)
+
+        self.classroom_id = None
+        self.lesson_id = None
+
+        if username and password:
+            self.login(username, password)
+        else:
+            self.fetch_csrf_token()
+
+    def _url(self, path):
+        """Construct full URL from path"""
+        return f"{self.base_url}{path}"
+
+    def get_device_info(self):
+        """
+        Get device information including Kolibri version.
+
+        Returns:
+            dict: Device info with kolibri_version, application, etc.
+        """
+        r = self.session.get(self._url("/api/public/info/"), params={"v": "3"})
+        r.raise_for_status()
+        return r.json()
+
+    # Device Management
+
+    def is_provisioned(self):
+        """
+        Check if device is provisioned.
+
+        Uses the public facilities endpoint - if any facilities exist,
+        the device must be provisioned.
+
+        Returns:
+            bool: True if device is provisioned
+        """
+        try:
+            facilities = self.get_facilities()
+            # If there are any facilities, device is provisioned
+            return len(facilities) > 0
+        except RequestException:
+            return False
+
+    def provision_device(self, facility_name, superuser_username, superuser_password):
+        """
+        Provision device via task API.
+
+        Args:
+            facility_name: Name of facility to create
+            superuser_username: Username for superuser
+            superuser_password: Password for superuser
+            preset: Facility preset (default: 'formal' for no-password login)
+            device_name: Name for the device
+
+        Returns:
+            dict: Job result
+        """
+        payload = {
+            "type": "kolibri.core.device.tasks.provisiondevice",
+            "facility": {"name": facility_name},
+            "preset": "formal",
+            "superuser": {
+                "username": superuser_username,
+                "full_name": "Load Test Admin",
+                "password": superuser_password,
+            },
+            "language_id": "en",
+            "device_name": "Load Test Device",
+            "settings": {"learner_can_login_with_no_password": True},
+            "allow_guest_access": False,
+        }
+
+        # Wait for provisioning to complete
+        return self.create_and_wait_for_task(json=payload)
+
+    # Session Management
+
+    def login(self, username, password):
+        """
+        Login to Kolibri.
+
+        Args:
+            username: Username
+            password: Password
+            facility_id: Optional facility ID
+
+        Returns:
+            dict: Session data
+        """
+        payload = {
+            "username": username,
+            "password": password,
+        }
+
+        r = self.session.post(self._url("/api/auth/session/"), json=payload)
+        r.raise_for_status()
+        session_data = r.json()
+
+        return session_data
+
+    def fetch_csrf_token(self):
+        """
+        Fetch CSRF token for session.
+
+        Required for authenticated POST requests.
+        """
+        r = self.session.put(self._url("/api/auth/session/current/"))
+        r.raise_for_status()
+        # Token is stored in cookies by requests.Session automatically
+
+    # Facility Management
+
+    def get_facilities(self):
+        """
+        Get list of facilities.
+
+        Returns:
+            list: Facilities
+        """
+        r = self.session.get(self._url("/api/public/v1/facility/"))
+        r.raise_for_status()
+        return r.json()
+
+    def get_facility(self, facility_name):
+        """
+        Get facility by name.
+
+        Args:
+            facility_name: Facility name to search for
+
+        Returns:
+            dict: Facility data or None if not found
+        """
+        facilities = self.get_facilities()
+        for facility in facilities:
+            if facility["name"] == facility_name:
+                return facility
+        return None
+
+    def get_or_create_facility(self, name):
+        """
+        Get existing facility or create new one.
+
+        Args:
+            name: Facility name to search for
+
+        Returns:
+            str: Facility ID
+        """
+        # Check if facility exists
+        facility = self.get_facility(name)
+        if facility:
+            return facility["id"]
+
+        # Create new facility
+        info(f"Creating facility '{name}'...")
+        r = self.session.post(
+            self._url("/api/auth/facility/create_facility/"),
+            json={
+                "name": name,
+                "preset": "formal",
+            },
+        )
+        r.raise_for_status()
+        facility = self.get_facility(name)
+        success(f"Facility created: {facility['id']}")
+        return facility["id"]
+
+    # Classroom Management
+
+    def get_classroom(self, facility_id, classroom_name):
+        """
+        Get classrooms for a facility.
+
+        Args:
+            facility_id: Facility ID
+
+        Returns:
+            list: Classrooms
+        """
+        r = self.session.get(
+            self._url("/api/auth/classroom/"), params={"parent": facility_id}
+        )
+        r.raise_for_status()
+        classrooms = r.json()
+        return next((c for c in classrooms if c["name"] == classroom_name), None)
+
+    # User Management
+
+    def import_users_csv(self, csv_content, facility_id):
+        """
+        Import users from CSV via task API.
+
+        Uploads CSV as multipart/form-data and triggers import task.
+
+        Args:
+            csv_content: CSV content as string or bytes
+            facility_id: Facility ID
+            dryrun: If True, validate only (don't actually import)
+            delete: If True, delete users not in CSV
+
+        Returns:
+            dict: Job result
+        """
+        # Convert string to bytes if needed
+        if isinstance(csv_content, str):
+            csv_bytes = csv_content.encode("utf-8")
+        else:
+            csv_bytes = csv_content
+
+        # Create file-like object
+        csv_file = io.BytesIO(csv_bytes)
+
+        # Prepare multipart form data
+        files = {"csvfile": ("users_load_test.csv", csv_file, "text/csv")}
+
+        data = {
+            "type": "kolibri.core.auth.tasks.importusersfromcsv",
+            "facility": facility_id,
+            "locale": "en",
+        }
+
+        # POST as multipart/form-data
+        return self.create_and_wait_for_task(data=data, files=files)
+
+    # Content Management
+
+    def import_channel(self, channel_id):
+        """
+        Import channel metadata and content.
+
+        Args:
+            channel_id: Channel ID
+            baseurl: Source URL (default: Kolibri Studio)
+
+        Returns:
+            dict: Job result
+        """
+        # Step 1: Import channel metadata
+        payload = {
+            "type": "kolibri.core.content.tasks.remotechannelimport",
+            "channel_id": channel_id,
+            "channel_name": "Kolibri QA Channel",
+        }
+
+        self.create_and_wait_for_task(json=payload)
+
+        # Step 2: Import all content
+        payload = {
+            "type": "kolibri.core.content.tasks.remotecontentimport",
+            "channel_id": channel_id,
+            "channel_name": "Kolibri QA Channel",
+        }
+
+        return self.create_and_wait_for_task(json=payload)
+
+    def get_content_nodes(self, channel_id, kind=None):
+        """
+        Get content nodes from a channel.
+
+        Args:
+            channel_id: Channel ID
+            kind: Optional content kind filter
+
+        Returns:
+            list: Content nodes
+        """
+        params = {"channel_id": channel_id, "available": True}
+        if kind:
+            params["kind"] = kind
+
+        r = self.session.get(self._url("/api/public/v2/contentnode/"), params=params)
+        r.raise_for_status()
+        return r.json()
+
+    # Lesson Management
+
+    def get_lesson(self, classroom_id):
+        """
+        Get lessons for a classroom.
+
+        Args:
+            classroom_id: Classroom ID
+
+        Returns:
+            list: Lessons
+        """
+        r = self.session.get(
+            self._url("/api/lessons/lesson/"), params={"collection": classroom_id}
+        )
+        r.raise_for_status()
+        existing_lessons = r.json()
+        for lesson in existing_lessons:
+            if lesson["title"] == LESSON_TITLE:
+                return lesson
+
+    def create_lesson(self, channel_id, classroom_id):
+        """
+        Create a lesson, or return existing lesson if one with the same title exists.
+
+        Args:
+            channel_id: Channel ID
+            classroom_id: Classroom ID
+        Returns:
+            str: Lesson ID
+        """
+        resources = get_or_generate_lesson_resources(self, channel_id)
+
+        # Check if lesson already exists
+        existing_lesson = self.get_lesson(classroom_id)
+        if existing_lesson:
+            return existing_lesson["id"]
+
+        info("Creating lesson...")
+
+        # Create new lesson
+        r = self.session.post(
+            self._url("/api/lessons/lesson/"),
+            json={
+                "title": LESSON_TITLE,
+                "description": LESSON_DESCRIPTION,
+                "resources": resources,
+                "active": True,
+                "collection": classroom_id,
+                "assignments": [classroom_id],  # Assign to whole classroom
+            },
+        )
+        r.raise_for_status()
+        lesson = r.json()
+        lesson_id = lesson["id"]
+        success(f"Lesson created: {lesson_id}")
+        return lesson_id
+
+    # High-level Setup Utilities
+
+    def provision_if_needed(self, username, password, facility_name):
+        """
+        Provision device if not already provisioned.
+
+        Args:
+            username: Superuser username
+            password: Superuser password
+            facility_name: Facility name to create
+
+        Returns:
+            dict: Provisioning result with facility_id
+        """
+        if self.is_provisioned():
+            success("Device already provisioned")
+            return
+
+        info("Device not provisioned. Provisioning...")
+
+        self.provision_device(
+            facility_name,
+            username,
+            password,
+        )
+
+        success("Device provisioned")
+
+        # Login with new credentials
+        self.login(username, password)
+
+    def import_users(self, facility_id, num_users, classroom_name):
+        """
+        Generate CSV and import users via task API.
+
+        Args:
+            facility_id: Facility ID to import users into
+            num_users: Number of users to create
+            classroom_name: Name of classroom
+
+        Returns:
+            str: Classroom ID (auto-created from CSV)
+        """
+        # Generate CSV
+        csv_content = generate_users_csv(num_users, classroom_name)
+
+        # Save to local file for reference
+        generated_dir = os.path.join(os.path.dirname(__file__), "generated")
+        os.makedirs(generated_dir, exist_ok=True)
+        csv_path = os.path.join(generated_dir, "users_load_test.csv")
+
+        with open(csv_path, "w", newline="") as f:
+            f.write(csv_content)
+
+        success(f"Generated CSV at: {csv_path}")
+        plain(f"Uploading and importing {num_users} users...")
+
+        # Upload and import via API
+        self.import_users_csv(csv_content, facility_id)
+
+        success("Import completed")
+
+        # Get classroom ID (created automatically by CSV import)
+        classroom = self.get_classroom(facility_id, classroom_name)
+
+        if not classroom:
+            raise Exception(f"Classroom '{classroom_name}' not found after user import")
+        success(f"Classroom created: {classroom['id']}")
+        return classroom["id"]
+
+    # Task Monitoring
+
+    def create_task(self, **kwargs):
+        """
+        Create a task.
+
+        Args:
+            payload: Task payload dict
+
+        Returns:
+            dict: Job info
+        """
+        r = self.session.post(self._url(TASKS_API_PATH), **kwargs)
+        r.raise_for_status()
+        return r.json()
+
+    def wait_for_job(self, job_id, timeout=600, poll_interval=2):
+        """
+        Wait for a job to complete.
+
+        Args:
+            job_id: Job ID
+            timeout: Timeout in seconds (default: 600)
+            poll_interval: Polling interval in seconds (default: 2)
+
+        Returns:
+            dict: Final job state
+
+        Raises:
+            TimeoutError: If job doesn't complete within timeout
+            Exception: If job fails or is canceled
+        """
+        start = time.time()
+
+        while time.time() - start < timeout:
+            r = self.session.get(self._url(f"{TASKS_API_PATH}{job_id}/"))
+            r.raise_for_status()
+            job = r.json()
+
+            if job["status"] == "COMPLETED":
+                return job
+            elif job["status"] in ["FAILED", "CANCELED"]:
+                error_msg = job.get("exception", "Unknown error")
+                raise Exception(f"Job {job_id} {job['status']}: {error_msg}")
+
+            time.sleep(poll_interval)
+
+        raise TimeoutError(f"Job {job_id} timed out after {timeout} seconds")
+
+    def create_and_wait_for_task(self, **kwargs):
+        """
+        Create a task and wait for it to complete.
+
+        Args:
+            kwargs: Task payload dict
+        Returns:
+            dict: Final job state
+        """
+        job = self.create_task(**kwargs)
+        return self.wait_for_job(job["id"])

--- a/integration_testing/load_testing/lesson_resources.json
+++ b/integration_testing/load_testing/lesson_resources.json
@@ -1,0 +1,52 @@
+[
+  {
+    "contentnode_id": "2ea9bda8703241be89b5b9fd87f88815",
+    "content_id": "682e09992e9c5f2baea4b8bee92c6c0c",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "3fae7d2932254cb988fc7f16dd99c33a",
+    "content_id": "946eedba10714fe1a649a9e4eb15df35",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "7f28fa6ee61543d7bfd9db39bc99c9c1",
+    "content_id": "7d17c730f151566d83a53d951af0f863",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "f8028bf893414221a141eef6b0830ce2",
+    "content_id": "d4ff8df518104d818dbcf66c469207b6",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "89393082a3af4c7280a504d87cd931ee",
+    "content_id": "bfc33b1c5a174d11bfde38db302b4685",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "d1b9f611b0364a45843e7df69e6f59ba",
+    "content_id": "8ee90d0bff1e49e8b5ddd0356e101b8a",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "e09797d2c6bd4a78af53a8340165ec1e",
+    "content_id": "ae0c035de1334acb95d5ba627d16a8a3",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "88557704d182447f8c86f7a51181dc06",
+    "content_id": "dd9dd43ca5ea5c6195a26401e07d7f8e",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "3b7833d038b24634be8e1377600fc3bc",
+    "content_id": "0766368ee8f55c35949cb25ac91e8bb5",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  },
+  {
+    "contentnode_id": "319bebf19b5443e1890b5c64b1514ec6",
+    "content_id": "71930d3a99a35d68badf4244c0e7f706",
+    "channel_id": "95a52b386f2c485cb97dd60901674a98"
+  }
+]

--- a/integration_testing/load_testing/loadtest.py
+++ b/integration_testing/load_testing/loadtest.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python
+"""
+Kolibri Load Testing Tool
+
+A comprehensive CLI for setting up and running load tests against Kolibri servers.
+Orchestrates device provisioning, user import, content setup, flow capture, and load testing.
+
+Usage:
+    # Full automated workflow
+    python loadtest.py
+
+    # Step-by-step
+    python loadtest.py provision
+    python loadtest.py setup-facility
+    python loadtest.py import-users
+    python loadtest.py import-channel
+    python loadtest.py create-lesson
+    python loadtest.py capture
+    python loadtest.py run --users 50 --duration 5m
+
+"""
+import os
+import subprocess
+import threading
+import time
+import webbrowser
+
+import click
+from kolibri_client import KolibriClient
+from logger import info
+from logger import plain
+from logger import section
+from logger import step
+from logger import success
+from recorder import capture_manual_flow
+
+
+# Constants
+HAR_FILES_DIR = os.path.join(os.path.dirname(__file__), "har_files")
+QA_CHANNEL_ID = "95a52b386f2c485cb97dd60901674a98"
+FACILITY_NAME = "Load Test Facility"
+CLASS_NAME = "Load Test Class"
+
+
+def _exit_with_error(message):
+    exception = click.ClickException(message)
+    exception.exit_code = 2
+    raise exception
+
+
+@click.group(invoke_without_command=True)
+@click.option("--server", prompt="Kolibri server URL", help="Kolibri server URL")
+@click.option("--username", prompt="Admin username", help="Admin username")
+@click.option(
+    "--password", prompt="Admin password", hide_input=True, help="Admin password"
+)
+@click.option("--har", "-h", help="Specific HAR file to use")
+@click.option("--users", "-u", default=50, help="Number of concurrent users")
+@click.option("--spawn-rate", "-r", default=50, help="Users spawned per second")
+@click.option("--duration", "-t", default="5m", help="Test duration (e.g., 5m, 1h)")
+@click.option(
+    "--headless", is_flag=True, help="Run without web UI (default: show web UI)"
+)
+@click.option(
+    "--max-retries",
+    default=5,
+    help="Max retries for 503 errors on trackprogress (default: 5)",
+)
+@click.option(
+    "--retry-delay",
+    default=5.0,
+    help="Retry delay in seconds for 503 errors (default: 5.0)",
+)
+@click.pass_context
+def cli(
+    ctx,
+    server,
+    username,
+    password,
+    har,
+    users,
+    spawn_rate,
+    duration,
+    headless,
+    max_retries,
+    retry_delay,
+):
+    """Kolibri Load Testing Tool"""
+    ctx.ensure_object(dict)
+    ctx.obj["server"] = server
+    ctx.obj["username"] = username
+    ctx.obj["password"] = password
+    ctx.obj["har"] = har
+    ctx.obj["users"] = users
+    ctx.obj["spawn_rate"] = spawn_rate
+    ctx.obj["duration"] = duration
+    ctx.obj["headless"] = headless
+    ctx.obj["max_retries"] = max_retries
+    ctx.obj["retry_delay"] = retry_delay
+
+    # If no subcommand provided, run full workflow
+    if ctx.invoked_subcommand is None:
+        full(ctx)
+
+
+@cli.command()
+@click.pass_context
+def provision(ctx):
+    """Provision device if not already provisioned"""
+    client = KolibriClient(ctx.obj["server"])
+
+    if not client.is_provisioned():
+        info("Provisioning device...")
+        client.provision_if_needed(
+            ctx.obj["username"], ctx.obj["password"], FACILITY_NAME
+        )
+        success("Device provisioned successfully")
+    else:
+        success("Device already provisioned")
+
+
+@cli.command()
+@click.pass_context
+def setup_facility(ctx):
+    """Setup or get facility"""
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+    facility_id = client.get_or_create_facility(FACILITY_NAME)
+    success(f"Facility: {facility_id}")
+
+
+@cli.command()
+@click.pass_context
+def import_users(ctx):
+    """Import users from CSV"""
+    num_users = ctx.obj["users"]
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+    facility_id = client.get_or_create_facility(FACILITY_NAME)
+
+    info(f"Importing {num_users} users...")
+    classroom_id = client.import_users(facility_id, num_users, CLASS_NAME)
+    success(f"Users imported, classroom: {classroom_id}")
+
+
+@cli.command()
+@click.pass_context
+def import_channel(ctx):
+    """Import channel content"""
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+    info(f"Importing channel {QA_CHANNEL_ID}...")
+    client.import_channel(QA_CHANNEL_ID)
+    success(f"Channel imported: {QA_CHANNEL_ID}")
+
+
+@cli.command()
+@click.pass_context
+def create_lesson(ctx):
+    """Create comprehensive lesson with mixed content"""
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+
+    # Get facility and classroom
+    facility_id = client.get_or_create_facility(FACILITY_NAME)
+    classroom = client.get_classroom(facility_id, CLASS_NAME)
+
+    if not classroom:
+        _exit_with_error(
+            f"Classroom '{CLASS_NAME}' not found. Run 'import-users' first."
+        )
+
+    client.create_lesson(QA_CHANNEL_ID, classroom["id"])
+
+
+@cli.command()
+@click.pass_context
+def capture(ctx):
+    """Capture HAR file for current Kolibri version"""
+    # Get Kolibri version for HAR filename
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+    device_info = client.get_device_info()
+    kolibri_version = device_info.get("kolibri_version", "unknown")
+
+    # Name HAR file with Kolibri version
+    har_filename = f"lesson_flow_kolibri_{kolibri_version}.har"
+    har_path = os.path.join(HAR_FILES_DIR, har_filename)
+
+    # Check if HAR already exists
+    if os.path.exists(har_path):
+        success(f"HAR file already exists for Kolibri {kolibri_version}")
+        plain(f"  {har_path}")
+        plain("\nDelete it to re-capture, or use a different Kolibri version")
+        return
+
+    os.makedirs(HAR_FILES_DIR, exist_ok=True)
+
+    info(f"Manual capture mode for Kolibri {kolibri_version}...")
+    capture_manual_flow(ctx.obj["server"], har_path)
+    success(f"✓ HAR file captured: {har_path}")
+
+
+@cli.command()
+@click.pass_context
+def run(ctx):
+    """Run Locust load test"""
+    client = KolibriClient(ctx.obj["server"], ctx.obj["username"], ctx.obj["password"])
+
+    # Get Kolibri version to find the right HAR file
+    device_info = client.get_device_info()
+    kolibri_version = device_info.get("kolibri_version", "unknown")
+
+    if ctx.obj["har"]:
+        har_path = ctx.obj["har"]
+    else:
+        # Find version-specific HAR file
+        har_filename = f"lesson_flow_kolibri_{kolibri_version}.har"
+        har_path = os.path.join(HAR_FILES_DIR, har_filename)
+
+    if not os.path.exists(har_path):
+        _exit_with_error(f"Specified HAR file does not exist: {har_path}")
+
+    # Get facility ID
+    facility_id = client.get_or_create_facility(FACILITY_NAME)
+    classroom = client.get_classroom(facility_id, CLASS_NAME)
+    if not classroom:
+        _exit_with_error(
+            f"Classroom '{CLASS_NAME}' not found. Run 'import-users' first."
+        )
+    classroom_id = classroom["id"]
+
+    lesson = client.get_lesson(classroom_id)
+    if not lesson:
+        _exit_with_error("Comprehensive lesson not found. Run 'create-lesson' first.")
+    lesson_id = lesson["id"]
+
+    # Path to locustfile.py in the load_testing directory
+    locust_path = os.path.join(os.path.dirname(__file__), "locustfile.py")
+
+    users = ctx.obj["users"]
+    spawn_rate = ctx.obj["spawn_rate"]
+    duration = ctx.obj["duration"]
+    headless = ctx.obj["headless"]
+    max_retries = ctx.obj["max_retries"]
+    retry_delay = ctx.obj["retry_delay"]
+
+    # Set up environment variables for locustfile
+    env = os.environ.copy()
+    env["KOLIBRI_HAR_FILE"] = har_path
+    env["KOLIBRI_SERVER_URL"] = ctx.obj["server"]
+    env["KOLIBRI_FACILITY_ID"] = facility_id
+    env["KOLIBRI_CLASSROOM_ID"] = classroom_id
+    env["KOLIBRI_LESSON_ID"] = lesson_id
+    env["KOLIBRI_NUM_USERS"] = str(users)
+    env["KOLIBRI_MAX_RETRIES"] = str(max_retries)
+    env["KOLIBRI_RETRY_DELAY"] = str(retry_delay)
+    env["KOLIBRI_VERSION"] = kolibri_version
+
+    cmd = [
+        "locust",
+        "-f",
+        locust_path,
+        "-u",
+        str(users),
+        "-r",
+        str(spawn_rate),
+        "--run-time",
+        duration,
+        "--processes",
+        "-1",
+    ]
+
+    # Only add --headless flag if explicitly requested
+    if headless:
+        cmd.append("--headless")
+    else:
+        # Auto-start the test when using web UI
+        cmd.append("--autostart")
+
+    info(f"Running Locust test (Kolibri {kolibri_version})...")
+    plain(f"HAR file: {har_path}")
+    plain(f"Users: {users}, Spawn rate: {spawn_rate}, Duration: {duration}")
+    plain(f"Retry config: max_retries={max_retries}, retry_delay={retry_delay}s")
+
+    if not headless:
+        web_ui_url = "http://localhost:8089"
+        info(f"Web UI: {web_ui_url}")
+        info("Opening web dashboard...")
+
+        # Open browser automatically
+        def open_browser():
+            # Wait a moment for Locust to start
+            time.sleep(2)
+            webbrowser.open(web_ui_url)
+
+        # Open browser in background thread
+        threading.Thread(target=open_browser, daemon=True).start()
+
+    subprocess.run(cmd, env=env)
+
+
+def full(ctx):
+    """Run complete setup → capture → test workflow"""
+    section("=" * 70)
+    section("KOLIBRI LOAD TEST - FULL WORKFLOW")
+    section("=" * 70)
+
+    total_steps = 6 if ctx.obj["har"] else 7
+
+    # Run each step with step numbering
+    step(1, total_steps, "Checking device provisioning...")
+    ctx.invoke(provision)
+
+    step(2, total_steps, "Setting up facility...")
+    ctx.invoke(setup_facility)
+
+    step(3, total_steps, "Importing users...")
+    ctx.invoke(import_users)
+
+    step(4, total_steps, "Importing QA channel...")
+    ctx.invoke(import_channel)
+
+    step(5, total_steps, "Creating comprehensive lesson...")
+    ctx.invoke(create_lesson)
+
+    if not ctx.obj["har"]:
+        step(6, total_steps, "Capturing lesson flow...")
+        ctx.invoke(capture)
+
+    step(total_steps, total_steps, "Running load test...")
+    ctx.invoke(run)
+
+    section("=" * 70)
+    success("WORKFLOW COMPLETE")
+    section("=" * 70)
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_testing/load_testing/locustfile.py
+++ b/integration_testing/load_testing/locustfile.py
@@ -1,0 +1,450 @@
+"""
+Kolibri Load Test - HAR-based Lesson Flow
+
+This Locust test replays a recorded HAR file containing a lesson flow.
+Configuration is passed via environment variables.
+
+HAR files are portable across Kolibri versions - static file URLs are
+automatically rewritten to match the target Kolibri version.
+
+Usage:
+    KOLIBRI_HAR_FILE=path/to/file.har \\
+    KOLIBRI_VERSION=0.18.4 \\
+    KOLIBRI_FACILITY_ID=xyz \\
+    KOLIBRI_NUM_USERS=50 \\
+    locust -f locustfile.py -u 50 -r 50 --run-time 5m
+"""
+import json
+import os
+import random
+import re
+import time
+from datetime import datetime
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+from kolibri_client import CSRFAdapter
+from locust import between
+from locust import HttpUser
+from locust import task
+
+
+# Load configuration from environment variables
+HAR_FILE = os.environ["KOLIBRI_HAR_FILE"]
+SERVER_URL = os.environ["KOLIBRI_SERVER_URL"]
+FACILITY_ID = os.environ["KOLIBRI_FACILITY_ID"]
+CLASSROOM_ID = os.environ["KOLIBRI_CLASSROOM_ID"]
+LESSON_ID = os.environ["KOLIBRI_LESSON_ID"]
+NUM_USERS = int(os.environ.get("KOLIBRI_NUM_USERS", 50))
+KOLIBRI_VERSION = os.environ["KOLIBRI_VERSION"]
+
+# Retry configuration for 503 errors on trackprogress endpoints
+# These match frontend behavior by default but can be tuned for load testing
+MAX_RETRIES = int(os.environ.get("KOLIBRI_MAX_RETRIES", 5))
+DEFAULT_RETRY_DELAY = float(os.environ.get("KOLIBRI_RETRY_DELAY", 5.0))
+
+
+# Load HAR file at module level (before worker processes fork)
+# This prevents blocking I/O in on_start() which can cause worker heartbeat failures
+def _load_and_parse_har(har_path):  # noqa: C901
+    """
+    Load and parse HAR file at module level into request list.
+
+    This is called once before worker processes fork, so all workers share
+    the same parsed data structure without blocking I/O during spawn.
+
+    Args:
+        har_path: Path to HAR file
+        server_url: Server URL to filter requests
+
+    Returns:
+        list: Parsed request list ready for replay
+    """
+    with open(har_path) as f:
+        har = json.load(f)
+
+    entries = har["log"]["entries"]
+
+    # Filter to requests to the Kolibri server only
+    # Extract the original server URL from the first Kolibri API request in the HAR
+    original_server_url = None
+    for entry in entries:
+        url = entry["request"]["url"]
+        if "/api/" in url or "/static/" in url:
+            parsed = urlparse(url)
+            original_server_url = f"{parsed.scheme}://{parsed.netloc}"
+            break
+
+    if not original_server_url:
+        raise ValueError("Could not determine original server URL from HAR file")
+
+    # Build request list with delays
+    # HAR spec: https://w3c.github.io/web-performance/specs/HAR/Overview.html
+    requests = []
+    for i, req in enumerate(entries):
+        har_request = req["request"]
+        method = har_request["method"].lower()
+        full_url = har_request["url"]
+
+        # Filter to requests from the original Kolibri server
+        if not full_url.startswith(original_server_url):
+            continue
+
+        # Parse URL to extract path
+        parsed = urlparse(full_url)
+        url_path = parsed.path or "/"
+
+        # Decode URL-encoded characters (e.g., %2B → +) for easier pattern matching
+        url_path = unquote(url_path)
+
+        # Replace version strings in static file filenames to match target Kolibri version
+        # Webpack generates filenames like:
+        # - JS files: filename-0.18.4.js (with dash)
+        # - CSS files: filename0.19.0b1.dev0+git.27.g9908774d.css (NO dash before version)
+        # Pattern matches version like: 0.18.4, 0.19.0b0.dev0+git.70.gb72619fc, etc.
+        url_path = re.sub(
+            r"\d+\.\d+\.\d+[a-zA-Z0-9+.]*\.(js|css)",
+            rf"{KOLIBRI_VERSION}.\1",
+            url_path,
+        )
+
+        request_info = {"method": method, "path": url_path}
+
+        # Extract POST/PUT/PATCH body if present (HAR spec: postData object)
+        post_data = har_request.get("postData", {})
+        if post_data.get("mimeType") == "application/json" and post_data.get("text"):
+            try:
+                body = json.loads(post_data["text"])
+                request_info["body"] = body
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # Extract query parameters (HAR spec: queryString is array of {name, value})
+        query_string = har_request.get("queryString", [])
+        if query_string:
+            request_info["params"] = {
+                item["name"]: item["value"] for item in query_string
+            }
+
+        # Calculate delay until next request (with jitter)
+        if i < len(entries) - 1:
+            curr_time = datetime.fromisoformat(
+                req["startedDateTime"].replace("Z", "+00:00")
+            )
+            next_time = datetime.fromisoformat(
+                entries[i + 1]["startedDateTime"].replace("Z", "+00:00")
+            )
+            delay = (next_time - curr_time).total_seconds()
+
+            # Apply jitter (±20%)
+            request_info["delay_min"] = delay * 0.8
+            request_info["delay_max"] = delay * 1.2
+
+        requests.append(request_info)
+
+    return requests
+
+
+# Parse HAR file once at module load time
+_HAR_REQUESTS = _load_and_parse_har(HAR_FILE)
+
+
+class LessonUser(HttpUser):
+    """
+    Simulates a user completing a lesson with realistic timing variance.
+
+    Each user is assigned a unique username (load_test_1 through load_test_N)
+    and logs in without a password (formal facility preset).
+    """
+
+    wait_time = between(1, 3)
+    host = SERVER_URL
+    # Will be set from login response
+    user_id = None
+    # Will be set from trackprogress POST
+    trackprogress_session_id = None
+
+    facility_id = FACILITY_ID
+    classroom_id = CLASSROOM_ID
+    lesson_id = LESSON_ID
+
+    URL_PARAM_REPLACEMENT = {
+        "/api/logger/userprogress/": "user_id",
+        "/api/logger/trackprogress/": "trackprogress_session_id",
+        "/learn/api/learnerclassroom/": "classroom_id",
+        "/learn/api/learnerlesson/": "lesson_id",
+    }
+
+    PARAM_REPLACEMENT = {
+        "facility_id": "facility_id",
+        "facility": "facility_id",
+        "classroom_id": "classroom_id",
+        "classroom": "classroom_id",
+        "lesson_id": "lesson_id",
+        "lesson": "lesson_id",
+        "user_id": "user_id",
+        "user": "user_id",
+        "username": "username",
+    }
+
+    def on_start(self):
+        """Initialize user and assign username"""
+        # Assign unique user number (1-N based on num_users)
+        user_num = (id(self) % NUM_USERS) + 1
+        self.username = f"load_test_{user_num}"
+        # Store the POST request for retry
+        self.trackprogress_init_request = None
+
+        # Mount CSRF adapter for all HTTP/HTTPS requests
+        csrf_adapter = CSRFAdapter()
+        self.client.mount("http://", csrf_adapter)
+        self.client.mount("https://", csrf_adapter)
+
+    def _make_request_with_retry(self, method, path, **kwargs):
+        """
+        Make HTTP request with retry logic for 503 errors on trackprogress endpoints.
+
+        Matches the retry behavior in useProgressTracking.js:
+        - Only retries on 503 status codes
+        - Respects Retry-After header if present
+        - Falls back to default 5 second delay
+        - Maximum of 5 retry attempts
+
+        Args:
+            method: HTTP method ('get', 'post', 'put', etc.)
+            path: URL path
+            **kwargs: Additional arguments to pass to the request
+
+        Returns:
+            Response object
+        """
+        is_trackprogress = "/api/logger/trackprogress" in path
+
+        for attempt in range(MAX_RETRIES):
+            method_func = getattr(self.client, method)
+            response = method_func(path, **kwargs)
+
+            # Only retry trackprogress requests with 503 status
+            if (
+                is_trackprogress
+                and response.status_code == 503
+                and attempt < MAX_RETRIES - 1
+            ):
+                # Check for Retry-After header
+                retry_after = response.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        # Retry-After is in seconds
+                        delay = float(retry_after)
+                    except (ValueError, TypeError):
+                        delay = DEFAULT_RETRY_DELAY
+                else:
+                    delay = DEFAULT_RETRY_DELAY
+
+                # Wait before retrying
+                time.sleep(delay)
+                continue
+
+            # Return response if not 503, or if we've exhausted retries
+            return response
+
+        return response
+
+    def _extract_trackprogress_session_id(self, response):
+        """
+        Extract and store trackprogress session ID from a successful response.
+
+        Args:
+            response: Response object from trackprogress POST request
+
+        Returns:
+            bool: True if session ID was successfully extracted
+        """
+        if response.status_code in [200, 201]:
+            try:
+                trackprogress_data = response.json()
+                session_id = trackprogress_data.get("session_id")
+                if session_id:
+                    self.trackprogress_session_id = session_id
+                    return True
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return False
+
+    def _handle_trackprogress_init(self, path, kwargs):
+        """
+        Handle trackprogress POST request - store for potential retry.
+
+        Args:
+            path: Request path
+            kwargs: Request kwargs
+        """
+        self.trackprogress_init_request = {"path": path, "kwargs": kwargs.copy()}
+        self.trackprogress_session_id = None
+
+    def _ensure_trackprogress_session(self, method):
+        """
+        Ensure trackprogress session is established before update requests.
+
+        If no session exists, retry the initialization POST. If still unsuccessful,
+        log a failure and return False.
+
+        Args:
+            method: HTTP method of the current request
+
+        Returns:
+            bool: True if session is established, False otherwise
+        """
+        if self.trackprogress_session_id:
+            return True
+
+        # Try to establish session by retrying init request
+        if self.trackprogress_init_request:
+            init_response = self._make_request_with_retry(
+                "post",
+                self.trackprogress_init_request["path"],
+                **self.trackprogress_init_request["kwargs"],
+            )
+            self._extract_trackprogress_session_id(init_response)
+
+        # Check if we succeeded
+        if not self.trackprogress_session_id:
+            # Record failure in Locust stats
+            self.environment.events.request.fire(
+                request_type=method.upper(),
+                name="/api/logger/trackprogress/[session_id]/ (no session)",
+                response_time=0,
+                response_length=0,
+                exception=Exception("No trackprogress session established"),
+            )
+            return False
+
+        return True
+
+    def _parameterize_url(self, path):
+        """
+        Replace dynamic IDs in URL path with actual values.
+
+        Args:
+            path: Original URL path from HAR
+
+        Returns:
+            str: Parameterized path with actual IDs
+        """
+        for url_fragment, value_key in self.URL_PARAM_REPLACEMENT.items():
+            actual_value = getattr(self, value_key, None)
+            if actual_value is not None and url_fragment in path:
+                pattern = re.escape(url_fragment) + r"[^/]+"
+                replacement = f"{url_fragment}{actual_value}"
+                return re.sub(pattern, replacement, path)
+
+        return path
+
+    def _extract_session_data(self, path, method, response):
+        """
+        Extract and store session data from responses (user ID, trackprogress session ID).
+
+        Args:
+            path: Request path
+            method: HTTP method
+            response: Response object
+        """
+        # Extract user ID from login response
+        if (
+            path == "/api/auth/session/"
+            and method == "post"
+            and response.status_code == 200
+        ):
+            try:
+                session_data = response.json()
+                self.user_id = session_data.get("user_id") or session_data.get("id")
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+    def _swap_param_value(self, argname, value, object):
+        if argname in object and value is not None:
+            object[argname] = value
+
+    def _swap_params(self, object):
+        for param, value_key in self.PARAM_REPLACEMENT.items():
+            actual_value = getattr(self, value_key, None)
+            self._swap_param_value(param, actual_value, object)
+
+    def _execute_request(self, req):
+        """
+        Execute a single request from the HAR replay.
+
+        Args:
+            req: Request dict with 'method', 'path', 'body', 'params', etc.
+
+        Returns:
+            bool: True if request was executed, False if skipped
+        """
+        # Build request kwargs
+        kwargs = {}
+        if "body" in req:
+            # Make a copy to avoid mutating the shared request structure
+            kwargs["json"] = req["body"].copy()
+            self._swap_params(kwargs["json"])
+        if "params" in req:
+            # Make a copy to avoid mutating the shared request structure
+            kwargs["params"] = req["params"].copy()
+            self._swap_params(kwargs["params"])
+
+        # Identify request type
+        path = req["path"]
+        method = req["method"]
+        is_trackprogress_post = (
+            path == "/api/logger/trackprogress/" and method == "post"
+        )
+        is_trackprogress_update = "/api/logger/trackprogress/" in path and method in [
+            "put",
+            "patch",
+        ]
+
+        # Handle trackprogress initialization
+        if is_trackprogress_post:
+            self._handle_trackprogress_init(path, kwargs)
+
+        # Parameterize URLs with dynamic IDs
+        path = self._parameterize_url(path)
+
+        # Ensure session exists for trackprogress updates
+        if is_trackprogress_update:
+            if not self._ensure_trackprogress_session(req["method"]):
+                return False
+
+        # Execute request with retry logic
+        response = self._make_request_with_retry(req["method"], path, **kwargs)
+
+        # Extract session data from responses
+        self._extract_session_data(path, req["method"], response)
+
+        # Extract trackprogress session ID from POST response
+        if is_trackprogress_post:
+            self._extract_trackprogress_session_id(response)
+
+        return True
+
+    @task
+    def lesson_flow(self):
+        """
+        Complete lesson with jittered timing (±20%).
+
+        Timing variance causes users to desynchronize over time:
+        - T=0s: Thundering herd (all users start together)
+        - T=10s: Starting to desynchronize
+        - T=60s: Continuous but spiky load
+        - T=300s: Fully desynchronized, realistic distribution
+        """
+        for req in _HAR_REQUESTS:
+            # Execute the request
+            executed = self._execute_request(req)
+
+            # If request was skipped, don't wait
+            if not executed:
+                continue
+
+            # Wait with jitter before next request
+            if "delay_min" in req:
+                time.sleep(random.uniform(req["delay_min"], req["delay_max"]))

--- a/integration_testing/load_testing/logger.py
+++ b/integration_testing/load_testing/logger.py
@@ -1,0 +1,41 @@
+"""
+Centralized colored logging for Kolibri Load Testing CLI
+
+Provides consistent colored output across all modules.
+"""
+import click
+
+
+def success(msg):
+    """Print success message in green"""
+    click.echo(click.style(f"✓ {msg}", fg="green"))
+
+
+def info(msg):
+    """Print info message in blue"""
+    click.echo(click.style(msg, fg="blue"))
+
+
+def warning(msg):
+    """Print warning message in yellow"""
+    click.echo(click.style(f"⚠ {msg}", fg="yellow"))
+
+
+def error(msg):
+    """Print error message in red"""
+    click.echo(click.style(f"✗ {msg}", fg="red"))
+
+
+def step(num, total, msg):
+    """Print step header in cyan"""
+    click.echo(click.style(f"\n[{num}/{total}] {msg}", fg="cyan", bold=True))
+
+
+def section(msg):
+    """Print section header in magenta"""
+    click.echo(click.style(f"\n{msg}", fg="magenta", bold=True))
+
+
+def plain(msg):
+    """Print plain message (for detailed info)"""
+    click.echo(f"  {msg}")

--- a/integration_testing/load_testing/recorder.py
+++ b/integration_testing/load_testing/recorder.py
@@ -1,0 +1,109 @@
+"""
+Playwright-based flow recording utilities.
+"""
+import subprocess
+
+from logger import info
+from logger import plain
+from logger import success
+from logger import warning
+from playwright.sync_api import sync_playwright
+
+
+def capture_manual_flow(server_url, output_har):
+    """
+    Launch Chromium with HAR recording for manual interaction.
+
+    User manually completes the lesson flow while browser records all network traffic.
+
+    Args:
+        server_url: Kolibri server URL
+        output_har: Path to save HAR file
+        lesson_metadata: Optional dict with lesson info for display
+
+    Returns:
+        str: Path to generated HAR file
+    """
+    info("\n" + "=" * 60)
+    info("MANUAL FLOW RECORDING")
+    info("=" * 60)
+    info(f"\n🎬 Opening browser to {server_url}")
+    info("\nPlease complete the following steps:")
+    plain("1. Login as any load_test_X user (no password needed)")
+    plain("2. Navigate to 'Load Test Class'")
+    plain("3. Open 'Load Test Lesson - All Types'")
+    plain("4. Interact with EACH resource type:")
+    plain("   - Click on each resource")
+    plain("   - Spend a few seconds on each (play video, read, answer questions)")
+    plain("   - Navigate back to lesson between resources")
+    plain("5. Close the browser when done")
+
+    warning("All network requests will be recorded to HAR file")
+    info("=" * 60 + "\n")
+
+    # Auto-install playwright browsers if needed
+    # This prevents confusing error backtraces if browsers aren't installed
+    try:
+        info("Checking Playwright browser installation...")
+        subprocess.run(
+            ["playwright", "install"],
+            check=False,
+            capture_output=True,
+            timeout=300,
+        )
+    except Exception:
+        # Installation may have already happened or failed - continue anyway
+        pass
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        context = browser.new_context(
+            record_har_path=output_har, record_har_mode="minimal"  # Minimize HAR size
+        )
+        page = context.new_page()
+
+        # Navigate to Kolibri
+        page.goto(server_url)
+
+        # Wait for user to close browser
+        try:
+            page.wait_for_event("close", timeout=0)  # No timeout
+        except Exception:
+            # Browser closed
+            pass
+
+        context.close()
+        browser.close()
+
+    # Strip response data from HAR file to reduce size and avoid version-specific content
+    _strip_har_responses(output_har)
+
+    success(f"HAR file saved to: {output_har}")
+    return output_har
+
+
+def _strip_har_responses(har_path):
+    """
+    Strip response content from HAR file to reduce size.
+
+    Response data is not needed for load testing - we only care about
+    making the requests, not validating the responses.
+
+    Args:
+        har_path: Path to HAR file to strip
+    """
+    import json
+
+    with open(har_path) as f:
+        har = json.load(f)
+
+    # Remove response content from all entries
+    for entry in har["log"]["entries"]:
+        if "response" in entry:
+            del entry["response"]
+
+    # Write back stripped HAR
+    with open(har_path, "w") as f:
+        json.dump(har, f, indent=2)
+
+    info("Stripped response data from HAR file")

--- a/integration_testing/load_testing/utils.py
+++ b/integration_testing/load_testing/utils.py
@@ -1,0 +1,237 @@
+"""
+Utility functions for load testing.
+"""
+import csv
+import io
+import json
+import os
+
+from le_utils.constants import content_kinds
+from logger import info
+from logger import plain
+from logger import warning
+
+
+# Path to saved lesson resources
+LESSON_RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "lesson_resources.json")
+
+# Content requirements: one of each technical implementation type
+CONTENT_REQUIREMENTS = {
+    # Simple kinds (no sub-filtering needed)
+    "video": {"kind": content_kinds.VIDEO},
+    "audio": {"kind": content_kinds.AUDIO},
+    "html5": {"kind": content_kinds.HTML5},
+    "h5p": {"kind": content_kinds.H5P},
+    # Document sub-types (by file extension)
+    "document_pdf": {"kind": content_kinds.DOCUMENT, "file_extension": "pdf"},
+    "document_epub": {"kind": content_kinds.DOCUMENT, "file_extension": "epub"},
+    "document_bloompub": {"kind": content_kinds.DOCUMENT, "file_extension": "bloompub"},
+    # Exercise sub-types (by options.modality)
+    "exercise_regular": {
+        "kind": content_kinds.EXERCISE,
+        "modality": None,  # No modality field or empty
+    },
+    "exercise_quiz": {"kind": content_kinds.EXERCISE, "modality": "QUIZ"},
+    "exercise_survey": {"kind": content_kinds.EXERCISE, "modality": "SURVEY"},
+}
+
+
+def generate_users_csv(num_users=50, classroom_name="Load Test Class"):
+    """
+    Generate CSV for bulk user import.
+
+    Args:
+        num_users: Number of users to generate (default: 50)
+        classroom_name: Name of classroom to enroll users in
+
+    Returns:
+        str: CSV content
+    """
+    csv_data = io.StringIO()
+    writer = csv.DictWriter(
+        csv_data,
+        fieldnames=[
+            "UUID",
+            "USERNAME",
+            "PASSWORD",
+            "FULL_NAME",
+            "USER_TYPE",
+            "IDENTIFIER",
+            "BIRTH_YEAR",
+            "GENDER",
+            "ENROLLED_IN",
+            "ASSIGNED_TO",
+        ],
+    )
+    writer.writeheader()
+
+    for i in range(1, num_users + 1):
+        writer.writerow(
+            {
+                "UUID": "",  # Auto-generate
+                "USERNAME": f"load_test_{i}",
+                "PASSWORD": "password",
+                "FULL_NAME": f"Load Test User {i}",
+                "USER_TYPE": "LEARNER",
+                "IDENTIFIER": "",
+                "BIRTH_YEAR": "",
+                "GENDER": "",
+                "ENROLLED_IN": classroom_name,  # Classroom auto-created by import!
+                "ASSIGNED_TO": "",
+            }
+        )
+
+    csv_data.seek(0)
+    return csv_data.getvalue()
+
+
+def has_file_extension(node, extension):
+    """
+    Check if a content node has a file with the specified extension.
+
+    Args:
+        node: Content node dict (with 'files' field populated by API)
+        extension: File extension to check for
+
+    Returns:
+        bool: True if node has file with this extension
+    """
+    files = node.get("files", [])
+    return any(f.get("extension") == extension for f in files)
+
+
+def get_node_by_criteria(client, channel_id, criteria):
+    """
+    Fetch content node matching specific criteria.
+
+    Args:
+        client: KolibriClient instance
+        channel_id: Channel ID
+        criteria: Dict with 'kind' and optional 'file_extension' or 'modality'
+
+    Returns:
+        dict or None: Matching content node
+    """
+    nodes = client.get_content_nodes(channel_id=channel_id, kind=criteria["kind"])
+
+    if "file_extension" in criteria:
+        # Filter by file extension
+        target_ext = criteria["file_extension"]
+        for node in nodes:
+            # Check if node has file with matching extension
+            if has_file_extension(node, target_ext):
+                return node
+        return None
+
+    elif "modality" in criteria:
+        # Filter by options.modality field
+        target_modality = criteria["modality"]
+        for node in nodes:
+            modality = node.get("options", {}).get("modality")
+
+            if target_modality is None:
+                # Regular exercise: no modality
+                if not modality:
+                    return node
+            elif modality == target_modality:
+                return node
+        return None
+
+    else:
+        # Simple kind-based query - return first match
+        return nodes[0] if nodes else None
+
+
+def generate_lesson_resources(client, channel_id):
+    """
+    Generate lesson resources list by searching for content matching requirements.
+
+    Args:
+        client: KolibriClient instance
+        channel_id: Channel ID to search
+
+    Returns:
+        tuple: (resources list, missing_types list)
+    """
+    resources = []
+    missing_types = []
+
+    # Try to find one content node for each requirement
+    for req_name, criteria in CONTENT_REQUIREMENTS.items():
+        info(f"Looking for {req_name}...")
+        node = get_node_by_criteria(client, channel_id, criteria)
+
+        if node:
+            resources.append(
+                {
+                    "contentnode_id": node["id"],
+                    "content_id": node["content_id"],
+                    "channel_id": channel_id,
+                }
+            )
+            plain(f"✓ Found: {node.get('title', node['id'])}")
+        else:
+            missing_types.append(req_name)
+            plain("✗ Not found")
+
+    if not resources:
+        raise Exception("No content found in channel")
+
+    if missing_types:
+        warning(f"Could not find content for: {', '.join(missing_types)}")
+
+    return resources
+
+
+def save_lesson_resources(resources):
+    """
+    Save lesson resources list to JSON file.
+
+    Args:
+        resources: List of resource dicts
+    """
+    with open(LESSON_RESOURCES_PATH, "w") as f:
+        json.dump(resources, f, indent=2)
+
+
+def load_lesson_resources():
+    """
+    Load lesson resources list from JSON file.
+
+    Returns:
+        list: Resources list, or None if file doesn't exist
+    """
+    if not os.path.exists(LESSON_RESOURCES_PATH):
+        return None
+
+    with open(LESSON_RESOURCES_PATH, "r") as f:
+        return json.load(f)
+
+
+def get_or_generate_lesson_resources(client, channel_id):
+    """
+    Load lesson resources from file, or generate and save if not found.
+
+    Args:
+        client: KolibriClient instance
+        channel_id: Channel ID to search
+
+    Returns:
+        tuple: (resources list, missing_types list)
+    """
+    # Try to load existing resources
+    resources = load_lesson_resources()
+
+    if resources:
+        info(f"Using saved lesson resources from: {LESSON_RESOURCES_PATH}")
+        return resources
+
+    # Generate new resources
+    info("No saved resources found, generating from channel content...")
+    resources = generate_lesson_resources(client, channel_id)
+
+    # Save for future use
+    save_lesson_resources(resources)
+    info(f"Saved lesson resources to: {LESSON_RESOURCES_PATH}")
+
+    return resources

--- a/requirements/load_test.txt
+++ b/requirements/load_test.txt
@@ -1,0 +1,7 @@
+# Load Testing Requirements
+# Inherits Kolibri's base requirements (includes click, requests, Django, etc.)
+-r ./base.txt
+
+# Load testing specific dependencies
+playwright>=1.40
+locust>=2.20


### PR DESCRIPTION
## Summary
* Creates a simple load testing CLI using click to do the following:
  * Setup an arbitrary Kolibri server to have a special load testing facility, with one classroom, with (by default) 50 students
  * Import the Kolibri QA channel
  * Create a lesson using a full range of resources from the Kolibri QA channel
  * Use playwright to launch a browser session that allows logging in as one of the load testing users, and then recording a HAR file of network interaction as a user navigates Kolibri and interacts with the resources in a lesson
  * Alternatively, allows usage of an existing HAR file using a command line parameter (or auto discovery if a HAR file has been generated for this exact version)
  * Runs a locust load test using the HAR file, with appropriate substitutions, so that all 50 users are used
 * Allows committing of HAR files that match a specific release version of Kolibri, so we can maintain versioned copies for testing
 * Adds documentation of the load testing process

## References
Will allow us to identify issues that may be causing poor performance or data loss under load

## Reviewer guidance

Run through the complete workflow with an unprovisioned server, then repeat it to ensure it is robust to repeated usage!

This was intially ideated with using Claude.ai (conversation here: https://claude.ai/share/256deb70-cdb1-4d24-ab8c-5d4bbb46a04c) then developed using Claude Code using the initial plan drafted in the above conversation.

The plan was refined before implementation, and then the implementation was significantly updated based on my input (both to Claude Code and by hand). I did experiment with using Playwright to record an interaction sequence to allow automated generation of HAR files, but unfortunately, it didn't retain timing information, so lost verissimilitude.

Lastly, I trimmed out unnecessary extra code that Claude Code added, including unnecessary parameter defaults (repeated across numerous function calls). I then did many rounds of testing to ensure it was giving meaningful information - including a final round after opening this PR which caught that it was looking for the session id as "id" rather than "session_id" - this has all been fixed.

With this final change, performance testing still shows considerable possibilities for data loss with many rejected requests due to 503s.

In a follow up PR, I will demonstrate that a single small change to transaction handling will ensure 0 errors on a similar test.