### PR TITLE
[Copy a class]: Use vuex getter for facility-aware redirection

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
@@ -149,7 +149,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import UserTable from 'kolibri-common/components/UserTable';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
-  import { PageNames, Modals } from '../../constants.js';
+  import { Modals } from '../../constants.js';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ClassCopyModal from '../common/ClassCopyModal.vue';
   import ClassDeleteModal from '../common/ClassDeleteModal';
@@ -232,7 +232,7 @@
     methods: {
       ...mapActions('classEditManagement', ['displayModal']),
       goToClassesPage() {
-        this.$router.push({ name: PageNames.CLASS_MGMT_PAGE });
+        this.$router.push(this.$store.getters.facilityPageLinks.ManageClassPage);
       },
       closeModal() {
         this.displayModal(false);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When only one facility exists, the redirection after copying a class from the class details page would work fine - but if you had multiple facilities, the redirection wasn't using it. 

This uses an existing utility (that should probably be replaced relatively soon) in vuex that gives facility-aware links.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13845 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Should fix the reported issue.
