### PR TITLE
have copy learners in copy class workflow set to true by default

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/common/ClassCopyModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/common/ClassCopyModal.vue
@@ -67,7 +67,7 @@
       const classCoachesIds = ref([]);
       const classLearnerIds = ref([]);
       const loading = ref(false);
-      const copyAllLearners = ref(false);
+      const copyAllLearners = ref(true);
       const copyAllCoaches = ref(false);
       const createdClass = ref(null);
       const copiedClassName = ref(null);


### PR DESCRIPTION
## Summary
Previously the learners checkbox was not true by default when copying a class. 

Since the intended use case was to make it easier to copy classes of learners, we should have this checked by default, and then allow people to "opt out".


## References

https://github.com/user-attachments/assets/10e1ad58-b7ee-4dcf-91ee-316897adceba


## Reviewer guidance
1. Create a class with learners in it 
2. Copy the class
3. observe that the "learners" checkbox defaults to true, and that the learners copy successfully

