### PR TITLE
Prevent dual enrollment 13847

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -786,6 +786,27 @@ class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet)
     serializer_class = MembershipSerializer
     filterset_class = MembershipFilter
 
+    def create(self, request):
+        serializer = self.get_serializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+
+        self.perform_create(serializer)
+
+        response_data = {"created": serializer.data}
+        status_code = status.HTTP_201_CREATED
+
+        if hasattr(serializer, "invalid_items") and serializer.invalid_items:
+            status_code = status.HTTP_207_MULTI_STATUS
+            response_data["invalid"] = [
+                {
+                    "user": item["user"].id,
+                    "collection": item["collection"].id,
+                }
+                for item in serializer.invalid_items
+            ]
+
+        return Response(response_data, status=status_code)
+
 
 class RoleFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -810,6 +810,28 @@ class RoleViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
     filterset_class = RoleFilter
     filterset_fields = ["user", "collection", "kind", "user_ids"]
 
+    def create(self, request):
+        serializer = self.get_serializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+
+        self.perform_create(serializer)
+
+        response_data = {"created": serializer.data}
+        status_code = status.HTTP_201_CREATED
+
+        if hasattr(serializer, "skipped_items") and serializer.skipped_items:
+            status_code = status.HTTP_207_MULTI_STATUS
+            response_data["skipped"] = [
+                {
+                    "user": item["user"].id,
+                    "collection": item["collection"].id,
+                    "kind": item["kind"],
+                }
+                for item in serializer.skipped_items
+            ]
+
+        return Response(response_data, status=status_code)
+
 
 dataset_keys = [
     "dataset__id",

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -787,7 +787,7 @@ class MembershipViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet)
     filterset_class = MembershipFilter
 
     def create(self, request):
-        serializer = self.get_serializer(data=request.data, many=True)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         self.perform_create(serializer)
@@ -832,7 +832,7 @@ class RoleViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
     filterset_fields = ["user", "collection", "kind", "user_ids"]
 
     def create(self, request):
-        serializer = self.get_serializer(data=request.data, many=True)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         self.perform_create(serializer)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -819,15 +819,15 @@ class RoleViewSet(BulkDeleteMixin, BulkCreateMixin, viewsets.ModelViewSet):
         response_data = {"created": serializer.data}
         status_code = status.HTTP_201_CREATED
 
-        if hasattr(serializer, "skipped_items") and serializer.skipped_items:
+        if hasattr(serializer, "invalid_items") and serializer.invalid_items:
             status_code = status.HTTP_207_MULTI_STATUS
-            response_data["skipped"] = [
+            response_data["invalid"] = [
                 {
                     "user": item["user"].id,
                     "collection": item["collection"].id,
                     "kind": item["kind"],
                 }
-                for item in serializer.skipped_items
+                for item in serializer.invalid_items
             ]
 
         return Response(response_data, status=status_code)

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -53,10 +53,11 @@ class RoleListSerializer(serializers.ListSerializer):
             kind = role_data["kind"]
 
             # Only validate classroom-level coach roles
-            if (
-                collection.kind == collection_kinds.CLASSROOM
-                and kind == role_kinds.COACH
-            ):
+            if collection.kind == collection_kinds.CLASSROOM and kind in [
+                role_kinds.COACH,
+                role_kinds.ADMIN,
+                role_kinds.ASSIGNABLE_COACH,
+            ]:
                 classroom_coach_items.append(role_data)
                 assignable_coach_ids.append(role_data["user"].id)
                 class_collection_ids.append(collection.id)
@@ -221,7 +222,7 @@ class MembershipListSerializer(serializers.ListSerializer):
         existing_roles = Role.objects.filter(
             collection_id__in=class_collection_ids,
             user_id__in=user_ids_to_validate,
-            kind=role_kinds.COACH,
+            kind__in=[role_kinds.COACH, role_kinds.ADMIN, role_kinds.ASSIGNABLE_COACH],
         ).values_list("collection_id", "user_id")
 
         valid_items = []

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -30,32 +30,58 @@ logger = logging.getLogger(__name__)
 class RoleListSerializer(serializers.ListSerializer):
     def validate(self, attrs):
         from .constants import collection_kinds, role_kinds
+        from collections import defaultdict
 
-        validated = []
+        # Separate classroom-level coach roles from others
+        classroom_coach_items = []
+        other_items = []
+
         for role_data in attrs:
-            user_id = role_data["user"].id
             collection = role_data["collection"]
             kind = role_data["kind"]
 
-            # Only check classroom-level coach roles
-            if collection.kind != collection_kinds.CLASSROOM:
-                validated.append(role_data)
-                continue
+            # Only validate classroom-level coach roles
+            if collection.kind == collection_kinds.CLASSROOM and kind in [
+                role_kinds.COACH,
+                role_kinds.ASSIGNABLE_COACH,
+            ]:
+                classroom_coach_items.append(role_data)
+            else:
+                other_items.append(role_data)
 
-            if kind not in [role_kinds.COACH, role_kinds.ASSIGNABLE_COACH]:
-                validated.append(role_data)
-                continue
+        # If no classroom coach items, return everything as-is
+        if not classroom_coach_items:
+            return attrs
 
-            # Check if user is already enrolled in this classroom
-            has_membership = Membership.objects.filter(
-                user_id=user_id, collection_id=collection.id
-            ).exists()
+        # Group classroom coach items by collection to minimize queries
+        items_by_collection = defaultdict(list)
+        for item in classroom_coach_items:
+            collection_id = item["collection"].id
+            items_by_collection[collection_id].append(item)
 
-            if not has_membership:
-                validated.append(role_data)
-            # else: silently skip this role
+        # For each collection, do one bulk query to get all conflicting users
+        members_by_collection = {}
+        for collection_id, items in items_by_collection.items():
+            user_ids = [item["user"].id for item in items]
+            # Single query per collection instead of N queries
+            member_user_ids = set(
+                Membership.objects.filter(
+                    collection_id=collection_id, user_id__in=user_ids
+                ).values_list("user_id", flat=True)
+            )
+            members_by_collection[collection_id] = member_user_ids
 
-        return validated
+        # Filter out items where user is already a member
+        validated_coach_items = []
+        for item in classroom_coach_items:
+            user_id = item["user"].id
+            collection_id = item["collection"].id
+            if user_id not in members_by_collection[collection_id]:
+                validated_coach_items.append(item)
+            # else: silently skip - user is already a member
+
+        # Return other items + validated coach items
+        return other_items + validated_coach_items
 
     def create(self, validated_data):
         created_objects = []
@@ -172,29 +198,54 @@ class FacilityUserSerializer(serializers.ModelSerializer):
 class MembershipListSerializer(serializers.ListSerializer):
     def validate(self, attrs):
         from .constants import collection_kinds, role_kinds
+        from collections import defaultdict
 
-        validated = []
+        # Separate classroom memberships from others
+        classroom_items = []
+        non_classroom_items = []
+
         for membership_data in attrs:
-            user_id = membership_data["user"].id
             collection = membership_data["collection"]
+            if collection.kind == collection_kinds.CLASSROOM:
+                classroom_items.append(membership_data)
+            else:
+                non_classroom_items.append(membership_data)
 
-            # Only check classroom-level memberships
-            if collection.kind != collection_kinds.CLASSROOM:
-                validated.append(membership_data)
-                continue
+        # If no classroom items, return everything as-is
+        if not classroom_items:
+            return attrs
 
-            # Check if user is already a coach for this classroom
-            has_coach_role = Role.objects.filter(
-                user_id=user_id,
-                collection_id=collection.id,
-                kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH],
-            ).exists()
+        # Group classroom items by collection to minimize queries
+        items_by_collection = defaultdict(list)
+        for item in classroom_items:
+            collection_id = item["collection"].id
+            items_by_collection[collection_id].append(item)
 
-            if not has_coach_role:
-                validated.append(membership_data)
-            # else: silently skip this membership
+        # For each collection, do one bulk query to get all conflicting users
+        coaches_by_collection = {}
+        for collection_id, items in items_by_collection.items():
+            user_ids = [item["user"].id for item in items]
+            # Single query per collection instead of N queries
+            coach_user_ids = set(
+                Role.objects.filter(
+                    collection_id=collection_id,
+                    user_id__in=user_ids,
+                    kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH],
+                ).values_list("user_id", flat=True)
+            )
+            coaches_by_collection[collection_id] = coach_user_ids
 
-        return validated
+        # Filter out items where user is already a coach
+        validated_classroom_items = []
+        for item in classroom_items:
+            user_id = item["user"].id
+            collection_id = item["collection"].id
+            if user_id not in coaches_by_collection[collection_id]:
+                validated_classroom_items.append(item)
+            # else: silently skip - user is already a coach
+
+        # Return non-classroom items + validated classroom items
+        return non_classroom_items + validated_classroom_items
 
     def create(self, validated_data):
         created_objects = []

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -141,6 +141,32 @@ class FacilityUserSerializer(serializers.ModelSerializer):
 
 
 class MembershipListSerializer(serializers.ListSerializer):
+    def validate(self, attrs):
+        from .constants import collection_kinds, role_kinds
+
+        validated = []
+        for membership_data in attrs:
+            user_id = membership_data["user"].id
+            collection = membership_data["collection"]
+
+            # Only check classroom-level memberships
+            if collection.kind != collection_kinds.CLASSROOM:
+                validated.append(membership_data)
+                continue
+
+            # Check if user is already a coach for this classroom
+            has_coach_role = Role.objects.filter(
+                user_id=user_id,
+                collection_id=collection.id,
+                kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH],
+            ).exists()
+
+            if not has_coach_role:
+                validated.append(membership_data)
+            # else: silently skip this membership
+
+        return validated
+
     def create(self, validated_data):
         created_objects = []
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -86,8 +86,7 @@ class RoleListSerializer(serializers.ListSerializer):
 
         for model_data in validated_data:
             obj, created = Role.objects.get_or_create(**model_data)
-            if created:
-                created_objects.append(obj)
+            created_objects.append(obj)
 
         return created_objects
 
@@ -240,8 +239,7 @@ class MembershipListSerializer(serializers.ListSerializer):
 
         for model_data in validated_data:
             obj, created = Membership.objects.get_or_create(**model_data)
-            if created:
-                created_objects.append(obj)
+            created_objects.append(obj)
 
         return created_objects
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -85,10 +85,9 @@ class RoleListSerializer(serializers.ListSerializer):
     def create(self, validated_data):
         created_objects = []
 
-        with transaction.atomic():
-            for model_data in validated_data:
-                obj, _ = Role.objects.get_or_create(**model_data)
-                created_objects.append(obj)
+        for model_data in validated_data:
+            obj, _ = Role.objects.get_or_create(**model_data)
+            created_objects.append(obj)
 
         return created_objects
 
@@ -239,10 +238,9 @@ class MembershipListSerializer(serializers.ListSerializer):
     def create(self, validated_data):
         created_objects = []
 
-        with transaction.atomic():
-            for model_data in validated_data:
-                obj, _ = Membership.objects.get_or_create(**model_data)
-                created_objects.append(obj)
+        for model_data in validated_data:
+            obj, _ = Membership.objects.get_or_create(**model_data)
+            created_objects.append(obj)
 
         return created_objects
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class RoleListSerializer(serializers.ListSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.skipped_items = []
+        self.invalid_items = []
 
     def validate(self, attrs):
 
@@ -76,7 +76,7 @@ class RoleListSerializer(serializers.ListSerializer):
 
         for item in classroom_coach_items:
             if (item["collection"].id, item["user"].id) in existing_memberships:
-                self.skipped_items.append(item)
+                self.invalid_items.append(item)
             else:
                 valid_items.append(item)
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -28,6 +28,35 @@ logger = logging.getLogger(__name__)
 
 
 class RoleListSerializer(serializers.ListSerializer):
+    def validate(self, attrs):
+        from .constants import collection_kinds, role_kinds
+
+        validated = []
+        for role_data in attrs:
+            user_id = role_data["user"].id
+            collection = role_data["collection"]
+            kind = role_data["kind"]
+
+            # Only check classroom-level coach roles
+            if collection.kind != collection_kinds.CLASSROOM:
+                validated.append(role_data)
+                continue
+
+            if kind not in [role_kinds.COACH, role_kinds.ASSIGNABLE_COACH]:
+                validated.append(role_data)
+                continue
+
+            # Check if user is already enrolled in this classroom
+            has_membership = Membership.objects.filter(
+                user_id=user_id, collection_id=collection.id
+            ).exists()
+
+            if not has_membership:
+                validated.append(role_data)
+            # else: silently skip this role
+
+        return validated
+
     def create(self, validated_data):
         created_objects = []
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -53,10 +53,10 @@ class RoleListSerializer(serializers.ListSerializer):
             kind = role_data["kind"]
 
             # Only validate classroom-level coach roles
-            if collection.kind == collection_kinds.CLASSROOM and kind in [
-                role_kinds.COACH,
-                role_kinds.ASSIGNABLE_COACH,
-            ]:
+            if (
+                collection.kind == collection_kinds.CLASSROOM
+                and kind == role_kinds.COACH
+            ):
                 classroom_coach_items.append(role_data)
                 assignable_coach_ids.append(role_data["user"].id)
                 class_collection_ids.append(collection.id)
@@ -84,9 +84,10 @@ class RoleListSerializer(serializers.ListSerializer):
     def create(self, validated_data):
         created_objects = []
 
-        for model_data in validated_data:
-            obj, created = Role.objects.get_or_create(**model_data)
-            created_objects.append(obj)
+        with transaction.atomic():
+            for model_data in validated_data:
+                obj, _ = Role.objects.get_or_create(**model_data)
+                created_objects.append(obj)
 
         return created_objects
 
@@ -220,7 +221,7 @@ class MembershipListSerializer(serializers.ListSerializer):
         existing_roles = Role.objects.filter(
             collection_id__in=class_collection_ids,
             user_id__in=user_ids_to_validate,
-            kind__in=[role_kinds.ASSIGNABLE_COACH, role_kinds.COACH],
+            kind=role_kinds.COACH,
         ).values_list("collection_id", "user_id")
 
         valid_items = []
@@ -237,9 +238,10 @@ class MembershipListSerializer(serializers.ListSerializer):
     def create(self, validated_data):
         created_objects = []
 
-        for model_data in validated_data:
-            obj, created = Membership.objects.get_or_create(**model_data)
-            created_objects.append(obj)
+        with transaction.atomic():
+            for model_data in validated_data:
+                obj, _ = Membership.objects.get_or_create(**model_data)
+                created_objects.append(obj)
 
         return created_objects
 

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MinLengthValidator
@@ -195,53 +194,46 @@ class FacilityUserSerializer(serializers.ModelSerializer):
 
 
 class MembershipListSerializer(serializers.ListSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.invalid_items = []
+
     def validate(self, attrs):
         # Separate classroom memberships from others
         classroom_items = []
-        non_classroom_items = []
+        other_items = []
+        user_ids_to_validate = []
+        class_collection_ids = []
 
         for membership_data in attrs:
             collection = membership_data["collection"]
             if collection.kind == collection_kinds.CLASSROOM:
                 classroom_items.append(membership_data)
+                class_collection_ids.append(collection.id)
+                user_ids_to_validate.append(membership_data["user"].id)
             else:
-                non_classroom_items.append(membership_data)
+                other_items.append(membership_data)
 
         # If no classroom items, return everything as-is
         if not classroom_items:
             return attrs
 
-        # Group classroom items by collection to minimize queries
-        items_by_collection = defaultdict(list)
-        for item in classroom_items:
-            collection_id = item["collection"].id
-            items_by_collection[collection_id].append(item)
+        existing_roles = Role.objects.filter(
+            collection_id__in=class_collection_ids,
+            user_id__in=user_ids_to_validate,
+            kind__in=[role_kinds.ASSIGNABLE_COACH, role_kinds.COACH],
+        ).values_list("collection_id", "user_id")
 
-        # For each collection, do one bulk query to get all conflicting users
-        coaches_by_collection = {}
-        for collection_id, items in items_by_collection.items():
-            user_ids = [item["user"].id for item in items]
-            # Single query per collection instead of N queries
-            coach_user_ids = set(
-                Role.objects.filter(
-                    collection_id=collection_id,
-                    user_id__in=user_ids,
-                    kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH],
-                ).values_list("user_id", flat=True)
-            )
-            coaches_by_collection[collection_id] = coach_user_ids
+        valid_items = []
 
-        # Filter out items where user is already a coach
-        validated_classroom_items = []
         for item in classroom_items:
-            user_id = item["user"].id
-            collection_id = item["collection"].id
-            if user_id not in coaches_by_collection[collection_id]:
-                validated_classroom_items.append(item)
-            # else: silently skip - user is already a coach
+            if (item["collection"].id, item["user"].id) in existing_roles:
+                self.invalid_items.append(item)
+            else:
+                valid_items.append(item)
 
         # Return non-classroom items + validated classroom items
-        return non_classroom_items + validated_classroom_items
+        return other_items + valid_items
 
     def create(self, validated_data):
         created_objects = []

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MinLengthValidator
@@ -7,7 +8,9 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.validators import UniqueTogetherValidator
 
+from .constants import collection_kinds
 from .constants import facility_presets
+from .constants import role_kinds
 from .errors import IncompatibleDeviceSettingError
 from .errors import InvalidCollectionHierarchy
 from .errors import InvalidMembershipError
@@ -28,13 +31,23 @@ logger = logging.getLogger(__name__)
 
 
 class RoleListSerializer(serializers.ListSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.skipped_items = []
+
     def validate(self, attrs):
-        from .constants import collection_kinds, role_kinds
-        from collections import defaultdict
 
         # Separate classroom-level coach roles from others
         classroom_coach_items = []
+
+        # Other items is for items that don't need to be validated for
+        # whether or not they're enrolled in a class already
         other_items = []
+
+        # Tracking the collections & users to query against for validating
+        # if they're members of the class already
+        assignable_coach_ids = []
+        class_collection_ids = []
 
         for role_data in attrs:
             collection = role_data["collection"]
@@ -46,6 +59,8 @@ class RoleListSerializer(serializers.ListSerializer):
                 role_kinds.ASSIGNABLE_COACH,
             ]:
                 classroom_coach_items.append(role_data)
+                assignable_coach_ids.append(role_data["user"].id)
+                class_collection_ids.append(collection.id)
             else:
                 other_items.append(role_data)
 
@@ -53,35 +68,19 @@ class RoleListSerializer(serializers.ListSerializer):
         if not classroom_coach_items:
             return attrs
 
-        # Group classroom coach items by collection to minimize queries
-        items_by_collection = defaultdict(list)
+        existing_memberships = Membership.objects.filter(
+            collection_id__in=class_collection_ids, user_id__in=assignable_coach_ids
+        ).values_list("collection_id", "user_id")
+
+        valid_items = []
+
         for item in classroom_coach_items:
-            collection_id = item["collection"].id
-            items_by_collection[collection_id].append(item)
+            if (item["collection"].id, item["user"].id) in existing_memberships:
+                self.skipped_items.append(item)
+            else:
+                valid_items.append(item)
 
-        # For each collection, do one bulk query to get all conflicting users
-        members_by_collection = {}
-        for collection_id, items in items_by_collection.items():
-            user_ids = [item["user"].id for item in items]
-            # Single query per collection instead of N queries
-            member_user_ids = set(
-                Membership.objects.filter(
-                    collection_id=collection_id, user_id__in=user_ids
-                ).values_list("user_id", flat=True)
-            )
-            members_by_collection[collection_id] = member_user_ids
-
-        # Filter out items where user is already a member
-        validated_coach_items = []
-        for item in classroom_coach_items:
-            user_id = item["user"].id
-            collection_id = item["collection"].id
-            if user_id not in members_by_collection[collection_id]:
-                validated_coach_items.append(item)
-            # else: silently skip - user is already a member
-
-        # Return other items + validated coach items
-        return other_items + validated_coach_items
+        return other_items + valid_items
 
     def create(self, validated_data):
         created_objects = []
@@ -197,9 +196,6 @@ class FacilityUserSerializer(serializers.ModelSerializer):
 
 class MembershipListSerializer(serializers.ListSerializer):
     def validate(self, attrs):
-        from .constants import collection_kinds, role_kinds
-        from collections import defaultdict
-
         # Separate classroom memberships from others
         classroom_items = []
         non_classroom_items = []

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2409,6 +2409,66 @@ class MembershipAPITestCase(APITestCase):
             ).exists()
         )
 
+    def test_bulk_enroll_multiple_classrooms_filters_correctly(self):
+        """Test that bulk enrollment across multiple classrooms filters per-collection"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # Create a second classroom
+        classroom2 = ClassroomFactory.create(parent=self.facility)
+
+        # Create two users
+        user1 = FacilityUserFactory.create(facility=self.facility)
+        user2 = FacilityUserFactory.create(facility=self.facility)
+
+        # user1 is a coach for classroom1, user2 is a coach for classroom2
+        models.Role.objects.create(
+            user=user1, collection=self.classroom, kind=role_kinds.COACH
+        )
+        models.Role.objects.create(
+            user=user2, collection=classroom2, kind=role_kinds.COACH
+        )
+
+        # Try to enroll both users in both classrooms (4 memberships total)
+        response = self.client.post(
+            reverse("kolibri:core:membership-list"),
+            data=[
+                {
+                    "user": user1.id,
+                    "collection": self.classroom.id,
+                },  # CONFLICT - filtered
+                {"user": user1.id, "collection": classroom2.id},  # OK
+                {"user": user2.id, "collection": self.classroom.id},  # OK
+                {"user": user2.id, "collection": classroom2.id},  # CONFLICT - filtered
+            ],
+            format="json",
+        )
+
+        # Should return 201 with only the 2 non-conflicting memberships
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 2)
+
+        # Verify user1 enrolled in classroom2 (not classroom1)
+        self.assertFalse(
+            models.Membership.objects.filter(
+                user=user1, collection=self.classroom
+            ).exists()
+        )
+        self.assertTrue(
+            models.Membership.objects.filter(user=user1, collection=classroom2).exists()
+        )
+
+        # Verify user2 enrolled in classroom1 (not classroom2)
+        self.assertTrue(
+            models.Membership.objects.filter(
+                user=user2, collection=self.classroom
+            ).exists()
+        )
+        self.assertFalse(
+            models.Membership.objects.filter(user=user2, collection=classroom2).exists()
+        )
+
     def test_can_enroll_in_learnergroup(self):
         """Test that LearnerGroup memberships work normally (validation only applies to classrooms)"""
         self.login_superuser()

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2371,7 +2371,7 @@ class MembershipAPITestCase(APITestCase):
             ).exists()
         )
 
-    def test_bulk_enroll_filters_coaches_silently(self):
+    def test_bulk_enroll_filters_coaches(self):
         """Test that bulk enrollment filters out coaches but creates valid memberships"""
 
         self.login_superuser()
@@ -2534,7 +2534,10 @@ class RoleAPITestCase(APITestCase):
         )
 
     def test_cannot_assign_learner_as_coach_in_same_classroom(self):
-        """Test that assigning a learner as coach in the same classroom is silently skipped"""
+        """
+        Test that assigning a learner as coach in the same classroom results
+        in `invalid` returned with the skipped users
+        """
 
         self.login_superuser()
 
@@ -2570,7 +2573,7 @@ class RoleAPITestCase(APITestCase):
             ).exists()
         )
 
-    def test_bulk_assign_coaches_filters_learners_silently(self):
+    def test_bulk_assign_coaches_filters_learners(self):
         """Test that bulk coach assignment filters out learners but creates valid roles"""
 
         self.login_superuser()

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2334,7 +2334,6 @@ class MembershipAPITestCase(APITestCase):
 
     def test_cannot_enroll_coach_as_learner_in_same_classroom(self):
         """Test that enrolling a coach as a learner in the same classroom is silently skipped"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2366,7 +2365,6 @@ class MembershipAPITestCase(APITestCase):
 
     def test_bulk_enroll_filters_coaches_silently(self):
         """Test that bulk enrollment filters out coaches but creates valid memberships"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2411,7 +2409,6 @@ class MembershipAPITestCase(APITestCase):
 
     def test_bulk_enroll_multiple_classrooms_filters_correctly(self):
         """Test that bulk enrollment across multiple classrooms filters per-collection"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2522,7 +2519,6 @@ class RoleAPITestCase(APITestCase):
 
     def test_cannot_assign_learner_as_coach_in_same_classroom(self):
         """Test that assigning a learner as coach in the same classroom is silently skipped"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2542,9 +2538,14 @@ class RoleAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 201 but with empty array (silently filtered)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 0)
+        # Should return 207 with skipped items
+        self.assertEqual(response.status_code, 207)
+        self.assertIn("created", response.data)
+        self.assertIn("skipped", response.data)
+        self.assertEqual(len(response.data["created"]), 0)
+        self.assertEqual(len(response.data["skipped"]), 1)
+        self.assertEqual(response.data["skipped"][0]["user"], self.user1.id)
+        self.assertEqual(response.data["skipped"][0]["collection"], self.classroom.id)
 
         # Verify no coach role was created
         self.assertFalse(
@@ -2555,7 +2556,6 @@ class RoleAPITestCase(APITestCase):
 
     def test_bulk_assign_coaches_filters_learners_silently(self):
         """Test that bulk coach assignment filters out learners but creates valid roles"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2581,10 +2581,14 @@ class RoleAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 201 with only user2's role
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["user"], self.user2.id)
+        # Should return 207 with mixed results
+        self.assertEqual(response.status_code, 207)
+        self.assertIn("created", response.data)
+        self.assertIn("skipped", response.data)
+        self.assertEqual(len(response.data["created"]), 1)
+        self.assertEqual(len(response.data["skipped"]), 1)
+        self.assertEqual(response.data["created"][0]["user"], self.user2.id)
+        self.assertEqual(response.data["skipped"][0]["user"], self.user1.id)
 
         # Verify user1 was not assigned as coach
         self.assertFalse(
@@ -2602,7 +2606,6 @@ class RoleAPITestCase(APITestCase):
 
     def test_can_assign_learner_as_facility_admin(self):
         """Test that learners CAN be assigned as facility admins (validation only for classroom coaches)"""
-        from kolibri.core.auth.constants import role_kinds
 
         self.login_superuser()
 
@@ -2622,9 +2625,11 @@ class RoleAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should succeed
+        # Should succeed with all items created
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 1)
+        self.assertIn("created", response.data)
+        self.assertEqual(len(response.data["created"]), 1)
+        self.assertEqual(response.data["created"][0]["user"], self.user1.id)
 
         # Verify role was created
         self.assertTrue(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2364,6 +2364,51 @@ class MembershipAPITestCase(APITestCase):
             ).exists()
         )
 
+    def test_bulk_enroll_filters_coaches_silently(self):
+        """Test that bulk enrollment filters out coaches but creates valid memberships"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # Create two new users for this test
+        user1 = FacilityUserFactory.create(facility=self.facility)
+        user2 = FacilityUserFactory.create(facility=self.facility)
+
+        # user1 is a coach for classroom
+        models.Role.objects.create(
+            user=user1, collection=self.classroom, kind=role_kinds.COACH
+        )
+
+        # user2 is not a coach
+        # Try to enroll both users
+        response = self.client.post(
+            reverse("kolibri:core:membership-list"),
+            data=[
+                {"user": user1.id, "collection": self.classroom.id},
+                {"user": user2.id, "collection": self.classroom.id},
+            ],
+            format="json",
+        )
+
+        # Should return 201 with only user2's membership
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["user"], user2.id)
+
+        # Verify user1 was not enrolled
+        self.assertFalse(
+            models.Membership.objects.filter(
+                user=user1, collection=self.classroom
+            ).exists()
+        )
+
+        # Verify user2 was enrolled
+        self.assertTrue(
+            models.Membership.objects.filter(
+                user=user2, collection=self.classroom
+            ).exists()
+        )
+
 
 class RoleAPITestCase(APITestCase):
     @classmethod
@@ -2412,6 +2457,53 @@ class RoleAPITestCase(APITestCase):
         self.assertFalse(
             models.Role.objects.filter(
                 user=self.user1, collection=self.classroom, kind=role_kinds.COACH
+            ).exists()
+        )
+
+    def test_bulk_assign_coaches_filters_learners_silently(self):
+        """Test that bulk coach assignment filters out learners but creates valid roles"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # user1 is enrolled as learner in classroom
+        models.Membership.objects.create(user=self.user1, collection=self.classroom)
+
+        # user2 is not enrolled
+        # Try to assign both as coaches
+        response = self.client.post(
+            reverse("kolibri:core:role-list"),
+            data=[
+                {
+                    "user": self.user1.id,
+                    "collection": self.classroom.id,
+                    "kind": role_kinds.COACH,
+                },
+                {
+                    "user": self.user2.id,
+                    "collection": self.classroom.id,
+                    "kind": role_kinds.COACH,
+                },
+            ],
+            format="json",
+        )
+
+        # Should return 201 with only user2's role
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["user"], self.user2.id)
+
+        # Verify user1 was not assigned as coach
+        self.assertFalse(
+            models.Role.objects.filter(
+                user=self.user1, collection=self.classroom, kind=role_kinds.COACH
+            ).exists()
+        )
+
+        # Verify user2 was assigned as coach
+        self.assertTrue(
+            models.Role.objects.filter(
+                user=self.user2, collection=self.classroom, kind=role_kinds.COACH
             ).exists()
         )
 

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2355,9 +2355,14 @@ class MembershipAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 201 but with empty array (silently filtered)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 0)
+        # Should return 207 with invalid items
+        self.assertEqual(response.status_code, 207)
+        self.assertIn("created", response.data)
+        self.assertIn("invalid", response.data)
+        self.assertEqual(len(response.data["created"]), 0)
+        self.assertEqual(len(response.data["invalid"]), 1)
+        self.assertEqual(response.data["invalid"][0]["user"], test_user.id)
+        self.assertEqual(response.data["invalid"][0]["collection"], self.classroom.id)
 
         # Verify no membership was created
         self.assertFalse(
@@ -2391,10 +2396,14 @@ class MembershipAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 201 with only user2's membership
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["user"], user2.id)
+        # Should return 207 with mixed results
+        self.assertEqual(response.status_code, 207)
+        self.assertIn("created", response.data)
+        self.assertIn("invalid", response.data)
+        self.assertEqual(len(response.data["created"]), 1)
+        self.assertEqual(len(response.data["invalid"]), 1)
+        self.assertEqual(response.data["created"][0]["user"], user2.id)
+        self.assertEqual(response.data["invalid"][0]["user"], user1.id)
 
         # Verify user1 was not enrolled
         self.assertFalse(
@@ -2445,9 +2454,12 @@ class MembershipAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 201 with only the 2 non-conflicting memberships
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 2)
+        # Should return 207 with mixed results
+        self.assertEqual(response.status_code, 207)
+        self.assertIn("created", response.data)
+        self.assertIn("invalid", response.data)
+        self.assertEqual(len(response.data["created"]), 2)
+        self.assertEqual(len(response.data["invalid"]), 2)
 
         # Verify user1 enrolled in classroom2 (not classroom1)
         self.assertFalse(
@@ -2493,7 +2505,8 @@ class MembershipAPITestCase(APITestCase):
 
         # Should succeed
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(len(response.data), 1)
+        self.assertIn("created", response.data)
+        self.assertEqual(len(response.data["created"]), 1)
 
         # Verify membership was created
         self.assertTrue(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2332,6 +2332,38 @@ class MembershipAPITestCase(APITestCase):
             expected_count,
         )
 
+    def test_cannot_enroll_coach_as_learner_in_same_classroom(self):
+        """Test that enrolling a coach as a learner in the same classroom is silently skipped"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # Create a new user to test with
+        test_user = FacilityUserFactory.create(facility=self.facility)
+
+        # Create a coach role for the user in the classroom
+        models.Role.objects.create(
+            user=test_user, collection=self.classroom, kind=role_kinds.COACH
+        )
+
+        # Try to enroll the same user as a learner in the same classroom
+        response = self.client.post(
+            reverse("kolibri:core:membership-list"),
+            data=[{"user": test_user.id, "collection": self.classroom.id}],
+            format="json",
+        )
+
+        # Should return 201 but with empty array (silently filtered)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 0)
+
+        # Verify no membership was created
+        self.assertFalse(
+            models.Membership.objects.filter(
+                user=test_user, collection=self.classroom
+            ).exists()
+        )
+
 
 class GroupMembership(APITestCase):
     @classmethod

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2365,6 +2365,57 @@ class MembershipAPITestCase(APITestCase):
         )
 
 
+class RoleAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility)
+        cls.user2 = FacilityUserFactory.create(facility=cls.facility)
+        cls.classroom = ClassroomFactory.create(parent=cls.facility)
+
+    def login_superuser(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    def test_cannot_assign_learner_as_coach_in_same_classroom(self):
+        """Test that assigning a learner as coach in the same classroom is silently skipped"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # Create a membership (learner enrollment) for the user in the classroom
+        models.Membership.objects.create(user=self.user1, collection=self.classroom)
+
+        # Try to assign the same user as a coach to the same classroom
+        response = self.client.post(
+            reverse("kolibri:core:role-list"),
+            data=[
+                {
+                    "user": self.user1.id,
+                    "collection": self.classroom.id,
+                    "kind": role_kinds.COACH,
+                }
+            ],
+            format="json",
+        )
+
+        # Should return 201 but with empty array (silently filtered)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 0)
+
+        # Verify no coach role was created
+        self.assertFalse(
+            models.Role.objects.filter(
+                user=self.user1, collection=self.classroom, kind=role_kinds.COACH
+            ).exists()
+        )
+
+
 class GroupMembership(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2333,7 +2333,10 @@ class MembershipAPITestCase(APITestCase):
         )
 
     def test_cannot_enroll_coach_as_learner_in_same_classroom(self):
-        """Test that enrolling a coach as a learner in the same classroom is silently skipped"""
+        """
+        Test that enrolling a coach as a learner in the same classroom is included in
+        the invalid_items
+        """
 
         self.login_superuser()
 
@@ -2538,14 +2541,14 @@ class RoleAPITestCase(APITestCase):
             format="json",
         )
 
-        # Should return 207 with skipped items
+        # Should return 207 with invalid items
         self.assertEqual(response.status_code, 207)
         self.assertIn("created", response.data)
-        self.assertIn("skipped", response.data)
+        self.assertIn("invalid", response.data)
         self.assertEqual(len(response.data["created"]), 0)
-        self.assertEqual(len(response.data["skipped"]), 1)
-        self.assertEqual(response.data["skipped"][0]["user"], self.user1.id)
-        self.assertEqual(response.data["skipped"][0]["collection"], self.classroom.id)
+        self.assertEqual(len(response.data["invalid"]), 1)
+        self.assertEqual(response.data["invalid"][0]["user"], self.user1.id)
+        self.assertEqual(response.data["invalid"][0]["collection"], self.classroom.id)
 
         # Verify no coach role was created
         self.assertFalse(
@@ -2584,11 +2587,11 @@ class RoleAPITestCase(APITestCase):
         # Should return 207 with mixed results
         self.assertEqual(response.status_code, 207)
         self.assertIn("created", response.data)
-        self.assertIn("skipped", response.data)
+        self.assertIn("invalid", response.data)
         self.assertEqual(len(response.data["created"]), 1)
-        self.assertEqual(len(response.data["skipped"]), 1)
+        self.assertEqual(len(response.data["invalid"]), 1)
         self.assertEqual(response.data["created"][0]["user"], self.user2.id)
-        self.assertEqual(response.data["skipped"][0]["user"], self.user1.id)
+        self.assertEqual(response.data["invalid"][0]["user"], self.user1.id)
 
         # Verify user1 was not assigned as coach
         self.assertFalse(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2409,6 +2409,39 @@ class MembershipAPITestCase(APITestCase):
             ).exists()
         )
 
+    def test_can_enroll_in_learnergroup(self):
+        """Test that LearnerGroup memberships work normally (validation only applies to classrooms)"""
+        self.login_superuser()
+
+        # Create a new user for this test
+        user1 = FacilityUserFactory.create(facility=self.facility)
+
+        # First enroll user in classroom (required for learnergroup membership)
+        models.Membership.objects.create(user=user1, collection=self.classroom)
+
+        # Create learner group
+        learner_group = LearnerGroupFactory.create(
+            name="Test Group", parent=self.classroom
+        )
+
+        # Try to enroll user in the learner group (should succeed)
+        response = self.client.post(
+            reverse("kolibri:core:membership-list"),
+            data=[{"user": user1.id, "collection": learner_group.id}],
+            format="json",
+        )
+
+        # Should succeed
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 1)
+
+        # Verify membership was created
+        self.assertTrue(
+            models.Membership.objects.filter(
+                user=user1, collection=learner_group
+            ).exists()
+        )
+
 
 class RoleAPITestCase(APITestCase):
     @classmethod
@@ -2504,6 +2537,39 @@ class RoleAPITestCase(APITestCase):
         self.assertTrue(
             models.Role.objects.filter(
                 user=self.user2, collection=self.classroom, kind=role_kinds.COACH
+            ).exists()
+        )
+
+    def test_can_assign_learner_as_facility_admin(self):
+        """Test that learners CAN be assigned as facility admins (validation only for classroom coaches)"""
+        from kolibri.core.auth.constants import role_kinds
+
+        self.login_superuser()
+
+        # Enroll user as learner in classroom
+        models.Membership.objects.create(user=self.user1, collection=self.classroom)
+
+        # Try to assign user as facility admin (should succeed)
+        response = self.client.post(
+            reverse("kolibri:core:role-list"),
+            data=[
+                {
+                    "user": self.user1.id,
+                    "collection": self.facility.id,
+                    "kind": role_kinds.ADMIN,
+                }
+            ],
+            format="json",
+        )
+
+        # Should succeed
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data), 1)
+
+        # Verify role was created
+        self.assertTrue(
+            models.Role.objects.filter(
+                user=self.user1, collection=self.facility, kind=role_kinds.ADMIN
             ).exists()
         )
 

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -1,7 +1,9 @@
 import { computed } from 'vue';
-import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
+import {
+  bulkUserManagementStrings
+} from 'kolibri-common/strings/bulkUserManagementStrings';
 
 /**
  *
@@ -28,8 +30,8 @@ import useSnackbar from 'kolibri/composables/useSnackbar';
  * @property {() => Promise<void>} performAction - A method to manually trigger the main action
  * with all the undo machinery set up.
  *
- * @param {ComputedRef<boolean>} options.canUndo - A computed ref that will return true when the undo
- * can be performed (Default: ComputedRef -> true)
+ * @param {ComputedRef<boolean>} options.canUndo - A computed ref that will return true when the
+ * undo can be performed (Default: ComputedRef -> true)
  *
  * @returns {UseActionWithUndoObject}
  */

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -1,4 +1,6 @@
+import { computed } from 'vue';
 import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
 
 /**
@@ -26,9 +28,13 @@ import useSnackbar from 'kolibri/composables/useSnackbar';
  * @property {() => Promise<void>} performAction - A method to manually trigger the main action
  * with all the undo machinery set up.
  *
+ * @param {ComputedRef<boolean>} options.canUndo - A computed ref that will return true when the undo
+ * can be performed (Default: ComputedRef -> true)
+ *
  * @returns {UseActionWithUndoObject}
  */
 export default function useActionWithUndo({
+  canUndo = (computed(() => true)),
   action,
   actionNotice$,
   undoAction,
@@ -39,6 +45,8 @@ export default function useActionWithUndo({
   const { createSnackbar, clearSnackbar } = useSnackbar();
 
   const performUndoAction = async () => {
+    if(!canUndo.value) return;
+
     clearSnackbar();
     try {
       await undoAction();
@@ -59,7 +67,7 @@ export default function useActionWithUndo({
       autofocus: true,
       autoDismiss: true,
       duration: 6000,
-      actionText: undoAction$(),
+      actionText: (canUndo.value ? undoAction$() : coreStrings.dismissAction$()),
       onBlur,
       actionCallback: performUndoAction,
     });

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -34,7 +34,7 @@ import useSnackbar from 'kolibri/composables/useSnackbar';
  * @returns {UseActionWithUndoObject}
  */
 export default function useActionWithUndo({
-  canUndo = (computed(() => true)),
+  canUndo = computed(() => true),
   action,
   actionNotice$,
   undoAction,
@@ -45,7 +45,7 @@ export default function useActionWithUndo({
   const { createSnackbar, clearSnackbar } = useSnackbar();
 
   const performUndoAction = async () => {
-    if(!canUndo.value) return;
+    if (!canUndo.value) return;
 
     clearSnackbar();
     try {
@@ -67,7 +67,7 @@ export default function useActionWithUndo({
       autofocus: true,
       autoDismiss: true,
       duration: 6000,
-      actionText: (canUndo.value ? undoAction$() : coreStrings.dismissAction$()),
+      actionText: canUndo.value ? undoAction$() : coreStrings.dismissAction$(),
       onBlur,
       actionCallback: performUndoAction,
     });

--- a/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
+++ b/kolibri/plugins/facility/assets/src/composables/useActionWithUndo.js
@@ -1,9 +1,7 @@
 import { computed } from 'vue';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
-import {
-  bulkUserManagementStrings
-} from 'kolibri-common/strings/bulkUserManagementStrings';
+import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
 /**
  *

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -38,23 +38,16 @@ export default function useUserManagement({
     dataLoading.value = true;
     try {
       const fetchResource = softDeletedUsers ? DeletedFacilityUserResource : FacilityUserResource;
-      const getParams = by_ids.value
-        ? pickBy({
-            by_ids: by_ids.value,
-            member_of: activeFacilityId,
-            page: page.value,
-            page_size: pageSize.value,
-            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
-          })
-        : pickBy({
-            member_of: activeFacilityId,
-            date_joined__gte: dateJoinedGt?.toISOString(),
-            page: page.value,
-            page_size: pageSize.value,
-            search: search.value?.trim() || null,
-            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
-            ...getBackendFilters(),
-          });
+      const getParams = pickBy({
+        by_ids: by_ids.value,
+        member_of: activeFacilityId,
+        date_joined__gte: dateJoinedGt?.toISOString(),
+        page: page.value,
+        page_size: pageSize.value,
+        search: search.value?.trim() || null,
+        ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
+        ...getBackendFilters(),
+      });
 
       const resp = await fetchResource.fetchCollection({
         getParams,

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -28,6 +28,7 @@ export default function useUserManagement({
   const ordering = computed(() => route.value.query.ordering || null);
   const order = computed(() => route.value.query.order || '');
   const search = computed(() => route.value.query.search || null);
+  const by_ids = computed(() => route.value.query.by_ids || null);
 
   const { routeFilters, numAppliedFilters, getBackendFilters, resetFilters } = useUsersFilters({
     classes,
@@ -37,8 +38,14 @@ export default function useUserManagement({
     dataLoading.value = true;
     try {
       const fetchResource = softDeletedUsers ? DeletedFacilityUserResource : FacilityUserResource;
-      const resp = await fetchResource.fetchCollection({
-        getParams: pickBy({
+      const getParams = Boolean(by_ids.value) ?
+        {
+          by_ids: by_ids.value,
+          member_of: activeFacilityId,
+          page: page.value,
+          page_size: pageSize.value,
+        } :
+        pickBy({
           member_of: activeFacilityId,
           date_joined__gte: dateJoinedGt?.toISOString(),
           page: page.value,
@@ -46,9 +53,13 @@ export default function useUserManagement({
           search: search.value?.trim() || null,
           ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
           ...getBackendFilters(),
-        }),
+        });
+
+      const resp = await fetchResource.fetchCollection({
+        getParams,
         force: true,
       });
+
       facilityUsers.value = resp.results.map(_userState);
       totalPages.value = resp.total_pages;
       usersCount.value = resp.count;
@@ -76,7 +87,7 @@ export default function useUserManagement({
     }
   };
 
-  function onChange({ resetSelection = false, affectedClasses = null } = {}) {
+  function onChange({ resetSelection = false, affectedClasses = null, created = [], invalid = [] } = {}) {
     if (resetSelection) {
       selectedUsers.value = new Set();
     }

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -39,13 +39,13 @@ export default function useUserManagement({
     try {
       const fetchResource = softDeletedUsers ? DeletedFacilityUserResource : FacilityUserResource;
       const getParams = by_ids.value
-        ? {
+        ? pickBy({
             by_ids: by_ids.value,
             member_of: activeFacilityId,
             page: page.value,
             page_size: pageSize.value,
-            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || 'username',
-          }
+            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
+          })
         : pickBy({
             member_of: activeFacilityId,
             date_joined__gte: dateJoinedGt?.toISOString(),

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -44,6 +44,7 @@ export default function useUserManagement({
             member_of: activeFacilityId,
             page: page.value,
             page_size: pageSize.value,
+            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || 'username',
           }
         : pickBy({
             member_of: activeFacilityId,

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -87,12 +87,7 @@ export default function useUserManagement({
     }
   };
 
-  function onChange({
-    resetSelection = false,
-    affectedClasses = null,
-    created = [],
-    invalid = [],
-  } = {}) {
+  function onChange({ resetSelection = false, affectedClasses = null } = {}) {
     if (resetSelection) {
       selectedUsers.value = new Set();
     }

--- a/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUserManagement.js
@@ -38,22 +38,22 @@ export default function useUserManagement({
     dataLoading.value = true;
     try {
       const fetchResource = softDeletedUsers ? DeletedFacilityUserResource : FacilityUserResource;
-      const getParams = Boolean(by_ids.value) ?
-        {
-          by_ids: by_ids.value,
-          member_of: activeFacilityId,
-          page: page.value,
-          page_size: pageSize.value,
-        } :
-        pickBy({
-          member_of: activeFacilityId,
-          date_joined__gte: dateJoinedGt?.toISOString(),
-          page: page.value,
-          page_size: pageSize.value,
-          search: search.value?.trim() || null,
-          ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
-          ...getBackendFilters(),
-        });
+      const getParams = by_ids.value
+        ? {
+            by_ids: by_ids.value,
+            member_of: activeFacilityId,
+            page: page.value,
+            page_size: pageSize.value,
+          }
+        : pickBy({
+            member_of: activeFacilityId,
+            date_joined__gte: dateJoinedGt?.toISOString(),
+            page: page.value,
+            page_size: pageSize.value,
+            search: search.value?.trim() || null,
+            ordering: order.value === 'desc' ? `-${ordering.value}` : ordering.value || null,
+            ...getBackendFilters(),
+          });
 
       const resp = await fetchResource.fetchCollection({
         getParams,
@@ -87,7 +87,12 @@ export default function useUserManagement({
     }
   };
 
-  function onChange({ resetSelection = false, affectedClasses = null, created = [], invalid = [] } = {}) {
+  function onChange({
+    resetSelection = false,
+    affectedClasses = null,
+    created = [],
+    invalid = [],
+  } = {}) {
     if (resetSelection) {
       selectedUsers.value = new Set();
     }

--- a/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
@@ -25,6 +25,7 @@ export default function useUsersFilters({ classes }) {
       birthYearStart: route.query.birth_year_start || null,
       birthYearEnd: route.query.birth_year_end || null,
       creationDate: route.query.creation_date || null,
+      by_ids: route.query.by_ids?.split(',') || [],
     };
   });
 
@@ -36,9 +37,13 @@ export default function useUsersFilters({ classes }) {
       end: null,
     },
     creationDate: {},
+    by_ids: [],
   });
 
   const numAppliedFilters = computed(() => {
+    if (routeFilters.value.by_ids?.length) {
+      return 1;
+    }
     let count = 0;
     if (routeFilters.value.userTypes.length) {
       count += 1;
@@ -119,6 +124,13 @@ export default function useUsersFilters({ classes }) {
   watch(
     routeFilters,
     newFilters => {
+      if(workingFilters.by_ids?.length) {
+        // If we're filtering by by_ids, it's programmatic navigation
+        // so we will clear all existing filters and set the ids alone
+        resetWorkingFilters();
+        workingFilters.by_ids = newFilters.by_ids;
+        return;
+      }
       workingFilters.userTypes = [...newFilters.userTypes];
       workingFilters.classes = [...newFilters.classes];
       workingFilters.birthYear.start = newFilters.birthYearStart;
@@ -141,6 +153,13 @@ export default function useUsersFilters({ classes }) {
   const applyFilters = ({ nextRouteName } = {}) => {
     const nextQuery = { ...route.query };
     delete nextQuery.page; // Reset to the first page when applying filters
+
+    if (workingFilters.by_ids.length) {
+      nextQuery.by_ids = workingFilters.by_ids.join(',');
+      return router.push({ ...route, name: nextRouteName || route.name, query: nextQuery });
+    } else {
+      delete nextQuery.by_ids;
+    }
 
     if (workingFilters.userTypes.length) {
       nextQuery.user_types = workingFilters.userTypes.join(',');
@@ -219,6 +238,7 @@ export default function useUsersFilters({ classes }) {
     workingFilters.birthYear.start = null;
     workingFilters.birthYear.end = null;
     workingFilters.creationDate = {};
+    workingFilters.by_id = [];
   };
 
   const resetFilters = () => {

--- a/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
@@ -41,10 +41,10 @@ export default function useUsersFilters({ classes }) {
   });
 
   const numAppliedFilters = computed(() => {
-    if (routeFilters.value.by_ids?.length) {
-      return 1;
-    }
     let count = 0;
+    if (routeFilters.value.by_ids.length) {
+      count += 1;
+    }
     if (routeFilters.value.userTypes.length) {
       count += 1;
     }
@@ -124,13 +124,7 @@ export default function useUsersFilters({ classes }) {
   watch(
     routeFilters,
     newFilters => {
-      if (workingFilters.by_ids?.length) {
-        // If we're filtering by by_ids, it's programmatic navigation
-        // so we will clear all existing filters and set the ids alone
-        resetWorkingFilters();
-        workingFilters.by_ids = newFilters.by_ids;
-        return;
-      }
+      workingFilters.by_ids = [...newFilters.by_ids];
       workingFilters.userTypes = [...newFilters.userTypes];
       workingFilters.classes = [...newFilters.classes];
       workingFilters.birthYear.start = newFilters.birthYearStart;
@@ -156,7 +150,6 @@ export default function useUsersFilters({ classes }) {
 
     if (workingFilters.by_ids.length) {
       nextQuery.by_ids = workingFilters.by_ids.join(',');
-      return router.push({ ...route, name: nextRouteName || route.name, query: nextQuery });
     } else {
       delete nextQuery.by_ids;
     }
@@ -238,7 +231,7 @@ export default function useUsersFilters({ classes }) {
     workingFilters.birthYear.start = null;
     workingFilters.birthYear.end = null;
     workingFilters.creationDate = {};
-    workingFilters.by_id = [];
+    workingFilters.by_ids = [];
   };
 
   const resetFilters = () => {

--- a/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
+++ b/kolibri/plugins/facility/assets/src/composables/useUsersFilters.js
@@ -124,7 +124,7 @@ export default function useUsersFilters({ classes }) {
   watch(
     routeFilters,
     newFilters => {
-      if(workingFilters.by_ids?.length) {
+      if (workingFilters.by_ids?.length) {
         // If we're filtering by by_ids, it's programmatic navigation
         // so we will clear all existing filters and set the ids alone
         resetWorkingFilters();

--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -25,11 +25,6 @@ export const PageNames = {
   ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS: 'ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS',
 };
 
-export const InvalidActionTypes = {
-  ASSIGN: 'assign',
-  ENROLL: 'enroll',
-};
-
 // modal names
 export const Modals = {
   CREATE_CLASS: 'CREATE_CLASS',

--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -25,10 +25,9 @@ export const PageNames = {
   ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS: 'ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS',
 };
 
-
 export const InvalidActionTypes = {
-  ASSIGN: "assign",
-  ENROLL: "enroll",
+  ASSIGN: 'assign',
+  ENROLL: 'enroll',
 };
 
 // modal names

--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -25,6 +25,12 @@ export const PageNames = {
   ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS: 'ENROLL_LEARNERS_SIDE_PANEL__NEW_USERS',
 };
 
+
+export const InvalidActionTypes = {
+  ASSIGN: "assign",
+  ENROLL: "enroll",
+};
+
 // modal names
 export const Modals = {
   CREATE_CLASS: 'CREATE_CLASS',

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
@@ -1,12 +1,10 @@
-import client from 'kolibri/client';
-import urls from 'kolibri/urls';
+import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
+import RoleResource from 'kolibri-common/apiResources/RoleResource';
 import { UserKinds } from 'kolibri/constants';
 import uniq from 'lodash/uniq';
 
-export async function enrollLearnersInClass(store, { classId, users }) {
-  return client({
-    url: urls['kolibri:core:membership_list'](),
-    method: 'POST',
+export async function enrollLearnersInClass(_, { classId, users }) {
+  return MembershipResource.saveCollection({
     data: uniq(users).map(userId => ({
       collection: classId,
       user: userId,
@@ -14,10 +12,8 @@ export async function enrollLearnersInClass(store, { classId, users }) {
   });
 }
 
-export async function assignCoachesToClass(store, { classId, coaches }) {
-  return client({
-    url: urls['kolibri:core:role_list'](),
-    method: 'POST',
+export async function assignCoachesToClass(_, { classId, coaches }) {
+  return RoleResource.saveCollection({
     data: uniq(coaches).map(userId => ({
       collection: classId,
       user: userId,

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
@@ -1,13 +1,12 @@
-import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
-import RoleResource from 'kolibri-common/apiResources/RoleResource';
+import client from 'kolibri/client';
+import urls from 'kolibri/urls';
 import { UserKinds } from 'kolibri/constants';
 import uniq from 'lodash/uniq';
 
-export function enrollLearnersInClass(store, { classId, users }) {
-  return MembershipResource.saveCollection({
-    getParams: {
-      collection: classId,
-    },
+export async function enrollLearnersInClass(store, { classId, users }) {
+  return client({
+    url: urls['kolibri:core:membership_list'](),
+    method: 'POST',
     data: uniq(users).map(userId => ({
       collection: classId,
       user: userId,
@@ -15,11 +14,10 @@ export function enrollLearnersInClass(store, { classId, users }) {
   });
 }
 
-export function assignCoachesToClass(store, { classId, coaches }) {
-  return RoleResource.saveCollection({
-    getParams: {
-      collection: classId,
-    },
+export async function assignCoachesToClass(store, { classId, coaches }) {
+  return client({
+    url: urls['kolibri:core:role_list'](),
+    method: 'POST',
     data: uniq(coaches).map(userId => ({
       collection: classId,
       user: userId,

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -29,6 +29,8 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import ClassEnrollForm from './ClassEnrollForm';
+  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import useActionWithUndo from '../composables/useActionWithUndo';
 
   export default {
     name: 'CoachClassAssignmentPage',
@@ -44,7 +46,16 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      return { createSnackbar };
+      const {
+        someLearnersEnrolledNotice$,
+        coachesAllAssignedNotice$,
+        someCoachesAssignedNotice$,
+      } = bulkUserManagementStrings;
+      return {
+        someCoachesAssignedNotice$,
+        coachesAllAssignedNotice$,
+        createSnackbar,
+      };
     },
     data() {
       return {
@@ -68,13 +79,17 @@
       assignCoaches(coaches) {
         this.formIsDisabled = true;
         this.assignCoachesToClass({ classId: this.class.id, coaches })
-          .then(() => {
-            // do this in action?
+          .then(response => {
+            const { created, invalid } = response.data;
+            if(created?.length) {
+              if(invalid?.length) {
+                this.createSnackbar(this.someCoachesAssignedNotice$());
+              } else {
+                this.createSnackbar(this.coachesAllAssignedNotice$());
+              }
+            }
             this.$router
               .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))
-              .then(() => {
-                this.showSnackbarNotification('coachesAssignedNoCount', { count: coaches.length });
-              });
           })
           .catch(() => {
             this.formIsDisabled = false;

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -45,10 +45,9 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const { coachesAllAssignedNotice$, someCoachesAssignedNotice$ } = bulkUserManagementStrings;
+      const { someCoachesAssignedNotice$ } = bulkUserManagementStrings;
       return {
         someCoachesAssignedNotice$,
-        coachesAllAssignedNotice$,
         createSnackbar,
       };
     },
@@ -76,17 +75,25 @@
         this.assignCoachesToClass({ classId: this.class.id, coaches })
           .then(response => {
             const { created, invalid } = response.data;
-            if (created?.length) {
-              if (invalid?.length) {
-                this.createSnackbar(this.someCoachesAssignedNotice$());
-              } else {
-                this.createSnackbar(this.coachesAllAssignedNotice$());
-              }
-            }
-            if (invalid?.length) {
-              this.createSnackbar(this.noCoachesAssigned$());
-            }
-            this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id));
+            this.$router
+              .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))
+              .then(() => {
+                if (created?.length) {
+                  if (invalid?.length) {
+                    // Partial success
+                    this.createSnackbar(this.someCoachesAssignedNotice$());
+                  } else {
+                    // Full success
+                    this.showSnackbarNotification('coachesAssignedNoCount', {
+                      count: created.length,
+                    });
+                  }
+                } else {
+                  // Whether we have invalid or not, if we haven't created any role assignments,
+                  // we should say "no coaches assigned".
+                  this.createSnackbar(this.noCoachesAssigned$());
+                }
+              });
           })
           .catch(() => {
             this.formIsDisabled = false;

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -83,6 +83,9 @@
                 this.createSnackbar(this.coachesAllAssignedNotice$());
               }
             }
+            if (invalid?.length) {
+              this.createSnackbar(this.noCoachesAssigned$());
+            }
             this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id));
           })
           .catch(() => {

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -28,9 +28,9 @@
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import ClassEnrollForm from './ClassEnrollForm';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useActionWithUndo from '../composables/useActionWithUndo';
+  import ClassEnrollForm from './ClassEnrollForm';
 
   export default {
     name: 'CoachClassAssignmentPage',
@@ -46,11 +46,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const {
-        someLearnersEnrolledNotice$,
-        coachesAllAssignedNotice$,
-        someCoachesAssignedNotice$,
-      } = bulkUserManagementStrings;
+      const { someLearnersEnrolledNotice$, coachesAllAssignedNotice$, someCoachesAssignedNotice$ } =
+        bulkUserManagementStrings;
       return {
         someCoachesAssignedNotice$,
         coachesAllAssignedNotice$,
@@ -81,15 +78,14 @@
         this.assignCoachesToClass({ classId: this.class.id, coaches })
           .then(response => {
             const { created, invalid } = response.data;
-            if(created?.length) {
-              if(invalid?.length) {
+            if (created?.length) {
+              if (invalid?.length) {
                 this.createSnackbar(this.someCoachesAssignedNotice$());
               } else {
                 this.createSnackbar(this.coachesAllAssignedNotice$());
               }
             }
-            this.$router
-              .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))
+            this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id));
           })
           .catch(() => {
             this.formIsDisabled = false;

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -29,7 +29,6 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
-  import useActionWithUndo from '../composables/useActionWithUndo';
   import ClassEnrollForm from './ClassEnrollForm';
 
   export default {
@@ -46,8 +45,7 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const { someLearnersEnrolledNotice$, coachesAllAssignedNotice$, someCoachesAssignedNotice$ } =
-        bulkUserManagementStrings;
+      const { coachesAllAssignedNotice$, someCoachesAssignedNotice$ } = bulkUserManagementStrings;
       return {
         someCoachesAssignedNotice$,
         coachesAllAssignedNotice$,

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -45,9 +45,10 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const { someCoachesAssignedNotice$ } = bulkUserManagementStrings;
+      const { noCoachesAssigned$, someCoachesAssignedNotice$ } = bulkUserManagementStrings;
       return {
         someCoachesAssignedNotice$,
+        noCoachesAssigned$,
         createSnackbar,
       };
     },

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -45,10 +45,9 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const { usersEnrolledNotice$, someLearnersEnrolledNotice$ } = bulkUserManagementStrings;
+      const { someLearnersEnrolledNotice$ } = bulkUserManagementStrings;
       return {
         createSnackbar,
-        usersEnrolledNotice$,
         someLearnersEnrolledNotice$,
       };
     },
@@ -80,22 +79,25 @@
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
           .then(response => {
             const { created, invalid } = response.data;
-            if (created?.length) {
-              if (invalid?.length) {
-                this.createSnackbar(this.someLearnersEnrolledNotice$());
-              } else {
-                this.createSnackbar(this.usersEnrolledNotice$());
-              }
-              if (invalid?.length) {
-                this.createSnackbar(this.noLearnersEnrolled$());
-              }
-            }
             this.$router
               .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))
               .then(() => {
-                this.showSnackbarNotification('learnersEnrolledNoCount', {
-                  count: selectedUsers.length,
-                });
+                if (created?.length) {
+                  if (invalid?.length) {
+                    // Patrial success - some users were unable to be enrolled
+                    // For example, if a user has been assigned as a coach to the class
+                    // after this page loaded
+                    this.createSnackbar(this.someLearnersEnrolledNotice$());
+                  } else {
+                    this.showSnackbarNotification('learnersEnrolledNoCount', {
+                      count: created.length,
+                    });
+                  }
+                } else {
+                  // Whether we have invalid or not, if we haven't created any memberships
+                  // we should say "no learners enrolled"
+                  this.createSnackbar(this.noLearnersEnrolled$());
+                }
               });
           })
           .catch(() => {

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -28,6 +28,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import ClassEnrollForm from './ClassEnrollForm';
 
   export default {
@@ -44,7 +45,15 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      return { createSnackbar };
+      const {
+        usersEnrolledNotice$,
+        someLearnersEnrolledNotice$,
+      } = bulkUserManagementStrings;
+      return {
+        createSnackbar,
+        usersEnrolledNotice$,
+        someLearnersEnrolledNotice$,
+      };
     },
     data() {
       return {
@@ -72,7 +81,15 @@
           window.localStorage.setItem(`${welcomeDismissalKey}-${id}`, false);
         });
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
-          .then(() => {
+          .then(response => {
+            const { created, invalid } = response.data;
+            if(created?.length) {
+              if(invalid?.length) {
+                this.createSnackbar(this.someLearnersEnrolledNotice$());
+              } else {
+                this.createSnackbar(this.usersEnrolledNotice$());
+              }
+            }
             this.$router
               .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))
               .then(() => {

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -45,8 +45,9 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const { someLearnersEnrolledNotice$ } = bulkUserManagementStrings;
+      const { noLearnersEnrolled$, someLearnersEnrolledNotice$ } = bulkUserManagementStrings;
       return {
+        noLearnersEnrolled$,
         createSnackbar,
         someLearnersEnrolledNotice$,
       };

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -45,10 +45,7 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
-      const {
-        usersEnrolledNotice$,
-        someLearnersEnrolledNotice$,
-      } = bulkUserManagementStrings;
+      const { usersEnrolledNotice$, someLearnersEnrolledNotice$ } = bulkUserManagementStrings;
       return {
         createSnackbar,
         usersEnrolledNotice$,
@@ -83,8 +80,8 @@
         this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
           .then(response => {
             const { created, invalid } = response.data;
-            if(created?.length) {
-              if(invalid?.length) {
+            if (created?.length) {
+              if (invalid?.length) {
                 this.createSnackbar(this.someLearnersEnrolledNotice$());
               } else {
                 this.createSnackbar(this.usersEnrolledNotice$());

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -86,6 +86,9 @@
               } else {
                 this.createSnackbar(this.usersEnrolledNotice$());
               }
+              if (invalid?.length) {
+                this.createSnackbar(this.noLearnersEnrolled$());
+              }
             }
             this.$router
               .push(this.$store.getters.facilityPageLinks.ClassEditPage(this.class.id))

--- a/kolibri/plugins/facility/assets/src/views/common/ClassCopyModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/common/ClassCopyModal.vue
@@ -131,7 +131,7 @@
         });
       }
 
-      function assignLearnersToClass() {
+      function enrollLearnersToClass() {
         if (!copyAllLearners.value || !classLearnerIds.value.length) return Promise.resolve();
         return MembershipResource.saveCollection({
           data: classLearnerIds.value.map(learnerId => ({
@@ -145,7 +145,7 @@
         loading.value = true;
         try {
           await createClass();
-          await Promise.all([assignCoachesToClass(), assignLearnersToClass()]);
+          await Promise.all([assignCoachesToClass(), enrollLearnersToClass()]);
 
           // Update createdClass obj with copied data if necessary
           if (copyAllCoaches.value) {

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -373,10 +373,6 @@
       // Alerting users about enrollment/assignment errors
       const alertDismissed = ref(false);
 
-      function handleAlertDismissal() {
-        alertDismissed.value = true;
-      }
-
       const showingInvalidUsers = computed(
         () => !alertDismissed.value && Boolean(route.query.by_ids),
       );

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -231,7 +231,7 @@
   import usePagination from '../../composables/usePagination';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
-  import { InvalidActionTypes, PageNames } from '../../constants';
+  import { ClassesActions, PageNames } from '../../constants';
   import { overrideRoute } from '../../utils';
   import UsersTable from './common/UsersTable.vue';
   import UsersTableToolbar from './common/UsersTableToolbar/index.vue';
@@ -370,13 +370,17 @@
         fetchClasses();
       });
 
-      const showingInvalidUsers = computed(() => Boolean(route.query.by_ids));
+      const failedAction = ref(null);
+
+      const showingInvalidUsers = computed(() => {
+        return Boolean(route.query.by_ids) && Boolean(failedAction.value);
+      });
 
       const warningMessage = computed(() => {
-        switch (route.query?.failedActionType) {
-          case InvalidActionTypes.ASSIGN:
+        switch (failedAction.value) {
+          case ClassesActions.ASSIGN_COACH:
             return someFailedToAssign$();
-          case InvalidActionTypes.ENROLL:
+          case ClassesActions.ENROLL_LEARNER:
             return someFailedToEnroll$();
           default:
             return '';

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -139,6 +139,15 @@
                 :numFilteredItems="usersCount"
               />
             </template>
+            <template #alert>
+              <UiAlert
+                v-if="showingInvalidUsers"
+                type="warning"
+                :dismissible="false"
+              >
+                {{ warningMessage }}
+              </UiAlert>
+            </template>
           </UsersTableToolbar>
         </div>
         <UsersTable
@@ -186,6 +195,7 @@
         :selectedUsers="selectedUsers"
         :onBlur="onModalBlur"
         :onChange="onChange"
+        @clearSelection="clearSelectedUsers"
       />
 
       <!-- Modals -->
@@ -211,18 +221,17 @@
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
-
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
-
   import { UserKinds } from 'kolibri/constants';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useUsersTableSearch from '../../composables/useUsersTableSearch';
   import usePagination from '../../composables/usePagination';
   import useUserManagement from '../../composables/useUserManagement';
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
-  import { PageNames } from '../../constants';
+  import { InvalidActionTypes, PageNames } from '../../constants';
   import { overrideRoute } from '../../utils';
   import UsersTable from './common/UsersTable.vue';
   import UsersTableToolbar from './common/UsersTableToolbar/index.vue';
@@ -240,6 +249,7 @@
       MoveToTrashModal,
       FilterTextbox,
       PaginationActions,
+      UiAlert,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -312,6 +322,8 @@
         filterLabel$,
         numUsersSelected$,
         clearFiltersLabel$,
+        someFailedToAssign$,
+        someFailedToEnroll$,
       } = bulkUserManagementStrings;
 
       function clearSelectedUsers() {
@@ -358,7 +370,30 @@
         fetchClasses();
       });
 
+      // Alerting users about enrollment/assignment errors
+      const alertDismissed = ref(false)
+
+      function handleAlertDismissal() {
+        alertDismissed.value = true
+      }
+
+      const showingInvalidUsers = computed(() => !alertDismissed.value && Boolean(route.query.by_ids));
+      const warningMessage = computed(
+        () => {
+          switch(route.query?.failedActionType) {
+            case(InvalidActionTypes.ASSIGN):
+              return someFailedToAssign$();
+            case(InvalidActionTypes.ENROLL):
+              return someFailedToEnroll$();
+            default:
+              return '';
+          }
+        }
+      );
+
       return {
+        warningMessage,
+        showingInvalidUsers,
         usersTableStyles,
         // Route utilities
         overrideRoute,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -371,25 +371,25 @@
       });
 
       // Alerting users about enrollment/assignment errors
-      const alertDismissed = ref(false)
+      const alertDismissed = ref(false);
 
       function handleAlertDismissal() {
-        alertDismissed.value = true
+        alertDismissed.value = true;
       }
 
-      const showingInvalidUsers = computed(() => !alertDismissed.value && Boolean(route.query.by_ids));
-      const warningMessage = computed(
-        () => {
-          switch(route.query?.failedActionType) {
-            case(InvalidActionTypes.ASSIGN):
-              return someFailedToAssign$();
-            case(InvalidActionTypes.ENROLL):
-              return someFailedToEnroll$();
-            default:
-              return '';
-          }
-        }
+      const showingInvalidUsers = computed(
+        () => !alertDismissed.value && Boolean(route.query.by_ids),
       );
+      const warningMessage = computed(() => {
+        switch (route.query?.failedActionType) {
+          case InvalidActionTypes.ASSIGN:
+            return someFailedToAssign$();
+          case InvalidActionTypes.ENROLL:
+            return someFailedToEnroll$();
+          default:
+            return '';
+        }
+      });
 
       return {
         warningMessage,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -196,6 +196,7 @@
         :onBlur="onModalBlur"
         :onChange="onChange"
         @clearSelection="clearSelectedUsers"
+        @failedAction="val => (failedAction = val)"
       />
 
       <!-- Modals -->
@@ -391,6 +392,7 @@
         warningMessage,
         showingInvalidUsers,
         usersTableStyles,
+        failedAction,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/NewUsersPage.vue
@@ -370,12 +370,8 @@
         fetchClasses();
       });
 
-      // Alerting users about enrollment/assignment errors
-      const alertDismissed = ref(false);
+      const showingInvalidUsers = computed(() => Boolean(route.query.by_ids));
 
-      const showingInvalidUsers = computed(
-        () => !alertDismissed.value && Boolean(route.query.by_ids),
-      );
       const warningMessage = computed(() => {
         switch (route.query?.failedActionType) {
           case InvalidActionTypes.ASSIGN:

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -99,6 +99,7 @@
               />
             </template>
             <template #userActions>
+
               <KIconButton
                 ref="assignButton"
                 icon="assignCoaches"
@@ -156,6 +157,15 @@
                 :numFilteredItems="usersCount"
               />
             </template>
+            <template #alert>
+              <UiAlert
+                v-if="showingInvalidUsers"
+                type="warning"
+                :dismissible="false"
+              >
+                {{ warningMessage }}
+              </UiAlert>
+            </template>
           </UsersTableToolbar>
         </div>
         <UsersTable
@@ -201,6 +211,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useUser from 'kolibri/composables/useUser';
   import { UserKinds } from 'kolibri/constants';
@@ -208,7 +219,7 @@
   import UsersTableToolbar from '../common/UsersTableToolbar/index.vue';
   import useUserManagement from '../../../composables/useUserManagement';
   import FacilityAppBarPage from '../../FacilityAppBarPage';
-  import { PageNames } from '../../../constants';
+  import { InvalidActionTypes, PageNames } from '../../../constants';
   import UsersTable from '../common/UsersTable.vue';
   import { overrideRoute } from '../../../utils';
   import MoveToTrashModal from '../common/MoveToTrashModal.vue';
@@ -228,6 +239,7 @@
       MoveToTrashModal,
       FacilityAppBarPage,
       FilterTextbox,
+      UiAlert,
       PaginationActions,
     },
     mixins: [commonCoreStrings],
@@ -252,7 +264,10 @@
         filterLabel$,
         numUsersSelected$,
         clearFiltersLabel$,
+        someFailedToAssign$,
+        someFailedToEnroll$,
       } = bulkUserManagementStrings;
+
 
       const { $store, $router } = getCurrentInstance().proxy;
       const activeFacilityId =
@@ -344,7 +359,32 @@
         return {};
       });
 
+
+      // Alerting users about enrollment/assignment errors
+      const alertDismissed = ref(false)
+
+      function handleAlertDismissal() {
+        alertDismissed.value = true
+      }
+
+      const showingInvalidUsers = computed(() => !alertDismissed.value && Boolean(route.query.by_ids));
+      const warningMessage = computed(
+        () => {
+          switch(route.query?.failedActionType) {
+            case(InvalidActionTypes.ASSIGN):
+              return someFailedToAssign$();
+            case(InvalidActionTypes.ENROLL):
+              return someFailedToEnroll$();
+            default:
+              return '';
+          }
+        }
+      );
+
       return {
+        handleAlertDismissal,
+        warningMessage,
+        showingInvalidUsers,
         windowIsSmall,
         usersTableStyles,
         // Route utilities
@@ -487,6 +527,12 @@
         }
       },
     },
+    beforeRouteLeave(to,__,next) {
+      this.alertDismissed = false;
+      const { query } = to;
+      delete query.failedActionType;
+      next(this.overrideRoute(to, { query }))
+    }
   };
 
 </script>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -304,7 +304,9 @@
       }
 
       function navigateToSidePanel(sidePanelName) {
-        const newRoute = overrideRoute(route, { name: sidePanelName });
+        const { query } = route;
+        delete query.failedActionType;
+        const newRoute = overrideRoute(route, { name: sidePanelName, query });
         router.push(newRoute);
       }
 
@@ -359,15 +361,12 @@
         return {};
       });
 
-
-      // Alerting users about enrollment/assignment errors
-      const alertDismissed = ref(false)
-
-      function handleAlertDismissal() {
-        alertDismissed.value = true
-      }
-
-      const showingInvalidUsers = computed(() => !alertDismissed.value && Boolean(route.query.by_ids));
+      const showingInvalidUsers = computed(() => {
+        return (
+          Boolean(route.query.by_ids) &&
+          Boolean(route.query.failedActionType)
+        );
+      });
       const warningMessage = computed(
         () => {
           switch(route.query?.failedActionType) {
@@ -376,13 +375,13 @@
             case(InvalidActionTypes.ENROLL):
               return someFailedToEnroll$();
             default:
+              // When the page loads
               return '';
           }
         }
       );
 
       return {
-        handleAlertDismissal,
         warningMessage,
         showingInvalidUsers,
         windowIsSmall,
@@ -527,12 +526,6 @@
         }
       },
     },
-    beforeRouteLeave(to,__,next) {
-      this.alertDismissed = false;
-      const { query } = to;
-      delete query.failedActionType;
-      next(this.overrideRoute(to, { query }))
-    }
   };
 
 </script>

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -99,7 +99,6 @@
               />
             </template>
             <template #userActions>
-
               <KIconButton
                 ref="assignButton"
                 icon="assignCoaches"
@@ -268,7 +267,6 @@
         someFailedToEnroll$,
       } = bulkUserManagementStrings;
 
-
       const { $store, $router } = getCurrentInstance().proxy;
       const activeFacilityId =
         $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
@@ -362,24 +360,19 @@
       });
 
       const showingInvalidUsers = computed(() => {
-        return (
-          Boolean(route.query.by_ids) &&
-          Boolean(route.query.failedActionType)
-        );
+        return Boolean(route.query.by_ids) && Boolean(route.query.failedActionType);
       });
-      const warningMessage = computed(
-        () => {
-          switch(route.query?.failedActionType) {
-            case(InvalidActionTypes.ASSIGN):
-              return someFailedToAssign$();
-            case(InvalidActionTypes.ENROLL):
-              return someFailedToEnroll$();
-            default:
-              // When the page loads
-              return '';
-          }
+      const warningMessage = computed(() => {
+        switch (route.query?.failedActionType) {
+          case InvalidActionTypes.ASSIGN:
+            return someFailedToAssign$();
+          case InvalidActionTypes.ENROLL:
+            return someFailedToEnroll$();
+          default:
+            // When the page loads
+            return '';
         }
-      );
+      });
 
       return {
         warningMessage,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -184,6 +184,7 @@
           :onBlur="onModalBlur"
           :onChange="onChange"
           @clearSelection="clearSelectedUsers"
+          @failedAction="val => (failedAction = val)"
         />
 
         <!-- Modals -->
@@ -218,7 +219,7 @@
   import UsersTableToolbar from '../common/UsersTableToolbar/index.vue';
   import useUserManagement from '../../../composables/useUserManagement';
   import FacilityAppBarPage from '../../FacilityAppBarPage';
-  import { InvalidActionTypes, PageNames } from '../../../constants';
+  import { ClassesActions, PageNames } from '../../../constants';
   import UsersTable from '../common/UsersTable.vue';
   import { overrideRoute } from '../../../utils';
   import MoveToTrashModal from '../common/MoveToTrashModal.vue';
@@ -357,18 +358,19 @@
         return {};
       });
 
+      const failedAction = ref(null);
+
       const showingInvalidUsers = computed(() => {
-        return Boolean(route.query.by_ids) && Boolean(route.query.failedActionType);
+        return Boolean(route.query.by_ids) && Boolean(failedAction.value);
       });
 
       const warningMessage = computed(() => {
-        switch (route.query?.failedActionType) {
-          case InvalidActionTypes.ASSIGN:
+        switch (failedAction.value) {
+          case ClassesActions.ASSIGN_COACH:
             return someFailedToAssign$();
-          case InvalidActionTypes.ENROLL:
+          case ClassesActions.ENROLL_LEARNER:
             return someFailedToEnroll$();
           default:
-            // When the page loads
             return '';
         }
       });
@@ -378,6 +380,7 @@
         showingInvalidUsers,
         windowIsSmall,
         usersTableStyles,
+        failedAction,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/UsersRootPage/index.vue
@@ -302,9 +302,7 @@
       }
 
       function navigateToSidePanel(sidePanelName) {
-        const { query } = route;
-        delete query.failedActionType;
-        const newRoute = overrideRoute(route, { name: sidePanelName, query });
+        const newRoute = overrideRoute(route, { name: sidePanelName });
         router.push(newRoute);
       }
 
@@ -362,6 +360,7 @@
       const showingInvalidUsers = computed(() => {
         return Boolean(route.query.by_ids) && Boolean(route.query.failedActionType);
       });
+
       const warningMessage = computed(() => {
         switch (route.query?.failedActionType) {
           case InvalidActionTypes.ASSIGN:

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/NormalLayout.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/NormalLayout.vue
@@ -32,6 +32,7 @@
       </div>
       <slot name="paginationControls"></slot>
     </div>
+    <div><slot name="alert"></slot></div>
   </div>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/SmallWindowLayout.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/SmallWindowLayout.vue
@@ -43,6 +43,7 @@
       </div>
       <slot name="paginationControls"></slot>
     </div>
+    <div><slot name="alert"></slot></div>
     <div
       v-if="showUsersTable"
       :style="{

--- a/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/common/UsersTableToolbar/index.vue
@@ -27,6 +27,9 @@
     <template #paginationControls>
       <slot name="paginationControls"></slot>
     </template>
+    <template #alert>
+      <slot name="alert"></slot>
+    </template>
   </component>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -158,7 +158,6 @@
 
       const {
         coachesAllAssignedNotice$,
-        coachesAllInvalidNotice$,
         someFailedToAssign$,
         someCoachesAssignedNotice$,
         assignCoachUndoneNotice$,
@@ -344,7 +343,6 @@
         ineligibleUsersCount,
         showErrorWarning,
         defaultErrorMessage$,
-        someFailedToAssign$,
         usersInClassNotAffected$,
         assignAction$,
         searchForAClass$,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -124,7 +124,7 @@
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
-  import { InvalidActionTypes, PageNames } from '../../../constants.js';
+  import { ClassesActions, PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import SelectableList from '../../common/SelectableList.vue';
   import { _userState } from '../../../modules/mappers';
@@ -137,7 +137,7 @@
       SelectableList,
       CloseConfirmationGuard,
     },
-    setup(props) {
+    setup(props, { emit }) {
       const selectedClasses = ref([]); // Array of selected class IDs
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
@@ -239,17 +239,18 @@
             resetSelection: true,
           });
           if (invalidRoles.value.length) {
+            emit('failedAction', ClassesActions.ASSIGN_COACH);
             router.push(
               overrideRoute(route, {
                 name: getRootRouteName(route),
                 query: {
                   by_ids: invalidRoles.value.map(r => r.user).join(','),
-                  failedActionType: InvalidActionTypes.ASSIGN,
                 },
               }),
             );
             return true;
           } else {
+            emit('failedAction', null);
             closeSidePanel();
             return true;
           }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -116,6 +116,8 @@
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import { UserKinds } from 'kolibri/constants';
+  import client from 'kolibri/client';
+  import urls from 'kolibri/urls';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
@@ -140,6 +142,7 @@
       const isLoading = ref(false);
       const showErrorWarning = ref(false);
       const createdRoles = ref(null);
+      const invalidRoles = ref(null);
       const facilityUsers = ref([]);
       const route = useRoute();
       const closeConfirmationGuardRef = ref(null);
@@ -153,7 +156,9 @@
       });
 
       const {
-        coachesAssignedNotice$,
+        coachesAllAssignedNotice$,
+        coachesAllInvalidNotice$,
+        coachesSomeInvalidNotice$,
         assignCoachUndoneNotice$,
         usersInClassNotAffected$,
         assignAction$,
@@ -259,13 +264,19 @@
           })),
         );
 
-        const newRoles = await RoleResource.saveCollection({
+        // Errors will be caught in _handleAssign
+        const response = await client({
+          url: urls['kolibri:core:role_list'](),
+          method: 'POST',
           data: roleData,
         });
 
+        const { created, invalid } = response.data;
+
         // Only add roles that were actually created (have an id)
-        const actuallyCreatedRoles = newRoles.filter(role => role.id);
+        const actuallyCreatedRoles = created.filter(role => role.id);
         createdRoles.value = actuallyCreatedRoles;
+        invalidRoles.value = invalid || [];
       }
 
       async function handleUndoAssignments() {
@@ -278,12 +289,24 @@
         }
       }
 
+      const snackbarMessage$ = () => {
+        if(createdRoles.value.length) {
+          if(invalidRoles.value.length) {
+            return coachesSomeInvalidNotice$();
+          } else {
+            return coachesAllAssignedNotice$();
+          }
+        }
+        return coachesAllInvalidNotice$();
+      };
+
       const { performAction: handleAssign } = useActionWithUndo({
         action: _handleAssign,
-        actionNotice$: coachesAssignedNotice$,
+        actionNotice$: snackbarMessage$,
         undoAction: handleUndoAssignments,
         undoActionNotice$: assignCoachUndoneNotice$,
         onBlur: props.onBlur,
+        canUndo: computed(() => createdRoles.value.length),
       });
 
       function closeSidePanel() {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -239,18 +239,15 @@
             affectedClasses: selectedClasses.value,
             resetSelection: true,
           });
-          if(invalidRoles.value.length) {
+          if (invalidRoles.value.length) {
             router.push(
-              overrideRoute(
-                route,
-                {
-                  name: getRootRouteName(route),
-                  query: {
-                    by_ids: invalidRoles.value.map(r => r.user).join(','),
-                    failedActionType: InvalidActionTypes.ASSIGN,
-                  },
+              overrideRoute(route, {
+                name: getRootRouteName(route),
+                query: {
+                  by_ids: invalidRoles.value.map(r => r.user).join(','),
+                  failedActionType: InvalidActionTypes.ASSIGN,
                 },
-              )
+              }),
             );
             return true;
           } else {
@@ -298,7 +295,7 @@
         invalidRoles.value = invalid || [];
       }
 
-      const canUndo = computed(() => createdRoles.value?.length)
+      const canUndo = computed(() => createdRoles.value?.length);
 
       async function handleUndoAssignments() {
         if (createdRoles.value?.length > 0) {
@@ -311,14 +308,14 @@
       }
 
       const snackbarMessage$ = () => {
-        if(createdRoles.value?.length) {
-          if(invalidRoles.value?.length) {
+        if (createdRoles.value?.length) {
+          if (invalidRoles.value?.length) {
             return someCoachesAssignedNotice$();
           } else {
             return coachesAllAssignedNotice$();
           }
         }
-        if(invalidRoles.value?.length) {
+        if (invalidRoles.value?.length) {
           return someFailedToAssign$();
         }
       };

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -112,7 +112,7 @@
 <script>
 
   import { ref, computed } from 'vue';
-  import { useRoute } from 'vue-router/composables';
+  import { useRouter, useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import { UserKinds } from 'kolibri/constants';
@@ -124,7 +124,7 @@
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
-  import { PageNames } from '../../../constants.js';
+  import { InvalidActionTypes, PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import SelectableList from '../../common/SelectableList.vue';
   import { _userState } from '../../../modules/mappers';
@@ -145,6 +145,7 @@
       const invalidRoles = ref(null);
       const facilityUsers = ref([]);
       const route = useRoute();
+      const router = useRouter();
       const closeConfirmationGuardRef = ref(null);
 
       const goBack = useGoBack({
@@ -158,7 +159,8 @@
       const {
         coachesAllAssignedNotice$,
         coachesAllInvalidNotice$,
-        coachesSomeInvalidNotice$,
+        unableToAssignAlert$,
+        someCoachesAssignedNotice$,
         assignCoachUndoneNotice$,
         usersInClassNotAffected$,
         assignAction$,
@@ -237,8 +239,24 @@
             affectedClasses: selectedClasses.value,
             resetSelection: true,
           });
-          closeSidePanel();
-          return true;
+          if(invalidRoles.value.length) {
+            router.push(
+              overrideRoute(
+                route,
+                {
+                  name: getRootRouteName(route),
+                  query: {
+                    by_ids: invalidRoles.value.map(r => r.user).join(','),
+                    failedActionType: InvalidActionTypes.ASSIGN,
+                  },
+                },
+              )
+            );
+            return true;
+          } else {
+            closeSidePanel();
+            return true;
+          }
         } catch (error) {
           showErrorWarning.value = true;
           isLoading.value = false;
@@ -275,12 +293,15 @@
 
         // Only add roles that were actually created (have an id)
         const actuallyCreatedRoles = created.filter(role => role.id);
+
         createdRoles.value = actuallyCreatedRoles;
         invalidRoles.value = invalid || [];
       }
 
+      const canUndo = computed(() => createdRoles.value?.length)
+
       async function handleUndoAssignments() {
-        if (createdRoles.value.length > 0) {
+        if (createdRoles.value?.length > 0) {
           const roleIds = createdRoles.value.map(role => role.id);
           await RoleResource.deleteCollection({ by_ids: roleIds });
           props.onChange({
@@ -290,14 +311,16 @@
       }
 
       const snackbarMessage$ = () => {
-        if(createdRoles.value.length) {
-          if(invalidRoles.value.length) {
-            return coachesSomeInvalidNotice$();
+        if(createdRoles.value?.length) {
+          if(invalidRoles.value?.length) {
+            return someCoachesAssignedNotice$();
           } else {
             return coachesAllAssignedNotice$();
           }
         }
-        return coachesAllInvalidNotice$();
+        if(invalidRoles.value?.length) {
+          return unableToAssignAlert$();
+        }
       };
 
       const { performAction: handleAssign } = useActionWithUndo({
@@ -306,7 +329,7 @@
         undoAction: handleUndoAssignments,
         undoActionNotice$: assignCoachUndoneNotice$,
         onBlur: props.onBlur,
-        canUndo: computed(() => createdRoles.value.length),
+        canUndo,
       });
 
       function closeSidePanel() {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -159,7 +159,7 @@
       const {
         coachesAllAssignedNotice$,
         coachesAllInvalidNotice$,
-        unableToAssignAlert$,
+        someFailedToAssign$,
         someCoachesAssignedNotice$,
         assignCoachUndoneNotice$,
         usersInClassNotAffected$,
@@ -347,6 +347,7 @@
         ineligibleUsersCount,
         showErrorWarning,
         defaultErrorMessage$,
+        someFailedToAssign$,
         usersInClassNotAffected$,
         assignAction$,
         searchForAClass$,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -319,7 +319,7 @@
           }
         }
         if(invalidRoles.value?.length) {
-          return unableToAssignAlert$();
+          return someFailedToAssign$();
         }
       };
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -116,8 +116,6 @@
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import { UserKinds } from 'kolibri/constants';
-  import client from 'kolibri/client';
-  import urls from 'kolibri/urls';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
@@ -280,12 +278,7 @@
         );
 
         // Errors will be caught in _handleAssign
-        const response = await client({
-          url: urls['kolibri:core:role_list'](),
-          method: 'POST',
-          data: roleData,
-        });
-
+        const response = await RoleResource.saveCollection({ data: roleData });
         const { created, invalid } = response.data;
 
         // Only add roles that were actually created (have an id)

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -113,6 +113,8 @@
 
 <script>
 
+  import client from 'kolibri/client';
+  import urls from 'kolibri/urls';
   import { useRoute } from 'vue-router/composables';
   import { getCurrentInstance, ref, computed } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
@@ -152,6 +154,7 @@
       const classLearners = ref([]);
       const classMembershipsByUser = ref({});
       const createdMemberships = ref(null);
+      const invalidMemberships = ref(null);
       const {
         enrollAction$,
         discardAction$,
@@ -163,6 +166,8 @@
         enrollUndoneNotice$,
         enrollInAllClasses$,
         usersEnrolledNotice$,
+        usersEnrolledSomeInvalidNotice$,
+        usersEnrolledAllInvalidNotice$,
         defaultErrorMessage$,
         numUsersNotEnrolled$,
         enrollUsersInClasses$,
@@ -222,9 +227,16 @@
         });
         if (enrollments.length > 0) {
           try {
-            const newMemberships = await MembershipResource.saveCollection({ data: enrollments });
-            createdMemberships.value = newMemberships;
+            const response = await client({
+              url: urls['kolibri:core:membership_list'](),
+              method: 'POST',
+              data: enrollments,
+            });
+            const { created, invalid } = response.data;
+            createdMemberships.value = created;
+            invalidMemberships.value = invalid;
           } catch (error) {
+            console.log(error);
             store.dispatch('handleApiError', { error });
             loading.value = false;
             return false;
@@ -233,6 +245,7 @@
           // Setting an empty array to flag that the operation was successful and no users
           // were enrolled
           createdMemberships.value = [];
+          invalidMemberships.value = [];
         }
         props.onChange({
           affectedClasses: selectedOptions.value,
@@ -242,12 +255,24 @@
         return true;
       }
 
+      const snackbarMessage$ = () => {
+        if(createdMemberships.value.length) {
+          if(invalidMemberships.value.length) {
+            return usersEnrolledSomeInvalidNotice$();
+          } else {
+            return usersEnrolledNotice$();
+          }
+        }
+        return usersEnrolledAllInvalidNotice$();
+      };
+
       const { performAction: enrollLearners } = useActionWithUndo({
         action: _enrollLearners,
-        actionNotice$: usersEnrolledNotice$,
+        actionNotice$: snackbarMessage$,
         undoAction: handleUndoEnrollments,
         undoActionNotice$: enrollUndoneNotice$,
         onBlur: props.onBlur,
+        canUndo: computed(() => invalidMemberships.value),
       });
 
       function closeSidePanel() {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -137,7 +137,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props, { emit }) {
+    setup(props) {
       const store = getCurrentInstance().proxy.$store;
       const route = useRoute();
       const router = useRouter();
@@ -252,7 +252,6 @@
                   },
                 }),
               );
-              emit('clearSelection');
               return true;
             }
           } catch (error) {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -240,24 +240,23 @@
 
             // nextTick to give the hasUnsavedChanges a chance to react
             // so that the confirmation guard doesn't trigger in this case
-            return nextTick(() => {
-              // This doesn't need to be done in the assign side panel but IDK for sure why
-              if (invalid) {
-                router.push(
-                  overrideRoute(route, {
-                    name: getRootRouteName(route),
-                    query: {
-                      by_ids: invalidMemberships.value.map(r => r.user).join(','),
-                      failedActionType: InvalidActionTypes.ENROLL,
-                    },
-                  }),
-                );
-                emit('clearSelection');
-                return true;
-              } else {
-                return true;
-              }
-            });
+            await nextTick();
+            // This doesn't need to be done in the assign side panel but IDK for sure why
+            if (invalid) {
+              router.push(
+                overrideRoute(route, {
+                  name: getRootRouteName(route),
+                  query: {
+                    by_ids: invalidMemberships.value.map(r => r.user).join(','),
+                    failedActionType: InvalidActionTypes.ENROLL,
+                  },
+                }),
+              );
+              emit('clearSelection');
+              return true;
+            } else {
+              return true;
+            }
           } catch (error) {
             store.dispatch('handleApiError', { error });
             loading.value = false;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -163,7 +163,7 @@
         discardChanges$,
         searchForAClass$,
         someLearnersEnrolledNotice$,
-        unableToEnrollAlert$,
+        someFailedToEnroll$,
         keepEditingAction$,
         selectClassesLabel$,
         enrollUndoneNotice$,
@@ -286,7 +286,7 @@
           }
         }
         if(invalidRoles.value?.length) {
-          return unableToEnrollAlert$();
+          return someFailedToEnroll$();
         }
       };
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -236,7 +236,6 @@
             createdMemberships.value = created;
             invalidMemberships.value = invalid;
           } catch (error) {
-            console.log(error);
             store.dispatch('handleApiError', { error });
             loading.value = false;
             return false;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -254,8 +254,6 @@
               );
               emit('clearSelection');
               return true;
-            } else {
-              return true;
             }
           } catch (error) {
             store.dispatch('handleApiError', { error });

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -223,8 +223,7 @@
       async function _enrollLearners() {
         loading.value = true;
         const enrollments = selectedOptions.value.flatMap(collection_id => {
-          return Array.from(props.selectedUsers)
-            .map(user => ({ collection: collection_id, user }));
+          return Array.from(props.selectedUsers).map(user => ({ collection: collection_id, user }));
         });
         if (enrollments.length > 0) {
           try {
@@ -243,18 +242,15 @@
             // so that the confirmation guard doesn't trigger in this case
             return nextTick(() => {
               // This doesn't need to be done in the assign side panel but IDK for sure why
-              if(Boolean(invalid)) {
+              if (invalid) {
                 router.push(
-                  overrideRoute(
-                    route,
-                    {
-                      name: getRootRouteName(route),
-                      query: {
-                        by_ids: invalidMemberships.value.map(r => r.user).join(','),
-                        failedActionType: InvalidActionTypes.ENROLL,
-                      },
+                  overrideRoute(route, {
+                    name: getRootRouteName(route),
+                    query: {
+                      by_ids: invalidMemberships.value.map(r => r.user).join(','),
+                      failedActionType: InvalidActionTypes.ENROLL,
                     },
-                  )
+                  }),
                 );
                 emit('clearSelection');
                 return true;
@@ -282,19 +278,19 @@
       }
 
       const snackbarMessage$ = () => {
-        if(createdMemberships.value?.length) {
-          if(invalidMemberships.value?.length) {
+        if (createdMemberships.value?.length) {
+          if (invalidMemberships.value?.length) {
             return someLearnersEnrolledNotice$();
           } else {
             return usersEnrolledNotice$();
           }
         }
-        if(invalidMemberships.value?.length) {
+        if (invalidMemberships.value?.length) {
           return someFailedToEnroll$();
         }
       };
 
-      const canUndo = computed(() => createdMemberships.value?.length)
+      const canUndo = computed(() => createdMemberships.value?.length);
 
       const { performAction: enrollLearners } = useActionWithUndo({
         action: _enrollLearners,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -137,14 +137,17 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props) {
+    setup(props, { emit }) {
       const store = getCurrentInstance().proxy.$store;
       const route = useRoute();
       const router = useRouter();
       const goBack = useGoBack({
         getFallbackRoute: () => {
+          const { query } = route;
+          delete query.failedActionType;
           return overrideRoute(route, {
             name: getRootRouteName(route),
+            query,
           });
         },
       });
@@ -220,7 +223,6 @@
       async function _enrollLearners() {
         loading.value = true;
         const enrollments = selectedOptions.value.flatMap(collection_id => {
-          const alreadyEnrolled = classMembershipsByUser.value;
           return Array.from(props.selectedUsers)
             .map(user => ({ collection: collection_id, user }));
         });
@@ -239,9 +241,10 @@
 
             // nextTick to give the hasUnsavedChanges a chance to react
             // so that the confirmation guard doesn't trigger in this case
-            nextTick(() => {
-              if(invalid?.length) {
-                return router.push(
+            return nextTick(() => {
+              // This doesn't need to be done in the assign side panel but IDK for sure why
+              if(Boolean(invalid)) {
+                router.push(
                   overrideRoute(
                     route,
                     {
@@ -253,8 +256,9 @@
                     },
                   )
                 );
+                emit('clearSelection');
+                return true;
               } else {
-                goBack();
                 return true;
               }
             });
@@ -285,7 +289,7 @@
             return usersEnrolledNotice$();
           }
         }
-        if(invalidRoles.value?.length) {
+        if(invalidMemberships.value?.length) {
           return someFailedToEnroll$();
         }
       };

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -113,8 +113,6 @@
 
 <script>
 
-  import client from 'kolibri/client';
-  import urls from 'kolibri/urls';
   import { useRouter, useRoute } from 'vue-router/composables';
   import { getCurrentInstance, ref, computed, nextTick } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
@@ -224,12 +222,7 @@
         });
         if (enrollments.length > 0) {
           try {
-            const response = await client({
-              url: urls['kolibri:core:membership_list'](),
-              method: 'POST',
-              data: enrollments,
-            });
-
+            const response = await MembershipResource.saveCollection({ data: enrollments });
             const { created, invalid } = response.data;
 
             createdMemberships.value = created;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -125,7 +125,7 @@
   import groupBy from 'lodash/groupBy';
   import SelectableList from '../../common/SelectableList.vue';
   import useActionWithUndo from '../../../composables/useActionWithUndo';
-  import { InvalidActionTypes, PageNames } from '../../../constants.js';
+  import { ClassesActions, PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
 
@@ -137,17 +137,14 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props) {
+    setup(props, { emit }) {
       const store = getCurrentInstance().proxy.$store;
       const route = useRoute();
       const router = useRouter();
       const goBack = useGoBack({
         getFallbackRoute: () => {
-          const { query } = route;
-          delete query.failedActionType;
           return overrideRoute(route, {
             name: getRootRouteName(route),
-            query,
           });
         },
       });
@@ -243,12 +240,12 @@
             await nextTick();
             // This doesn't need to be done in the assign side panel but IDK for sure why
             if (invalid) {
+              emit('failedAction', ClassesActions.ENROLL_LEARNER);
               router.push(
                 overrideRoute(route, {
                   name: getRootRouteName(route),
                   query: {
                     by_ids: invalidMemberships.value.map(r => r.user).join(','),
-                    failedActionType: InvalidActionTypes.ENROLL,
                   },
                 }),
               );
@@ -262,6 +259,7 @@
         } else {
           // Setting an empty array to flag that the operation was successful and no users
           // were enrolled
+          emit('failedAction', null);
           createdMemberships.value = [];
           invalidMemberships.value = [];
         }

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -115,8 +115,8 @@
 
   import client from 'kolibri/client';
   import urls from 'kolibri/urls';
-  import { useRoute } from 'vue-router/composables';
-  import { getCurrentInstance, ref, computed } from 'vue';
+  import { useRouter, useRoute } from 'vue-router/composables';
+  import { getCurrentInstance, ref, computed, nextTick } from 'vue';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
@@ -125,7 +125,7 @@
   import groupBy from 'lodash/groupBy';
   import SelectableList from '../../common/SelectableList.vue';
   import useActionWithUndo from '../../../composables/useActionWithUndo';
-  import { PageNames } from '../../../constants.js';
+  import { InvalidActionTypes, PageNames } from '../../../constants.js';
   import { getRootRouteName, overrideRoute } from '../../../utils';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
 
@@ -140,6 +140,7 @@
     setup(props) {
       const store = getCurrentInstance().proxy.$store;
       const route = useRoute();
+      const router = useRouter();
       const goBack = useGoBack({
         getFallbackRoute: () => {
           return overrideRoute(route, {
@@ -161,13 +162,13 @@
         discardWarning$,
         discardChanges$,
         searchForAClass$,
+        someLearnersEnrolledNotice$,
+        unableToEnrollAlert$,
         keepEditingAction$,
         selectClassesLabel$,
         enrollUndoneNotice$,
         enrollInAllClasses$,
         usersEnrolledNotice$,
-        usersEnrolledSomeInvalidNotice$,
-        usersEnrolledAllInvalidNotice$,
         defaultErrorMessage$,
         numUsersNotEnrolled$,
         enrollUsersInClasses$,
@@ -193,7 +194,8 @@
       });
 
       const hasUnsavedChanges = computed(() => {
-        if (createdMemberships.value) {
+        // If either of these are not empty, then the enroll action has been taken
+        if (createdMemberships.value || invalidMemberships.value) {
           return false;
         }
         return selectedOptions.value.length > 0;
@@ -220,9 +222,6 @@
         const enrollments = selectedOptions.value.flatMap(collection_id => {
           const alreadyEnrolled = classMembershipsByUser.value;
           return Array.from(props.selectedUsers)
-            .filter(
-              userId => !(alreadyEnrolled[userId] || []).some(m => m.collection === collection_id),
-            )
             .map(user => ({ collection: collection_id, user }));
         });
         if (enrollments.length > 0) {
@@ -232,9 +231,33 @@
               method: 'POST',
               data: enrollments,
             });
+
             const { created, invalid } = response.data;
+
             createdMemberships.value = created;
             invalidMemberships.value = invalid;
+
+            // nextTick to give the hasUnsavedChanges a chance to react
+            // so that the confirmation guard doesn't trigger in this case
+            nextTick(() => {
+              if(invalid?.length) {
+                return router.push(
+                  overrideRoute(
+                    route,
+                    {
+                      name: getRootRouteName(route),
+                      query: {
+                        by_ids: invalidMemberships.value.map(r => r.user).join(','),
+                        failedActionType: InvalidActionTypes.ENROLL,
+                      },
+                    },
+                  )
+                );
+              } else {
+                goBack();
+                return true;
+              }
+            });
           } catch (error) {
             store.dispatch('handleApiError', { error });
             loading.value = false;
@@ -255,15 +278,19 @@
       }
 
       const snackbarMessage$ = () => {
-        if(createdMemberships.value.length) {
-          if(invalidMemberships.value.length) {
-            return usersEnrolledSomeInvalidNotice$();
+        if(createdMemberships.value?.length) {
+          if(invalidMemberships.value?.length) {
+            return someLearnersEnrolledNotice$();
           } else {
             return usersEnrolledNotice$();
           }
         }
-        return usersEnrolledAllInvalidNotice$();
+        if(invalidRoles.value?.length) {
+          return unableToEnrollAlert$();
+        }
       };
+
+      const canUndo = computed(() => createdMemberships.value?.length)
 
       const { performAction: enrollLearners } = useActionWithUndo({
         action: _enrollLearners,
@@ -271,7 +298,7 @@
         undoAction: handleUndoEnrollments,
         undoActionNotice$: enrollUndoneNotice$,
         onBlur: props.onBlur,
-        canUndo: computed(() => invalidMemberships.value),
+        canUndo,
       });
 
       function closeSidePanel() {

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -118,9 +118,9 @@
 
 <script>
 
-  import { ref, computed, onMounted, nextTick } from 'vue';
+  import { ref, computed, onMounted } from 'vue';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { useRouter, useRoute } from 'vue-router/composables';
+  import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
@@ -143,7 +143,7 @@
       CloseConfirmationGuard,
     },
     mixins: [commonCoreStrings],
-    setup(props) {
+    setup(props, { emit }) {
       const closeConfirmationGuardRef = ref(null);
       const showErrorWarning = ref(false);
       const selectedOptions = ref([]);
@@ -154,7 +154,6 @@
       const removedLearnerMemberships = ref([]);
       const removedCoachRoles = ref([]);
       const route = useRoute();
-      const router = useRouter();
       const {
         numUsersCoaches$,
         searchForAClass$,
@@ -319,19 +318,10 @@
           props.onChange({
             affectedClasses: selectedOptions.value,
           });
-          if (route.query.failedActionType) {
-            const { query } = route;
-            delete query.failedActionType;
-            await nextTick();
-            router.push(
-              overrideRoute(route, {
-                name: getRootRouteName(route),
-                query,
-              }),
-            );
-          } else {
-            goBack();
-          }
+
+          // Clears failed action notification
+          emit('failedAction', null);
+          goBack();
           return true;
         } catch (error) {
           showErrorWarning.value = true;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -118,9 +118,9 @@
 
 <script>
 
-  import { ref, computed, onMounted } from 'vue';
+  import { ref, computed, onMounted, nextTick } from 'vue';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { useRoute } from 'vue-router/composables';
+  import { useRouter, useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
@@ -154,6 +154,7 @@
       const removedLearnerMemberships = ref([]);
       const removedCoachRoles = ref([]);
       const route = useRoute();
+      const router = useRouter();
       const {
         numUsersCoaches$,
         searchForAClass$,
@@ -318,7 +319,19 @@
           props.onChange({
             affectedClasses: selectedOptions.value,
           });
-          goBack();
+          if (route.query.failedActionType) {
+            const { query } = route;
+            delete query.failedActionType;
+            await nextTick();
+            router.push(
+              overrideRoute(route, {
+                name: getRootRouteName(route),
+                query,
+              }),
+            );
+          } else {
+            goBack();
+          }
           return true;
         } catch (error) {
           showErrorWarning.value = true;

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -147,20 +147,19 @@
 <script>
 
   import store from 'kolibri/store';
-  import client from 'kolibri/client';
-  import urls from 'kolibri/urls';
   import { ref, computed, nextTick, onBeforeMount, getCurrentInstance } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import notificationStrings from 'kolibri/uiText/notificationStrings';
+  import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+  import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
   import GenderSelect from 'kolibri-common/components/userAccounts/GenderSelect';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-  import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import { UserKinds, ERROR_CONSTANTS, DemographicConstants } from 'kolibri/constants';
   import BirthYearSelect from 'kolibri-common/components/userAccounts/BirthYearSelect';
   import FullNameTextbox from 'kolibri-common/components/userAccounts/FullNameTextbox';
@@ -356,19 +355,13 @@
       };
 
       const enrollLearnerInClasses = (userId, classIds) => {
-        return client({
-          url: urls['kolibri:core:membership_list'](),
-          method: 'POST',
+        return MembershipResource.saveCollection({
           data: classIds.map(cid => ({ collection: cid, user: userId })),
         });
       };
 
       const assignCoachToClasses = (userId, classIds) => {
-        // The endpoint still expects COACH for the kind when assigning,
-        // even if the user's facility role is an admin
-        return client({
-          url: urls['kolibri:core:role_list'](),
-          method: 'POST',
+        return RoleResource.saveCollection({
           data: classIds.map(cid => ({ collection: cid, user: userId, kind: UserKinds.COACH })),
         });
       };

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -366,16 +366,10 @@
       const assignCoachToClasses = (userId, classIds) => {
         // The endpoint still expects COACH for the kind when assigning,
         // even if the user's facility role is an admin
-        let kind;
-        if (newUserRole.value === UserKinds.ADMIN) {
-          kind = UserKinds.COACH;
-        } else {
-          kind = newUserRole.value;
-        }
         return client({
           url: urls['kolibri:core:role_list'](),
           method: 'POST',
-          data: classIds.map(cid => ({ collection: cid, user: userId, kind })),
+          data: classIds.map(cid => ({ collection: cid, user: userId, kind: UserKinds.COACH })),
         });
       };
 

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -147,6 +147,8 @@
 <script>
 
   import store from 'kolibri/store';
+  import client from 'kolibri/client';
+  import urls from 'kolibri/urls';
   import { ref, computed, nextTick, onBeforeMount, getCurrentInstance } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import CatchErrors from 'kolibri/utils/CatchErrors';
@@ -157,7 +159,6 @@
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import ExtraDemographics from 'kolibri-common/components/ExtraDemographics';
   import GenderSelect from 'kolibri-common/components/userAccounts/GenderSelect';
-  import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import { UserKinds, ERROR_CONSTANTS, DemographicConstants } from 'kolibri/constants';
@@ -331,7 +332,6 @@
 
       const handleSubmitSuccess = () => {
         createSnackbar(notificationStrings.userCreated$());
-        props.onChange();
       };
 
       const handleSubmitFailure = error => {
@@ -356,21 +356,26 @@
       };
 
       const enrollLearnerInClasses = (userId, classIds) => {
-        return MembershipResource.saveCollection({
-          data: classIds.map(classId => ({
-            collection: classId,
-            user: userId,
-          })),
+        return client({
+          url: urls['kolibri:core:membership_list'](),
+          method: 'POST',
+          data: classIds.map(cid => ({ collection: cid, user: userId })),
         });
       };
 
       const assignCoachToClasses = (userId, classIds) => {
-        return RoleResource.saveCollection({
-          data: classIds.map(classId => ({
-            collection: classId,
-            user: userId,
-            kind: UserKinds.COACH,
-          })),
+        // The endpoint still expects COACH for the kind when assigning,
+        // even if the user's facility role is an admin
+        let kind;
+        if (newUserRole.value === UserKinds.ADMIN) {
+          kind = UserKinds.COACH;
+        } else {
+          kind = newUserRole.value;
+        }
+        return client({
+          url: urls['kolibri:core:role_list'](),
+          method: 'POST',
+          data: classIds.map(cid => ({ collection: cid, user: userId, kind })),
         });
       };
 
@@ -400,6 +405,9 @@
           } else {
             await enrollLearnerInClasses(facilityUser.id, selectedClasses.value);
           }
+          // affectedClasses null here to force users reload, even if classes are
+          // affected
+          props.onChange({ affectedClasses: null });
         }
       };
 
@@ -469,6 +477,7 @@
         passwordValid,
         gender,
         birthYear,
+        showErrorWarning,
         extraDemographics,
         idNumber,
         loading,

--- a/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/users/sidePanels/UserCreate/index.vue
@@ -399,10 +399,10 @@
           } else {
             await enrollLearnerInClasses(facilityUser.id, selectedClasses.value);
           }
-          // affectedClasses null here to force users reload, even if classes are
-          // affected
-          props.onChange({ affectedClasses: null });
         }
+        // affectedClasses null here to force users reload, even if classes are
+        // affected
+        props.onChange({ affectedClasses: null });
       };
 
       const submitForm = async () => {

--- a/packages/kolibri-common/apiResources/MembershipResource.js
+++ b/packages/kolibri-common/apiResources/MembershipResource.js
@@ -1,4 +1,5 @@
 import { Resource } from 'kolibri/apiResource';
+import client from 'kolibri/client';
 
 /**
  * @example Get all memberships for a given user
@@ -6,4 +7,12 @@ import { Resource } from 'kolibri/apiResource';
  */
 export default new Resource({
   name: 'membership',
+  saveCollection({ data = [], getParams = {} } = {}) {
+    return client({
+      url: this.collectionUrl(),
+      method: 'POST',
+      params: getParams,
+      data,
+    });
+  },
 });

--- a/packages/kolibri-common/apiResources/RoleResource.js
+++ b/packages/kolibri-common/apiResources/RoleResource.js
@@ -1,5 +1,14 @@
 import { Resource } from 'kolibri/apiResource';
+import client from 'kolibri/client';
 
 export default new Resource({
   name: 'role',
+  saveCollection({ data = [], getParams = {} } = {}) {
+    return client({
+      url: this.collectionUrl(),
+      method: 'POST',
+      params: getParams,
+      data,
+    });
+  },
 });

--- a/packages/kolibri-common/apiResources/__tests__/MembershipResource.spec.js
+++ b/packages/kolibri-common/apiResources/__tests__/MembershipResource.spec.js
@@ -1,0 +1,187 @@
+import client from 'kolibri/client';
+import MembershipResource from '../MembershipResource';
+
+jest.mock('kolibri/client');
+jest.mock('kolibri/urls');
+
+describe('MembershipResource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveCollection', () => {
+    it('should call client with POST method to collectionUrl', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1' }];
+      const mockResponse = {
+        data: { created: [{ id: 'membership1', user: 'user1', collection: 'class1' }] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await MembershipResource.saveCollection({ data: mockData });
+
+      expect(client).toHaveBeenCalledTimes(1);
+      expect(client).toHaveBeenCalledWith({
+        url: MembershipResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: mockData,
+      });
+    });
+
+    it('should handle successful response with 201 status', async () => {
+      const mockData = [
+        { user: 'user1', collection: 'class1' },
+        { user: 'user2', collection: 'class1' },
+      ];
+      const mockResponse = {
+        data: {
+          created: [
+            { id: 'membership1', user: 'user1', collection: 'class1' },
+            { id: 'membership2', user: 'user2', collection: 'class1' },
+          ],
+        },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await MembershipResource.saveCollection({ data: mockData });
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe(201);
+      expect(result.data.created).toHaveLength(2);
+    });
+
+    it('should handle partial success response with 207 status', async () => {
+      const mockData = [
+        { user: 'user1', collection: 'class1' },
+        { user: 'user2', collection: 'class1' },
+      ];
+      const mockResponse = {
+        data: {
+          created: [{ id: 'membership1', user: 'user1', collection: 'class1' }],
+          failed: [{ user: 'user2', collection: 'class1', error: 'Already exists' }],
+        },
+        status: 207,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await MembershipResource.saveCollection({ data: mockData });
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe(207);
+      expect(result.data.created).toHaveLength(1);
+      expect(result.data.failed).toHaveLength(1);
+    });
+
+    it('should pass getParams to client', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1' }];
+      const mockGetParams = { user_id: 'user1' };
+      const mockResponse = {
+        data: { created: [{ id: 'membership1', user: 'user1', collection: 'class1' }] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await MembershipResource.saveCollection({ data: mockData, getParams: mockGetParams });
+
+      expect(client).toHaveBeenCalledWith({
+        url: MembershipResource.collectionUrl(),
+        method: 'POST',
+        params: mockGetParams,
+        data: mockData,
+      });
+    });
+
+    it('should handle empty data array', async () => {
+      const mockResponse = {
+        data: { created: [] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await MembershipResource.saveCollection({ data: [] });
+
+      expect(client).toHaveBeenCalledWith({
+        url: MembershipResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: [],
+      });
+      expect(result.data.created).toHaveLength(0);
+    });
+
+    it('should handle client errors', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1' }];
+      const mockError = {
+        response: { status: 500, data: { error: 'Server error' } },
+      };
+
+      client.mockRejectedValue(mockError);
+
+      await expect(MembershipResource.saveCollection({ data: mockData })).rejects.toEqual(
+        mockError,
+      );
+    });
+
+    it('should use default values when no parameters provided', async () => {
+      const mockResponse = {
+        data: { created: [] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await MembershipResource.saveCollection();
+
+      expect(client).toHaveBeenCalledWith({
+        url: MembershipResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: [],
+      });
+    });
+  });
+
+  describe('saveModel', () => {
+    it('should use default Resource behavior for creating new model', async () => {
+      const mockData = { user: 'user1', collection: 'class1' };
+      const mockResponse = {
+        data: { id: 'membership1', ...mockData },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await MembershipResource.saveModel({ data: mockData });
+
+      expect(client).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    });
+
+    it('should use default Resource behavior for updating existing model', async () => {
+      const mockId = 'membership1';
+      const mockData = { collection: 'class2' };
+      const mockResponse = {
+        data: { id: mockId, user: 'user1', collection: 'class2' },
+        status: 200,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await MembershipResource.saveModel({
+        id: mockId,
+        data: mockData,
+        exists: true,
+      });
+
+      expect(client).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/kolibri-common/apiResources/__tests__/MembershipResource.spec.js
+++ b/packages/kolibri-common/apiResources/__tests__/MembershipResource.spec.js
@@ -30,53 +30,6 @@ describe('MembershipResource', () => {
       });
     });
 
-    it('should handle successful response with 201 status', async () => {
-      const mockData = [
-        { user: 'user1', collection: 'class1' },
-        { user: 'user2', collection: 'class1' },
-      ];
-      const mockResponse = {
-        data: {
-          created: [
-            { id: 'membership1', user: 'user1', collection: 'class1' },
-            { id: 'membership2', user: 'user2', collection: 'class1' },
-          ],
-        },
-        status: 201,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await MembershipResource.saveCollection({ data: mockData });
-
-      expect(result).toEqual(mockResponse);
-      expect(result.status).toBe(201);
-      expect(result.data.created).toHaveLength(2);
-    });
-
-    it('should handle partial success response with 207 status', async () => {
-      const mockData = [
-        { user: 'user1', collection: 'class1' },
-        { user: 'user2', collection: 'class1' },
-      ];
-      const mockResponse = {
-        data: {
-          created: [{ id: 'membership1', user: 'user1', collection: 'class1' }],
-          failed: [{ user: 'user2', collection: 'class1', error: 'Already exists' }],
-        },
-        status: 207,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await MembershipResource.saveCollection({ data: mockData });
-
-      expect(result).toEqual(mockResponse);
-      expect(result.status).toBe(207);
-      expect(result.data.created).toHaveLength(1);
-      expect(result.data.failed).toHaveLength(1);
-    });
-
     it('should pass getParams to client', async () => {
       const mockData = [{ user: 'user1', collection: 'class1' }];
       const mockGetParams = { user_id: 'user1' };
@@ -95,38 +48,6 @@ describe('MembershipResource', () => {
         params: mockGetParams,
         data: mockData,
       });
-    });
-
-    it('should handle empty data array', async () => {
-      const mockResponse = {
-        data: { created: [] },
-        status: 201,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await MembershipResource.saveCollection({ data: [] });
-
-      expect(client).toHaveBeenCalledWith({
-        url: MembershipResource.collectionUrl(),
-        method: 'POST',
-        params: {},
-        data: [],
-      });
-      expect(result.data.created).toHaveLength(0);
-    });
-
-    it('should handle client errors', async () => {
-      const mockData = [{ user: 'user1', collection: 'class1' }];
-      const mockError = {
-        response: { status: 500, data: { error: 'Server error' } },
-      };
-
-      client.mockRejectedValue(mockError);
-
-      await expect(MembershipResource.saveCollection({ data: mockData })).rejects.toEqual(
-        mockError,
-      );
     });
 
     it('should use default values when no parameters provided', async () => {

--- a/packages/kolibri-common/apiResources/__tests__/RoleResource.spec.js
+++ b/packages/kolibri-common/apiResources/__tests__/RoleResource.spec.js
@@ -30,53 +30,6 @@ describe('RoleResource', () => {
       });
     });
 
-    it('should handle successful response with 201 status', async () => {
-      const mockData = [
-        { user: 'user1', collection: 'class1', kind: 'coach' },
-        { user: 'user2', collection: 'class1', kind: 'coach' },
-      ];
-      const mockResponse = {
-        data: {
-          created: [
-            { id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' },
-            { id: 'role2', user: 'user2', collection: 'class1', kind: 'coach' },
-          ],
-        },
-        status: 201,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await RoleResource.saveCollection({ data: mockData });
-
-      expect(result).toEqual(mockResponse);
-      expect(result.status).toBe(201);
-      expect(result.data.created).toHaveLength(2);
-    });
-
-    it('should handle partial success response with 207 status', async () => {
-      const mockData = [
-        { user: 'user1', collection: 'class1', kind: 'coach' },
-        { user: 'user2', collection: 'class1', kind: 'coach' },
-      ];
-      const mockResponse = {
-        data: {
-          created: [{ id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' }],
-          failed: [{ user: 'user2', collection: 'class1', kind: 'coach', error: 'Already exists' }],
-        },
-        status: 207,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await RoleResource.saveCollection({ data: mockData });
-
-      expect(result).toEqual(mockResponse);
-      expect(result.status).toBe(207);
-      expect(result.data.created).toHaveLength(1);
-      expect(result.data.failed).toHaveLength(1);
-    });
-
     it('should pass getParams to client', async () => {
       const mockData = [{ user: 'user1', collection: 'class1', kind: 'coach' }];
       const mockGetParams = { facility: 'facility1' };
@@ -95,36 +48,6 @@ describe('RoleResource', () => {
         params: mockGetParams,
         data: mockData,
       });
-    });
-
-    it('should handle empty data array', async () => {
-      const mockResponse = {
-        data: { created: [] },
-        status: 201,
-      };
-
-      client.mockResolvedValue(mockResponse);
-
-      const result = await RoleResource.saveCollection({ data: [] });
-
-      expect(client).toHaveBeenCalledWith({
-        url: RoleResource.collectionUrl(),
-        method: 'POST',
-        params: {},
-        data: [],
-      });
-      expect(result.data.created).toHaveLength(0);
-    });
-
-    it('should handle client errors', async () => {
-      const mockData = [{ user: 'user1', collection: 'class1', kind: 'coach' }];
-      const mockError = {
-        response: { status: 500, data: { error: 'Server error' } },
-      };
-
-      client.mockRejectedValue(mockError);
-
-      await expect(RoleResource.saveCollection({ data: mockData })).rejects.toEqual(mockError);
     });
 
     it('should use default values when no parameters provided', async () => {

--- a/packages/kolibri-common/apiResources/__tests__/RoleResource.spec.js
+++ b/packages/kolibri-common/apiResources/__tests__/RoleResource.spec.js
@@ -1,0 +1,181 @@
+import client from 'kolibri/client';
+import RoleResource from '../RoleResource';
+
+jest.mock('kolibri/client');
+jest.mock('kolibri/urls');
+
+describe('RoleResource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveCollection', () => {
+    it('should call client with POST method to collectionUrl', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1', kind: 'coach' }];
+      const mockResponse = {
+        data: { created: [{ id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' }] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await RoleResource.saveCollection({ data: mockData });
+
+      expect(client).toHaveBeenCalledTimes(1);
+      expect(client).toHaveBeenCalledWith({
+        url: RoleResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: mockData,
+      });
+    });
+
+    it('should handle successful response with 201 status', async () => {
+      const mockData = [
+        { user: 'user1', collection: 'class1', kind: 'coach' },
+        { user: 'user2', collection: 'class1', kind: 'coach' },
+      ];
+      const mockResponse = {
+        data: {
+          created: [
+            { id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' },
+            { id: 'role2', user: 'user2', collection: 'class1', kind: 'coach' },
+          ],
+        },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await RoleResource.saveCollection({ data: mockData });
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe(201);
+      expect(result.data.created).toHaveLength(2);
+    });
+
+    it('should handle partial success response with 207 status', async () => {
+      const mockData = [
+        { user: 'user1', collection: 'class1', kind: 'coach' },
+        { user: 'user2', collection: 'class1', kind: 'coach' },
+      ];
+      const mockResponse = {
+        data: {
+          created: [{ id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' }],
+          failed: [{ user: 'user2', collection: 'class1', kind: 'coach', error: 'Already exists' }],
+        },
+        status: 207,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await RoleResource.saveCollection({ data: mockData });
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe(207);
+      expect(result.data.created).toHaveLength(1);
+      expect(result.data.failed).toHaveLength(1);
+    });
+
+    it('should pass getParams to client', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1', kind: 'coach' }];
+      const mockGetParams = { facility: 'facility1' };
+      const mockResponse = {
+        data: { created: [{ id: 'role1', user: 'user1', collection: 'class1', kind: 'coach' }] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await RoleResource.saveCollection({ data: mockData, getParams: mockGetParams });
+
+      expect(client).toHaveBeenCalledWith({
+        url: RoleResource.collectionUrl(),
+        method: 'POST',
+        params: mockGetParams,
+        data: mockData,
+      });
+    });
+
+    it('should handle empty data array', async () => {
+      const mockResponse = {
+        data: { created: [] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await RoleResource.saveCollection({ data: [] });
+
+      expect(client).toHaveBeenCalledWith({
+        url: RoleResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: [],
+      });
+      expect(result.data.created).toHaveLength(0);
+    });
+
+    it('should handle client errors', async () => {
+      const mockData = [{ user: 'user1', collection: 'class1', kind: 'coach' }];
+      const mockError = {
+        response: { status: 500, data: { error: 'Server error' } },
+      };
+
+      client.mockRejectedValue(mockError);
+
+      await expect(RoleResource.saveCollection({ data: mockData })).rejects.toEqual(mockError);
+    });
+
+    it('should use default values when no parameters provided', async () => {
+      const mockResponse = {
+        data: { created: [] },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      await RoleResource.saveCollection();
+
+      expect(client).toHaveBeenCalledWith({
+        url: RoleResource.collectionUrl(),
+        method: 'POST',
+        params: {},
+        data: [],
+      });
+    });
+  });
+
+  describe('saveModel', () => {
+    it('should use default Resource behavior for creating new model', async () => {
+      const mockData = { user: 'user1', collection: 'class1', kind: 'coach' };
+      const mockResponse = {
+        data: { id: 'role1', ...mockData },
+        status: 201,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await RoleResource.saveModel({ data: mockData });
+
+      expect(client).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    });
+
+    it('should use default Resource behavior for updating existing model', async () => {
+      const mockId = 'role1';
+      const mockData = { kind: 'admin' };
+      const mockResponse = {
+        data: { id: mockId, user: 'user1', collection: 'class1', kind: 'admin' },
+        status: 200,
+      };
+
+      client.mockResolvedValue(mockResponse);
+
+      const result = await RoleResource.saveModel({ id: mockId, data: mockData, exists: true });
+
+      expect(client).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -207,15 +207,11 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     message: 'Some learners enrolled succesfully, but some were not',
     context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
-  unableToEnrollAlert: {
-    message: 'The users shown were unable to be enrolled',
-    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
-  },
   someCoachesAssignedNotice: {
     message: 'Some coaches assigned succesfully, but some were not.',
     context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
-  unableToAssignAlert: {
+  someFailedToAssign: {
     message: 'The users shown were unable to be assigned.',
     context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -213,6 +213,16 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
     context:
       'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
+  noCoachesAssigned: {
+    message: 'No selected coaches could be assigned.',
+    context:
+      'The user has selected users who are unable to be assigned, an edge case possible if multiple tabs or people are working simultaneously.',
+  },
+  noLearnersEnrolled: {
+    message: 'No selected learners could be enrolled.',
+    context:
+      'The user has selected users who are unable to be enrolled, an edge case possible if multiple tabs or people are working simultaneously.',
+  },
   someFailedToAssign: {
     message: 'The users shown were unable to be assigned.',
     context:

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -205,19 +205,23 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   },
   someLearnersEnrolledNotice: {
     message: 'Some learners enrolled succesfully, but some were not',
-    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+    context:
+      'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
   someCoachesAssignedNotice: {
     message: 'Some coaches assigned succesfully, but some were not.',
-    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+    context:
+      'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
   someFailedToAssign: {
     message: 'The users shown were unable to be assigned.',
-    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+    context:
+      'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
   someFailedToEnroll: {
     message: 'The users shown were unable to be enrolled.',
-    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+    context:
+      'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
   assignCoachUndoneNotice: {
     message: 'Assign action has been undone',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -199,17 +199,29 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
 
   // Assign coaches to class
   coachesAllAssignedNotice: {
-    message: 'All selected coaches have been assigned',
+    message: 'Selected coaches have been assigned',
     context:
       'Success notification shown after coaches have been successfully assigned to users/classes.',
   },
-  coachesSomeInvalidNotice: {
-    message: 'Some selected coaches were assigned, but some selected users were not assigned because they are already enrolled in a selected class.',
-    context: 'Some of the user\'s selected coaches were assigned, but others were not because they are already enrolled in the class as a Learner.',
+  someLearnersEnrolledNotice: {
+    message: 'Some learners enrolled succesfully, but some were not',
+    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
-  coachesAllInvalidNotice: {
-    message: 'None of the selected coaches were assigned. Please check that they are not enrolled in the selected classes and try again.',
-    context: 'Some of the user\'s selected coaches were assigned, but others were not because they are already enrolled in the class as a Learner.',
+  unableToEnrollAlert: {
+    message: 'The users shown were unable to be enrolled',
+    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+  },
+  someCoachesAssignedNotice: {
+    message: 'Some coaches assigned succesfully, but some were not.',
+    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+  },
+  unableToAssignAlert: {
+    message: 'The users shown were unable to be assigned.',
+    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
+  },
+  someFailedToEnroll: {
+    message: 'The users shown were unable to be enrolled.',
+    context: 'Shown at the top of a table that is filtered to show the users which did not get assigned successfully',
   },
   assignCoachUndoneNotice: {
     message: 'Assign action has been undone',
@@ -284,14 +296,6 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   usersEnrolledNotice: {
     message: 'Selected users have been enrolled',
     context: 'Confirmation message when users are enrolled in classes',
-  },
-  usersEnrolledSomeInvalidNotice: {
-    message: 'Some selected users were enrolled. Some users were not enrolled because they are assigned as coaches.',
-    context: 'Some of the user\'s selected users were enrolled, but some were not due to their being assigned as coaches',
-  },
-  usersEnrolledAllInvalidNotice: {
-    message: 'None of the selected users were enrolled. Check that your selected users are not assigned as coaches to the selected classes and try again',
-    context: 'The user\'s selected users were not allowed to be enrolled because they are assigned as coaches to the selected classes.',
   },
   enrollUndoneNotice: {
     message: 'Enroll action has been undone',

--- a/packages/kolibri-common/strings/bulkUserManagementStrings.js
+++ b/packages/kolibri-common/strings/bulkUserManagementStrings.js
@@ -198,10 +198,18 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   },
 
   // Assign coaches to class
-  coachesAssignedNotice: {
-    message: 'Selected coaches have been assigned',
+  coachesAllAssignedNotice: {
+    message: 'All selected coaches have been assigned',
     context:
       'Success notification shown after coaches have been successfully assigned to users/classes.',
+  },
+  coachesSomeInvalidNotice: {
+    message: 'Some selected coaches were assigned, but some selected users were not assigned because they are already enrolled in a selected class.',
+    context: 'Some of the user\'s selected coaches were assigned, but others were not because they are already enrolled in the class as a Learner.',
+  },
+  coachesAllInvalidNotice: {
+    message: 'None of the selected coaches were assigned. Please check that they are not enrolled in the selected classes and try again.',
+    context: 'Some of the user\'s selected coaches were assigned, but others were not because they are already enrolled in the class as a Learner.',
   },
   assignCoachUndoneNotice: {
     message: 'Assign action has been undone',
@@ -276,6 +284,14 @@ export const bulkUserManagementStrings = createTranslator('BulkUserManagementStr
   usersEnrolledNotice: {
     message: 'Selected users have been enrolled',
     context: 'Confirmation message when users are enrolled in classes',
+  },
+  usersEnrolledSomeInvalidNotice: {
+    message: 'Some selected users were enrolled. Some users were not enrolled because they are assigned as coaches.',
+    context: 'Some of the user\'s selected users were enrolled, but some were not due to their being assigned as coaches',
+  },
+  usersEnrolledAllInvalidNotice: {
+    message: 'None of the selected users were enrolled. Check that your selected users are not assigned as coaches to the selected classes and try again',
+    context: 'The user\'s selected users were not allowed to be enrolled because they are assigned as coaches to the selected classes.',
   },
   enrollUndoneNotice: {
     message: 'Enroll action has been undone',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

_Work planned interactively with Claude Code (+superpowers),  some (mostly backend) code updates performed by Claude code._

Disallows in the API the ability to enroll a user to a class if they're already assigned to that class as a coach (or vice 
versa).

This maintains the same behavior of enrolling/assigning users through the Class Details page, where we are filtering out the users which are not permitted.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #13847 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->


#### Known issues 

- You should not see any error when you try to add a user who would not be added - the snackbar "users enrolled successfully" may not be 100% true, but it's not in scope here as UX writing review can help us poilsh this UX
- **Currently** there is just a message like "Users already in selected classes will not be affected" - we _may_ update some of this through the UX writing reviwe

#### Fixes the related issue

Basically, you should be able to use the bulk user management flows without issue such that if you try to assign/enroll a user who is not permitted to be assigned/enrolled _because they're already one or the other_. Users included in the selection are basically ignored/filtered out during the request to assign/enroll them - so there should be basically no effect on that user's relation to the class(es) selected.

- Test one user who should be ignored
- Test a selection with a mix of users - some who will certainly be enrolled/assigned and others who won't
- Test both of the above with 1 selected class, and when selecting multiple classes to assign/enroll them to
- Be sure to test both directions (ie, an admin enrolled as a learner cannot be then assigned as a coach, and vice versa). 