### PR TITLE
shows error message immediately the token entered fails

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
@@ -24,6 +24,7 @@
       :label="$tr('channelTokenLabel')"
       :invalid="!tokenIsValid"
       :invalidText="$tr('invalidTokenMessage')"
+      :showInvalidText="!tokenIsValid"
       autofocus
       :disabled="formIsDisabled || $attrs.disabled"
       autocapitalize="none"


### PR DESCRIPTION

## Summary
This PR fixes swallowing of error message on token modal
Closes[#13794](https://github.com/learningequality/kolibri/issues/13794)

## References
https://github.com/learningequality/kolibri/issues/13794
### Before
https://private-user-images.githubusercontent.com/17235236/495257926-ed151117-38f7-4829-9d66-b67edbf9a991.mov?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjE5MzU1MzYsIm5iZiI6MTc2MTkzNTIzNiwicGF0aCI6Ii8xNzIzNTIzNi80OTUyNTc5MjYtZWQxNTExMTctMzhmNy00ODI5LTlkNjYtYjY3ZWRiZjlhOTkxLm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMzElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDMxVDE4MjcxNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWI0OGMxNDM3MTk5ZTkwMjBhNGM0YWI4ZWI1ZmNiYmE2Mjg0Yzc4NzNjZmMwNjZjZjczNmEzOTU4YWI1Yjc0YjUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0._J8_lUU06ZIuQGIEM-Utcnrmh3wWTNj1r_hNLVKDTbU

### After
https://github.com/user-attachments/assets/b79f3eed-a9ac-4d5d-862c-57b6a2208ca8


## Reviewer guidance
1. Navigate to Device plugin > channels > Import studio
2. Enter an incorrect token
3. observe that the form field error only occurs when the field is active
