### PR TITLE
Use BEGIN IMMEDIATE for all SQLite transactions by default

### DIFF
--- a/kolibri/deployment/default/db/backends/sqlite3/base.py
+++ b/kolibri/deployment/default/db/backends/sqlite3/base.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+Custom SQLite3 database backend for Kolibri.
+
+This is a restricted backport of Django 5.2's ability to specify the kind of
+transaction to use. This allows us to use BEGIN IMMEDIATE transactions to improve
+concurrency behavior in SQLite databases, by acquiring write locks at transaction
+start rather than at the first write operation.
+Once Kolibri upgrades to Django 5.2 or later, this custom backend can be removed
+and the settings can revert to using "django.db.backends.sqlite3" directly.
+
+Django 5.2 added support for a transaction_mode option for SQLite, which allows
+specifying the transaction behavior (DEFERRED, IMMEDIATE, or EXCLUSIVE) without
+needing to override the database backend. We should switch to that option once we
+upgrade to Django 5.2+.
+
+See: https://docs.djangoproject.com/en/5.2/ref/databases/#sqlite-transaction-behavior
+"""
+from django.db.backends.sqlite3.base import (
+    DatabaseWrapper as DjangoSQLiteDatabaseWrapper,
+)
+
+
+class DatabaseWrapper(DjangoSQLiteDatabaseWrapper):
+    """
+    Custom SQLite3 database wrapper that uses BEGIN IMMEDIATE for transactions.
+    """
+
+    def _start_transaction_under_autocommit(self):
+        """
+        Start a transaction explicitly in autocommit mode.
+
+        Staying in autocommit mode works around a bug of sqlite3 that breaks
+        savepoints when autocommit is disabled.
+
+        Uses BEGIN IMMEDIATE instead of BEGIN to acquire write locks immediately,
+        improving concurrency behavior under high load.
+        """
+        self.cursor().execute("BEGIN IMMEDIATE")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -140,9 +140,12 @@ WSGI_APPLICATION = "kolibri.deployment.default.wsgi.application"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
+    # Using custom SQLite backend that uses BEGIN IMMEDIATE transactions.
+    # Once upgraded to Django 5.2+, revert to "django.db.backends.sqlite3" and use
+    # the transaction_mode option instead.
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.sqlite3",
+            "ENGINE": "kolibri.deployment.default.db.backends.sqlite3",
             "NAME": os.path.join(
                 conf.KOLIBRI_HOME,
                 conf.OPTIONS["Database"]["DATABASE_NAME"] or "db.sqlite3",
@@ -153,7 +156,7 @@ if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
 
     for additional_db in ADDITIONAL_SQLITE_DATABASES:
         DATABASES[additional_db] = {
-            "ENGINE": "django.db.backends.sqlite3",
+            "ENGINE": "kolibri.deployment.default.db.backends.sqlite3",
             "NAME": os.path.join(conf.KOLIBRI_HOME, "{}.sqlite3".format(additional_db)),
             "OPTIONS": {"timeout": 100},
         }


### PR DESCRIPTION
## Summary
Our assumptions about SQLite write concurrency have been that opening a transaction would wait for the write lock to be acquired, and that it would wait up until the 100s timeout that we have configured before raising a db locked error.
Unfortunately, this is not the case: https://forum.djangoproject.com/t/sqlite-and-database-is-locked-error/26994/6

Instead, because the default transaction type is DEFERRED, a write lock is not acquired when the transaction is opened, but only on the first _write_ operation. If a write lock cannot be acquired, SQLite does not respect the 100 second timeout, and instead immediately throws a DatabaseLocked error.

Our expectations are significantly better satisfied by the BEGIN IMMEDIATE transaction, which opens a write lock immediately when the transaction is opened. So, to make Kolibri behave the way we expect, this PR creates a custom SQLite database backend that implements this behaviour.

The possible downside to this is if we wrapped every request in an atomic transaction, so every request was acquring a write lock on the database - we do not use this Django option, so I think that is not an issue. However, we should continue not to use `ATOMIC_REQUESTS = True`. This may also cause some performance degradation if any parts of our codebase are opening transactions for long periods of time, but as this solves a critical issue for data collection, I think this is reasonable to move forward with for now.

## References
Running the locust load tests against this PR results in no failures:
<img width="1058" height="118" alt="image" src="https://github.com/user-attachments/assets/30cb8131-fd04-4a1f-ad3f-5fdfe8939685" />

This is in contrast to running without this fix that results in a relatively high percentage of failures, with all of them happening in the trackprogress endpoint, being indicative of potential data loss:
<img width="1136" height="126" alt="Screenshot From 2025-10-23 10-38-41" src="https://github.com/user-attachments/assets/1028d14d-1411-4c75-b253-673701b55ec1" />


## Reviewer guidance
Run the performance test.
Check the reported 503 during class copying is fixed by this.