### PR TITLE
Fix CopyClassModal handle removed coaches

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
@@ -41,6 +41,10 @@ export default {
     },
     DELETE_CLASS_COACH(state, id) {
       state.classCoaches = state.classCoaches.filter(user => user.id !== id);
+      // Note that we only do this here because we use `currentClass.coaches` when relevant,
+      // but there is no equivalent `currentClass.learners` - instead code uses `classLearners`
+      // where relevant. This is a bit of a stop-gap before this is converted away from Vuex
+      // in the near future.
       if (state.currentClass) {
         state.currentClass.coaches = state.currentClass.coaches.filter(u => u.id !== id);
       }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
@@ -41,6 +41,9 @@ export default {
     },
     DELETE_CLASS_COACH(state, id) {
       state.classCoaches = state.classCoaches.filter(user => user.id !== id);
+      if (state.currentClass) {
+        state.currentClass.coaches = state.currentClass.coaches.filter(u => u.id !== id);
+      }
     },
   },
   actions: {


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixing a bug described by @pcenov during his testing on #13865 

In the ClassEditPage, when a user would remove a coach, the state for the `currentClass` was not being updated. Manually updating it here fixes the reported issue.

This only affected the coaches because, despite there being `classLearners` and `classCoaches` properties on the module's state, the ClassCopyModal fetches the learners for the target class, but uses the `currentClass.coaches` value passed into it's `classToCopy` prop.

This isn't really the ideal solution, but it'll avoid introducing a bug to our new-to-this-page class copy functionality.


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to a class's details page and, in general:

- Copy the class by clicking the "Options" dropdown - be sure that the same number of learners & coaches (and the same actual users) are in the new copy
- Open the "Copy class" modal, cancel it, then remove coaches and/or learners, go to copy again and verify the numbers shown reflect the users who remain in your class. Copy them and verify that the users you'd removed aren't included in the copied class.
