### PR TITLE
Do proper conditional check for display of learner needs labels

### DIFF
--- a/kolibri/plugins/learn/frontend/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/frontend/views/BrowseResourceMetadata.vue
@@ -107,7 +107,7 @@
     </div>
 
     <div
-      v-if="content.learner_needs"
+      v-if="learnerNeedsLabels"
       class="section"
       data-test="learner-needs"
     >


### PR DESCRIPTION
## Summary
* The previous conditional check was doing a boolean check on an Array, which will always be truthy, even if empty
* In addition, it could still erroneously be displayed because we remove the "For beginners" from the displayed labels to show elsewhere
* Change the check to emulate other checks that check the text to be displayed instead

## Reviewer guidance
Import the KA Bangla channel, ensure that the "What do you need?" section does not get erroneously displayed in the resource metadata.