### PR TITLE
Update macOS runner versions to avoid deprecation and removal - needed before December 4th

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -34,10 +34,10 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.4
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.5
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v0.4.4
+      ref: v0.4.5
   deb:
     name: Build DEB file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -54,11 +54,11 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.4
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.5
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v0.4.4
+      ref: v0.4.5
     secrets:
       KOLIBRI_MAC_APP_IDENTITY: ${{ secrets.KOLIBRI_MAC_APP_IDENTITY }}
       KOLIBRI_MAC_APP_CERTIFICATE: ${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -126,7 +126,7 @@ jobs:
   macos:
     name: Python unit tests on Mac OS
     needs: pre_job
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       max-parallel: 5
       matrix:


### PR DESCRIPTION
## Summary
Update the macos runner to 14 for tox tests
Updates Mac DMG build to version that uses a newer runner also

## References
https://github.com/actions/runner-images/issues/13046

## Reviewer guidance
Do Python tests still pass?

I am deliberately targeting this to 0.19.0 to prevent more brownout/removal related issues for release.