### PR TITLE
Cherry picks BEGIN IMMEDIATE for all SQLite transactions to improve performance

### DIFF
--- a/kolibri/deployment/default/db/backends/sqlite3/base.py
+++ b/kolibri/deployment/default/db/backends/sqlite3/base.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+Custom SQLite3 database backend for Kolibri.
+
+This is a restricted backport of Django 5.2's ability to specify the kind of
+transaction to use. This allows us to use BEGIN IMMEDIATE transactions to improve
+concurrency behavior in SQLite databases, by acquiring write locks at transaction
+start rather than at the first write operation.
+Once Kolibri upgrades to Django 5.2 or later, this custom backend can be removed
+and the settings can revert to using "django.db.backends.sqlite3" directly.
+
+Django 5.2 added support for a transaction_mode option for SQLite, which allows
+specifying the transaction behavior (DEFERRED, IMMEDIATE, or EXCLUSIVE) without
+needing to override the database backend. We should switch to that option once we
+upgrade to Django 5.2+.
+
+See: https://docs.djangoproject.com/en/5.2/ref/databases/#sqlite-transaction-behavior
+"""
+from django.db.backends.sqlite3.base import (
+    DatabaseWrapper as DjangoSQLiteDatabaseWrapper,
+)
+
+
+class DatabaseWrapper(DjangoSQLiteDatabaseWrapper):
+    """
+    Custom SQLite3 database wrapper that uses BEGIN IMMEDIATE for transactions.
+    """
+
+    def _start_transaction_under_autocommit(self):
+        """
+        Start a transaction explicitly in autocommit mode.
+
+        Staying in autocommit mode works around a bug of sqlite3 that breaks
+        savepoints when autocommit is disabled.
+
+        Uses BEGIN IMMEDIATE instead of BEGIN to acquire write locks immediately,
+        improving concurrency behavior under high load.
+        """
+        self.cursor().execute("BEGIN IMMEDIATE")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -140,9 +140,12 @@ WSGI_APPLICATION = "kolibri.deployment.default.wsgi.application"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
+    # Using custom SQLite backend that uses BEGIN IMMEDIATE transactions.
+    # Once upgraded to Django 5.2+, revert to "django.db.backends.sqlite3" and use
+    # the transaction_mode option instead.
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.sqlite3",
+            "ENGINE": "kolibri.deployment.default.db.backends.sqlite3",
             "NAME": os.path.join(
                 conf.KOLIBRI_HOME,
                 conf.OPTIONS["Database"]["DATABASE_NAME"] or "db.sqlite3",
@@ -153,7 +156,7 @@ if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
 
     for additional_db in ADDITIONAL_SQLITE_DATABASES:
         DATABASES[additional_db] = {
-            "ENGINE": "django.db.backends.sqlite3",
+            "ENGINE": "kolibri.deployment.default.db.backends.sqlite3",
             "NAME": os.path.join(conf.KOLIBRI_HOME, "{}.sqlite3".format(additional_db)),
             "OPTIONS": {"timeout": 100},
         }


### PR DESCRIPTION
## Summary
Based on reported feedback from Flying Colors YIDA staff, we learned of data loss due to too many server requests. This change better matches the intended behavior and prevents the server from getting overwhelmed and having many failed requests.

## Reviewer guidance
This fix has been verified in 0.19.x, but the key testing here is ensuring that there are not regressions or any other issues/concers if we share this installer with the YIDA team to upgrade. 