### PR TITLE
Remove Python 2.7 legacy:  hasattr(output, 'decode') runtime checks

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -1171,9 +1171,7 @@ def get_installer_version(installer_type):  # noqa: C901
         if dpkg > madison, it's dpkg otherwise it's apt
         """
         try:
-            output = check_output(["dpkg", "-s", package])
-            if hasattr(output, "decode"):  # needed in python 2.x
-                output = output.decode("utf-8")
+            output = check_output(["dpkg", "-s", package], encoding="utf-8")
             package_info = output.split("\n")
             version_info = [line for line in package_info if "Version" in line]
             if version_info:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
In Python 2, strings and bytes were often confused, requiring runtime checks to determine whether output needed decoding. In Python 3, strings (`str`) and bytes (`bytes`) are distinct types, making these runtime checks unnecessary.

From my investigation, `kolibri/utils/server.py` is the only file that still contains this old method of handling bytes. I verified this using terminal searches and manual inspection, and I could not find any other lines using `.decode` together with `hasattr`.

For the instance I found, I followed the expected investigation. `check_output()` in Python 3 always returns bytes unless `text=True` or `encoding=...` is explicitly passed, which was not the case here. So I applied the only valid bytes-handling approach: directly decoding the value. To make the code cleaner and more modular, instead of using:

```
output = check_output(["dpkg", "-s", package])
output = output.decode("utf-8")
```
I replaced it with:
```
output = check_output(["dpkg", "-s", package], encoding="utf-8")
```


This performs direct decoding inside the function call, removes legacy Python 2 logic, and makes the code Python-3-friendly.




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #13888 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Location of change:  `kolibri/utils/server.py` 

I verfied it by running tests specifc to the server file as well.
