### PR TITLE
Bump python requests to 2.27.1 to match core requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ django==3.2.25
 colorlog==6.8.2
 configobj==5.0.8
 django-mptt==0.14.0
-requests==2.27.1
+requests==2.27.1  # latest version to support Python 3.6
 cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.10

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,7 +6,7 @@ pex==2.1.153
 pip>=20.3.4
 setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.8.2
-requests==2.21.0
+requests==2.27.1  # latest version to support Python 3.6
 pkginfo==1.8.2
 wheel>=0.31.1
 importlib-metadata==4.8.3


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
I was assigned to review https://github.com/learningequality/kolibri/pull/13911, and according to the changelog, the latest version of `requests` to support python 3.6 was v2.27.1. The core requirements were already set to that version, and so I updated the build deps to match, and added a comment to both.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/pull/13911

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Does the build pass?