### PR TITLE
Remove Python 2.7 : Replace mkdirp() with os.makedirs() 

### DIFF
--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -19,7 +19,6 @@ from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 
-from kolibri.utils.filesystem import mkdirp
 
 
 try:
@@ -246,7 +245,7 @@ class ChunkedFile(TransferFileBase):
         return Cache(self.cache_dir)
 
     def _initialize(self):
-        mkdirp(self.chunk_dir, exist_ok=True)
+        os.makedirs(self.chunk_dir, exist_ok=True)
         self.cache_dir = os.path.join(self.chunk_dir, ".cache")
         self.position = 0
 
@@ -549,7 +548,7 @@ class TransferFile(TransferFileBase):
 
     def ensure_writable(self):
         # ensure the directories in the destination path exist
-        mkdirp(os.path.dirname(self.filepath), exist_ok=True)
+        os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
 
     def write(self, data):
         """Write data to the transfer file."""
@@ -690,7 +689,7 @@ class Transfer(ABC):
             )
 
         # ensure the directories in the destination path exist
-        mkdirp(os.path.dirname(self.dest), exist_ok=True)
+        os.makedirs(os.path.dirname(self.dest), exist_ok=True)
 
     @abstractmethod
     def start(self):

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -20,7 +20,6 @@ from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 
 
-
 try:
     # Pre-empt the PanicException that importing cryptography can cause
     # when we are using a non-compatible version of cffi on Python 3.13

--- a/kolibri/utils/filesystem.py
+++ b/kolibri/utils/filesystem.py
@@ -43,15 +43,3 @@ def resolve_path(path):
         return os.path.realpath(os.path.expanduser(path))
     except (IOError, OSError):
         return None
-
-
-def mkdirp(path, exist_ok=False):
-    """
-    Make a directory and any missing parent directories.
-    Do this to add the exist_ok parameter to Python 2's os.makedirs.
-    """
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno != 17 or not exist_ok:
-            raise e

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -22,8 +22,6 @@ from kolibri.utils.file_transfer import retry_import
 from kolibri.utils.file_transfer import RETRY_STATUS_CODE
 from kolibri.utils.file_transfer import SSLERROR
 from kolibri.utils.file_transfer import TransferFailed
-from kolibri.utils.filesystem import mkdirp
-
 
 class BaseTestTransfer(unittest.TestCase):
     def set_test_data(self, partial=False, incomplete=False, finished=False):
@@ -38,7 +36,7 @@ class BaseTestTransfer(unittest.TestCase):
             math.ceil(float(self.file_size) / float(ChunkedFile.chunk_size))
         )
 
-        mkdirp(self.dest + ".chunks", exist_ok=True)
+        os.makedirs(self.dest + ".chunks", exist_ok=True)
 
         hash = hashlib.md5()
 

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -23,6 +23,7 @@ from kolibri.utils.file_transfer import RETRY_STATUS_CODE
 from kolibri.utils.file_transfer import SSLERROR
 from kolibri.utils.file_transfer import TransferFailed
 
+
 class BaseTestTransfer(unittest.TestCase):
     def set_test_data(self, partial=False, incomplete=False, finished=False):
         self.dest = self.destdir + "/test_file_{}".format(self.num_files)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
In Python 2, the absence of an exist_ok parameter required custom wrappers such as mkdirp to safely create directories without raising errors if they already existed. In Python 3, os.makedirs(..., exist_ok=True) provides the same functionality natively, making the custom helper unnecessary.

For the instances I found, I followed the expected  approach:
- Remove mkdirp calls entirely
- Replace them with a single call to os.makedirs(..., exist_ok=True)
- All of them had `import os` already
- Remove imports of mkdirp

I performed the the necessary testing for the files i made changes , and ensures the proper functionality.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes #13885 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Location of changes:

1. `kolibri/utils/file_transfer.py`
2. `kolibri/utils/filesystem.py`
3. `kolibri/utils/tests/test_file_transfer.py`
