### PR TITLE
Install dependencies for message upload and download actions

### DIFF
--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
-          cache-dependency-path: 'build_tools/i18n/*.py'
+          cache-dependency-path: |
+            'build_tools/i18n/*.py'
+            requirements/base.txt
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -28,6 +30,9 @@ jobs:
 
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: Install Python dependencies
+        run: pip install -r requirements/base.txt
 
       - name: Install JavaScript dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
-          cache-dependency-path: 'build_tools/i18n/*.py'
+          cache-dependency-path: 'requirements/base.txt'
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: Install Python dependencies
+        run: pip install -r requirements/base.txt
 
       - name: Install JavaScript dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
## Summary
The i18n upload and download actions did not properly install Python dependencies, as they both require running kolibri itself, so need all of Kolibri's base dependencies installed.

## References
Follow up from https://github.com/learningequality/kolibri/pull/13869

## Reviewer guidance
Can't really test this, so have to eyeball it! If you look through the commands in the Makefile, are there any other dependencies that need to be installed here (bearing in mind the i18n Python scripts automatically install dependencies themselves).
