### PR TITLE
Add ESLint rule to validate translator key destructuring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         entry: yarn run lint-frontend:format
         language: system
         files: \.(js|vue|scss|css)$
-        exclude: ^kolibri/plugins/qti_viewer/assets/src/components/__fixtures__/items\.js
+        exclude: (?x)^(kolibri/plugins/qti_viewer/assets/src/components/__fixtures__/items\.js|packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/malformed\.js)
 -   repo: local
     hooks:
     -   id: core-js-api

--- a/packages/eslint-plugin-kolibri/lib/rules/no-undefined-translator-keys.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/no-undefined-translator-keys.js
@@ -67,6 +67,29 @@ function getVariableName(node) {
 }
 
 /**
+ * Gets the object variable name and property name for a createTranslator in an object
+ * @param {Object} node - AST CallExpression node
+ * @returns {{objectName: string, propertyName: string}|null}
+ */
+function getObjectPropertyInfo(node) {
+  // Handle: const obj = { prop: createTranslator(...) }
+  if (
+    node.parent.type === 'Property' &&
+    node.parent.value === node &&
+    node.parent.key.type === 'Identifier' &&
+    node.parent.parent.type === 'ObjectExpression' &&
+    node.parent.parent.parent.type === 'VariableDeclarator' &&
+    node.parent.parent.parent.id.type === 'Identifier'
+  ) {
+    return {
+      objectName: node.parent.parent.parent.id.name,
+      propertyName: node.parent.key.name,
+    };
+  }
+  return null;
+}
+
+/**
  * Gets the variable name that a createTranslator call is exported as
  * @param {Object} node - AST CallExpression node
  * @returns {string|null} Export name or null
@@ -92,6 +115,27 @@ function getExportName(node) {
 function getSourceVariableName(node) {
   if (node.type === 'Identifier') {
     return node.name;
+  }
+  return null;
+}
+
+/**
+ * Gets member expression information for destructuring from object.property
+ * @param {Object} node - AST node (the init part of VariableDeclarator)
+ * @returns {{objectName: string, propertyName: string}|null}
+ */
+function getMemberExpressionInfo(node) {
+  // Handle: const { key$ } = obj.prop
+  if (
+    node.type === 'MemberExpression' &&
+    node.object.type === 'Identifier' &&
+    node.property.type === 'Identifier' &&
+    !node.computed
+  ) {
+    return {
+      objectName: node.object.name,
+      propertyName: node.property.name,
+    };
   }
   return null;
 }
@@ -371,6 +415,13 @@ const create = context => {
   // Map of imported translators: localName -> { keys: Set<string> }
   const importedTranslators = new Map();
 
+  // Map of objects containing translators: objectName -> Map<propertyName, { keys: Set<string> }>
+  const objectsWithTranslators = new Map();
+
+  // Map of member references: variableName -> { keys: Set<string> }
+  // Tracks variables that hold references to translator properties
+  const memberReferences = new Map();
+
   return {
     // Track createTranslator calls in this file
     CallExpression(node) {
@@ -380,6 +431,17 @@ const create = context => {
 
       const keys = extractMessageKeys(node);
       if (!keys) {
+        return;
+      }
+
+      // Check if this is inside an object property
+      const objInfo = getObjectPropertyInfo(node);
+      if (objInfo) {
+        // Track object with translator property
+        if (!objectsWithTranslators.has(objInfo.objectName)) {
+          objectsWithTranslators.set(objInfo.objectName, new Map());
+        }
+        objectsWithTranslators.get(objInfo.objectName).set(objInfo.propertyName, { keys });
         return;
       }
 
@@ -440,6 +502,41 @@ const create = context => {
         return;
       }
 
+      // Try to get member expression info (e.g., obj.prop)
+      const memberInfo = getMemberExpressionInfo(node.init);
+      if (memberInfo) {
+        // Handle: const { key$ } = obj.prop
+        if (objectsWithTranslators.has(memberInfo.objectName)) {
+          const translatorProps = objectsWithTranslators.get(memberInfo.objectName);
+          if (translatorProps.has(memberInfo.propertyName)) {
+            const translatorInfo = translatorProps.get(memberInfo.propertyName);
+            validateDestructuring(
+              node,
+              translatorInfo,
+              context,
+              `${memberInfo.objectName}.${memberInfo.propertyName}`,
+            );
+            return;
+          }
+        }
+        // If it's not tracked, might be from an object property reference
+        // e.g., const { prop } = obj; const { key$ } = prop;
+        if (memberReferences.has(memberInfo.objectName)) {
+          const refInfo = memberReferences.get(memberInfo.objectName);
+          if (refInfo.has(memberInfo.propertyName)) {
+            const translatorInfo = refInfo.get(memberInfo.propertyName);
+            validateDestructuring(
+              node,
+              translatorInfo,
+              context,
+              `${memberInfo.objectName}.${memberInfo.propertyName}`,
+            );
+            return;
+          }
+        }
+        return;
+      }
+
       const sourceName = getSourceVariableName(node.init);
       if (!sourceName) {
         return;
@@ -448,10 +545,39 @@ const create = context => {
       // Check if destructuring from a local translator
       if (localTranslators.has(sourceName)) {
         validateDestructuring(node, localTranslators.get(sourceName), context, sourceName);
+        return;
       }
+
       // Check if destructuring from an imported translator
-      else if (importedTranslators.has(sourceName)) {
+      if (importedTranslators.has(sourceName)) {
         validateDestructuring(node, importedTranslators.get(sourceName), context, sourceName);
+        return;
+      }
+
+      // Check if destructuring from a member reference
+      if (memberReferences.has(sourceName)) {
+        // This is a reference to a translator property, validate it
+        const refInfo = memberReferences.get(sourceName);
+        validateDestructuring(node, refInfo, context, sourceName);
+        return;
+      }
+
+      // Check if destructuring properties from an object with translators
+      // e.g., const { completed } = obj where obj.completed is a translator
+      if (objectsWithTranslators.has(sourceName)) {
+        // Track the extracted properties as member references
+        const translatorProps = objectsWithTranslators.get(sourceName);
+        node.id.properties.forEach(prop => {
+          if (prop.type === 'Property' && prop.key.type === 'Identifier') {
+            const propName = prop.key.name;
+            const localName = prop.value.type === 'Identifier' ? prop.value.name : prop.key.name;
+
+            if (translatorProps.has(propName)) {
+              // Store this as a member reference for future destructuring
+              memberReferences.set(localName, translatorProps.get(propName));
+            }
+          }
+        });
       }
     },
   };

--- a/packages/eslint-plugin-kolibri/lib/rules/no-undefined-translator-keys.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/no-undefined-translator-keys.js
@@ -1,0 +1,477 @@
+/**
+ * @fileoverview Disallow destructuring undefined keys from createTranslator objects.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const espree = require('espree');
+
+// Cache for parsed translator definitions to avoid re-parsing files
+// Map: filePath -> Map<exportName, Set<keys>>
+const translatorCache = new Map();
+
+/**
+ * Checks if a node is a call to createTranslator
+ * @param {Object} node - AST node
+ * @returns {boolean}
+ */
+function isCreateTranslatorCall(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'createTranslator' &&
+    node.arguments.length >= 2
+  );
+}
+
+/**
+ * Extracts message keys from a createTranslator call's second argument
+ * @param {Object} node - AST CallExpression node
+ * @returns {Set<string>|null} Set of message keys or null if extraction fails
+ */
+function extractMessageKeys(node) {
+  if (!isCreateTranslatorCall(node)) {
+    return null;
+  }
+
+  const messagesArg = node.arguments[1];
+  if (messagesArg.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  const keys = new Set();
+  messagesArg.properties.forEach(prop => {
+    if (prop.type === 'Property' && prop.key.type === 'Identifier') {
+      keys.add(prop.key.name);
+    } else if (prop.type === 'Property' && prop.key.type === 'Literal') {
+      keys.add(prop.key.value);
+    }
+  });
+
+  return keys;
+}
+
+/**
+ * Gets the variable name that a createTranslator call is assigned to
+ * @param {Object} node - AST CallExpression node
+ * @returns {string|null} Variable name or null
+ */
+function getVariableName(node) {
+  // Handle: const translator = createTranslator(...)
+  if (node.parent.type === 'VariableDeclarator' && node.parent.id.type === 'Identifier') {
+    return node.parent.id.name;
+  }
+  return null;
+}
+
+/**
+ * Gets the variable name that a createTranslator call is exported as
+ * @param {Object} node - AST CallExpression node
+ * @returns {string|null} Export name or null
+ */
+function getExportName(node) {
+  // Handle: export const translator = createTranslator(...)
+  if (
+    node.parent.type === 'VariableDeclarator' &&
+    node.parent.id.type === 'Identifier' &&
+    node.parent.parent.type === 'VariableDeclaration' &&
+    node.parent.parent.parent.type === 'ExportNamedDeclaration'
+  ) {
+    return node.parent.id.name;
+  }
+  return null;
+}
+
+/**
+ * Gets the source variable name from a destructuring assignment
+ * @param {Object} node - AST node (the init part of VariableDeclarator)
+ * @returns {string|null} Source variable name or null
+ */
+function getSourceVariableName(node) {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  return null;
+}
+
+/**
+ * Checks if a file path exists and is a file
+ * @param {string} filePath - Path to check
+ * @returns {boolean}
+ */
+function isFile(filePath) {
+  try {
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Tries to resolve a path with various extensions
+ * @param {string} basePath - Base path to try
+ * @param {Array<string>} extensions - Extensions to try
+ * @returns {string|null} Resolved path or null
+ */
+function tryResolveWithExtensions(basePath, extensions) {
+  // Try without extension first
+  if (isFile(basePath)) {
+    return basePath;
+  }
+
+  // Try with each extension
+  for (const ext of extensions) {
+    const withExt = basePath + ext;
+    if (isFile(withExt)) {
+      return withExt;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolves an import path to an absolute file path using Node.js resolution
+ * @param {string} importPath - The import path (e.g., './strings' or 'kolibri/utils/i18n')
+ * @param {string} currentFile - The absolute path of the current file
+ * @returns {string|null} Absolute path to the imported file or null if not found
+ */
+function resolveImportPath(importPath, currentFile) {
+  const currentDir = path.dirname(currentFile);
+  const extensions = ['.js', '.ts', '.jsx', '.tsx'];
+
+  // Handle relative imports (./file or ../file)
+  if (importPath.startsWith('.')) {
+    const basePath = path.resolve(currentDir, importPath);
+    return tryResolveWithExtensions(basePath, extensions);
+  }
+
+  // For absolute imports, use Node.js module resolution
+  try {
+    return require.resolve(importPath, { paths: [currentDir] });
+  } catch {
+    // Module not found - return null and skip validation
+    return null;
+  }
+}
+
+/**
+ * Walks an AST to find all createTranslator exports and declarations
+ * @param {Object} ast - Parsed AST
+ * @returns {Map<string, Set<string>>} Map of export name to Set of message keys
+ */
+function findTranslatorsInAST(ast) {
+  const translators = new Map();
+  const localTranslators = new Map(); // Track non-exported translators for re-export pattern
+
+  function walk(node) {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    // Pattern 1: export const name = createTranslator(...)
+    if (
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration &&
+      node.declaration.type === 'VariableDeclaration'
+    ) {
+      node.declaration.declarations.forEach(declarator => {
+        if (
+          declarator.type === 'VariableDeclarator' &&
+          declarator.id.type === 'Identifier' &&
+          declarator.init &&
+          isCreateTranslatorCall(declarator.init)
+        ) {
+          const exportName = declarator.id.name;
+          const keys = extractMessageKeys(declarator.init);
+          if (keys) {
+            translators.set(exportName, keys);
+          }
+        }
+      });
+    }
+
+    // Pattern 2: export default createTranslator(...)
+    if (
+      node.type === 'ExportDefaultDeclaration' &&
+      node.declaration &&
+      isCreateTranslatorCall(node.declaration)
+    ) {
+      const keys = extractMessageKeys(node.declaration);
+      if (keys) {
+        translators.set('default', keys);
+      }
+    }
+
+    // Pattern 3: const name = createTranslator(...) (for later re-export)
+    // We track ALL variable declarations; Pattern 1 will override if it's an export
+    if (node.type === 'VariableDeclaration') {
+      node.declarations.forEach(declarator => {
+        if (
+          declarator.type === 'VariableDeclarator' &&
+          declarator.id.type === 'Identifier' &&
+          declarator.init &&
+          isCreateTranslatorCall(declarator.init)
+        ) {
+          const name = declarator.id.name;
+          const keys = extractMessageKeys(declarator.init);
+          if (keys) {
+            // Only add to localTranslators if not already in translators
+            // (Pattern 1 would have added it to translators already)
+            if (!translators.has(name)) {
+              localTranslators.set(name, keys);
+            }
+          }
+        }
+      });
+    }
+
+    // Pattern 4: export { name } (re-export pattern)
+    if (node.type === 'ExportNamedDeclaration' && !node.declaration && node.specifiers) {
+      node.specifiers.forEach(spec => {
+        if (spec.type === 'ExportSpecifier') {
+          const localName = spec.local.name;
+          const exportedName = spec.exported.name;
+          if (localTranslators.has(localName)) {
+            translators.set(exportedName, localTranslators.get(localName));
+          }
+        }
+      });
+    }
+
+    // Walk child nodes
+    for (const key in node) {
+      if (node[key] && typeof node[key] === 'object') {
+        if (Array.isArray(node[key])) {
+          node[key].forEach(child => walk(child));
+        } else {
+          walk(node[key]);
+        }
+      }
+    }
+  }
+
+  walk(ast);
+  return translators;
+}
+
+/**
+ * Parses a file and extracts translator keys for a specific export
+ * @param {string} filePath - Absolute path to the file
+ * @param {string} exportedName - Name of the exported translator
+ * @returns {Set<string>|null} Set of message keys or null if not found
+ */
+function getTranslatorKeysFromFile(filePath, exportedName) {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+
+    // Check cache first
+    if (translatorCache.has(filePath)) {
+      const fileCache = translatorCache.get(filePath);
+      return fileCache.get(exportedName) || null;
+    }
+
+    // Read and parse file
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const ast = espree.parse(fileContent, {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    });
+
+    // Find all translators in the file
+    const translators = findTranslatorsInAST(ast);
+
+    // Cache the results
+    translatorCache.set(filePath, translators);
+
+    // Return the requested translator's keys
+    return translators.get(exportedName) || null;
+  } catch (error) {
+    // If we can't read or parse the file, return null
+    // This is acceptable - we simply skip validation for imports we can't resolve
+    return null;
+  }
+}
+
+/**
+ * Validates destructuring against defined translator keys
+ * @param {Object} node - AST VariableDeclarator node
+ * @param {Object} translatorInfo - Object with keys: Set<string>
+ * @param {Object} context - ESLint context
+ * @param {string} translatorName - Name of the translator variable
+ */
+function validateDestructuring(node, translatorInfo, context, translatorName) {
+  const { keys } = translatorInfo;
+
+  if (node.id.type !== 'ObjectPattern') {
+    return;
+  }
+
+  node.id.properties.forEach(prop => {
+    // Skip spread elements
+    if (prop.type === 'RestElement') {
+      return;
+    }
+
+    // Get the property name
+    let propertyName;
+    if (prop.key.type === 'Identifier') {
+      propertyName = prop.key.name;
+    } else if (prop.key.type === 'Literal') {
+      propertyName = prop.key.value;
+    } else {
+      // Skip computed properties
+      return;
+    }
+
+    // Check if property ends with $
+    if (!propertyName.endsWith('$')) {
+      // Report error for missing $ suffix
+      context.report({
+        node: prop,
+        messageId: 'missingSuffix',
+        data: {
+          property: propertyName,
+          translatorName: translatorName,
+        },
+      });
+      return;
+    }
+
+    // Strip the $ suffix to get the message key
+    const messageKey = propertyName.slice(0, -1);
+
+    // Check if the key exists in the translator
+    if (!keys.has(messageKey)) {
+      const availableKeys = Array.from(keys)
+        .sort()
+        .map(k => `${k}$`)
+        .join(', ');
+      context.report({
+        node: prop,
+        messageId: 'undefinedTranslatorKey',
+        data: {
+          property: propertyName,
+          translatorName: translatorName,
+          availableKeys: availableKeys,
+        },
+      });
+    }
+  });
+}
+
+const create = context => {
+  // Map of local translators: variableName -> { keys: Set<string> }
+  const localTranslators = new Map();
+
+  // Map of imported translators: localName -> { keys: Set<string> }
+  const importedTranslators = new Map();
+
+  return {
+    // Track createTranslator calls in this file
+    CallExpression(node) {
+      if (!isCreateTranslatorCall(node)) {
+        return;
+      }
+
+      const keys = extractMessageKeys(node);
+      if (!keys) {
+        return;
+      }
+
+      // Get export name first (takes precedence), then variable name
+      const exportName = getExportName(node);
+      const varName = getVariableName(node);
+      const name = exportName || varName;
+
+      if (name) {
+        localTranslators.set(name, { keys });
+      }
+    },
+
+    // Track imports of translator objects
+    ImportDeclaration(node) {
+      const importPath = node.source.value;
+      const currentFile = context.getFilename();
+
+      node.specifiers.forEach(spec => {
+        if (spec.type === 'ImportSpecifier') {
+          const importedName = spec.imported.name;
+          const localName = spec.local.name;
+
+          // Resolve the import path
+          const resolvedPath = resolveImportPath(importPath, currentFile);
+          if (!resolvedPath) {
+            // Can't resolve - skip validation for this import
+            return;
+          }
+
+          // Get translator keys from the imported file
+          const keys = getTranslatorKeysFromFile(resolvedPath, importedName);
+          if (keys) {
+            importedTranslators.set(localName, { keys });
+          }
+        } else if (spec.type === 'ImportDefaultSpecifier') {
+          // Handle default imports: import translator from './strings'
+          const localName = spec.local.name;
+
+          // Resolve the import path
+          const resolvedPath = resolveImportPath(importPath, currentFile);
+          if (!resolvedPath) {
+            return;
+          }
+
+          // Get keys for default export
+          const keys = getTranslatorKeysFromFile(resolvedPath, 'default');
+          if (keys) {
+            importedTranslators.set(localName, { keys });
+          }
+        }
+      });
+    },
+
+    // Validate destructuring
+    VariableDeclarator(node) {
+      if (node.id.type !== 'ObjectPattern' || !node.init) {
+        return;
+      }
+
+      const sourceName = getSourceVariableName(node.init);
+      if (!sourceName) {
+        return;
+      }
+
+      // Check if destructuring from a local translator
+      if (localTranslators.has(sourceName)) {
+        validateDestructuring(node, localTranslators.get(sourceName), context, sourceName);
+      }
+      // Check if destructuring from an imported translator
+      else if (importedTranslators.has(sourceName)) {
+        validateDestructuring(node, importedTranslators.get(sourceName), context, sourceName);
+      }
+    },
+  };
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow destructuring undefined keys from createTranslator objects',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      undefinedTranslatorKey:
+        "Destructured property '{{property}}' does not exist in translator '{{translatorName}}'. Available keys: {{availableKeys}}",
+      missingSuffix:
+        "Destructured property '{{property}}' from translator '{{translatorName}}' should end with '$'. Did you mean '{{property}}$'?",
+    },
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/defaultExport.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/defaultExport.js
@@ -1,0 +1,7 @@
+// Test fixture with default export
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export default createTranslator('DefaultExportNamespace', {
+  defaultMessage: 'This is a default export',
+  anotherMessage: 'Another message',
+});

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/malformed.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/malformed.js
@@ -1,0 +1,6 @@
+// Malformed file that will fail to parse
+export const malformed = createTranslator('NS', {
+  key: 'value'
+}); // Missing semicolon and has syntax errors below
+
+this is not valid javascript syntax {{{{

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/reExport.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/reExport.js
@@ -1,0 +1,9 @@
+// Test fixture with separate declaration and export
+import { createTranslator } from 'kolibri/utils/i18n';
+
+const reExportedStrings = createTranslator('ReExportNamespace', {
+  reExportedMessage: 'This is re-exported',
+  anotherReExported: 'Another re-exported message',
+});
+
+export { reExportedStrings };

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/testStrings.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/fixtures/testStrings.js
@@ -1,0 +1,32 @@
+// Test fixture for cross-file translator imports
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export const testStrings = createTranslator('TestNamespace', {
+  userLabel: 'User',
+  adminLabel: 'Administrator',
+  coachLabel: 'Coach',
+  learnerLabel: 'Learner',
+  goBackAction: 'Go back',
+});
+
+export const anotherTranslator = createTranslator('AnotherNamespace', {
+  saveAction: 'Save',
+  cancelAction: 'Cancel',
+  deleteAction: 'Delete',
+});
+
+// Translator with object-format messages (message + context)
+export const objectFormatStrings = createTranslator('ObjectFormatNamespace', {
+  welcomeMessage: {
+    message: 'Welcome, {name}!',
+    context: 'Greeting message shown to users when they log in',
+  },
+  errorTitle: {
+    message: 'Error',
+    context: 'Title for error dialogs',
+  },
+  successMessage: {
+    message: 'Operation completed successfully',
+    context: 'Generic success message',
+  },
+});

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/no-undefined-translator-keys.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/no-undefined-translator-keys.spec.js
@@ -55,7 +55,8 @@ tester.run('no-undefined-translator-keys', rule, {
       `,
     },
 
-    // 5. No destructuring (direct usage)
+    // 5. Direct method calls (not validated by this rule)
+    // This rule only validates destructuring, not $tr() method calls
     {
       code: `
         const translator = createTranslator('NS', { key: 'msg' });
@@ -255,10 +256,71 @@ tester.run('no-undefined-translator-keys', rule, {
     },
 
     // ========================================
+    // Object-of-Translators Pattern Cases
+    // ========================================
+
+    // 25. Object containing translator - direct member access
+    {
+      code: `
+        const translators = {
+          completed: createTranslator('NS', { validKey: 'msg' })
+        };
+        const { validKey$ } = translators.completed;
+      `,
+    },
+
+    // 26. Object containing translator - two-step destructuring
+    {
+      code: `
+        const translators = {
+          completed: createTranslator('NS', { validKey: 'msg' })
+        };
+        const { completed } = translators;
+        const { validKey$ } = completed;
+      `,
+    },
+
+    // 27. Object with multiple translators - direct access
+    {
+      code: `
+        const progressTranslators = {
+          completed: createTranslator('NS1', { key1: 'a' }),
+          inProgress: createTranslator('NS2', { key2: 'b' })
+        };
+        const { key1$ } = progressTranslators.completed;
+        const { key2$ } = progressTranslators.inProgress;
+      `,
+    },
+
+    // 28. Object with multiple translators - two-step
+    {
+      code: `
+        const progressTranslators = {
+          completed: createTranslator('NS1', { key1: 'a' }),
+          inProgress: createTranslator('NS2', { key2: 'b' })
+        };
+        const { completed, inProgress } = progressTranslators;
+        const { key1$ } = completed;
+        const { key2$ } = inProgress;
+      `,
+    },
+
+    // 29. Object with aliased extraction
+    {
+      code: `
+        const translators = {
+          main: createTranslator('NS', { validKey: 'msg' })
+        };
+        const { main: myTranslator } = translators;
+        const { validKey$ } = myTranslator;
+      `,
+    },
+
+    // ========================================
     // Import Resolution Failure Cases (should silently skip)
     // ========================================
 
-    // 25. Import from non-existent file - should not error
+    // 30. Import from non-existent file - should not error
     {
       filename: testFilePath,
       code: `
@@ -267,7 +329,7 @@ tester.run('no-undefined-translator-keys', rule, {
       `,
     },
 
-    // 26. Import from malformed file - should not error (parse failure)
+    // 31. Import from malformed file - should not error (parse failure)
     {
       filename: testFilePath,
       code: `
@@ -715,6 +777,82 @@ tester.run('no-undefined-translator-keys', rule, {
         {
           message:
             "Destructured property 'invalidKey$' does not exist in translator 'testStrings'. Available keys: adminLabel$, coachLabel$, goBackAction$, learnerLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Object-of-Translators Invalid Cases
+    // ========================================
+
+    // 27. Object containing translator - direct member access with invalid key
+    {
+      code: `
+        const translators = {
+          completed: createTranslator('NS', { validKey: 'msg' })
+        };
+        const { invalidKey$ } = translators.completed;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'translators.completed'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 28. Object containing translator - two-step with invalid key
+    {
+      code: `
+        const translators = {
+          completed: createTranslator('NS', { validKey: 'msg' })
+        };
+        const { completed } = translators;
+        const { invalidKey$ } = completed;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'completed'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 29. Object with multiple translators - wrong property access
+    {
+      code: `
+        const progressTranslators = {
+          completed: createTranslator('NS1', { key1: 'a' }),
+          inProgress: createTranslator('NS2', { key2: 'b' })
+        };
+        const { key2$ } = progressTranslators.completed;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'key2$' does not exist in translator 'progressTranslators.completed'. Available keys: key1$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 30. Object with multiple translators - two-step wrong extraction
+    {
+      code: `
+        const progressTranslators = {
+          completed: createTranslator('NS1', { key1: 'a' }),
+          inProgress: createTranslator('NS2', { key2: 'b' })
+        };
+        const { completed } = progressTranslators;
+        const { key2$ } = completed;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'key2$' does not exist in translator 'completed'. Available keys: key1$",
           type: 'Property',
         },
       ],

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/no-undefined-translator-keys.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/no-undefined-translator-keys.spec.js
@@ -1,0 +1,723 @@
+'use strict';
+
+const path = require('path');
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/no-undefined-translator-keys');
+
+// Compute test file path dynamically so it works on any machine
+const testFilePath = path.join(__dirname, 'test.js');
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+tester.run('no-undefined-translator-keys', rule, {
+  valid: [
+    // ========================================
+    // Valid Cases
+    // ========================================
+
+    // 1. Basic valid destructuring
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { validKey$ } = translator;
+      `,
+    },
+
+    // 2. Multiple valid keys
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a', key2: 'b', key3: 'c' });
+        const { key1$, key2$, key3$ } = translator;
+      `,
+    },
+
+    // 3. Object format messages
+    {
+      code: `
+        const translator = createTranslator('NS', {
+          key1: { message: 'msg', context: 'ctx' },
+          key2: { message: 'msg2' }
+        });
+        const { key1$, key2$ } = translator;
+      `,
+    },
+
+    // 4. Exported translator with destructuring in same file
+    {
+      code: `
+        export const translator = createTranslator('NS', { validKey: 'msg', anotherKey: 'msg2' });
+        const { validKey$ } = translator;
+      `,
+    },
+
+    // 5. No destructuring (direct usage)
+    {
+      code: `
+        const translator = createTranslator('NS', { key: 'msg' });
+        translator.$tr('key');
+      `,
+    },
+
+    // 6. Non-translator destructuring (should not error)
+    {
+      code: `
+        const regularObj = { someKey$: () => {} };
+        const { someKey$ } = regularObj;
+      `,
+    },
+
+    // 7. Partial destructuring (only some keys)
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a', key2: 'b', key3: 'c' });
+        const { key1$ } = translator;
+        const { key2$ } = translator;
+      `,
+    },
+
+    // 8. Spread operator with valid key
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a', key2: 'b' });
+        const { key1$, ...rest } = translator;
+      `,
+    },
+
+    // 9. Renamed destructuring (aliasing)
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { validKey$: myLabel } = translator;
+      `,
+    },
+
+    // 10. Multiple destructuring statements from same translator
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a', key2: 'b' });
+        const { key1$ } = translator;
+        const { key2$ } = translator;
+      `,
+    },
+
+    // 11. Complex nested property values
+    {
+      code: `
+        const translator = createTranslator('NS', {
+          userLabel: 'User',
+          adminLabel: 'Administrator',
+          coachLabel: 'Coach',
+          learnerLabel: 'Learner',
+        });
+        const { userLabel$, adminLabel$, coachLabel$, learnerLabel$ } = translator;
+      `,
+    },
+
+    // 12. String literal keys
+    {
+      code: `
+        const translator = createTranslator('NS', {
+          'key-with-dash': 'msg',
+        });
+        const { 'key-with-dash$': keyWithDash } = translator;
+      `,
+    },
+
+    // 13. Empty destructuring (no properties)
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a' });
+        const {} = translator;
+      `,
+    },
+
+    // 14. Multiple translators
+    {
+      code: `
+        const translator1 = createTranslator('NS1', { key1: 'a' });
+        const translator2 = createTranslator('NS2', { key2: 'b' });
+        const { key1$ } = translator1;
+        const { key2$ } = translator2;
+      `,
+    },
+
+    // 15. Translator not immediately destructured
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a' });
+        function useTranslator() {
+          const { key1$ } = translator;
+        }
+      `,
+    },
+
+    // ========================================
+    // Cross-file Import Cases
+    // ========================================
+
+    // 16. Import and destructure valid key
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { userLabel$ } = testStrings;
+      `,
+    },
+
+    // 17. Import and destructure multiple valid keys
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { userLabel$, adminLabel$, coachLabel$ } = testStrings;
+      `,
+    },
+
+    // 18. Import from another translator
+    {
+      filename: testFilePath,
+      code: `
+        import { anotherTranslator } from './fixtures/testStrings';
+        const { saveAction$, cancelAction$ } = anotherTranslator;
+      `,
+    },
+
+    // 19. Multiple imports and destructuring
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings, anotherTranslator } from './fixtures/testStrings';
+        const { userLabel$ } = testStrings;
+        const { saveAction$ } = anotherTranslator;
+      `,
+    },
+
+    // 20. Object-format messages - valid destructuring
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { welcomeMessage$, errorTitle$ } = objectFormatStrings;
+      `,
+    },
+
+    // 21. Object-format messages - all valid keys
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { welcomeMessage$, errorTitle$, successMessage$ } = objectFormatStrings;
+      `,
+    },
+
+    // ========================================
+    // Default Export Cases
+    // ========================================
+
+    // 22. Default import - valid destructuring
+    {
+      filename: testFilePath,
+      code: `
+        import defaultStrings from './fixtures/defaultExport';
+        const { defaultMessage$, anotherMessage$ } = defaultStrings;
+      `,
+    },
+
+    // ========================================
+    // Re-export Pattern Cases
+    // ========================================
+
+    // 23. Re-export pattern - valid destructuring
+    {
+      filename: testFilePath,
+      code: `
+        import { reExportedStrings } from './fixtures/reExport';
+        const { reExportedMessage$, anotherReExported$ } = reExportedStrings;
+      `,
+    },
+
+    // ========================================
+    // Cross-file Aliasing Cases
+    // ========================================
+
+    // 24. Cross-file import with aliasing
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { userLabel$: myUserLabel } = testStrings;
+      `,
+    },
+
+    // ========================================
+    // Import Resolution Failure Cases (should silently skip)
+    // ========================================
+
+    // 25. Import from non-existent file - should not error
+    {
+      filename: testFilePath,
+      code: `
+        import { nonExistent } from './fixtures/doesNotExist';
+        const { anyKey$ } = nonExistent;
+      `,
+    },
+
+    // 26. Import from malformed file - should not error (parse failure)
+    {
+      filename: testFilePath,
+      code: `
+        import { malformed } from './fixtures/malformed';
+        const { anyKey$ } = malformed;
+      `,
+    },
+  ],
+
+  invalid: [
+    // ========================================
+    // Invalid Cases
+    // ========================================
+
+    // 1. Basic undefined key
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { undefinedKey$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'undefinedKey$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 2. Mix of valid and invalid keys
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { validKey$, undefinedKey$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'undefinedKey$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 3. Typo in key name
+    {
+      code: `
+        const translator = createTranslator('NS', { userLabel: 'User' });
+        const { usrLabel$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'usrLabel$' does not exist in translator 'translator'. Available keys: userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 4. Missing $ suffix
+    {
+      code: `
+        const translator = createTranslator('NS', { key: 'msg' });
+        const { key } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'key' from translator 'translator' should end with '$'. Did you mean 'key$'?",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 5. Case sensitivity error
+    {
+      code: `
+        const translator = createTranslator('NS', { myKey: 'msg' });
+        const { MyKey$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'MyKey$' does not exist in translator 'translator'. Available keys: myKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 6. Empty messages object with attempted destructuring
+    {
+      code: `
+        const translator = createTranslator('NS', {});
+        const { anyKey$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'anyKey$' does not exist in translator 'translator'. Available keys: ",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 7. Multiple undefined keys
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { invalid1$, invalid2$, invalid3$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalid1$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+        {
+          message:
+            "Destructured property 'invalid2$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+        {
+          message:
+            "Destructured property 'invalid3$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 8. Renamed destructuring with invalid key
+    {
+      code: `
+        const translator = createTranslator('NS', { validKey: 'msg' });
+        const { invalidKey$: myLabel } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 9. Spread operator with invalid key
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a' });
+        const { invalidKey$, ...rest } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'translator'. Available keys: key1$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 10. Wrong key from different translator
+    {
+      code: `
+        const translator1 = createTranslator('NS1', { key1: 'a' });
+        const translator2 = createTranslator('NS2', { key2: 'b' });
+        const { key2$ } = translator1;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'key2$' does not exist in translator 'translator1'. Available keys: key1$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 11. Exported translator with invalid key
+    {
+      code: `
+        export const translator = createTranslator('NS', { validKey: 'msg' });
+        const { invalidKey$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'translator'. Available keys: validKey$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 12. Complex object format with invalid key
+    {
+      code: `
+        const translator = createTranslator('NS', {
+          userLabel: { message: 'User', context: 'Label for user' },
+          adminLabel: { message: 'Admin' },
+        });
+        const { userLabel$, invalidLabel$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidLabel$' does not exist in translator 'translator'. Available keys: adminLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 13. Destructuring in nested scope
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a' });
+        function useTranslator() {
+          const { invalidKey$ } = translator;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'translator'. Available keys: key1$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 14. Missing $ with multiple keys
+    {
+      code: `
+        const translator = createTranslator('NS', { key1: 'a', key2: 'b' });
+        const { key1, key2$ } = translator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'key1' from translator 'translator' should end with '$'. Did you mean 'key1$'?",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Cross-file Import Invalid Cases
+    // ========================================
+
+    // 15. Import and destructure invalid key
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { invalidKey$ } = testStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'testStrings'. Available keys: adminLabel$, coachLabel$, goBackAction$, learnerLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 16. Import and typo in key name
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { usrLabel$ } = testStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'usrLabel$' does not exist in translator 'testStrings'. Available keys: adminLabel$, coachLabel$, goBackAction$, learnerLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 17. Import and mix valid and invalid keys
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { userLabel$, invalidLabel$ } = testStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidLabel$' does not exist in translator 'testStrings'. Available keys: adminLabel$, coachLabel$, goBackAction$, learnerLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 18. Import from another translator with invalid key
+    {
+      filename: testFilePath,
+      code: `
+        import { anotherTranslator } from './fixtures/testStrings';
+        const { invalidAction$ } = anotherTranslator;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidAction$' does not exist in translator 'anotherTranslator'. Available keys: cancelAction$, deleteAction$, saveAction$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 19. Import missing $ suffix
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { userLabel } = testStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'userLabel' from translator 'testStrings' should end with '$'. Did you mean 'userLabel$'?",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Object-format Invalid Cases (Testing Issue #1 fix)
+    // ========================================
+
+    // 20. Object-format - trying to destructure nested 'message' property
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { message$ } = objectFormatStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'message$' does not exist in translator 'objectFormatStrings'. Available keys: errorTitle$, successMessage$, welcomeMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 21. Object-format - trying to destructure nested 'context' property
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { context$ } = objectFormatStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'context$' does not exist in translator 'objectFormatStrings'. Available keys: errorTitle$, successMessage$, welcomeMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 22. Object-format - invalid key with object-format translator
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { invalidKey$ } = objectFormatStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'objectFormatStrings'. Available keys: errorTitle$, successMessage$, welcomeMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // 23. Object-format - mix of valid and nested property
+    {
+      filename: testFilePath,
+      code: `
+        import { objectFormatStrings } from './fixtures/testStrings';
+        const { welcomeMessage$, message$ } = objectFormatStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'message$' does not exist in translator 'objectFormatStrings'. Available keys: errorTitle$, successMessage$, welcomeMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Default Export Invalid Cases
+    // ========================================
+
+    // 24. Default import - invalid key
+    {
+      filename: testFilePath,
+      code: `
+        import defaultStrings from './fixtures/defaultExport';
+        const { invalidKey$ } = defaultStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'defaultStrings'. Available keys: anotherMessage$, defaultMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Re-export Invalid Cases
+    // ========================================
+
+    // 25. Re-export - invalid key
+    {
+      filename: testFilePath,
+      code: `
+        import { reExportedStrings } from './fixtures/reExport';
+        const { invalidKey$ } = reExportedStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'reExportedStrings'. Available keys: anotherReExported$, reExportedMessage$",
+          type: 'Property',
+        },
+      ],
+    },
+
+    // ========================================
+    // Cross-file Aliasing Invalid Cases
+    // ========================================
+
+    // 26. Cross-file aliasing - invalid key
+    {
+      filename: testFilePath,
+      code: `
+        import { testStrings } from './fixtures/testStrings';
+        const { invalidKey$: myLabel } = testStrings;
+      `,
+      errors: [
+        {
+          message:
+            "Destructured property 'invalidKey$' does not exist in translator 'testStrings'. Available keys: adminLabel$, coachLabel$, goBackAction$, learnerLabel$, userLabel$",
+          type: 'Property',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-format/.eslintrc.js
+++ b/packages/kolibri-format/.eslintrc.js
@@ -252,6 +252,7 @@ module.exports = {
     'kolibri/vue-watch-no-string': ERROR,
     'kolibri/vue-no-unused-translations': ERROR,
     'kolibri/vue-no-undefined-string-uses': ERROR,
+    'kolibri/no-undefined-translator-keys': ERROR,
     'kolibri/vue-string-objects-formatting': ERROR,
     'kolibri/vue-component-block-padding': ERROR,
     'kolibri/vue-component-block-tag-newline': ERROR,


### PR DESCRIPTION
## Summary
Implements no-undefined-translator-keys rule that prevents destructuring undefined keys from createTranslator objects. Validates both same-file and cross-file imports using AST parsing and Node.js module resolution.

## References
No open issue, but observed as a problem during recent string updates for release

## Reviewer guidance
:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 
