### PR TITLE
Remove Python 2.7 legacy: Simplify OSError/IOError exception

### DIFF
--- a/build_tools/customize_requirements.py
+++ b/build_tools/customize_requirements.py
@@ -40,7 +40,7 @@ def add_requirements_to_base():
                     os.path.join(os.path.dirname(__file__), "../requirements.txt"), "a"
                 ) as f:
                     f.writelines(requirements)
-        except IOError:
+        except OSError:
             pass
 
 

--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -254,7 +254,7 @@ def check_cache_path_writable(cache_path):
             f.write("check")
         os.remove(check_file)
         return cache_path
-    except (OSError, IOError):
+    except OSError:
         new_path = os.path.realpath("cext_cache")
         logger.info(
             "The cache directory {old_path} is not writable. Changing to directory {new_path}.".format(

--- a/kolibri/core/analytics/management/commands/profile.py
+++ b/kolibri/core/analytics/management/commands/profile.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
             with open(PROFILE_LOCK, "w") as f:
                 f.write("%d" % this_pid)
                 f.write("\n{}".format(file_timestamp))
-        except (IOError, OSError):
+        except OSError:
             logger.error(
                 "Impossible to create profile lock file. Kolibri won't profile its requests"
             )

--- a/kolibri/core/analytics/measurements.py
+++ b/kolibri/core/analytics/measurements.py
@@ -165,7 +165,7 @@ def get_kolibri_process_info():
         with open(PID_FILE, "r") as f:
             kolibri_pid = int(f.readline())
             kolibri_port = int(f.readline())
-    except IOError:
+    except OSError:
         pass  # Kolibri PID file does not exist
     except ValueError:
         pass  # corrupted Kolibri PID file

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -270,7 +270,7 @@ class multiple_kolibri_servers(object):
             server_conn = connections[server.db_alias]
             try:
                 server_conn.creation.destroy_test_db()
-            except IOError:
+            except OSError:
                 pass
             server_conn.close()
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -320,7 +320,7 @@ def remove_provisioning_file(file_path):
                 file_path
             )
         )
-    except (IOError, OSError):
+    except OSError:
         logger.warning(
             "Unable to remove provisioning file {} after successful provisioning".format(
                 file_path
@@ -368,7 +368,7 @@ def provision_from_file(file_path):
     try:
         with open(file_path, "r") as f:
             options = json.load(f)
-    except IOError:
+    except OSError:
         raise ValidationError("File {} could not be opened".format(file_path))
     except ValueError:
         raise ValidationError("File {} did not contain valid JSON".format(file_path))

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -21,9 +21,8 @@ def check_if_port_open(base_url, timeout=1):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             sock.settimeout(timeout)
             return sock.connect_ex((host, port)) == 0
-    except (OSError, IOError):
+    except OSError:
         # Catch any errors in trying to connect with the socket
-        # In Python 2 all socket errors are subclasses of IOError, in Python 3 of OSError
         return False
 
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -158,7 +158,7 @@ class WebpackBundleHook(hooks.KolibriHook):
                 .joinpath("{plugin}_stats.json".format(plugin=self.unique_id))
                 .read_text()
             )
-        except IOError as e:
+        except OSError as e:
             raise WebpackError(
                 "Error accessing stats file '{}': {}".format(self.unique_id, e)
             )

--- a/kolibri/utils/filesystem.py
+++ b/kolibri/utils/filesystem.py
@@ -14,7 +14,7 @@ def get_path_permission(path):
     """
     try:
         return os.access(resolve_path(path), os.W_OK)
-    except (IOError, OSError):
+    except OSError:
         return False
 
 
@@ -26,7 +26,7 @@ def check_is_directory(path):
     """
     try:
         return os.path.exists(resolve_path(path))
-    except (IOError, OSError):
+    except OSError:
         return False
 
 
@@ -41,5 +41,5 @@ def resolve_path(path):
 
     try:
         return os.path.realpath(os.path.expanduser(path))
-    except (IOError, OSError):
+    except OSError:
         return None

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -387,7 +387,7 @@ class DynamicWhiteNoise(WhiteNoise):
                     try:
                         comp_path = "{}.{}".format(path, ext)
                         stat_cache[comp_path] = os.stat(comp_path)
-                    except (IOError, OSError):
+                    except OSError:
                         pass
                 self.add_file_to_dictionary(url, path, stat_cache=stat_cache)
         elif (

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -96,7 +96,7 @@ def get_version():
         with open(version_file(), "r") as f:
             version = f.read()
         return version.strip() if version else ""
-    except IOError:
+    except OSError:
         return ""
 
 

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -138,7 +138,7 @@ def check_default_options_exist():
     if not os.path.exists(options_path):
         try:
             generate_empty_options_file()
-        except IOError:
+        except OSError:
             logger.warning(
                 "Failed to create an options.ini file at this path: {}".format(
                     options_path

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -617,7 +617,7 @@ class ProcessControlPlugin(Monitor):
             with open(PROCESS_CONTROL_FLAG, "r") as f:
                 try:
                     command = f.read().strip()
-                except (IOError, OSError):
+                except OSError:
                     # If the file does not exist, or there is
                     # an error when reading the file, we just carry on.
                     command = ""
@@ -944,7 +944,7 @@ def signal_restart():
     try:
         with open(PROCESS_CONTROL_FLAG, "w") as f:
             f.write(RESTART)
-    except (IOError, OSError):
+    except OSError:
         return False
     return True
 

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -96,7 +96,7 @@ def test_conditional_backup():
     default_path = default_backup_folder()
     try:
         os.rmdir(default_path)
-    except (IOError, OSError):
+    except OSError:
         pass
     os.mkdir(default_path)
 

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -239,7 +239,7 @@ def get_version_file():
     """
     try:
         return pkgutil.get_data("kolibri", "VERSION").decode("utf-8")
-    except IOError:
+    except OSError:
         return None
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This Simplifies redundant exception handling by replacing all `except (OSError, IOError)`  and ` except IOError` cases with `except OSError` In Python 3, IOError is an alias of OSError, so catching both is unnecessary. No functional behavior changes; tests pass.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes #13887 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
**Location of changes**
```
build_tools/customize_requirements.py
build_tools/install_cexts.py
kolibri/core/analytics/management/commands/profile.py
kolibri/core/analytics/measurements.py
kolibri/core/auth/test/sync_utils.py
kolibri/core/device/utils.py
kolibri/core/discovery/utils/network/connections.py
kolibri/core/webpack/hooks.py
kolibri/utils/filesystem.py
kolibri/utils/kolibri_whitenoise.py
kolibri/utils/main.py
kolibri/utils/sanity_checks.py
kolibri/utils/server.py
kolibri/utils/tests/test_main.py
kolibri/utils/version.py
```