### PR TITLE
Fix regression that caused all devserver building to use hot reload

### DIFF
--- a/packages/kolibri-build/src/cli.js
+++ b/packages/kolibri-build/src/cli.js
@@ -215,7 +215,7 @@ function getBundleData(options) {
 // Dev command
 addBuildOptions(program.command('dev'))
   .description('Start development server with hot module reloading')
-  .option('-h, --hot', 'Use hot module reloading in the webpack devserver', true)
+  .option('-h, --hot', 'Use hot module reloading in the webpack devserver', false)
   .option('--port <port>', 'Set a port number to start devserver on', Number, 3000)
   .option('--host <host>', 'Set a host to serve devserver', String, '127.0.0.1')
   .option('--write-to-disk', 'Write files to disk instead of using webpack devserver', false)


### PR DESCRIPTION
## Summary
Recent refactors of the kolibri packages accidentally flipped the `hot` option for dev builds from defaulting to true from false - meaning that there wasn't actually any way to turn off hot reloading mode.
This PR reverts that error.

## References
Fixes regression from #13869

## Reviewer guidance
Make sure if you run `yarn run devserver` it doesn't use hot reload!