### PR TITLE
refactor replace replace() with os.replace()

### DIFF
--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -98,18 +98,6 @@ def retry_import(e):
     return False
 
 
-def replace(file_path, new_file_path):
-    """
-    Do a replace type operation.
-    This is not the same as an atomic replacement, as it could result
-    in the target file being removed before the rename happens.
-    This can be removed once Python 2.7 support is dropped
-    """
-    if os.path.exists(new_file_path):
-        os.remove(new_file_path)
-    os.rename(file_path, new_file_path)
-
-
 class ChunkedFileDoesNotExist(Exception):
     pass
 
@@ -442,7 +430,7 @@ class ChunkedFile(TransferFileBase):
                 chunk_file = self._get_chunk_file_name(chunk_index)
                 with open(chunk_file, "rb") as input_file:
                     shutil.copyfileobj(input_file, output_file)
-        replace(tmp_filepath, self.filepath)
+        os.replace(tmp_filepath, self.filepath)
 
     def _get_expected_chunk_size(self, chunk_index):
         return (
@@ -578,7 +566,7 @@ class TransferFile(TransferFileBase):
             self._file_obj.close()
             self._file_obj = None
         if os.path.exists(self._tmp_filepath):
-            replace(self._tmp_filepath, self.filepath)
+            os.replace(self._tmp_filepath, self.filepath)
         self._finalized = True
 
     def delete(self):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR removes the legacy `replace()` function in `kolibri/utils/file_transfer.py` , which was originally a Python 2.7 compatibility wrapper. Since the function is only used within the same file and not imported elsewhere, all calls to `replace()` have been updated to use `os.replace` instead.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes #13886 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
#### Location of Changes: 
1. `kolibri/utils/file_transfer.py`
