### PR TITLE
Remove Python 2.7 legacy: Update JSONDecodeError exception handling

### DIFF
--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -13,10 +13,7 @@ try:
 except NameError:
     FileNotFoundError = IOError
 
-try:
-    from json import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
+from json import JSONDecodeError
 
 
 logger = logging.getLogger(__name__)

--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -36,7 +36,7 @@ def json_file_contents(parser, arg):
     with open(arg, "r") as f:
         try:
             return json.load(f)
-        except ValueError as e:  # Use ValueError rather than JSONDecodeError for Py2 compatibility
+        except json.JSONDecodeError as e:
             return parser.error("The file '{}' is not valid JSON:\n{}".format(arg, e))
 
 

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -225,7 +225,7 @@ class NetworkClient(requests.Session):
                 parsed_url.netloc,
                 parsed_url.path.rstrip("/").replace("api/public/info", ""),
             )
-        except (requests.exceptions.JSONDecodeError, ValueError) as e:
+        except requests.exceptions.JSONDecodeError as e:
             logger.info(
                 "Invalid JSON returned when attempting to connect to a remote server"
             )

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -108,7 +108,7 @@ class JSONField(JSONFieldBase):
         if isinstance(value, str):
             try:
                 return json.loads(value, **self.load_kwargs)
-            except ValueError:
+            except json.JSONDecodeError:
                 pass
 
         return value
@@ -117,7 +117,7 @@ class JSONField(JSONFieldBase):
         if isinstance(value, str):
             try:
                 return json.loads(value, **self.load_kwargs)
-            except ValueError:
+            except json.JSONDecodeError:
                 pass
 
         return value

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -204,7 +204,7 @@ def get_public_file_checksums(request, version):
             return HttpResponseBadRequest("POST body must be either json or gzip")
         try:
             checksums = json.loads(data.decode("utf-8"))
-        except ValueError:
+        except json.JSONDecodeError:
             return HttpResponseBadRequest("POST body must be valid json")
 
         checksums = [

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -33,7 +33,7 @@ class ConfigDict(dict):
                 with open(conf_file, "r") as kolibri_conf_file:
                     self.update(json.load(kolibri_conf_file))
                 return
-            except ValueError:
+            except json.JSONDecodeError:
                 logger.warning(
                     "Attempted to load plugins.json but encountered a file that could not be decoded as valid JSON."
                 )


### PR DESCRIPTION
Fixes #13889 

## Summary
This PR removes Python 2.7 legacy code by updating JSON parsing exception handling from `ValueError` to `json.JSONDecodeError`. The changes make exception handling more specific and remove outdated compatibility code.

## References
Fixes #13889
## Reviewer guidance
- Review the specific file changes to ensure only JSON parsing-related `ValueError` instances were updated
- Verify that the exception handling logic remains the same, only the exception type changed
- Confirm that Python 2 compatibility comments have been removed

## Files changed:
- kolibri/core/device/management/commands/provisiondevice.py
- kolibri/plugins/__init__.py
- kolibri/core/public/api.py
- kolibri/core/fields.py