### PR TITLE
HTML5 Article Renderer : Adds polyfill for <dialog> to ensure browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,24 +49,24 @@
   },
   "private": true,
   "devDependencies": {
-    "@types/jest": "^30.0.0",
-    "xhr-mock": "^2.5.1",
-    "concurrently": "^8.0.1",
     "@crowdin/cli": "^4.11.0",
     "@rushstack/eslint-patch": "^1.15.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/user-event": "^14.6.1",
     "@testing-library/vue": "^5",
+    "@types/jest": "^30.0.0",
     "@vue/test-utils": "^1.3.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^30.2.0",
+    "concurrently": "^8.0.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-serializer-vue": "^3.1.0",
     "rewire": "^6.0.0",
     "vue-jest": "^3.0.0",
     "vue-template-compiler": "2.7.16",
-    "webpack": "^5.102.1"
+    "webpack": "^5.102.1",
+    "xhr-mock": "^2.5.1"
   },
   "optionalDependencies": {
     "fsevents": "*"
@@ -82,5 +82,8 @@
   "volta": {
     "node": "20.19.3",
     "yarn": "1.22.22"
+  },
+  "dependencies": {
+    "dialog-polyfill": "^0.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,24 +49,24 @@
   },
   "private": true,
   "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "xhr-mock": "^2.5.1",
+    "concurrently": "^8.0.1",
     "@crowdin/cli": "^4.11.0",
     "@rushstack/eslint-patch": "^1.15.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/user-event": "^14.6.1",
     "@testing-library/vue": "^5",
-    "@types/jest": "^30.0.0",
     "@vue/test-utils": "^1.3.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^30.2.0",
-    "concurrently": "^8.0.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-serializer-vue": "^3.1.0",
     "rewire": "^6.0.0",
     "vue-jest": "^3.0.0",
     "vue-template-compiler": "2.7.16",
-    "webpack": "^5.102.1",
-    "xhr-mock": "^2.5.1"
+    "webpack": "^5.102.1"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -4,7 +4,7 @@
     v-if="open"
     ref="dialogRef"
     closedby="any"
-    :aria-label="$tr('expandedImage')"
+    :aria-label="coreString('expandedImage')"
     class="lightbox-dialog"
     data-testid="lightbox-dialog"
     @close="closeLightbox"
@@ -19,8 +19,8 @@
           icon="remove"
           :color="$themeTokens.surface"
           size="small"
-          :aria-label="$tr('zoomOut')"
-          :tooltip="$tr('zoomOut')"
+          :aria-label="coreString('zoomOut')"
+          :tooltip="coreString('zoomOut')"
           :disabled="scale === minScale"
           @click="zoomImage('out')"
         />
@@ -30,8 +30,8 @@
           icon="add"
           :color="$themeTokens.surface"
           size="small"
-          :aria-label="$tr('zoomIn')"
-          :tooltip="$tr('zoomIn')"
+          :aria-label="coreString('zoomIn')"
+          :tooltip="coreString('zoomIn')"
           :disabled="scale === maxScale"
           autofocus
           @click="zoomImage('in')"
@@ -42,8 +42,8 @@
           icon="close"
           :color="$themeTokens.surface"
           size="small"
-          :aria-label="$tr('close')"
-          :tooltip="$tr('close')"
+          :aria-label="coreString('closeAction')"
+          :tooltip="coreString('closeAction')"
           @click="closeLightbox"
         />
       </div>
@@ -68,7 +68,13 @@
 
 <script>
 
+  import dialogPolyfill from 'dialog-polyfill';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+
   function supportsDialogClosedBy() {
+    if (typeof document === 'undefined') {
+      return false;
+    }
     const dialog = document.createElement('dialog');
     return 'closedBy' in dialog;
   }
@@ -79,13 +85,20 @@
 
   export default {
     name: 'Lightbox',
+    mixins: [commonCoreStrings],
     props: {
       open: {
         type: Boolean,
         required: true,
       },
-      src: { type: String, required: true },
-      alt: { type: String, default: '' },
+      src: {
+        type: String,
+        required: true,
+      },
+      alt: {
+        type: String,
+        default: '',
+      },
       styleOverrides: {
         type: Object,
         default: () => ({}),
@@ -104,6 +117,7 @@
         isDragging: false,
         dragStart: { x: 0, y: 0 },
         backdropClickValid: false,
+        polyfillRegistered: false,
       };
     },
     computed: {
@@ -127,25 +141,40 @@
     },
     watch: {
       open(val) {
+        const dialog = this.$refs.dialogRef;
+
         if (val) {
           this.$nextTick(() => {
-            if (this.$refs.dialogRef) {
-              this.$refs.dialogRef.showModal();
-              if (!supportsDialogClosedBy()) {
-                this.$refs.dialogRef.addEventListener('mousedown', this.onBackdropMouseDown);
-                this.$refs.dialogRef.addEventListener('mouseup', this.onBackdropMouseUp);
-              }
+            const dlg = this.$refs.dialogRef;
+            if (!dlg) return;
+
+            // If this dialog element itself doesn't have showModal, register polyfill.
+            if (typeof dlg.showModal !== 'function' && !this.polyfillRegistered) {
+              dialogPolyfill.registerDialog(dlg);
+              this.polyfillRegistered = true;
+            }
+
+            dlg.showModal();
+
+            if (!supportsDialogClosedBy()) {
+              dlg.addEventListener('mousedown', this.onBackdropMouseDown);
+              dlg.addEventListener('mouseup', this.onBackdropMouseUp);
             }
           });
         } else {
           if (this.$refs.imageRef) {
             this.$refs.imageRef.classList.remove('with-transition');
           }
-          if (this.$refs.dialogRef) {
-            this.$refs.dialogRef.close();
+          if (dialog) {
+            if (typeof dialog.close === 'function') {
+              dialog.close();
+            } else {
+              dialog.removeAttribute('open');
+            }
+
             if (!supportsDialogClosedBy()) {
-              this.$refs.dialogRef.removeEventListener('mousedown', this.onBackdropMouseDown);
-              this.$refs.dialogRef.removeEventListener('mouseup', this.onBackdropMouseUp);
+              dialog.removeEventListener('mousedown', this.onBackdropMouseDown);
+              dialog.removeEventListener('mouseup', this.onBackdropMouseUp);
             }
           }
         }
@@ -153,10 +182,8 @@
       scale(newScale) {
         this.$nextTick(() => {
           if (!this.$refs.imageRef) return;
-          // Keep focus within the dialog when zoom-out or zoom-in button become disabled
-          if (newScale == this.minScale || newScale == this.maxScale) {
+          if (newScale === this.minScale || newScale === this.maxScale) {
             this.$refs.imageRef.focus();
-            return;
           }
         });
       },
@@ -166,6 +193,9 @@
     },
     beforeDestroy() {
       window.removeEventListener('resize', this.onWindowResize);
+      // Extra safety in case the component is destroyed mid-drag
+      window.removeEventListener('mousemove', this.onMouseMove);
+      window.removeEventListener('mouseup', this.onMouseUp);
     },
     methods: {
       enableTransitionsAfterPaint() {
@@ -183,26 +213,34 @@
           });
         });
       },
+
+      /**
+       * Compute base image size (scale=1) to fit within viewport minus margins.
+       */
       calculateSize() {
         this.backdropSize.width = window.innerWidth;
-        this.backdropSize.height = window.innerHeight - 40; // 40px for action bar
-        const isSmallWindow = this.styleOverrides.windowSizeClass.includes('small-window');
-        const maxW = this.backdropSize.width - (isSmallWindow ? 32 : 64); // 32px margin for small window, 64px for larger
+        this.backdropSize.height = window.innerHeight - 40; // action bar height
+
+        const isSmallWindow = this.styleOverrides.windowSizeClass?.includes('small-window');
+        const maxW = this.backdropSize.width - (isSmallWindow ? 32 : 64);
         const maxH = this.backdropSize.height - (isSmallWindow ? 32 : 64);
 
         const img = this.$refs.imageRef;
         if (!img) return;
+
         const naturalW = img.naturalWidth;
         const naturalH = img.naturalHeight;
 
         const widthRatio = maxW / naturalW;
         const heightRatio = maxH / naturalH;
         const scale = Math.min(widthRatio, heightRatio, 1);
+
         this.baseSize.width = Math.round(naturalW * scale);
         this.baseSize.height = Math.round(naturalH * scale);
 
         this.enableTransitionsAfterPaint();
       },
+
       onWindowResize() {
         const img = this.$refs.imageRef;
         if (img && img.complete) {
@@ -221,6 +259,7 @@
         );
         return { DeltaLimitX, DeltaLimitY };
       },
+
       clampDelta() {
         const { DeltaLimitX, DeltaLimitY } = this.getDeltaLimits();
         this.delta.x = clamp(this.delta.x, -DeltaLimitX, DeltaLimitX);
@@ -230,7 +269,9 @@
         if (this.scale <= 1) return; // No reposition if not zoomed
         e.preventDefault();
         this.isDragging = true;
-        this.$refs.imageRef.classList.remove('with-transition');
+        if (this.$refs.imageRef) {
+          this.$refs.imageRef.classList.remove('with-transition');
+        }
         this.dragStart = { x: e.clientX, y: e.clientY };
         this.origin = { x: this.delta.x, y: this.delta.y };
         window.addEventListener('mousemove', this.onMouseMove);
@@ -244,7 +285,9 @@
       },
       onMouseUp() {
         this.isDragging = false;
-        this.$refs.imageRef.classList.add('with-transition');
+        if (this.$refs.imageRef) {
+          this.$refs.imageRef.classList.add('with-transition');
+        }
         window.removeEventListener('mousemove', this.onMouseMove);
         window.removeEventListener('mouseup', this.onMouseUp);
       },
@@ -262,19 +305,24 @@
         this.clampDelta();
       },
       handleTab(e) {
-        const focusables = this.$refs.dialogRef.querySelectorAll('button:not([disabled])');
+        const dialog = this.$refs.dialogRef;
+        if (!dialog) return;
+
+        const focusables = dialog.querySelectorAll('button:not([disabled])');
         if (!focusables.length) return;
-        const firstFocusable = focusables[0];
-        const lastFocusable = focusables[focusables.length - 1];
+
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+
         if (e.shiftKey && e.key === 'Tab') {
-          if (document.activeElement === firstFocusable) {
+          if (document.activeElement === first) {
             e.preventDefault();
-            lastFocusable.focus();
+            last.focus();
           }
         } else if (e.key === 'Tab') {
-          if (document.activeElement === lastFocusable) {
-            firstFocusable.focus();
+          if (document.activeElement === last) {
             e.preventDefault();
+            first.focus();
           }
         }
       },
@@ -300,19 +348,19 @@
         newDeltaX = clamp(newDeltaX, -DeltaLimitX, DeltaLimitX);
         newDeltaY = clamp(newDeltaY, -DeltaLimitY, DeltaLimitY);
 
-        // Update delta and scale together
         this.delta.x = newDeltaX;
         this.delta.y = newDeltaY;
         this.scale = newScale;
 
-        if (this.scale === 1) this.resetPosition();
+        if (this.scale === 1) {
+          this.resetPosition();
+        }
       },
       onWheel(e) {
         e.preventDefault();
         const img = this.$refs.imageRef;
         if (!img) return;
         const rect = img.getBoundingClientRect();
-        // Cursor's position ratio relative to the center of the image
         const relX = (e.clientX - rect.left) / rect.width - 0.5;
         const relY = (e.clientY - rect.top) / rect.height - 0.5;
         if (e.deltaY < 0) {
@@ -326,7 +374,7 @@
         this.resetPosition();
         this.scale = 1;
       },
-      // Fallback backdrop mouse event handlers for browsers without `closedby` support
+
       onBackdropMouseDown(e) {
         // Only track if mousedown started on the backdrop (not on the actionbar nor image)
         this.backdropClickValid = e.target === this.$refs.dialogRef;
@@ -339,18 +387,14 @@
         this.backdropClickValid = false;
       },
     },
-    $trs: {
-      expandedImage: 'Expanded image',
-      zoomOut: 'Zoom out',
-      zoomIn: 'Zoom in',
-      close: 'Close',
-    },
   };
 
 </script>
 
 
 <style>
+
+  @import '~dialog-polyfill/dist/dialog-polyfill.css';
 
   .action-bar {
     position: fixed;
@@ -361,11 +405,12 @@
     display: flex;
     gap: 8px;
     align-items: center;
-    justify-content: end;
+    justify-content: flex-end;
     height: 40px;
     padding-right: 8px;
   }
 
+  /* Main dialog region under the action bar */
   .lightbox-dialog {
     position: fixed;
     inset: 40px 0 0;
@@ -379,10 +424,17 @@
     border: 0;
   }
 
+  /* Native backdrop */
   .lightbox-dialog::backdrop {
     background-color: rgba(51, 51, 51, 0.5);
   }
 
+  /* Polyfill backdrop (dialog + .backdrop sibling) */
+  .lightbox-dialog + .backdrop {
+    background-color: rgba(51, 51, 51, 0.5);
+  }
+
+  /* Image inside dialog */
   .expanded-image {
     position: relative;
     z-index: 110;

--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -4,63 +4,70 @@
     v-if="open"
     ref="dialogRef"
     closedby="any"
-    :aria-label="coreString('expandedImage')"
+    :aria-label="$tr('expandedImage')"
     class="lightbox-dialog"
     data-testid="lightbox-dialog"
     @close="closeLightbox"
     @keydown="onKeyDown"
   >
-    <div
-      class="action-bar"
-      :style="{ backgroundColor: $themePalette.grey.v_900 }"
+    <KFocusTrap
+      @shouldFocusFirstEl="focusFirstEl"
+      @shouldFocusLastEl="focusLastEl"
     >
-      <div :class="scale !== minScale ? $computedClass(btnHoverStyle) : ''">
-        <KIconButton
-          icon="remove"
-          :color="$themeTokens.surface"
-          size="small"
-          :aria-label="coreString('zoomOut')"
-          :tooltip="coreString('zoomOut')"
-          :disabled="scale === minScale"
-          @click="zoomImage('out')"
-        />
+      <div
+        class="action-bar"
+        :style="{ backgroundColor: $themePalette.grey.v_900 }"
+      >
+        <div :class="scale !== minScale ? $computedClass(btnHoverStyle) : ''">
+          <KIconButton
+            icon="remove"
+            :color="$themeTokens.surface"
+            size="small"
+            :aria-label="coreString('zoomOut')"
+            :tooltip="coreString('zoomOut')"
+            :disabled="scale === minScale"
+            @click="zoomImage('out')"
+          />
+        </div>
+        <div :class="scale !== maxScale ? $computedClass(btnHoverStyle) : ''">
+          <KIconButton
+            icon="add"
+            :color="$themeTokens.surface"
+            size="small"
+            :aria-label="coreString('zoomIn')"
+            :tooltip="coreString('zoomIn')"
+            :disabled="scale === maxScale"
+            autofocus
+            @click="zoomImage('in')"
+          />
+        </div>
+        <div :class="$computedClass(btnHoverStyle)">
+          <KIconButton
+            ref="closeButton"
+            icon="close"
+            :color="$themeTokens.surface"
+            size="small"
+            :aria-label="coreString('closeAction')"
+            :tooltip="coreString('closeAction')"
+            @click="closeLightbox"
+          />
+        </div>
       </div>
-      <div :class="scale !== maxScale ? $computedClass(btnHoverStyle) : ''">
-        <KIconButton
-          icon="add"
-          :color="$themeTokens.surface"
-          size="small"
-          :aria-label="coreString('zoomIn')"
-          :tooltip="coreString('zoomIn')"
-          :disabled="scale === maxScale"
-          autofocus
-          @click="zoomImage('in')"
-        />
-      </div>
-      <div :class="$computedClass(btnHoverStyle)">
-        <KIconButton
-          icon="close"
-          :color="$themeTokens.surface"
-          size="small"
-          :aria-label="coreString('closeAction')"
-          :tooltip="coreString('closeAction')"
-          @click="closeLightbox"
-        />
-      </div>
-    </div>
-    <img
-      ref="imageRef"
-      :src="src"
-      :alt="alt"
-      tabindex="-1"
-      class="expanded-image"
-      :class="styleOverrides.windowSizeClass"
-      :style="imgStyle"
-      @load="calculateSize"
-      @mousedown="onMouseDown"
-      @wheel="onWheel"
-      @dragstart.prevent
-    >
+
+      <img
+        ref="imageRef"
+        :src="src"
+        :alt="alt"
+        tabindex="-1"
+        class="expanded-image"
+        :class="styleOverrides.windowSizeClass"
+        :style="imgStyle"
+        @load="calculateSize"
+        @mousedown="onMouseDown"
+        @wheel="onWheel"
+        @dragstart.prevent
+      >
+    </KFocusTrap>
   </dialog>
 
 </template>
@@ -117,7 +124,6 @@
         isDragging: false,
         dragStart: { x: 0, y: 0 },
         backdropClickValid: false,
-        polyfillRegistered: false,
       };
     },
     computed: {
@@ -146,13 +152,10 @@
         if (val) {
           this.$nextTick(() => {
             const dlg = this.$refs.dialogRef;
-            if (!dlg) return;
-
-            // If this dialog element itself doesn't have showModal, register polyfill.
-            if (typeof dlg.showModal !== 'function' && !this.polyfillRegistered) {
-              dialogPolyfill.registerDialog(dlg);
-              this.polyfillRegistered = true;
+            if (!dlg) {
+              return;
             }
+            dialogPolyfill.registerDialog(dlg);
 
             dlg.showModal();
 
@@ -292,11 +295,18 @@
         window.removeEventListener('mouseup', this.onMouseUp);
       },
       onKeyDown(e) {
+        if (e.key === 'Escape' || e.key === 'Esc') {
+          e.preventDefault();
+          this.closeLightbox();
+          return;
+        }
+
         this.handleArrowKeys(e);
-        this.handleTab(e);
       },
       handleArrowKeys(e) {
-        if (this.scale === 1) return;
+        if (this.scale === 1) {
+          return;
+        }
         const step = 50;
         if (e.key === 'ArrowLeft') this.delta.x += step;
         if (e.key === 'ArrowRight') this.delta.x -= step;
@@ -304,26 +314,25 @@
         if (e.key === 'ArrowDown') this.delta.y -= step;
         this.clampDelta();
       },
-      handleTab(e) {
+
+      focusFirstEl() {
         const dialog = this.$refs.dialogRef;
-        if (!dialog) return;
-
+        if (!dialog) {
+          return;
+        }
         const focusables = dialog.querySelectorAll('button:not([disabled])');
-        if (!focusables.length) return;
-
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
-
-        if (e.shiftKey && e.key === 'Tab') {
-          if (document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          }
-        } else if (e.key === 'Tab') {
-          if (document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
+        if (focusables.length) {
+          focusables[0].focus();
+        }
+      },
+      focusLastEl() {
+        const dialog = this.$refs.dialogRef;
+        if (!dialog) {
+          return;
+        }
+        const focusables = dialog.querySelectorAll('button:not([disabled])');
+        if (focusables.length) {
+          focusables[focusables.length - 1].focus();
         }
       },
       resetPosition() {
@@ -374,7 +383,7 @@
         this.resetPosition();
         this.scale = 1;
       },
-
+      // Fallback backdrop mouse event handlers for browsers without `closedby` support
       onBackdropMouseDown(e) {
         // Only track if mousedown started on the backdrop (not on the actionbar nor image)
         this.backdropClickValid = e.target === this.$refs.dialogRef;
@@ -385,6 +394,12 @@
           this.closeLightbox();
         }
         this.backdropClickValid = false;
+      },
+    },
+    $trs: {
+      expandedImage: {
+        message: 'Expanded image',
+        context: 'Label for an image that is shown in an expanded view',
       },
     },
   };

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -82,4 +82,9 @@
       opacity 0.15s;
   }
 
+  .img-wrapper {
+    max-width: 900px;
+    max-height: 584px;
+  }
+
 </style>

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -222,11 +222,6 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context: 'Label for a button used to zoom out the document view (make it smaller)',
   },
 
-  expandedImage: {
-    message: 'Expanded image',
-    context: 'Label for an image that is shown in an expanded view',
-  },
-
   // labels, phrases, titles, headers...
   adminLabel: {
     message: 'Admin',

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -222,6 +222,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context: 'Label for a button used to zoom out the document view (make it smaller)',
   },
 
+  expandedImage: {
+    message: 'Expanded image',
+    context: 'Label for an image that is shown in an expanded view',
+  },
+
   // labels, phrases, titles, headers...
   adminLabel: {
     message: 'Admin',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,6 +4918,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+dialog-polyfill@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz#7507b4c745a82fcee0fa07ce64d835979719599a"
+  integrity sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"


### PR DESCRIPTION

## Summary
This PR adds [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill) to provide consistent <dialog> behavior across all browsers.

Closes #13716

## References
 #13716

## Reviewer guidance
Verify if :

-  Polyfill is registered only when native <dialog> APIs are missing.
-  Lightbox opens and closes using consistent methods (showModal, close).
-  Backdrop and background-inert behaviour are correctly handled.
-  The escape key and backdrop click dismiss the Lightbox.
-  Focus is trapped inside the dialog while open.
-  Focus returns to an appropriate element after closing
-  Logic doesn’t break native <dialog> in supported browsers.
- Confirm no regressions in modern browsers
-  Polyfill path is correctly exercised for unsupported browsers. 