### PR TITLE
Remove Python 2.7: Simple syntax and import cleanups

### DIFF
--- a/build_tools/i18n/fonts.py
+++ b/build_tools/i18n/fonts.py
@@ -6,7 +6,6 @@ For usage instructions, see:
 import argparse
 import base64
 import functools
-import io
 import json
 import logging
 import mimetypes
@@ -354,7 +353,7 @@ def _write_inline_font(file_object, font_path, font_family, weight):
     """
     Inlines a font as base64 encoding within a CSS file
     """
-    with io.open(font_path, mode="rb") as f:
+    with open(font_path, mode="rb") as f:
         data = f.read()
     data_uri = "data:application/x-font-woff;charset=utf-8;base64,\\\n{}".format(
         "\\\n".join(_chunks(base64.b64encode(data).decode()))
@@ -417,7 +416,7 @@ def _get_lang_strings(locale_dir):
             continue
 
         file_path = os.path.join(locale_dir, file_name)
-        with io.open(file_path, mode="r", encoding="utf-8") as f:
+        with open(file_path, mode="r", encoding="utf-8") as f:
             lang_strings = json.load(f).values()
 
         for s in lang_strings:

--- a/build_tools/i18n/utils.py
+++ b/build_tools/i18n/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import functools
-import io
 import json
 import logging
 import os
@@ -52,7 +51,7 @@ def available_languages():
     Returns all available languages including English and in-context language.
     Callers should filter as needed.
     """
-    with io.open(LANGUAGE_INFO_PATH, mode="r", encoding="utf-8") as f:
+    with open(LANGUAGE_INFO_PATH, mode="r", encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -88,7 +87,7 @@ def json_dump_formatted(data, file_path):
         os.makedirs(dir_name)
 
     # Format and write the JSON file
-    with io.open(file_path, mode="w+", encoding="utf-8") as file_object:
+    with open(file_path, mode="w+", encoding="utf-8") as file_object:
         # Manage unicode for the JSON dumping
         json.dump(
             data,

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -13,13 +13,9 @@ import os
 import re
 import subprocess
 import sys
-
-
-# py2+py3 compatible imports via http://python-future.org/compatible_idioms.html
-try:
-    from urllib.request import Request, build_opener, HTTPRedirectHandler
-except ImportError:
-    from urllib2 import Request, HTTPRedirectHandler, build_opener
+from urllib.request import build_opener
+from urllib.request import HTTPRedirectHandler
+from urllib.request import Request
 
 logging.basicConfig(level=logging.INFO)
 

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -2,7 +2,6 @@ import base64
 import csv
 import datetime
 import hashlib
-import io
 import os
 import random
 import uuid
@@ -79,7 +78,7 @@ class BaseDeviceSetupMixin(object):
 
         # Load in the user data from the csv file to give a predictable source of user data
         data_path = os.path.join(USER_CSV_PATH)
-        with io.open(data_path, mode="r", encoding="utf-8") as f:
+        with open(data_path, mode="r", encoding="utf-8") as f:
             users = [data for data in csv.DictReader(f)]
 
         cls.facilities = user_data.get_or_create_facilities(

--- a/kolibri/core/auth/constants/facility_presets.py
+++ b/kolibri/core/auth/constants/facility_presets.py
@@ -1,11 +1,10 @@
-import io
 import json
 import os
 
 presets_file = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "./facility_configuration_presets.json")
 )
-with io.open(presets_file, mode="r", encoding="utf-8") as f:
+with open(presets_file, mode="r", encoding="utf-8") as f:
     presets = json.load(f)
 
 choices = [(key, key) for key in presets]

--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -1,5 +1,4 @@
 import inspect
-import io
 import json
 import os
 import shutil
@@ -137,7 +136,7 @@ class Command(BaseCommand):
             metadata, False, True, True, True, False, nocomments=False
         )
 
-        with io.open(
+        with open(
             SQLALCHEMY_CLASSES_PATH_TEMPLATE.format(
                 name=coerce_version_name_to_valid_module_path(version)
             ),
@@ -157,7 +156,7 @@ class Command(BaseCommand):
                 data[table_name] = [get_dict(r) for r in session.query(record).all()]
 
             data_path = DATA_PATH_TEMPLATE.format(name=version)
-            with io.open(data_path, mode="w", encoding="utf-8") as f:
+            with open(data_path, mode="w", encoding="utf-8") as f:
                 json.dump(data, f)
 
             shutil.rmtree(

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -1,4 +1,3 @@
-import io
 import json
 import logging
 import os
@@ -420,7 +419,7 @@ class ContentImportTestBase(TransactionTestCase):
         metadata = load_metadata(self.schema_name)
 
         data_path = DATA_PATH_TEMPLATE.format(name=self.data_name)
-        with io.open(data_path, mode="r", encoding="utf-8") as f:
+        with open(data_path, mode="r", encoding="utf-8") as f:
             data = json.load(f)
 
         metadata.bind = self.content_engine
@@ -536,7 +535,7 @@ def alternate_existing_channel(request):
 class ContentImportDataTestBase(ContentImportTestBase):
     def set_content_fixture(self):
         data_path = DATA_PATH_TEMPLATE.format(name=self.data_name)
-        with io.open(data_path, mode="r", encoding="utf-8") as f:
+        with open(data_path, mode="r", encoding="utf-8") as f:
             data = json.load(f)
         self.content_engine = create_engine("sqlite://")
 
@@ -553,7 +552,7 @@ class ContentImportDataTestBase(ContentImportTestBase):
 class ContentImportPartialChannelDataTestBase(ContentImportTestBase):
     def set_content_fixture(self):
         data_path = DATA_PATH_TEMPLATE.format(name=self.data_name)
-        with io.open(data_path, mode="r", encoding="utf-8") as fp:
+        with open(data_path, mode="r", encoding="utf-8") as fp:
             data = json.load(fp)
         self.content_engine = create_engine("sqlite://")
 

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -1,4 +1,3 @@
-import io
 import os
 import re
 
@@ -293,7 +292,7 @@ SANDBOX_FILENAME = None
 def get_sandbox_html_filename():
     global SANDBOX_FILENAME
     if SANDBOX_FILENAME is None or getattr(settings, "DEVELOPER_MODE", None):
-        with io.open(
+        with open(
             os.path.abspath(
                 os.path.join(os.path.dirname(__file__), "../build/sandbox_filename")
             ),

--- a/kolibri/core/content/utils/stopwords.py
+++ b/kolibri/core/content/utils/stopwords.py
@@ -1,4 +1,3 @@
-import io
 import json
 import os
 
@@ -8,7 +7,7 @@ stopwords_path = os.path.abspath(
         os.path.dirname(__file__), os.path.pardir, "constants", "stopwords-all.json"
     )
 )
-with io.open(stopwords_path, mode="r", encoding="utf-8") as f:
+with open(stopwords_path, mode="r", encoding="utf-8") as f:
     stopwords = json.load(f)
 
 # load into a set

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import os
 import re
@@ -103,9 +102,8 @@ def dbbackup(old_version, dest_folder=None):
 
     backup_path = os.path.join(dest_folder, fname)
 
-    # Setting encoding=utf-8: io.open() is Python 2 compatible
     # See: https://github.com/learningequality/kolibri/issues/2875
-    with io.open(backup_path, **KWARGS_IO_WRITE) as f:
+    with open(backup_path, **KWARGS_IO_WRITE) as f:
         # If the connection hasn't been opened yet, then open it
         if not db.connections["default"].connection:
             db.connections["default"].connect()
@@ -138,7 +136,6 @@ def dbrestore(from_file):
     else:
         logger.info("In memory database, not truncating: {}".format(dst_file))
 
-    # Setting encoding=utf-8: io.open() is Python 2 compatible
     # See: https://github.com/learningequality/kolibri/issues/2875
     with open(from_file, **KWARGS_IO_READ) as f:
         db.connections["default"].connect()

--- a/kolibri/core/logger/management/commands/generateuserdata.py
+++ b/kolibri/core/logger/management/commands/generateuserdata.py
@@ -1,5 +1,4 @@
 import csv
-import io
 import logging
 import os
 import random
@@ -111,7 +110,7 @@ class Command(BaseCommand):
         data_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "user_data.csv")
         )
-        with io.open(data_path, mode="r", encoding="utf-8") as f:
+        with open(data_path, mode="r", encoding="utf-8") as f:
             user_data = [data for data in csv.DictReader(f)]
 
         n_seed = options["seed"]

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import os
 import sqlite3
@@ -110,7 +109,7 @@ def repair_sqlite_db(connection):
     # now, let's try to repair it, if possible:
     # os.remove(original_path)
     fixed_db_path = "{}.2".format(original_path)
-    with io.open(fixed_db_path, **KWARGS_IO_WRITE) as f:
+    with open(fixed_db_path, **KWARGS_IO_WRITE) as f:
         # If the connection hasn't been opened yet, then open it
         try:
             for line in connection.connection.iterdump():

--- a/kolibri/core/utils/nothing.py
+++ b/kolibri/core/utils/nothing.py
@@ -7,10 +7,8 @@ class Nothing:
     def __repr__(self):
         return "Nothing(%s)" % self.kind
 
-    def __nonzero__(self):
+    def __bool__(self):
         return False
-
-    __bool__ = __nonzero__  # this is for python3
 
     def __eq__(self, other):
         try:

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -6,7 +6,6 @@ To manage assets, we use the webpack format. In order to have assets bundled in,
 you should put them in ``yourapp/assets/src``.
 """
 import codecs
-import io
 import json
 import logging
 import os
@@ -176,7 +175,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         lang_code = get_language()
         frontend_message_file = self.frontend_message_file(lang_code)
         if frontend_message_file:
-            with io.open(frontend_message_file, mode="r", encoding="utf-8") as f:
+            with open(frontend_message_file, mode="r", encoding="utf-8") as f:
                 message_file_content = json.load(f)
             return message_file_content
 

--- a/kolibri/plugins/qti_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/qti_viewer/kolibri_plugin.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from le_utils.constants import format_presets
 
 from kolibri.core.content import hooks as content_hooks

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import importlib
-import io
 import json
 import locale
 import os
@@ -32,7 +31,7 @@ def _get_language_info():
     file_path = os.path.abspath(
         os.path.join(os.path.dirname(kolibri.__file__), "locale", "language_info.json")
     )
-    with io.open(file_path, encoding="utf-8") as f:
+    with open(file_path, encoding="utf-8") as f:
         languages = json.load(f)
         output = {}
         for language in languages:

--- a/kolibri/utils/pskolibri/common.py
+++ b/kolibri/utils/pskolibri/common.py
@@ -1,5 +1,4 @@
 import functools
-import io
 import os
 import sys
 from collections import namedtuple
@@ -129,7 +128,7 @@ def memoize_when_activated(fun):
 
 
 def open_binary(fname, **kwargs):
-    return io.open(fname, "rb", **kwargs)
+    return open(fname, "rb", **kwargs)
 
 
 def open_text(fname, **kwargs):
@@ -138,4 +137,4 @@ def open_text(fname, **kwargs):
     """
     kwargs.setdefault("encoding", ENCODING)
     kwargs.setdefault("errors", ENCODING_ERRS)
-    return io.open(fname, "rt", **kwargs)
+    return open(fname, "rt", **kwargs)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR removes Python 2.7 compatibility code across the codebase, replacing deprecated `io.open()` calls with the built-in `open()` function, removing `__future__` imports, dropping Python 2-only shims (such as __nonzero__ and urllib2 fallbacks), and simplifying file I/O helpers. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #13883 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
#### Location of Changes: 
1. `build_tools/i18n/fonts.py`
2. `build_tools/i18n/utils.py`
3. `docker/entrypoint.py`
4. `kolibri/core/analytics/test/test_utils.py`
5. `kolibri/core/auth/constants/facility_presets.py`
6. `kolibri/core/content/management/commands/generate_schema.py`
7. `kolibri/core/content/test/test_channel_import.py`
8. `kolibri/core/content/utils/paths.py`
9. `kolibri/core/content/utils/stopwords.py`
10. `kolibri/core/deviceadmin/utils.py`
11. `kolibri/core/logger/management/commands/generateuserdata.py`
12. `kolibri/core/sqlite/utils.py`
13. `kolibri/core/utils/nothing.py`
14. `kolibri/core/webpack/hooks.py`
15. `kolibri/plugins/qti_viewer/kolibri_plugin.py`
16. `kolibri/utils/i18n.py`
17. `kolibri/utils/pskolibri/common.py`