### PR TITLE
Center pagination buttons

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -26,7 +26,7 @@
     <PaginationActions
       v-if="totalPages > 1"
       v-model="currentPage"
-      style="text-align: right"
+      style="display: flex; justify-content: flex-end"
       :itemsPerPage="itemsPerPage"
       :totalPageNumber="totalPages"
       :numFilteredItems="totalLearners"

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -449,8 +449,9 @@
   }
 
   .bottom-pagination-actions {
+    display: flex;
+    justify-content: flex-end;
     margin-top: 1em;
-    text-align: right;
   }
 
 </style>

--- a/packages/kolibri-common/components/PaginationActions.vue
+++ b/packages/kolibri-common/components/PaginationActions.vue
@@ -8,7 +8,7 @@
       >
         {{ $tr('pagination', { visibleStartRange, visibleEndRange, numFilteredItems }) }}
       </span>
-      <KButtonGroup>
+      <div class="pagination-buttons">
         <KIconButton
           :ariaLabel="$tr('previousResults')"
           :disabled="previousButtonDisabled"
@@ -23,7 +23,7 @@
           icon="forward"
           @click="changePage(+1)"
         />
-      </KButtonGroup>
+      </div>
     </div>
   </nav>
 
@@ -104,3 +104,19 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .pagination-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .pagination-buttons {
+      display: flex;
+      gap: 4px;
+    }
+  }
+
+</style>


### PR DESCRIPTION
## Summary

Center label with pagination buttons on the `PaginationActions` component. Also checked all references to this component and fixed the ones affected by this change.

| Before | After |
| --- | --- |
| <img width="228" height="69" alt="image" src="https://github.com/user-attachments/assets/15d6689c-bf1f-4a78-b23a-e5e4dc9e8054" /> | <img width="215" height="72" alt="image" src="https://github.com/user-attachments/assets/1a0bc71b-8a3b-4a07-b481-13e64f0ce19b" /> | 
## References

Closes #13842.

## Reviewer guidance

Check that the pagination label is centered with the pagination buttons.
Check that no regressions are introduced in other places with pagination actions.
