### PR TITLE
Remove Python 2.7 legacy: Update super() calls to Python 3 syntax

### DIFF
--- a/docs/backend_architecture/tasks.rst
+++ b/docs/backend_architecture/tasks.rst
@@ -62,7 +62,7 @@ We will refer to below sample code in the later sections also.
         def validate(self, data):
             if data['a'] + data['b'] > 100:
                 raise serializers.ValidationError("Sum of a and b should be less than 100")
-            job_data = super(AddValidator, self).validate(data)
+            job_data = super().validate(data)
             job_data["extra_metadata"].update({"user": "kolibri"})
             return job_data
 

--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -141,7 +141,7 @@ class MetricsMiddleware(MiddlewareMixin):
     command_pid = 0
 
     def __init__(self, get_response=None):
-        super(MetricsMiddleware, self).__init__(get_response=get_response)
+        super().__init__(get_response=get_response)
         if not conf.OPTIONS["Server"]["PROFILE"]:
             raise MiddlewareNotUsed("Request profiling is not enabled")
 

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -59,7 +59,7 @@ class BaseDeviceSetupMixin(object):
 
     @classmethod
     def setUpTestData(cls):
-        super(BaseDeviceSetupMixin, cls).setUpTestData()
+        super().setUpTestData()
         clear_process_cache()
         # create dummy channel
         channel_id = uuid.uuid4().hex
@@ -218,7 +218,7 @@ class BaseDeviceSetupMixin(object):
                         )
 
     def tearDown(self):
-        super(BaseDeviceSetupMixin, self).tearDown()
+        super().tearDown()
         DeviceSettings.objects.delete()
 
 

--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -147,7 +147,7 @@ class BaseValuesViewset(viewsets.GenericViewSet):
     field_map = {}
 
     def __init__(self, *args, **kwargs):
-        super(BaseValuesViewset, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if not hasattr(self, "values") or not isinstance(self.values, tuple):
             raise TypeError("values must be defined as a tuple")
         self._values = tuple(self.values)
@@ -252,7 +252,7 @@ class BaseValuesViewset(viewsets.GenericViewSet):
 
 class QueryParamRequest(Request):
     def __init__(self, query_params, *args, **kwargs):
-        super(QueryParamRequest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._query_params = QueryDict(mutable=True)
         for key, value in query_params.items():
             self._query_params[key] = (
@@ -364,10 +364,10 @@ class ValuesViewset(
 class HexUUIDField(UUIDField):
     def __init__(self, **kwargs):
         kwargs["format"] = "hex"
-        super(HexUUIDField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
-        return super(HexUUIDField, self).to_internal_value(data).hex
+        return super().to_internal_value(data).hex
 
     def to_representation(self, value):
         if isinstance(value, uuid.UUID):

--- a/kolibri/core/auth/constants/demographics.py
+++ b/kolibri/core/auth/constants/demographics.py
@@ -75,9 +75,7 @@ custom_demographics_schema = {
 @deconstructible
 class UniqueIdsValidator(NoRepeatedValueJSONArrayValidator):
     def __init__(self, custom_demographics_key):
-        super().__init__(
-            array_key=custom_demographics_key, object_key="id"
-        )
+        super().__init__(array_key=custom_demographics_key, object_key="id")
 
 
 unique_translations_validator = NoRepeatedValueJSONArrayValidator(

--- a/kolibri/core/auth/constants/demographics.py
+++ b/kolibri/core/auth/constants/demographics.py
@@ -75,7 +75,7 @@ custom_demographics_schema = {
 @deconstructible
 class UniqueIdsValidator(NoRepeatedValueJSONArrayValidator):
     def __init__(self, custom_demographics_key):
-        super(UniqueIdsValidator, self).__init__(
+        super().__init__(
             array_key=custom_demographics_key, object_key="id"
         )
 
@@ -164,4 +164,4 @@ class FacilityUserDemographicValidator(JSON_Schema_Validator):
                 "type": "string",
                 "enum": [enum["value"] for enum in field["enumValues"]],
             }
-        super(FacilityUserDemographicValidator, self).__init__(schema)
+        super().__init__(schema)

--- a/kolibri/core/auth/management/commands/cleanupsyncs.py
+++ b/kolibri/core/auth/management/commands/cleanupsyncs.py
@@ -9,4 +9,4 @@ class Command(CleanupsyncCommand):
         if not device_provisioned():
             raise CommandError("Kolibri is unprovisioned")
 
-        return super(Command, self).handle(*args, **options)
+        return super().handle(*args, **options)

--- a/kolibri/core/auth/middleware.py
+++ b/kolibri/core/auth/middleware.py
@@ -140,4 +140,4 @@ class KolibriSessionMiddleware(SessionMiddleware):
     def process_response(self, request, response):
         if self._is_exempt(request):
             return response
-        return super(KolibriSessionMiddleware, self).process_response(request, response)
+        return super().process_response(request, response)

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -1560,11 +1560,7 @@ class Role(AbstractFacilityDataModel):
 
 class CollectionProxyManager(SyncableModelManager):
     def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .filter(kind=self.model._KIND)
-        )
+        return super().get_queryset().filter(kind=self.model._KIND)
 
 
 class Facility(Collection):

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -245,7 +245,7 @@ class FacilityDataset(FacilityDataSyncableModel):
 
     def save(self, *args, **kwargs):
         self.ensure_compatibility()
-        super(FacilityDataset, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def ensure_compatibility(self, *args, **kwargs):
         if self.learner_can_login_with_no_password and self.learner_can_edit_password:
@@ -353,13 +353,13 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         # ensure that we have, or can infer, a dataset for the model instance
         if not self.dataset_id:
             self.ensure_dataset(validating=True)
-        super(AbstractFacilityDataModel, self).clean_fields(*args, **kwargs)
+        super().clean_fields(*args, **kwargs)
 
     def full_clean(self, *args, **kwargs):
         kwargs["exclude"] = kwargs.get("exclude", []) + getattr(
             self, "FIELDS_TO_EXCLUDE_FROM_VALIDATION", []
         )
-        super(AbstractFacilityDataModel, self).full_clean(*args, **kwargs)
+        super().full_clean(*args, **kwargs)
 
     def pre_save(self):
         # before saving, ensure we have a dataset, and convert any validation errors into integrity
@@ -372,7 +372,7 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
 
     def save(self, *args, **kwargs):
         self.pre_save()
-        super(AbstractFacilityDataModel, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def ensure_dataset(self, *args, **kwargs):
         """
@@ -846,7 +846,7 @@ def validate_role_kinds(kinds):
 
 class AllObjectsFacilityUserModelManager(BaseFacilityUserModelManager):
     def get_queryset(self):
-        return super(AllObjectsFacilityUserModelManager, self).get_queryset()
+        return super().get_queryset()
 
 
 class FacilityUser(AbstractBaseUser, KolibriBaseUserMixin, AbstractFacilityDataModel):
@@ -921,7 +921,7 @@ class FacilityUser(AbstractBaseUser, KolibriBaseUserMixin, AbstractFacilityDataM
         if len(password) == 0:
             dict_model.update(password=NOT_SPECIFIED)
 
-        return super(FacilityUser, cls).deserialize(dict_model)
+        return super().deserialize(dict_model)
 
     @classmethod
     def get_is_active_q(cls, relation_prefix=""):
@@ -1204,18 +1204,18 @@ class Collection(AbstractFacilityDataModel):
     def __init__(self, *args, **kwargs):
         if self._KIND:
             kwargs["kind"] = self._KIND
-        super(Collection, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def calculate_partition(self):
         return "{dataset_id}:allusers-ro".format(dataset_id=self.dataset_id)
 
     def clean_fields(self, *args, **kwargs):
         self._ensure_kind()
-        super(Collection, self).clean_fields(*args, **kwargs)
+        super().clean_fields(*args, **kwargs)
 
     def save(self, *args, **kwargs):
         self._ensure_kind()
-        super(Collection, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def _ensure_kind(self):
         """
@@ -1439,7 +1439,7 @@ class Membership(AbstractFacilityDataModel):
                 raise InvalidMembershipError(
                     "Cannot create membership for a user in a LearnerGroup or AdHocGroup when they are not a member of the parent Classrooom"
                 )
-        return super(Membership, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def delete(self, **kwargs):
         with transaction.atomic():
@@ -1451,7 +1451,7 @@ class Membership(AbstractFacilityDataModel):
                 Membership.objects.filter(
                     user=self.user, collection__in=self.collection.children.all()
                 ).delete()
-            return super(Membership, self).delete(**kwargs)
+            return super().delete(**kwargs)
 
 
 class Role(AbstractFacilityDataModel):
@@ -1539,7 +1539,7 @@ class Role(AbstractFacilityDataModel):
                         collection_id=self.collection.parent_id,
                         kind=role_kinds.ASSIGNABLE_COACH,
                     )
-            return super(Role, self).save(*args, **kwargs)
+            return super().save(*args, **kwargs)
 
     def delete(self, **kwargs):
         with transaction.atomic():
@@ -1555,13 +1555,13 @@ class Role(AbstractFacilityDataModel):
                     collection__in=self.collection.children.all(),
                     kind=role_kinds.COACH,
                 ).delete()
-            return super(Role, self).delete(**kwargs)
+            return super().delete(**kwargs)
 
 
 class CollectionProxyManager(SyncableModelManager):
     def get_queryset(self):
         return (
-            super(CollectionProxyManager, self)
+            super()
             .get_queryset()
             .filter(kind=self.model._KIND)
         )
@@ -1604,13 +1604,13 @@ class Facility(Collection):
             raise IntegrityError(
                 "Facility must be the root of a collection tree, and cannot have a parent."
             )
-        super(Facility, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def ensure_dataset(self, *args, **kwargs):
         # if we're just validating, we don't want to trigger creation of a FacilityDataset
         if kwargs.get("validating"):
             return
-        super(Facility, self).ensure_dataset(*args, **kwargs)
+        super().ensure_dataset(*args, **kwargs)
 
     def infer_dataset(self, *args, **kwargs):
         # if we don't yet have a dataset, create a new one for this facility
@@ -1715,7 +1715,7 @@ class Classroom(Collection):
                 "Classroom must be the child of a Facility"
             )
 
-        super(Classroom, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def get_facility(self):
         """
@@ -1784,7 +1784,7 @@ class LearnerGroup(Collection):
             raise InvalidCollectionHierarchy(
                 "LearnerGroup must be the child of a Classroom"
             )
-        super(LearnerGroup, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def get_classroom(self):
         """
@@ -1830,7 +1830,7 @@ class AdHocGroup(Collection):
         if len(name) == 0:
             dict_model.update(name="Ad hoc")
 
-        return super(AdHocGroup, cls).deserialize(dict_model)
+        return super().deserialize(dict_model)
 
     def save(self, *args, **kwargs):
         if not self.parent:
@@ -1841,7 +1841,7 @@ class AdHocGroup(Collection):
             raise InvalidCollectionHierarchy(
                 "AdHocGroup must be the child of a Classroom"
             )
-        super(AdHocGroup, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def get_classroom(self):
         """

--- a/kolibri/core/auth/permissions/auth.py
+++ b/kolibri/core/auth/permissions/auth.py
@@ -21,7 +21,7 @@ class CollectionSpecificRoleBasedPermissions(RoleBasedPermissions):
     """
 
     def __init__(self):
-        super(CollectionSpecificRoleBasedPermissions, self).__init__(
+        super().__init__(
             target_field=".",
             can_be_created_by=None,
             can_be_read_by=(ADMIN, COACH),

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -79,7 +79,7 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         read_only_fields = ("is_superuser",)
 
     def save(self, **kwargs):
-        instance = super(FacilityUserSerializer, self).save(**kwargs)
+        instance = super().save(**kwargs)
         validated_data = dict(list(self.validated_data.items()) + list(kwargs.items()))
         password = validated_data.get("password")
         if password and password != NOT_SPECIFIED:
@@ -164,7 +164,7 @@ class MembershipSerializer(serializers.ModelSerializer):
 
     def save(self, **kwargs):
         try:
-            return super(MembershipSerializer, self).save(**kwargs)
+            return super().save(**kwargs)
         except InvalidMembershipError as e:
             raise serializers.ValidationError(str(e))
 
@@ -193,7 +193,7 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
 
     def save(self, **kwargs):
         try:
-            return super(FacilityDatasetSerializer, self).save(**kwargs)
+            return super().save(**kwargs)
         except IncompatibleDeviceSettingError as e:
             raise serializers.ValidationError(str(e))
 
@@ -268,7 +268,7 @@ class ClassroomSerializer(serializers.ModelSerializer):
 
     def save(self, **kwargs):
         try:
-            return super(ClassroomSerializer, self).save(**kwargs)
+            return super().save(**kwargs)
         except InvalidCollectionHierarchy as e:
             raise serializers.ValidationError(str(e))
 
@@ -286,7 +286,7 @@ class LearnerGroupSerializer(serializers.ModelSerializer):
 
     def save(self, **kwargs):
         try:
-            return super(LearnerGroupSerializer, self).save(**kwargs)
+            return super().save(**kwargs)
         except InvalidCollectionHierarchy as e:
             raise serializers.ValidationError(str(e))
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -69,7 +69,7 @@ class LocaleChoiceField(serializers.ChoiceField):
     """
 
     def __init__(self, **kwargs):
-        super(LocaleChoiceField, self).__init__([], **kwargs)
+        super().__init__([], **kwargs)
         self._choices_set = False
 
     @property
@@ -86,15 +86,15 @@ class LocaleChoiceField(serializers.ChoiceField):
         if not self._choices_set:
             self._choices_set = True
             # Use the internal Choice field _set_choices setter method here
-            super(LocaleChoiceField, self)._set_choices(settings.LANGUAGES)
+            super()._set_choices(settings.LANGUAGES)
 
     def to_internal_value(self, data):
         self._set_choices()
-        return super(LocaleChoiceField, self).to_internal_value(data)
+        return super().to_internal_value(data)
 
     def to_representation(self, value):
         self._set_choices()
-        return super(LocaleChoiceField, self).to_representation(value)
+        return super().to_representation(value)
 
     @property
     def choices(self):
@@ -310,7 +310,7 @@ class PeerSyncJobValidator(SyncJobValidator):
     )
 
     def validate(self, data):
-        job_data = super(PeerSyncJobValidator, self).validate(data)
+        job_data = super().validate(data)
         if "baseurl" not in data and "device_id" not in data:
             raise serializers.ValidationError(
                 "Either baseurl or device_id must be specified"
@@ -351,7 +351,7 @@ class PeerSyncJobValidator(SyncJobValidator):
 
 class PeerFacilitySyncJobValidator(PeerSyncJobValidator):
     def validate(self, data):
-        job_data = super(PeerFacilitySyncJobValidator, self).validate(data)
+        job_data = super().validate(data)
         validate_and_create_sync_credentials(
             job_data["kwargs"]["baseurl"],
             job_data["facility_id"],
@@ -384,7 +384,7 @@ class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     password = serializers.CharField(default=NOT_SPECIFIED, required=False)
 
     def validate(self, data):
-        job_data = super(PeerFacilityImportJobValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data["kwargs"].update(
             dict(
                 no_push=True,
@@ -541,7 +541,7 @@ class PeerImportSingleSyncJobValidator(PeerSyncJobValidator):
         In case an admin account credentials are provided, to sync a non-admin user,
         the user_id of this non-admin user must be provided.
         """
-        job_data = super(PeerImportSingleSyncJobValidator, self).validate(data)
+        job_data = super().validate(data)
         user_id = data.get("user_id", None)
         using_admin = data.get("using_admin", False)
         force_non_learner_import = data.get("force_non_learner_import", False)

--- a/kolibri/core/auth/test/migrationtestcase.py
+++ b/kolibri/core/auth/test/migrationtestcase.py
@@ -15,7 +15,7 @@ class TestMigrations(TransactionTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestMigrations, cls).setUpClass()
+        super().setUpClass()
 
         # get the latest migration before starting
         latest_migration = MigrationRecorder.Migration.objects.filter(
@@ -57,4 +57,4 @@ class TestMigrations(TransactionTestCase):
         executor.loader.build_graph()
         executor.migrate([cls.latest_migration])
 
-        super(TestMigrations, cls).tearDownClass()
+        super().tearDownClass()

--- a/kolibri/core/auth/test/test_sync_event_hook_utils.py
+++ b/kolibri/core/auth/test/test_sync_event_hook_utils.py
@@ -13,7 +13,7 @@ MODULE_NAME = "kolibri.core.auth.sync_event_hook_utils"
 @mock.patch("kolibri.core.auth.sync_event_hook_utils.FacilityDataSyncHook")
 class FacilityDataSyncHooksTestCase(SimpleTestCase):
     def setUp(self):
-        super(FacilityDataSyncHooksTestCase, self).setUp()
+        super().setUp()
 
         class TestHook(object):
             pre_transfer = mock.Mock()

--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -17,7 +17,7 @@ from kolibri.core.auth.sync_operations import KolibriVersionedSyncOperation
 
 class KolibriSyncOperationsTestCase(SimpleTestCase):
     def setUp(self):
-        super(KolibriSyncOperationsTestCase, self).setUp()
+        super().setUp()
         self.operation = KolibriSyncOperations()
         self.context = mock.Mock(spec_set=SessionContext)()
 
@@ -175,7 +175,7 @@ class KolibriSyncOperationMixinTestCase(SimpleTestCase):
 
 class KolibriVersionedSyncOperationTestCase(SimpleTestCase):
     def setUp(self):
-        super(KolibriVersionedSyncOperationTestCase, self).setUp()
+        super().setUp()
         self.operation = KolibriVersionedSyncOperation()
         self.operation.version = "0.15.0"
         self.upgrade = mock.Mock()
@@ -300,7 +300,7 @@ class KolibriVersionedSyncOperationTestCase(SimpleTestCase):
 @mock.patch("kolibri.core.auth.sync_operations.this_side_using_single_user_cert")
 class KolibriSingleUserSyncOperationTestCase(SimpleTestCase):
     def setUp(self):
-        super(KolibriSingleUserSyncOperationTestCase, self).setUp()
+        super().setUp()
         self.operation = KolibriSingleUserSyncOperation()
         self.handle_local_user = mock.Mock()
         self.operation.handle_local_user = self.handle_local_user

--- a/kolibri/core/auth/test/test_sync_utils.py
+++ b/kolibri/core/auth/test/test_sync_utils.py
@@ -79,7 +79,7 @@ class TestProgressTracking(TestCase):
 
 class CanonicalizeAssignmentsTestCase(TestCase):
     def setUp(self):
-        super(CanonicalizeAssignmentsTestCase, self).setUp()
+        super().setUp()
         provision_device()
         self.test_data = create_dummy_facility_data()
         self.ad_hoc_group = AdHocGroup.objects.create(

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -249,12 +249,12 @@ class RemoteViewSet(ReadOnlyValuesViewset, RemoteMixin):
             raise Http404
         if self._should_proxy_request(request):
             return self._hande_proxied_request(request)
-        return super(RemoteViewSet, self).retrieve(request, pk=pk)
+        return super().retrieve(request, pk=pk)
 
     def list(self, request, *args, **kwargs):
         if self._should_proxy_request(request):
             return self._hande_proxied_request(request)
-        return super(RemoteViewSet, self).list(request, *args, **kwargs)
+        return super().list(request, *args, **kwargs)
 
 
 class ChannelMetadataFilter(FilterSet):
@@ -847,7 +847,7 @@ class OptionalContentNodePagination(OptionalPagination):
     def paginate_queryset(self, queryset, request, view=None):
         # Record the queryset for use in returning available filters
         self.queryset = queryset
-        return super(OptionalContentNodePagination, self).paginate_queryset(
+        return super().paginate_queryset(
             queryset, request, view=view
         )
 
@@ -907,7 +907,7 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
                 # Used in the update method for remote request retrieval
                 self.locally_admin_imported_ids = set()
             return self._hande_proxied_request(request)
-        return super(ContentNodeViewset, self).retrieve(request, pk=pk)
+        return super().retrieve(request, pk=pk)
 
     def list(self, request, *args, **kwargs):
         if self._should_proxy_request(request):
@@ -917,7 +917,7 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
                 queryset.filter(admin_imported=True).values_list("id", flat=True)
             )
             return self._hande_proxied_request(request)
-        return super(ContentNodeViewset, self).list(request, *args, **kwargs)
+        return super().list(request, *args, **kwargs)
 
     @action(detail=False)
     def random(self, request, **kwargs):
@@ -1208,7 +1208,7 @@ class ContentNodeTreeViewset(BaseContentNodeTreeViewset, RemoteMixin):
                 # Used in the update method for remote request retrieval
                 self.locally_admin_imported_ids = set()
             return self._hande_proxied_request(request)
-        return super(ContentNodeTreeViewset, self).retrieve(request, pk=pk)
+        return super().retrieve(request, pk=pk)
 
 
 # return the result of and-ing a list of queries
@@ -1392,10 +1392,10 @@ class ContentNodeBookmarksViewset(
         queryset = models.ContentNode.objects.filter(
             id__in=queryset.values_list("contentnode_id", flat=True)
         )
-        return super(ContentNodeBookmarksViewset, self).serialize(queryset)
+        return super().serialize(queryset)
 
     def consolidate(self, items, queryset):
-        items = super(ContentNodeBookmarksViewset, self).consolidate(items, queryset)
+        items = super().consolidate(items, queryset)
         sorted_items = []
         if items:
             item_lookup = {item["id"]: item for item in items}
@@ -1511,7 +1511,7 @@ class ContentNodeGranularViewset(mixins.RetrieveModelMixin, viewsets.GenericView
         )
 
     def get_serializer_context(self):
-        context = super(ContentNodeGranularViewset, self).get_serializer_context()
+        context = super().get_serializer_context()
         if hasattr(self, "channel_stats"):
             context.update({"channel_stats": self.channel_stats})
         return context

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -847,9 +847,7 @@ class OptionalContentNodePagination(OptionalPagination):
     def paginate_queryset(self, queryset, request, view=None):
         # Record the queryset for use in returning available filters
         self.queryset = queryset
-        return super().paginate_queryset(
-            queryset, request, view=view
-        )
+        return super().paginate_queryset(queryset, request, view=view)
 
     def get_paginated_response(self, data):
         return Response(

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -127,7 +127,7 @@ class ContentNodeManager(
         Ensures that this manager always returns nodes in tree order.
         """
         return (
-            super(TreeManager, self)
+            super()
             .get_queryset(*args, **kwargs)
             .order_by(self.tree_id_attr, self.left_attr)
         )
@@ -451,7 +451,7 @@ class ContentRequestManager(models.Manager):
         Automatically filters on the request type for use with proxy models
         :rtype: django.db.models.QuerySet
         """
-        queryset = super(ContentRequestManager, self).get_queryset()
+        queryset = super().get_queryset()
         if self.request_type is not None:
             queryset = queryset.filter(type=self.request_type)
         return queryset
@@ -499,7 +499,7 @@ class ContentRequest(models.Model):
         Save override to set type for the proxy models
         """
         self.type = getattr(self.__class__.objects, "request_type", None)
-        return super(ContentRequest, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     @classmethod
     def build_for_user(cls, user):

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -17,7 +17,7 @@ from kolibri.core.fields import create_timezonestamp
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         # Instantiate the superclass normally
-        super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # enable dynamic fields specification!
         if "request" in self.context and self.context["request"].GET.get(
@@ -123,7 +123,7 @@ class PublicChannelSerializer(serializers.ModelSerializer):
 
 class LowerCaseField(serializers.CharField):
     def to_representation(self, obj):
-        return super(LowerCaseField, self).to_representation(obj).lower()
+        return super().to_representation(obj).lower()
 
 
 class LanguageSerializer(serializers.ModelSerializer):

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -73,7 +73,7 @@ class ChannelValidator(JobValidator):
     channel_name = serializers.CharField()
 
     def validate(self, data):
-        job_data = super(ChannelValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data.update(
             {
                 "kwargs": {},
@@ -91,7 +91,7 @@ class ChannelResourcesValidator(ChannelValidator):
     exclude_node_ids = serializers.ListField(child=HexOnlyUUIDField(), required=False)
 
     def validate(self, data):
-        job_data = super(ChannelResourcesValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data["kwargs"].update(
             {
                 "node_ids": data.get("node_ids"),
@@ -109,7 +109,7 @@ class ChannelResourcesImportValidator(ChannelResourcesValidator):
     all_thumbnails = serializers.BooleanField(default=False)
 
     def validate(self, data):
-        job_data = super(ChannelResourcesImportValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data["kwargs"].update(
             {
                 "update": data.get("update"),
@@ -138,7 +138,7 @@ class LocalMixin(metaclass=serializers.SerializerMetaclass):
     drive_id = DriveIdField()
 
     def validate(self, data):
-        job_data = super(LocalMixin, self).validate(data)
+        job_data = super().validate(data)
         job_data["extra_metadata"].update(dict(drive_id=data["drive_id"]))
         job_data["args"] += [data["drive_id"]]
         return job_data
@@ -190,7 +190,7 @@ class RemoteImportMixin(metaclass=serializers.SerializerMetaclass):
     )
 
     def validate(self, data):
-        job_data = super(RemoteImportMixin, self).validate(data)
+        job_data = super().validate(data)
         peer = data.get(
             "peer",
             {
@@ -273,7 +273,7 @@ class ResourceNodeValidator(JobValidator):
     node_name = serializers.CharField()
 
     def validate(self, data):
-        job_data = super(ResourceNodeValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data.update(
             {
                 "kwargs": {},
@@ -295,7 +295,7 @@ class RemoteResourceImportValidator(ResourceNodeValidator):
     )
 
     def validate(self, data):
-        job_data = super(RemoteResourceImportValidator, self).validate(data)
+        job_data = super().validate(data)
         peer = data.get(
             "peer",
             {
@@ -377,7 +377,7 @@ def enqueue_automatic_resource_import_if_needed(instance_id=None):
 
 class AutomaticDownloadValidator(JobValidator):
     def validate(self, data):
-        job_data = super(AutomaticDownloadValidator, self).validate(data)
+        job_data = super().validate(data)
         if not automatic_download_enabled():
             raise ValidationError("Automatic download is not enabled")
         return job_data
@@ -479,7 +479,7 @@ class DeleteChannelValidator(ChannelResourcesValidator):
     force_delete = serializers.BooleanField(default=False)
 
     def validate(self, data):
-        job_data = super(DeleteChannelValidator, self).validate(data)
+        job_data = super().validate(data)
         job_data["kwargs"].update(
             {
                 "force_delete": data.get("force_delete"),
@@ -617,7 +617,7 @@ def diskchannelimport(
 
 class RemoteChannelDiffStatsValidator(RemoteChannelImportValidator):
     def validate(self, data):
-        job_data = super(RemoteChannelDiffStatsValidator, self).validate(data)
+        job_data = super().validate(data)
         # get channel version metadata
         if job_data["kwargs"]["peer_id"]:
             client = NetworkClient.build_for_address(job_data["kwargs"]["baseurl"])
@@ -658,7 +658,7 @@ def remotechanneldiffstats(
 
 class LocalChannelDiffStatsValidator(LocalChannelImportValidator, LocalMixin):
     def validate(self, data):
-        job_data = super(LocalChannelDiffStatsValidator, self).validate(data)
+        job_data = super().validate(data)
         # get channel version metadata
         drive = get_mounted_drive_by_id(data["drive_id"])
         channel_metadata = read_channel_metadata_from_db_file(

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -221,7 +221,7 @@ class SetContentNodesInvisibleTestCase(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(SetContentNodesInvisibleTestCase, self).tearDown()
+        super().tearDown()
 
 
 @patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
@@ -516,7 +516,7 @@ class AnnotationFromLocalFileAvailability(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(AnnotationFromLocalFileAvailability, self).tearDown()
+        super().tearDown()
 
 
 @patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
@@ -525,7 +525,7 @@ class AnnotationTreeRecursion(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(AnnotationTreeRecursion, self).setUp()
+        super().setUp()
         ContentNode.objects.all().update(available=False)
 
     def test_all_content_nodes_available(self):
@@ -747,7 +747,7 @@ class AnnotationTreeRecursion(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(AnnotationTreeRecursion, self).tearDown()
+        super().tearDown()
 
 
 @patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
@@ -756,7 +756,7 @@ class LocalFileAvailableByChecksum(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(LocalFileAvailableByChecksum, self).setUp()
+        super().setUp()
         LocalFile.objects.all().update(available=False)
 
     def test_set_one_file(self):
@@ -775,7 +775,7 @@ class LocalFileAvailableByChecksum(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(LocalFileAvailableByChecksum, self).tearDown()
+        super().tearDown()
 
 
 @patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
@@ -784,7 +784,7 @@ class LocalFileUnAvailableByChecksum(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(LocalFileUnAvailableByChecksum, self).setUp()
+        super().setUp()
         LocalFile.objects.all().update(available=True)
 
     def test_set_one_file(self):
@@ -803,7 +803,7 @@ class LocalFileUnAvailableByChecksum(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(LocalFileUnAvailableByChecksum, self).tearDown()
+        super().tearDown()
 
 
 mock_content_file = tempfile.mkstemp()
@@ -818,7 +818,7 @@ class LocalFileByDisk(TransactionTestCase):
     file_id_2 = "e00699f859624e0f875ac6fe1e13d648"
 
     def setUp(self):
-        super(LocalFileByDisk, self).setUp()
+        super().setUp()
         LocalFile.objects.all().update(available=False)
 
     @patch(
@@ -936,7 +936,7 @@ class LocalFileByDisk(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(LocalFileByDisk, self).tearDown()
+        super().tearDown()
 
 
 class SetChannelMetadataFieldsTestCase(TestCase):

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -409,7 +409,7 @@ class ContentImportTestBase(TransactionTestCase):
                 "No content schema and/or data for {name}".format(name=self.schema_name)
             )
 
-        super(ContentImportTestBase, self).setUp()
+        super().setUp()
 
     @patch("kolibri.core.content.utils.channel_import.get_content_database_file_path")
     def set_content_fixture(self, db_path_mock):
@@ -452,12 +452,12 @@ class ContentImportTestBase(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(ContentImportTestBase, self).tearDown()
+        super().tearDown()
 
     @classmethod
     def tearDownClass(cls):
         django_connection_engine().dispose()
-        super(ContentImportTestBase, cls).tearDownClass()
+        super().tearDownClass()
 
 
 @pytest.fixture(scope="class")
@@ -887,11 +887,11 @@ class Version4ImportTestCase(NaiveImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(Version4ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(Version4ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class Version3ImportTestCase(NaiveImportTestCase):
@@ -903,11 +903,11 @@ class Version3ImportTestCase(NaiveImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(Version3ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(Version3ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class Version2ImportTestCase(NaiveImportTestCase):
@@ -919,11 +919,11 @@ class Version2ImportTestCase(NaiveImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(Version2ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(Version2ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class Version1ImportTestCase(NaiveImportTestCase):
@@ -935,11 +935,11 @@ class Version1ImportTestCase(NaiveImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(Version1ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(Version1ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class NoVersionImportTestCase(NaiveImportTestCase):
@@ -951,11 +951,11 @@ class NoVersionImportTestCase(NaiveImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(NoVersionImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(NoVersionImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class NoVersionv020ImportTestCase(NoVersionImportTestCase):
@@ -973,11 +973,11 @@ class NoVersionv020ImportTestCase(NoVersionImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(NoVersionv020ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(NoVersionv020ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
@@ -990,11 +990,11 @@ class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(NoVersionv020ImportTestCase, cls).tearDownClass()
+        super().tearDownClass()
 
     @classmethod
     def setUpClass(cls):
-        super(NoVersionv040ImportTestCase, cls).setUpClass()
+        super().setUpClass()
 
 
 @patch("kolibri.core.content.utils.channel_import.Bridge")
@@ -1006,7 +1006,7 @@ class ChannelImportTestCase(ContentImportTestBase, TransactionTestCase):
     legacy_schema = None
 
     def setUp(self):
-        super(ChannelImportTestCase, self).setUp()
+        super().setUp()
         self.channel_id = "6199dde695db4ee4ab392222d5af1e5c"
         self.channel_version = 2
         self.current_channel = None

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -25,7 +25,7 @@ class ChannelUpdateTestBase(TestCase):
         # Do this as tearDown doesn't get called if there is an error in the test.
         self.addCleanup(patcher.stop)
         self.db_path_mock = patcher.start()
-        super(ChannelUpdateTestBase, self).setUp()
+        super().setUp()
 
     @classmethod
     def set_content_fixture(cls):

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1989,7 +1989,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         clean up files/folders created during the test
         """
         cache.clear()
-        super(ContentNodeAPITestCase, self).tearDown()
+        super().tearDown()
 
 
 def mock_patch_decorator(func):

--- a/kolibri/core/content/test/test_content_request.py
+++ b/kolibri/core/content/test/test_content_request.py
@@ -15,14 +15,14 @@ from kolibri.core.content.models import ContentRequestStatus
 class ContentDownloadRequestSerializerTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        super(ContentDownloadRequestSerializerTestCase, cls).setUpTestData()
+        super().setUpTestData()
         cls.facility = Facility.objects.create(name="a")
         cls.user = FacilityUser.objects.create(
             username="learner", password="password", facility=cls.facility
         )
 
     def setUp(self):
-        super(ContentDownloadRequestSerializerTestCase, self).setUp()
+        super().setUp()
         self.data = {
             "contentnode_id": "877a1b783fd348bfb87559883e60e9bf",
             "metadata": {
@@ -109,14 +109,14 @@ class ContentDownloadRequestSerializerTestCase(TestCase):
 class ContentDownloadRequestViewsetTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        super(ContentDownloadRequestViewsetTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.facility = Facility.objects.create(name="a")
         cls.user = FacilityUser.objects.create(
             username="learner", password="password", facility=cls.facility
         )
 
     def setUp(self):
-        super(ContentDownloadRequestViewsetTest, self).setUp()
+        super().setUp()
         self.client.force_authenticate(user=self.user)
         self.data = {
             "contentnode_id": "877a1b783fd348bfb87559883e60e9bf",

--- a/kolibri/core/content/test/test_content_sync_hook.py
+++ b/kolibri/core/content/test/test_content_sync_hook.py
@@ -11,7 +11,7 @@ from kolibri.core.device.models import DeviceStatus
 
 class KolibriContentSyncHookTestCase(BaseIncompleteDownloadsQuerysetTestCase):
     def setUp(self):
-        super(KolibriContentSyncHookTestCase, self).setUp()
+        super().setUp()
         self.operation = KolibriSyncOperations()
         self.context = mock.Mock(spec_set=SessionContext)()
 

--- a/kolibri/core/content/test/test_data_migrations.py
+++ b/kolibri/core/content/test/test_data_migrations.py
@@ -15,7 +15,7 @@ class ChannelFieldsTestCase(TestMigrations):
 
     def setUp(self):
         self.file_size = 10
-        super(ChannelFieldsTestCase, self).setUp()
+        super().setUp()
 
     def setUpBeforeMigration(self, apps):
         ChannelMetadata = apps.get_model("content", "ChannelMetadata")
@@ -88,7 +88,7 @@ class ChannelOrderTestCase(TestMigrations):
     app = "content"
 
     def setUp(self):
-        super(ChannelOrderTestCase, self).setUp()
+        super().setUp()
 
     def setUpBeforeMigration(self, apps):
         ChannelMetadata = apps.get_model("content", "ChannelMetadata")

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -28,7 +28,7 @@ class UnavailableContentDeletion(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(UnavailableContentDeletion, self).setUp()
+        super().setUp()
 
         # create an unavailable contentnode
         self.unavailable_contentnode = ContentNode(
@@ -192,4 +192,4 @@ class DeleteContentTestCase(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(DeleteContentTestCase, self).tearDown()
+        super().tearDown()

--- a/kolibri/core/content/test/test_deletechannel.py
+++ b/kolibri/core/content/test/test_deletechannel.py
@@ -89,4 +89,4 @@ class DeleteChannelTestCase(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(DeleteChannelTestCase, self).tearDown()
+        super().tearDown()

--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -35,7 +35,7 @@ class LocalFileByDisk(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(LocalFileByDisk, self).setUp()
+        super().setUp()
         process_cache.clear()
         self.mock_home_dir = tempfile.mkdtemp()
         self.mock_storage_dir = os.path.join(self.mock_home_dir, "content", "storage")
@@ -121,7 +121,7 @@ class LocalFileByDisk(TransactionTestCase):
 
     def tearDown(self):
         shutil.rmtree(self.mock_home_dir)
-        super(LocalFileByDisk, self).tearDown()
+        super().tearDown()
 
 
 local_file_qs = LocalFile.objects.filter(
@@ -136,7 +136,7 @@ class LocalFileRemote(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(LocalFileRemote, self).setUp()
+        super().setUp()
         process_cache.clear()
         self.location = NetworkLocation.objects.create(base_url="test")
 

--- a/kolibri/core/content/test/test_importability.py
+++ b/kolibri/core/content/test/test_importability.py
@@ -39,4 +39,4 @@ class ImportabilityStats(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(ImportabilityStats, self).tearDown()
+        super().tearDown()

--- a/kolibri/core/content/test/test_upgrade.py
+++ b/kolibri/core/content/test/test_upgrade.py
@@ -181,7 +181,7 @@ class UpdateNumCoachContents(TransactionTestCase):
     fixtures = ["content_test.json"]
 
     def setUp(self):
-        super(UpdateNumCoachContents, self).setUp()
+        super().setUp()
         ContentNode.objects.all().update(available=False)
 
     def test_no_content_nodes_coach_content(self):
@@ -291,4 +291,4 @@ class UpdateNumCoachContents(TransactionTestCase):
 
     def tearDown(self):
         call_command("flush", interactive=False)
-        super(UpdateNumCoachContents, self).tearDown()
+        super().tearDown()

--- a/kolibri/core/content/test/utils/test_assignment.py
+++ b/kolibri/core/content/test/utils/test_assignment.py
@@ -23,7 +23,7 @@ class ContentAssignmentManagerTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(ContentAssignmentManagerTestCase, self).setUp()
+        super().setUp()
 
         self.model = mock.MagicMock()
         self.model.objects = mock.MagicMock()
@@ -294,7 +294,7 @@ class ContentAssignmentManagerIntegrationTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(ContentAssignmentManagerIntegrationTestCase, cls).setUpClass()
+        super().setUpClass()
 
         provision_device()
         cls.facility = Facility.objects.create(name="My Facility")

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -91,7 +91,7 @@ class BaseTestCase(TestCase):
 @mock.patch(_module + "Facility.objects.get", new=_facility)
 class ContentRequestsTestCase(TestCase):
     def setUp(self):
-        super(ContentRequestsTestCase, self).setUp()
+        super().setUp()
 
         self.dataset_id = uuid.uuid4().hex
         self.transfer_session = mock.MagicMock()
@@ -140,7 +140,7 @@ class ContentRequestsTestCase(TestCase):
 class ProcessMetadataImportTestCase(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
-        super(ProcessMetadataImportTestCase, cls).setUpTestData()
+        super().setUpTestData()
         cls.facility = Facility.objects.create(name="a")
         cls.learner = FacilityUser.objects.create(
             username="learner", password="password", facility=cls.facility
@@ -151,7 +151,7 @@ class ProcessMetadataImportTestCase(BaseTestCase):
         cls.facility.add_admin(cls.admin)
 
     def setUp(self):
-        super(ProcessMetadataImportTestCase, self).setUp()
+        super().setUp()
 
         self.mock_client = mock.MagicMock()
 
@@ -345,7 +345,7 @@ class ProcessMetadataImportTestCase(BaseTestCase):
 class BaseQuerysetTestCase(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
-        super(BaseQuerysetTestCase, cls).setUpTestData()
+        super().setUpTestData()
         cls.facility = Facility.objects.create(name="a")
         cls.learner = FacilityUser.objects.create(
             username="learner", password="password", facility=cls.facility
@@ -417,7 +417,7 @@ class BaseQuerysetTestCase(BaseTestCase):
 
 class BaseIncompleteDownloadsQuerysetTestCase(BaseQuerysetTestCase):
     def setUp(self):
-        super(BaseIncompleteDownloadsQuerysetTestCase, self).setUp()
+        super().setUp()
         self.admin_request = ContentDownloadRequest.build_for_user(self.admin)
         self.admin_request.contentnode_id = uuid.uuid4().hex
         self.admin_request.save()
@@ -492,7 +492,7 @@ class IncompleteDownloadsQuerysetTestCase(BaseIncompleteDownloadsQuerysetTestCas
 
 class CompletedDownloadsQuerysetTestCase(BaseQuerysetTestCase):
     def setUp(self):
-        super(CompletedDownloadsQuerysetTestCase, self).setUp()
+        super().setUp()
         self.request = ContentDownloadRequest.build_for_user(self.learner)
         self.request.contentnode_id = uuid.uuid4().hex
         self.request.status = ContentRequestStatus.Completed
@@ -677,7 +677,7 @@ class PreferredDevicesTestCase(BaseTestCase):
 
 class PreferredDevicesWithClientTestCase(BaseTestCase):
     def setUp(self):
-        super(PreferredDevicesWithClientTestCase, self).setUp()
+        super().setUp()
 
         capture_connection_patcher = mock.patch(_module + "capture_connection_state")
         self.mock_capture = capture_connection_patcher.start()
@@ -748,7 +748,7 @@ class PreferredDevicesWithClientTestCase(BaseTestCase):
 
 class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
     def setUp(self):
-        super(ProcessContentRequestsTestCase, self).setUp()
+        super().setUp()
         self.request = ContentDownloadRequest.build_for_user(self.learner)
         self.request.contentnode_id = uuid.uuid4().hex
         self.request.save()
@@ -888,7 +888,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
 
 class ProcessContentRemovalRequestsTestCase(BaseQuerysetTestCase):
     def setUp(self):
-        super(ProcessContentRemovalRequestsTestCase, self).setUp()
+        super().setUp()
         self.download = ContentDownloadRequest.build_for_user(self.learner)
         self.download.contentnode_id = uuid.uuid4().hex
         self.download.status = ContentRequestStatus.Completed
@@ -966,7 +966,7 @@ class ProcessContentRemovalRequestsTestCase(BaseQuerysetTestCase):
 
 class ProcessDownloadRequestTestCase(BaseQuerysetTestCase):
     def setUp(self):
-        super(ProcessDownloadRequestTestCase, self).setUp()
+        super().setUp()
         self.request = ContentDownloadRequest.build_for_user(self.learner)
         self.request.contentnode_id = uuid.uuid4().hex
         self.request.save()

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -314,7 +314,7 @@ class PreferredDevicesWithClient(PreferredDevices):
         Iterate over the network locations, yielding the network location and a network client
         :rtype: Generator<(NetworkLocation, NetworkClient)>
         """
-        for peer in super(PreferredDevicesWithClient, self).__iter__():
+        for peer in super().__iter__():
             # during processing, if there's a critical failure in making requests to the peer,
             # this will capture those errors, and obviously the raising of exceptions
             # will interrupt processing

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -90,7 +90,7 @@ class ResourceImportManagerBase(JobProgressMixin, metaclass=ABCMeta):
         self.fail_on_error = fail_on_error
         self.content_dir = content_dir or conf.OPTIONS["Paths"]["CONTENT_DIR"]
         self.admin_imported = admin_imported
-        super(ResourceImportManagerBase, self).__init__()
+        super().__init__()
 
     @classmethod
     def from_manifest(cls, channel_id, manifest_file, **kwargs):
@@ -360,7 +360,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
         admin_imported=True,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
-        super(RemoteResourceImportManagerBase, self).__init__(
+        super().__init__(
             channel_id,
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
@@ -425,7 +425,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
 
         self.path = path
 
-        super(DiskResourceImportManagerBase, self).__init__(
+        super().__init__(
             channel_id,
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
@@ -468,7 +468,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
             if os.path.exists(manifest_file_path):
                 manifest_file = manifest_file_path
         if manifest_file:
-            return super(DiskResourceImportManagerBase, cls).from_manifest(
+            return super().from_manifest(
                 channel_id, manifest_file, path=path, drive_id=drive_id, **kwargs
             )
         return cls(channel_id, path=path, drive_id=drive_id, **kwargs)
@@ -557,7 +557,7 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
         :param timeout: The timeout for the download request
         :type timeout: int
         """
-        super(ContentDownloadRequestResourceImportManager, self).__init__(
+        super().__init__(
             channel_id,
             peer_id=peer.id,
             baseurl=peer.base_url,
@@ -624,15 +624,15 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
                     if self.fail_on_error:
                         raise LocationError("Required files not available from remote")
 
-        return super(ContentDownloadRequestResourceImportManager, self).run()
+        return super().run()
 
     def start_progress(self, total=100):
-        super(ContentDownloadRequestResourceImportManager, self).start_progress(total)
+        super().start_progress(total)
         if self.download_request:
             self.download_request.update_progress(0, total)
 
     def update_progress(self, increment=1, message="", extra_data=None):
-        super(ContentDownloadRequestResourceImportManager, self).update_progress(
+        super().update_progress(
             increment, message, extra_data
         )
         if self.download_request:

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -632,9 +632,7 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
             self.download_request.update_progress(0, total)
 
     def update_progress(self, increment=1, message="", extra_data=None):
-        super().update_progress(
-            increment, message, extra_data
-        )
+        super().update_progress(increment, message, extra_data)
         if self.download_request:
             self.download_request.update_progress(
                 self.download_request.progress + increment,

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -94,7 +94,7 @@ class SQLiteBitwiseORAggregate(Aggregate):
         if not num_bits:
             raise ValueError("num_bits must be a positive integer")
         self.num_bits = num_bits
-        super(SQLiteBitwiseORAggregate, self).__init__(
+        super().__init__(
             expression, output_field=IntegerField(), **extra
         )
 

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -94,9 +94,7 @@ class SQLiteBitwiseORAggregate(Aggregate):
         if not num_bits:
             raise ValueError("num_bits must be a positive integer")
         self.num_bits = num_bits
-        super().__init__(
-            expression, output_field=IntegerField(), **extra
-        )
+        super().__init__(expression, output_field=IntegerField(), **extra)
 
     @property
     def template(self):

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -62,7 +62,7 @@ class SharingPool(NullPool):
 
     def __init__(self, get_connection, **kwargs):
         kwargs["reset_on_return"] = False
-        super(SharingPool, self).__init__(get_conn, **kwargs)
+        super().__init__(get_conn, **kwargs)
 
     def status(self):
         return "Sharing Pool"

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -304,7 +304,7 @@ def query_params_required(**kwargs):  # noqa: C901
                 )
             # Update the kwargs on the view itself
             self.kwargs = kwargs
-            super(cls, self).initial(request, *args, **kwargs)
+            super().initial(request, *args, **kwargs)
 
         setattr(cls, "initial", initial)
 

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -65,7 +65,7 @@ DEVICE_SETTINGS_CACHE_KEY = "device_settings_cache_key"
 class DeviceSettingsQuerySet(QuerySet):
     def delete(self, **kwargs):
         cache.delete(DEVICE_SETTINGS_CACHE_KEY)
-        return super(DeviceSettingsQuerySet, self).delete(**kwargs)
+        return super().delete(**kwargs)
 
 
 class DeviceSettingsManager(models.Manager.from_queryset(DeviceSettingsQuerySet)):
@@ -78,7 +78,7 @@ class DeviceSettingsManager(models.Manager.from_queryset(DeviceSettingsQuerySet)
 
         # ensure cached value is of correct type, otherwise allow .get to raise if not created
         if not isinstance(model, DeviceSettings):
-            model = super(DeviceSettingsManager, self).get(**kwargs)
+            model = super().get(**kwargs)
             cache.set(DEVICE_SETTINGS_CACHE_KEY, model, 600)
         return model
 
@@ -181,12 +181,12 @@ class DeviceSettings(models.Model):
     def save(self, *args, **kwargs):
         self.pk = 1
         self.full_clean()
-        out = super(DeviceSettings, self).save(*args, **kwargs)
+        out = super().save(*args, **kwargs)
         cache.set(DEVICE_SETTINGS_CACHE_KEY, self, 600)
         return out
 
     def delete(self, *args, **kwargs):
-        out = super(DeviceSettings, self).delete(*args, **kwargs)
+        out = super().delete(*args, **kwargs)
         cache.delete(DEVICE_SETTINGS_CACHE_KEY)
         return out
 
@@ -220,13 +220,13 @@ class DeviceSettings(models.Model):
     def __getattribute__(self, name):
         if name in extra_settings_schema["properties"]:
             return self._get_extra(name)
-        return super(DeviceSettings, self).__getattribute__(name)
+        return super().__getattribute__(name)
 
     def __setattr__(self, name, value):
         if name in extra_settings_schema["properties"]:
             self.extra_settings[name] = value
         else:
-            super(DeviceSettings, self).__setattr__(name, value)
+            super().__setattr__(name, value)
 
 
 CONTENT_CACHE_KEY_CACHE_KEY = "content_cache_key"
@@ -242,7 +242,7 @@ class ContentCacheKey(models.Model):
 
     def save(self, *args, **kwargs):
         self.pk = 1
-        super(ContentCacheKey, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     @classmethod
     def update_cache_key(cls):
@@ -279,7 +279,7 @@ class DeviceAppKey(models.Model):
 
     def save(self, *args, **kwargs):
         self.pk = 1
-        super(DeviceAppKey, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     @classmethod
     def update_app_key(cls):
@@ -307,7 +307,7 @@ class SQLiteLock(models.Model):
 
     def save(self, *args, **kwargs):
         self.pk = 1
-        super(SQLiteLock, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class SyncQueueStatus(ChoicesEnum):
@@ -448,7 +448,7 @@ class SyncQueue(models.Model):
     # the save operation if we hit a lock.
     @retry_on_db_lock
     def save(self, *args, **kwargs):
-        return super(SyncQueue, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     class Meta:
         unique_together = ("user_id", "instance_id")

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -89,13 +89,13 @@ class DeviceSettingsSerializer(DeviceSerializerMixin, serializers.ModelSerialize
                         automatic_synchronize_content_requests_and_import.cancel_all()
                         automatic_resource_import.cancel_all()
 
-        instance = super(DeviceSettingsSerializer, self).update(
+        instance = super().update(
             instance, validated_data
         )
         return instance
 
     def validate(self, data):
-        data = super(DeviceSettingsSerializer, self).validate(data)
+        data = super().validate(data)
         if "primary_storage_location" in data:
             if not check_is_directory(data["primary_storage_location"]):
                 raise serializers.ValidationError(

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -89,9 +89,7 @@ class DeviceSettingsSerializer(DeviceSerializerMixin, serializers.ModelSerialize
                         automatic_synchronize_content_requests_and_import.cancel_all()
                         automatic_resource_import.cancel_all()
 
-        instance = super().update(
-            instance, validated_data
-        )
+        instance = super().update(instance, validated_data)
         return instance
 
     def validate(self, data):

--- a/kolibri/core/device/tasks.py
+++ b/kolibri/core/device/tasks.py
@@ -73,7 +73,7 @@ class DeviceProvisionValidator(DeviceSerializerMixin, JobValidator):
                 "Please provide `preset` if `facility` is specified"
             )
 
-        return super(DeviceProvisionValidator, self).validate(data)
+        return super().validate(data)
 
 
 @register_task(

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -61,7 +61,7 @@ class DeviceSettingsTestCase(APITestCase):
         cls.user = FacilityUserFactory.create(facility=cls.facility)
 
     def setUp(self):
-        super(DeviceSettingsTestCase, self).setUp()
+        super().setUp()
         clear_process_cache()
         self.client.login(
             username=self.superuser.username,
@@ -288,7 +288,7 @@ class DeviceNameTestCase(APITestCase):
 
     def setUp(self):
         clear_process_cache()
-        super(DeviceNameTestCase, self).setUp()
+        super().setUp()
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -29,7 +29,7 @@ class SoudContextTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(SoudContextTestCase, self).setUp()
+        super().setUp()
         self.context = Context(uuid.uuid4().hex, uuid.uuid4().hex)
 
     def test_property__network_location(self):
@@ -64,7 +64,7 @@ class SoudRequestSyncHookHandlerTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(SoudRequestSyncHookHandlerTestCase, self).setUp()
+        super().setUp()
         self.instance_id = uuid.uuid4().hex
         self.user_ids = [
             uuid.uuid4().hex,
@@ -176,7 +176,7 @@ class SoudExecuteSyncsTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(SoudExecuteSyncsTestCase, self).setUp()
+        super().setUp()
         self.user_id = uuid.uuid4().hex
         self.instance_id = uuid.uuid4().hex
 
@@ -378,7 +378,7 @@ class SoudExecuteSyncTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(SoudExecuteSyncTestCase, self).setUp()
+        super().setUp()
         self.user_id = uuid.uuid4().hex
         self.instance_id = uuid.uuid4().hex
 

--- a/kolibri/core/device/test/test_sync_operations.py
+++ b/kolibri/core/device/test/test_sync_operations.py
@@ -16,7 +16,7 @@ from kolibri.core.device.models import LearnerDeviceStatus
 
 class LearnerDeviceStatusOperationTestCase(TestCase):
     def setUp(self):
-        super(LearnerDeviceStatusOperationTestCase, self).setUp()
+        super().setUp()
         self.facility = Facility.objects.create(name="Test")
         self.user = FacilityUser.objects.create(username="test", facility=self.facility)
         self.instance = InstanceIDModel.get_or_create_current_instance()[0]

--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -104,14 +104,14 @@ class NetworkLocation(models.Model):
     is_local = models.BooleanField(default=False)
 
     def __init__(self, *args, **kwargs):
-        super(NetworkLocation, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._set_fields_for_type()
 
     def save(self, *args, **kwargs):
         self._set_fields_for_type()
         if self.operating_system is None:
             self.operating_system = ""
-        return super(NetworkLocation, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def _set_fields_for_type(self):
         """Abstract method to set fields for type"""
@@ -163,7 +163,7 @@ class NetworkLocation(models.Model):
 
 class StaticNetworkLocationManager(models.Manager):
     def get_queryset(self):
-        queryset = super(StaticNetworkLocationManager, self).get_queryset()
+        queryset = super().get_queryset()
         return queryset.filter(location_type=LocationTypes.Static).all()
 
 
@@ -179,17 +179,17 @@ class StaticNetworkLocation(NetworkLocation):
 
 class DynamicNetworkLocationManager(models.Manager):
     def get_queryset(self):
-        queryset = super(DynamicNetworkLocationManager, self).get_queryset()
+        queryset = super().get_queryset()
         return queryset.filter(location_type=LocationTypes.Dynamic).all()
 
     def create(self, *args, **kwargs):
         kwargs = _filter_out_unsupported_fields(kwargs)
-        return super(DynamicNetworkLocationManager, self).create(*args, **kwargs)
+        return super().create(*args, **kwargs)
 
     def update_or_create(self, defaults, **kwargs):
         defaults = _filter_out_unsupported_fields(defaults)
 
-        return super(DynamicNetworkLocationManager, self).update_or_create(
+        return super().update_or_create(
             defaults, **kwargs
         )
 
@@ -211,7 +211,7 @@ class DynamicNetworkLocation(NetworkLocation):
             )
 
         if self.instance_id:
-            return super(DynamicNetworkLocation, self).save(*args, **kwargs)
+            return super().save(*args, **kwargs)
         else:
             raise ValidationError(
                 {

--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -189,9 +189,7 @@ class DynamicNetworkLocationManager(models.Manager):
     def update_or_create(self, defaults, **kwargs):
         defaults = _filter_out_unsupported_fields(defaults)
 
-        return super().update_or_create(
-            defaults, **kwargs
-        )
+        return super().update_or_create(defaults, **kwargs)
 
 
 class DynamicNetworkLocation(NetworkLocation):

--- a/kolibri/core/discovery/serializers.py
+++ b/kolibri/core/discovery/serializers.py
@@ -62,7 +62,7 @@ class NetworkLocationSerializer(serializers.ModelSerializer):
         data["connection_status"] = ConnectionStatus.Okay
         info = {k: v for (k, v) in client.device_info.items() if v is not None}
         data.update(info)
-        return super(NetworkLocationSerializer, self).validate(data)
+        return super().validate(data)
 
 
 class PinnedDeviceSerializer(ModelSerializer):
@@ -82,4 +82,4 @@ class PinnedDeviceSerializer(ModelSerializer):
         else:
             raise serializers.ValidationError("User must be defined")
         validated_data["user"] = user
-        return super(PinnedDeviceSerializer, self).create(validated_data)
+        return super().create(validated_data)

--- a/kolibri/core/discovery/test/test_connections.py
+++ b/kolibri/core/discovery/test/test_connections.py
@@ -94,7 +94,7 @@ class CaptureConnectionStateTestCase(BaseTestCase):
 
 class UpdateNetworkLocationTestCase(BaseTestCase):
     def setUp(self):
-        super(UpdateNetworkLocationTestCase, self).setUp()
+        super().setUp()
         build_from_network_location_patcher = mock.patch.object(
             NetworkClient, "build_from_network_location"
         )

--- a/kolibri/core/discovery/test/test_network_broadcast.py
+++ b/kolibri/core/discovery/test/test_network_broadcast.py
@@ -173,7 +173,7 @@ class KolibriInstanceTestCase(SimpleTestCase):
 
 class KolibriTestInstanceListener(KolibriInstanceListener):
     def __init__(self, *args, **kwargs):
-        super(KolibriTestInstanceListener, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mock = mock.Mock()
 
     def register_instance(self, instance):
@@ -213,7 +213,7 @@ def test_instance_listener_events(event_name):
 
 class KolibriInstanceListenerTestCase(SimpleTestCase):
     def setUp(self):
-        super(KolibriInstanceListenerTestCase, self).setUp()
+        super().setUp()
         self.instance = KolibriInstance(MOCK_ID)
         self.broadcast = mock.Mock(spec_set=KolibriBroadcast)(self.instance)
         self.events = Bus(extra_channels=ALL_EVENTS)
@@ -229,7 +229,7 @@ class KolibriInstanceListenerTestCase(SimpleTestCase):
 
 class KolibriBroadcastTestCase(SimpleTestCase):
     def setUp(self):
-        super(KolibriBroadcastTestCase, self).setUp()
+        super().setUp()
         self.instance = mock.Mock(spec_set=KolibriInstance)(
             MOCK_ID, ip=MOCK_INTERFACE_IP, port=MOCK_PORT
         )

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -20,7 +20,7 @@ class NetworkLocationListenerTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(NetworkLocationListenerTestCase, self).setUp()
+        super().setUp()
         self.instance = KolibriInstance(
             MOCK_ID,
             ip=MOCK_INTERFACE_IP,

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -293,7 +293,7 @@ class KolibriBroadcastEvents(Bus):
 
     def __init__(self):
         # keep it simple, `extra_channels` is the list of the events we need
-        super(KolibriBroadcastEvents, self).__init__(
+        super().__init__(
             extra_channels=[
                 # these receive a `KolibriInstance`
                 EVENT_REGISTER_INSTANCE,
@@ -332,7 +332,7 @@ class KolibriInstanceListener(SimplePlugin):
         """
         :type broadcast: KolibriBroadcast
         """
-        super(KolibriInstanceListener, self).__init__(broadcast.events)
+        super().__init__(broadcast.events)
         self.broadcast = broadcast
 
 

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -121,9 +121,7 @@ class NetworkClient(requests.Session):
 
         url = join_url(self.base_url, path)
         try:
-            with super().request(
-                method, url, stream=True, **kwargs
-            ) as response:
+            with super().request(method, url, stream=True, **kwargs) as response:
                 if response.raw._connection.sock is None:
                     raise requests.exceptions.ConnectionError("No socket available")
 

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -41,7 +41,7 @@ class NetworkClient(requests.Session):
         :param timeout: A timeout value in seconds or tuple for (connect, read)
         :type timeout: float|tuple
         """
-        super(NetworkClient, self).__init__()
+        super().__init__()
 
         self.base_url = base_url
         self.timeout = timeout or (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
@@ -121,7 +121,7 @@ class NetworkClient(requests.Session):
 
         url = join_url(self.base_url, path)
         try:
-            with super(NetworkClient, self).request(
+            with super().request(
                 method, url, stream=True, **kwargs
             ) as response:
                 if response.raw._connection.sock is None:

--- a/kolibri/core/discovery/utils/network/errors.py
+++ b/kolibri/core/discovery/utils/network/errors.py
@@ -39,7 +39,7 @@ class NetworkLocationResponseFailure(NetworkClientError):
 
     def __init__(self, *args, **kwargs):
         self.response = kwargs.pop("response", None)
-        super(NetworkLocationResponseFailure, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class NetworkLocationInvalidResponse(NetworkClientError):

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -263,10 +263,10 @@ class Exam(AbstractExam, AbstractFacilityDataModel):
         We delete all notifications objects whose quiz is this exam id.
         """
         LearnerProgressNotification.objects.filter(quiz_id=self.id).delete()
-        super(Exam, self).delete(using, keep_parents)
+        super().delete(using, keep_parents)
 
     def pre_save(self):
-        super(Exam, self).pre_save()
+        super().pre_save()
 
         # maintain stricter enforcement on when creator is allowed to be null
         if self._state.adding and self.creator is None:
@@ -298,7 +298,7 @@ class Exam(AbstractExam, AbstractFacilityDataModel):
             self.question_sources = [
                 section for section in self.question_sources if section.get("questions")
             ]
-        super(Exam, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def infer_dataset(self, *args, **kwargs):
         return self.cached_related_dataset_lookup("collection")
@@ -348,7 +348,7 @@ class ExamAssignment(AbstractFacilityDataModel):
     )
 
     def pre_save(self):
-        super(ExamAssignment, self).pre_save()
+        super().pre_save()
 
         # this shouldn't happen
         if (

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -95,7 +95,7 @@ class Lesson(AbstractFacilityDataModel):
         return "Lesson {} for Classroom {}".format(self.title, self.collection.name)
 
     def pre_save(self):
-        super(Lesson, self).pre_save()
+        super().pre_save()
 
         # maintain stricter enforcement on when assigned_by is allowed to be null
         if self._state.adding and self.created_by is None:
@@ -113,7 +113,7 @@ class Lesson(AbstractFacilityDataModel):
         We delete all notifications objects whose lesson is this lesson id.
         """
         LearnerProgressNotification.objects.filter(lesson_id=self.id).delete()
-        super(Lesson, self).delete(using, keep_parents)
+        super().delete(using, keep_parents)
 
     def infer_dataset(self, *args, **kwargs):
         return self.cached_related_dataset_lookup("collection")
@@ -166,7 +166,7 @@ class LessonAssignment(AbstractFacilityDataModel):
     morango_model_name = "lessonassignment"
 
     def pre_save(self):
-        super(LessonAssignment, self).pre_save()
+        super().pre_save()
 
         # this shouldn't happen
         if (

--- a/kolibri/core/lessons/serializers.py
+++ b/kolibri/core/lessons/serializers.py
@@ -92,7 +92,7 @@ class LessonSerializer(ModelSerializer):
     def to_internal_value(self, data):
         data = OrderedDict(data)
         data["created_by"] = self.context["request"].user.id
-        return super(LessonSerializer, self).to_internal_value(data)
+        return super().to_internal_value(data)
 
     def create(self, validated_data):
         """

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -66,10 +66,10 @@ logger = logging.getLogger(__name__)
 class HexStringUUIDField(serializers.UUIDField):
     def __init__(self, **kwargs):
         self.uuid_format = "hex"
-        super(HexStringUUIDField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
-        return super(HexStringUUIDField, self).to_internal_value(data).hex
+        return super().to_internal_value(data).hex
 
 
 class MasteryModelSerializer(serializers.Serializer):

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -132,7 +132,7 @@ class ContentSessionLog(BaseLogModel):
         if self.progress < 0:
             raise ValidationError("Progress out of range (<0)")
 
-        super(ContentSessionLog, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class ContentSummaryLog(BaseLogModel):
@@ -166,7 +166,7 @@ class ContentSummaryLog(BaseLogModel):
         if self.progress < 0 or self.progress > 1.01:
             raise ValidationError("Content summary progress out of range (0-1)")
 
-        super(ContentSummaryLog, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class UserSessionLog(BaseLogModel):

--- a/kolibri/core/logger/test/helpers.py
+++ b/kolibri/core/logger/test/helpers.py
@@ -38,7 +38,7 @@ class EvaluationMixin(object):
 
     @classmethod
     def setUpTestData(cls):
-        super(EvaluationMixin, cls).setUpTestData()
+        super().setUpTestData()
         cls.facility = FacilityFactory.create()
         cls.users = [
             FacilityUserFactory.create(facility=cls.facility) for _ in range(6)

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -23,7 +23,7 @@ class BulkCreateMixin(object):
         """ if an array is passed, set serializer to many """
         if isinstance(kwargs.get("data", {}), list):
             kwargs["many"] = True
-        return super(BulkCreateMixin, self).get_serializer(*args, **kwargs)
+        return super().get_serializer(*args, **kwargs)
 
 
 class BulkDeleteMixin(object):
@@ -102,7 +102,7 @@ class UUIDIn(In):
             sqls_params = ()
             return (placeholder, sqls_params)
         else:
-            return super(UUIDIn, self).process_rhs(compiler, connection)
+            return super().process_rhs(compiler, connection)
 
     def split_parameter_list_as_sql(self, compiler, connection):
         # This is a special case for databases which limit the number of

--- a/kolibri/core/query.py
+++ b/kolibri/core/query.py
@@ -10,7 +10,7 @@ try:
     class NotNullArrayAgg(ArrayAgg):
         def __init__(self, *args, **kwargs):
             self.result_field = kwargs.pop("result_field", None)
-            super(NotNullArrayAgg, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
         def convert_value(self, value, expression, connection):
             if not value:
@@ -45,7 +45,7 @@ class GroupConcatSubquery(Subquery):
         self.template = (
             "(SELECT STRING_AGG(%(field)s, ',') FROM (%(subquery)s) AS %(field)s__sum)"
         )
-        return super(GroupConcatSubquery, self).as_sql(compiler, connection)
+        return super().as_sql(compiler, connection)
 
 
 class GroupConcat(Aggregate):
@@ -54,7 +54,7 @@ class GroupConcat(Aggregate):
 
     def __init__(self, *args, **kwargs):
         self.result_field = kwargs.pop("result_field", None)
-        super(GroupConcat, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def convert_value(self, value, expression, connection):
         if not value:

--- a/kolibri/core/serializers.py
+++ b/kolibri/core/serializers.py
@@ -20,7 +20,7 @@ from .fields import DateTimeTzField as DjangoDateTimeTzField
 
 class DateTimeTzField(DateTimeField):
     def to_internal_value(self, data):
-        data = super(DateTimeTzField, self).to_internal_value(data)
+        data = super().to_internal_value(data)
         tz = timezone.get_current_timezone()
         if not data.tzinfo:
             data = timezone.make_aware(data, pytz.utc)
@@ -108,7 +108,7 @@ class KolibriModelSerializer(ModelSerializer):
 class HexOnlyUUIDField(UUIDFieldBase):
     def __init__(self, **kwargs):
         kwargs["format"] = "hex"
-        super(HexOnlyUUIDField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
-        return super(HexOnlyUUIDField, self).to_internal_value(data).hex
+        return super().to_internal_value(data).hex

--- a/kolibri/core/tasks/permissions.py
+++ b/kolibri/core/tasks/permissions.py
@@ -154,7 +154,7 @@ class IsFacilityAdmin(BasePermission):
 
 class IsAdmin(PermissionsFromAny):
     def __init__(self):
-        super(IsAdmin, self).__init__(IsSuperAdmin(), IsFacilityAdmin())
+        super().__init__(IsSuperAdmin(), IsFacilityAdmin())
 
 
 class HasSameFacilityAsJob(BasePermission):
@@ -167,14 +167,14 @@ class HasSameFacilityAsJob(BasePermission):
 
 class IsFacilityAdminForJob(PermissionsFromAll):
     def __init__(self):
-        super(IsFacilityAdminForJob, self).__init__(
+        super().__init__(
             IsFacilityAdmin(), HasSameFacilityAsJob()
         )
 
 
 class IsAdminForJob(PermissionsFromAny):
     def __init__(self):
-        super(IsAdminForJob, self).__init__(IsSuperAdmin(), IsFacilityAdminForJob())
+        super().__init__(IsSuperAdmin(), IsFacilityAdminForJob())
 
 
 class NotProvisioned(BasePermission):

--- a/kolibri/core/tasks/permissions.py
+++ b/kolibri/core/tasks/permissions.py
@@ -167,9 +167,7 @@ class HasSameFacilityAsJob(BasePermission):
 
 class IsFacilityAdminForJob(PermissionsFromAll):
     def __init__(self):
-        super().__init__(
-            IsFacilityAdmin(), HasSameFacilityAsJob()
-        )
+        super().__init__(IsFacilityAdmin(), HasSameFacilityAsJob())
 
 
 class IsAdminForJob(PermissionsFromAny):

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -45,46 +45,46 @@ class _registry(dict):
 
     def __getitem__(self, key):
         self.__init_check()
-        return super(_registry, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __contains__(self, key):
         self.__init_check()
-        return super(_registry, self).__contains__(key)
+        return super().__contains__(key)
 
     def __iter__(self):
         self.__init_check()
-        return super(_registry, self).__iter__()
+        return super().__iter__()
 
     def __len__(self):
         self.__init_check()
-        return super(_registry, self).__len__()
+        return super().__len__()
 
     def __repr__(self):
         self.__init_check()
-        return super(_registry, self).__repr__()
+        return super().__repr__()
 
     def copy(self):
         self.__init_check()
-        return super(_registry, self).copy()
+        return super().copy()
 
     def has_key(self, key):
         return key in self
 
     def keys(self):
         self.__init_check()
-        return super(_registry, self).keys()
+        return super().keys()
 
     def values(self):
         self.__init_check()
-        return super(_registry, self).values()
+        return super().values()
 
     def items(self):
         self.__init_check()
-        return super(_registry, self).items()
+        return super().items()
 
     def __cmp__(self, other):
         self.__init_check()
-        return super(_registry, self).__cmp__(other)
+        return super().__cmp__(other)
 
     def _initialize(self):
         logger.debug("Importing 'tasks' module from django apps")
@@ -106,7 +106,7 @@ class _registry(dict):
     def __setitem__(self, key, value):
         if not isinstance(value, RegisteredTask):
             raise TypeError("Value must be an instance of RegisteredTask")
-        return super(_registry, self).__setitem__(key, value)
+        return super().__setitem__(key, value)
 
     def update(self, other):
         # Coerce args to a dict and then set each key in that dict

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -602,7 +602,7 @@ class CreateTaskAPITestCase(BaseAPITestCase):
 class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        super(EnqueueArgsCreateAPITestCase, cls).setUpTestData()
+        super().setUpTestData()
 
         cls.datetime_obj = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
         cls.timedelta_obj = datetime.timedelta(days=1, hours=1)
@@ -867,7 +867,7 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
 class EnqueueArgsUpdateAPITestCase(BaseAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        super(EnqueueArgsUpdateAPITestCase, cls).setUpTestData()
+        super().setUpTestData()
 
         cls.datetime_obj = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
         cls.timedelta_obj = datetime.timedelta(days=1, hours=1)
@@ -1129,7 +1129,7 @@ class EnqueueArgsUpdateAPITestCase(BaseAPITestCase):
 class ListAPIRepeat(BaseAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        super(ListAPIRepeat, cls).setUpTestData()
+        super().setUpTestData()
 
         @register_task
         def life():

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -86,7 +86,7 @@ class InfiniteLoopThread(Thread):
         self.full_thread_name = "{thread_name}-{thread_id}".format(
             thread_name=self.thread_name, thread_id=self.thread_id
         )
-        super(InfiniteLoopThread, self).__init__(
+        super().__init__(
             name=self.full_thread_name, *args, **kwargs
         )
         self.func = func
@@ -284,7 +284,7 @@ class JobProgressMixin(object):
     def __init__(self, *args, **kwargs):
         self.progresstracker = None
         self.job = get_current_job()
-        super(JobProgressMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def update_progress(
         self, increment=None, message="", current_progress=None, extra_data=None

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -86,9 +86,7 @@ class InfiniteLoopThread(Thread):
         self.full_thread_name = "{thread_name}-{thread_id}".format(
             thread_name=self.thread_name, thread_id=self.thread_id
         )
-        super().__init__(
-            name=self.full_thread_name, *args, **kwargs
-        )
+        super().__init__(name=self.full_thread_name, *args, **kwargs)
         self.func = func
         self.wait = wait_between_runs
 

--- a/kolibri/core/test/test_apps.py
+++ b/kolibri/core/test/test_apps.py
@@ -41,7 +41,7 @@ def do_setup(**cache_opts):
 @mock.patch("kolibri.core.apps.process_cache")
 class KolibriCoreConfigTestCase(TestCase):
     def setUp(self):
-        super(KolibriCoreConfigTestCase, self).setUp()
+        super().setUp()
         self.client = mock.MagicMock(spec=Redis)
         self.helper = mock.MagicMock(spec=RedisSettingsHelper)
 

--- a/kolibri/core/test/test_drf_mixins.py
+++ b/kolibri/core/test/test_drf_mixins.py
@@ -32,7 +32,7 @@ class TestBulkAPIMixins(TestCase):
     lang2 = {"id": "fr-fr", "lang_code": "fr", "lang_subcode": "fr"}
 
     def setUp(self):
-        super(TestBulkAPIMixins, self).setUp()
+        super().setUp()
         self.request = RequestFactory()
 
     def test_get(self):

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -75,7 +75,7 @@ try:
             We use a similar pattern in our own caching decorator in kolibri/core/content/api.py and saw errors
             due to the fact if the lambda returns a value, it is interpreted as a replacement for the response object.
             """
-            super(RedisCache, self).set(*args, **kwargs)
+            super().set(*args, **kwargs)
 
 
 except (ImportError, InvalidCacheBackendError):

--- a/kolibri/core/utils/pagination.py
+++ b/kolibri/core/utils/pagination.py
@@ -210,9 +210,7 @@ class ValuesViewsetLimitOffsetPagination(LimitOffsetPagination):
 
 class ValuesViewsetCursorPagination(CursorPagination):
     def paginate_queryset(self, queryset, request, view=None):
-        pks_queryset = super().paginate_queryset(
-            queryset, request, view=view
-        )
+        pks_queryset = super().paginate_queryset(queryset, request, view=view)
         if pks_queryset is None:
             return None
         self.request = request

--- a/kolibri/core/utils/pagination.py
+++ b/kolibri/core/utils/pagination.py
@@ -34,7 +34,7 @@ class ValuesViewsetPaginator(Paginator):
             )
         self.queryset = object_list
         object_list = object_list.values_list("pk", flat=True).distinct()
-        super(ValuesViewsetPaginator, self).__init__(object_list, *args, **kwargs)
+        super().__init__(object_list, *args, **kwargs)
 
     def _get_page(self, object_list, *args, **kwargs):
         pks = list(object_list)
@@ -54,7 +54,7 @@ class CachedValuesViewsetPaginator(ValuesViewsetPaginator):
             cache_key = "query-count:" + hashlib.md5(query_string).hexdigest()
             value = cache.get(cache_key)
             if value is None:
-                value = super(CachedValuesViewsetPaginator, self).count
+                value = super().count
                 cache.set(cache_key, value, 300)  # save the count for 5 minutes
         except EmptyResultSet:
             # If the query is an empty result set, then this error will be raised by
@@ -210,7 +210,7 @@ class ValuesViewsetLimitOffsetPagination(LimitOffsetPagination):
 
 class ValuesViewsetCursorPagination(CursorPagination):
     def paginate_queryset(self, queryset, request, view=None):
-        pks_queryset = super(ValuesViewsetCursorPagination, self).paginate_queryset(
+        pks_queryset = super().paginate_queryset(
             queryset, request, view=view
         )
         if pks_queryset is None:

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -193,7 +193,7 @@ class UnsupportedBrowserView(TemplateView):
     template_name = "kolibri/unsupported_browser.html"
 
     def get_context_data(self, **kwargs):
-        context = super(UnsupportedBrowserView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context["brand_primary_v400"] = (
             ThemeHook.get_theme()
             .get("brandColors", {})

--- a/kolibri/core/webpack/test/test_webpack_tags.py
+++ b/kolibri/core/webpack/test/test_webpack_tags.py
@@ -6,7 +6,7 @@ from kolibri.plugins.hooks import register_hook
 
 class KolibriTagNavigationTestCase(TestCase):
     def setUp(self):
-        super(KolibriTagNavigationTestCase, self).setUp()
+        super().setUp()
         Hook.__module__ = "test.kolibri_plugin"
         self.test_hook = register_hook(Hook)()
 

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -26,7 +26,7 @@ class CustomDjangoCache(DjangoCache):
                      otherwise returns error_return_value
         """
         try:
-            method = getattr(super(CustomDjangoCache, self), method_name)
+            method = getattr(super(), method_name)
             if method is None:
                 raise ValueError(
                     "{method_name} is not a valid method".format(

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -116,7 +116,7 @@ class ConfigDict(dict):
         for key in self.SET_KEYS:
             if key in values_copy:
                 values_copy[key] = set(values_copy[key])
-        super(ConfigDict, self).update(values_copy)
+        super()
 
     def save(self):
         # use default OS encoding
@@ -193,7 +193,7 @@ class SingletonMeta(ABCMeta):
     # being overwritten.
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(SingletonMeta, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -25,7 +25,7 @@ class ClassSummaryTestCase(EvaluationMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
         provision_device()
-        super(ClassSummaryTestCase, cls).setUpTestData()
+        super().setUpTestData()
         cls.classroom = Classroom.objects.create(name="classrom", parent=cls.facility)
         cls.another_classroom = Classroom.objects.create(
             name="another classrom", parent=cls.facility

--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -28,7 +28,7 @@ from kolibri.core.utils.cache import process_cache
 
 class DeviceChannelMetadataSerializer(ChannelMetadataSerializer):
     def to_representation(self, instance):
-        value = super(ChannelMetadataSerializer, self).to_representation(instance)
+        value = super().to_representation(instance)
 
         # if the request includes a GET param 'include_fields', add the requested calculated fields
         if "request" in self.context:

--- a/kolibri/plugins/learn/test/test_hooks.py
+++ b/kolibri/plugins/learn/test/test_hooks.py
@@ -9,7 +9,7 @@ class NetworkDiscoveryForSoUDHookTestCase(TestCase):
     databases = "__all__"
 
     def setUp(self):
-        super(NetworkDiscoveryForSoUDHookTestCase, self).setUp()
+        super().setUp()
         self.hook = NetworkLocationDiscoveryHook.get_hook(
             "kolibri.plugins.learn.NetworkDiscoveryForSoUDHook"
         )

--- a/kolibri/plugins/pwa/views.py
+++ b/kolibri/plugins/pwa/views.py
@@ -23,7 +23,7 @@ class PwaManifestView(TemplateView):
     content_type = "application/manifest+json"
 
     def get_context_data(self, **kwargs):
-        context = super(PwaManifestView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         theme = ThemeHook.get_theme()
 
         # App should be scoped to the deployment path of Kolibri, no higher
@@ -108,7 +108,7 @@ class PwaServiceWorkerView(TemplateView):
     content_type = "application/javascript"
 
     def get_context_data(self, **kwargs):
-        context = super(PwaServiceWorkerView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         # This needs to increment each time a potentially cached asset changes.
         context["version"] = kolibri.__version__
         return context

--- a/kolibri/plugins/setup_wizard/views.py
+++ b/kolibri/plugins/setup_wizard/views.py
@@ -11,4 +11,4 @@ class SetupWizardView(TemplateView):
     def dispatch(self, *args, **kwargs):
         if device_provisioned():
             return redirect(reverse("kolibri:core:redirect_user"))
-        return super(SetupWizardView, self).dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)

--- a/kolibri/plugins/user_auth/views.py
+++ b/kolibri/plugins/user_auth/views.py
@@ -12,4 +12,4 @@ class UserAuthView(TemplateView):
         """
         if request.user.is_authenticated:
             return RootURLRedirectView.as_view()(request)
-        return super(UserAuthView, self).get(request)
+        return super().get(request)

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -41,7 +41,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
 
     def validate(self, data):
         try:
-            job_data = super(MergeUserValidator, self).validate(data)
+            job_data = super().validate(data)
         except ValidationError as e:
             details = e.detail if isinstance(e.detail, list) else [e.detail]
             for detail in details:
@@ -51,7 +51,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
                     or detail.code == error_constants.INVALID_USERNAME
                 ):
                     self.create_remote_user(data)
-                    job_data = super(MergeUserValidator, self).validate(data)
+                    job_data = super().validate(data)
                     break
             else:
                 # If we didn't break out of the loop, then we need to raise the original error

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -132,7 +132,7 @@ class KolibriCommand(click.Command):
         kwargs["params"] = base_params + (
             kwargs["params"] if "params" in kwargs else []
         )
-        super(KolibriCommand, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def invoke(self, ctx):
         # Check if the current user is the kolibri user when running kolibri from Debian installer.
@@ -145,7 +145,7 @@ class KolibriCommand(click.Command):
         set_django_settings_and_python_path(None, ctx.params.get("pythonpath"))
         for param in base_params:
             ctx.params.pop(param.name)
-        return super(KolibriCommand, self).invoke(ctx)
+        return super().invoke(ctx)
 
 
 class KolibriGroupCommand(click.Group):
@@ -162,7 +162,7 @@ class KolibriGroupCommand(click.Group):
         kwargs["params"] = base_params + (
             kwargs["params"] if "params" in kwargs else []
         )
-        super(KolibriGroupCommand, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def invoke(self, ctx):
         # Check if the current user is the kolibri user when running kolibri from Debian installer.
@@ -175,7 +175,7 @@ class KolibriGroupCommand(click.Group):
         set_django_settings_and_python_path(None, ctx.params.get("pythonpath"))
         for param in base_params:
             ctx.params.pop(param.name)
-        return super(KolibriGroupCommand, self).invoke(ctx)
+        return super().invoke(ctx)
 
 
 class KolibriDjangoCommand(click.Command):
@@ -192,7 +192,7 @@ class KolibriDjangoCommand(click.Command):
         kwargs["params"] = initialize_params + (
             kwargs["params"] if "params" in kwargs else []
         )
-        super(KolibriDjangoCommand, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def invoke(self, ctx):
         try:
@@ -203,7 +203,7 @@ class KolibriDjangoCommand(click.Command):
         # Remove parameters that are not for Django management command
         for param in initialize_params:
             ctx.params.pop(param.name)
-        return super(KolibriDjangoCommand, self).invoke(ctx)
+        return super().invoke(ctx)
 
 
 main_help = """Kolibri command-line utility

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -802,7 +802,7 @@ class FileDownload(Transfer):
 
         self.transfer_size = None
 
-        super(FileDownload, self).__init__(
+        super().__init__(
             source, dest, checksum=checksum, cancel_check=cancel_check
         )
 
@@ -864,7 +864,7 @@ class FileDownload(Transfer):
     def finalize(self):
         if not self.finalize_download:
             return
-        return super(FileDownload, self).finalize()
+        return super().finalize()
 
     def _catch_exception_and_retry(func):
         def inner(self, *args, **kwargs):
@@ -1069,7 +1069,7 @@ class FileDownload(Transfer):
     def close(self):
         if hasattr(self, "response"):
             self.response.close()
-        super(FileDownload, self).close()
+        super().close()
 
 
 class FileCopy(Transfer):
@@ -1098,7 +1098,7 @@ class FileCopy(Transfer):
 
     def close(self):
         self.source_file_obj.close()
-        super(FileCopy, self).close()
+        super().close()
 
 
 class RemoteFile(ChunkedFile):
@@ -1107,7 +1107,7 @@ class RemoteFile(ChunkedFile):
     """
 
     def __init__(self, filepath, remote_url):
-        super(RemoteFile, self).__init__(filepath)
+        super().__init__(filepath)
         self.remote_url = remote_url
         self._dest_file_handle = None
         self.transfer = None
@@ -1161,14 +1161,14 @@ class RemoteFile(ChunkedFile):
         )
         if needs_download:
             self._run_transfer()
-        return super(RemoteFile, self).read(size)
+        return super().read(size)
 
     def seek(self, offset, whence=0):
         dest_file_handle = self.dest_file_handle
         if dest_file_handle:
             return dest_file_handle.seek(offset, whence)
         self.get_file_size()
-        return super(RemoteFile, self).seek(offset, whence)
+        return super().seek(offset, whence)
 
     def close(self):
         if self.transfer:

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -802,9 +802,7 @@ class FileDownload(Transfer):
 
         self.transfer_size = None
 
-        super().__init__(
-            source, dest, checksum=checksum, cancel_check=cancel_check
-        )
+        super().__init__(source, dest, checksum=checksum, cancel_check=cancel_check)
 
         self._initialize_dest_file()
 

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -125,7 +125,7 @@ COMPRESSED_FILE_FOR_REGULAR_PATH = ".compressed_file_for_regular_path"
 
 class TruncatableFileEntry(FileEntry):
     def __init__(self, path, stat_cache=None):
-        super(TruncatableFileEntry, self).__init__(path, stat_cache)
+        super().__init__(path, stat_cache)
         if self.stat.st_size == 0:
             stat_path = "{}.{}".format(path, "file_size")
             if stat_cache is None or stat_path not in stat_cache:
@@ -252,7 +252,7 @@ class StreamingStaticFile(EndRangeStaticFile):
     def __init__(self, path, headers, remote_url, encodings=None, stat_cache=None):
         self.path = path
         self.remote_url = remote_url
-        super(StreamingStaticFile, self).__init__(path, headers, encodings, stat_cache)
+        super().__init__(path, headers, encodings, stat_cache)
 
     @staticmethod
     def get_file_stats(path, encodings, stat_cache):
@@ -330,7 +330,7 @@ class DynamicWhiteNoise(WhiteNoise):
             "add_headers_function": add_headers_function,
         }
         kwargs.update(whitenoise_settings)
-        super(DynamicWhiteNoise, self).__init__(application, **kwargs)
+        super().__init__(application, **kwargs)
         self.dynamic_finder = FileFinder(dynamic_locations or [])
         # Generate a regex to check if a path matches one of our dynamic
         # location prefixes
@@ -414,7 +414,7 @@ class DynamicWhiteNoise(WhiteNoise):
             pass
 
     def candidate_paths_for_url(self, url):
-        paths = super(DynamicWhiteNoise, self).candidate_paths_for_url(url)
+        paths = super().candidate_paths_for_url(url)
         for path in paths:
             yield path
         path = self.get_dynamic_path(url)

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -87,7 +87,7 @@ class EncodingStreamHandler(logging.StreamHandler):
     terminator = "\n"
 
     def __init__(self, stream=None, encoding="utf-8"):
-        super(EncodingStreamHandler, self).__init__(stream)
+        super().__init__(stream)
         self.encoding = encoding
 
     def emit(self, record):
@@ -121,7 +121,7 @@ class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
     """
 
     def __init__(self, *args, **kwargs):
-        super(KolibriTimedRotatingFileHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         dirname, basename = os.path.split(self.baseFilename)
         archive_dir = os.path.join(dirname, "archive")
 
@@ -159,7 +159,7 @@ class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
         be renamed from KOLIBRI_HOME/logs/kolibri.txt.YYYY-MM-DD to
         KOLIBRI_HOME/logs/archive/KOLIBRI-YYYY-MM-DD.txt.
         """
-        super(KolibriTimedRotatingFileHandler, self).doRollover()
+        super().doRollover()
         filenames = os.listdir(self.dirname)
         prefix = self.basename + "."
 

--- a/kolibri/utils/pskolibri/_pswindows.py
+++ b/kolibri/utils/pskolibri/_pswindows.py
@@ -81,7 +81,7 @@ class MEMORYSTATUSEX(ctypes.Structure):
     def __init__(self):
         # have to initialize this to the size of MEMORYSTATUSEX
         self.dwLength = ctypes.sizeof(self)
-        super(MEMORYSTATUSEX, self).__init__()
+        super().__init__()
 
 
 class FILETIME(ctypes.Structure):

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -24,7 +24,7 @@ class SanityException(RuntimeError):
 class DatabaseNotMigrated(SanityException):
     def __init__(self, *args, **kwargs):
         self.db_exception = kwargs.get("db_exception")
-        super(DatabaseNotMigrated, self).__init__(
+        super().__init__(
             "An exception occurred for which it is assumed that the "
             "database is not fully migrated.\n\n"
             "Exception: {}".format(str(self.db_exception))
@@ -34,7 +34,7 @@ class DatabaseNotMigrated(SanityException):
 class DatabaseInaccessible(SanityException):
     def __init__(self, *args, **kwargs):
         self.db_exception = kwargs.get("db_exception")
-        super(DatabaseInaccessible, self).__init__(
+        super().__init__(
             "Not able to access the database while checking it.\n\n"
             "Exception: {}".format(str(self.db_exception))
         )

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -110,7 +110,7 @@ class NotRunning(Exception):
 
     def __init__(self, status_code):
         self.status_code = status_code
-        super(NotRunning, self).__init__()
+        super().__init__()
 
 
 class PortOccupied(OSError):
@@ -156,7 +156,7 @@ class ServerPlugin(BaseServerPlugin):
         # in the super invocation here, results in the httpserver's `bind_addr` property being set.
         address = (conf.OPTIONS["Deployment"]["LISTEN_ADDRESS"], port)
 
-        super(ServerPlugin, self).__init__(
+        super().__init__(
             bus,
             httpserver=Server(None, self.application, **self.server_config),
             bind_addr=address,
@@ -193,7 +193,7 @@ class ServerPlugin(BaseServerPlugin):
         # Reset httpserver bind_addr. This value changes if httpserver has
         # been started before.
         self.httpserver.bind_addr = self._default_bind_addr
-        super(ServerPlugin, self).START()
+        super().START()
 
     @property
     def interface(self):
@@ -222,7 +222,7 @@ class KolibriServerPlugin(ServerPlugin):
                 "Please use `kolibri stop` and try again."
             )
             raise RunningException("There is another Kolibri server running.")
-        super(KolibriServerPlugin, self).__init__(bus, port)
+        super().__init__(bus, port)
 
     @property
     def application(self):
@@ -231,12 +231,12 @@ class KolibriServerPlugin(ServerPlugin):
         return application
 
     def ENTER(self):
-        super(KolibriServerPlugin, self).ENTER()
+        super().ENTER()
         # Clear old sessions up
         call_command("clearsessions")
 
     def START(self):
-        super(KolibriServerPlugin, self).START()
+        super().START()
         _, bind_port = self.httpserver.bind_addr
         self.bus.publish("SERVING", bind_port)
         __, urls = get_urls(listen_port=bind_port)
@@ -254,7 +254,7 @@ class ZipContentServerPlugin(ServerPlugin):
         return alt_application
 
     def START(self):
-        super(ZipContentServerPlugin, self).START()
+        super().START()
         _, bind_port = self.httpserver.bind_addr
         self.bus.publish("ZIP_SERVING", bind_port)
 
@@ -358,7 +358,7 @@ class ZeroConfPlugin(Monitor):
         self.RUN()
 
     def STOP(self):
-        super(ZeroConfPlugin, self).STOP()
+        super().STOP()
 
         if self.broadcast is not None:
             self.broadcast.stop_broadcast()
@@ -512,7 +512,7 @@ def _port_check(port):
 class DaemonizePlugin(SimplePlugin):
     def __init__(self, bus, check_ports):
         self.check_ports = check_ports
-        super(DaemonizePlugin, self).__init__(bus)
+        super().__init__(bus)
 
     def ENTER(self):
         self.bus.publish("log", "Running Kolibri as background process", 20)
@@ -569,7 +569,7 @@ class LogPlugin(SimplePlugin):
 
 class SignalHandler(BaseSignalHandler):
     def __init__(self, bus):
-        super(SignalHandler, self).__init__(bus)
+        super().__init__(bus)
         self.process_pid = None
 
         self.handlers.update(
@@ -582,12 +582,12 @@ class SignalHandler(BaseSignalHandler):
 
     def _handle_signal(self, signum=None, frame=None):
         if self.process_pid is None:
-            return super(SignalHandler, self)._handle_signal(signum, frame)
+            return super()._handle_signal(signum, frame)
         if os.getpid() == self.process_pid:
-            return super(SignalHandler, self)._handle_signal(signum, frame)
+            return super()._handle_signal(signum, frame)
 
     def subscribe(self):
-        super(SignalHandler, self).subscribe()
+        super().subscribe()
         self.bus.subscribe("ENTER", self.ENTER)
 
     def ENTER(self):
@@ -738,7 +738,7 @@ class BaseKolibriProcessBus(ProcessBus):
         self.port = int(port)
         self.zip_port = int(zip_port)
 
-        super(BaseKolibriProcessBus, self).__init__()
+        super().__init__()
         # This can be removed when a new version of magicbus is released that
         # includes their fix for Python 3.9 compatibility.
         self.thread_wait.unsubscribe()
@@ -861,7 +861,7 @@ class BaseKolibriProcessBus(ProcessBus):
 
 class KolibriServicesProcessBus(BaseKolibriProcessBus):
     def __init__(self, *args, **kwargs):
-        super(KolibriServicesProcessBus, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Setup plugin for services
         service_plugin = ServicesPlugin(self)
@@ -894,7 +894,7 @@ class KolibriProcessBus(KolibriServicesProcessBus):
     """
 
     def __init__(self, *args, **kwargs):
-        super(KolibriProcessBus, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         kolibri_server = KolibriServerPlugin(
             self,

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -41,7 +41,7 @@ class override_option(TestContextDecorator):
         self.section = section
         self.key = key
         self.temp_value = value
-        super(override_option, self).__init__()
+        super().__init__()
 
     def enable(self):
         self.old_value = conf.OPTIONS[self.section][self.key]

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -175,7 +175,7 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
         self.mock_session.head.side_effect = self.mock_head_request
 
     def setUp(self):
-        super(TestTransferDownloadByteRangeSupport, self).setUp()
+        super().setUp()
         self.source = "http://example.com/testfile"
         self.set_session_mock()
 
@@ -968,7 +968,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupportNotReported(
 
 class TestTransferCopy(BaseTestTransfer):
     def setUp(self):
-        super(TestTransferCopy, self).setUp()
+        super().setUp()
         self.copy_source = tempfile.NamedTemporaryFile(delete=False).name
         # Test FileCopy iterator
         with open(self.copy_source, "wb") as testfile:


### PR DESCRIPTION
# Summary

**Title:** Remove Python 2.7 legacy: Replace old `super(Class, self)` calls with Python 3 `super()` syntax

This PR removes Python 2.7 legacy code by updating all occurrences of the old-style `super(ClassName, self)` and `super(ClassName, cls)` calls to the modern Python 3 `super()` syntax. 


# References

Fixes **#13884**

---

# Reviewer guidance

- Confirm that all legacy super calls:
  - `super(ClassName, self)`
  - `super(ClassName, cls)`
  have been correctly replaced with the Python 3 form:
  - `super()`
- Ensure no remaining occurrences exist across the codebase  
  (recommended check: `grep -R "super(" -n kolibri | grep ","`)
- Verify that no behavioral logic changed; this PR is strictly a syntax update.
- Run the full test suite to ensure no regressions were introduced.
- Optionally manually inspect a few modules with inheritance to ensure correctness.