### PR TITLE
Remove component for redirect only route.

### DIFF
--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -117,7 +117,6 @@ export default [
         router.replace({ name: PageNames.ROOT });
       });
     },
-    component: TopicsPage,
   },
   {
     // Handle redirect for links without the /folder appended


### PR DESCRIPTION
## Summary
* Under conditions I am not able to organically replicate, it is possible for the TopicsPage to load before the appropriate redirect has taken place
* However, this is clearly due to the fact that the redirect only route has a component property, which causes the component to be loaded

## References
Fixes #13978

## Reviewer guidance
I was not able to replicate this entirely manually, it appears to be specific to the timing that occurs on BCK, maybe?

But, I was able to replicate by updating the handler for the relevant route to this:

```
    handler: to => {
      return fetchChannels().then(async() => {
        const { channel_id } = to.params;
        const channel = get(channelsMap)[channel_id];
        if (channel) {
          const id = get(channelsMap)[channel_id].root;
          await new Promise(resolve => setTimeout(resolve, 10000));
          router.replace({
            name: PageNames.TOPICS_TOPIC,
            params: {
              id,
            },
          });
          return;
        }
        router.replace({ name: PageNames.ROOT });
      });
```

This adds an artificial wait before the redirect - with the component in place, this replicates the error in the issue, with the component removed, it simply waits 10 seconds and then properly redirects.
