### PR TITLE
Mask sensitive fields in error reports and console logging

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -6,6 +6,7 @@ import logger from 'kolibri-logging';
 import UserSyncStatusResource from 'kolibri-common/apiResources/UserSyncStatusResource';
 import { nextTick } from 'vue';
 import { DisconnectionErrorCodes } from 'kolibri/constants';
+import sanitizeError from 'kolibri/utils/sanitizeError';
 
 const logging = logger.getLogger(__filename);
 
@@ -35,7 +36,7 @@ export function clearError(store) {
 export function handleApiError(store, { error, reloadOnReconnect = false } = {}) {
   let errorString = error;
   if (typeof error === 'object' && !(error instanceof Error)) {
-    errorString = JSON.stringify(error, null, 2);
+    errorString = JSON.stringify(sanitizeError(error), null, 2);
   } else if (error.response) {
     if (DisconnectionErrorCodes.includes(error.response.status)) {
       // Do not log errors for disconnections, as it disrupts the user experience
@@ -45,7 +46,7 @@ export function handleApiError(store, { error, reloadOnReconnect = false } = {})
     }
     // Reassign object properties here as Axios error objects have built in
     // pretty printing support which messes with this.
-    errorString = JSON.stringify(error.response, null, 2);
+    errorString = JSON.stringify(sanitizeError(error).response, null, 2);
   } else if (error instanceof Error) {
     errorString = error.toString();
   }

--- a/packages/kolibri/apiResource.js
+++ b/packages/kolibri/apiResource.js
@@ -4,6 +4,7 @@ import find from 'lodash/find';
 import matches from 'lodash/matches';
 import isEqual from 'lodash/isEqual';
 import urls from 'kolibri/urls';
+import sanitizeError from './utils/sanitizeError';
 
 export const logging = logger.getLogger(__filename);
 
@@ -1033,6 +1034,7 @@ export class Resource {
     if (!err.config) {
       return;
     }
+    const sanitized = sanitizeError(err);
     /* eslint-disable no-console */
     console.groupCollapsed(
       `%cRequest error: ${err.response.statusText}, ${
@@ -1054,16 +1056,16 @@ export class Resource {
       }
       console.groupEnd();
     }
-    if (err.config?.params && Object.keys(err.config.params).length) {
+    if (sanitized.config?.params && Object.keys(sanitized.config.params).length) {
       console.group('Query parameters');
-      for (const [k, v] of Object.entries(err.config.params)) {
+      for (const [k, v] of Object.entries(sanitized.config.params)) {
         console.log(`${k}: ${v}`);
       }
       console.groupEnd();
     }
-    if (err.config.data) {
+    if (sanitized.config?.data) {
       try {
-        const data = JSON.parse(err.config.data);
+        const data = JSON.parse(sanitized.config.data);
         if (Object.keys(data).length) {
           console.group('Data');
           for (const [k, v] of Object.entries(data)) {
@@ -1073,9 +1075,9 @@ export class Resource {
         }
       } catch (e) {} // eslint-disable-line no-empty
     }
-    if (err.config?.headers && Object.keys(err.config.headers).length) {
+    if (sanitized.config?.headers && Object.keys(sanitized.config.headers).length) {
       console.group('Headers');
-      for (const [k, v] of Object.entries(err.config.headers)) {
+      for (const [k, v] of Object.entries(sanitized.config.headers)) {
         console.log(`${k}: ${v}`);
       }
       console.groupEnd();

--- a/packages/kolibri/internal/apiSpec.js
+++ b/packages/kolibri/internal/apiSpec.js
@@ -60,6 +60,7 @@ export default {
   'kolibri/utils/objectSpecs': require('kolibri/utils/objectSpecs'),
   'kolibri/utils/onboardingSteps': require('kolibri/utils/onboardingSteps'),
   'kolibri/utils/redirectBrowser': require('kolibri/utils/redirectBrowser'),
+  'kolibri/utils/sanitizeError': require('kolibri/utils/sanitizeError'),
   'kolibri/utils/scriptLoader': require('kolibri/utils/scriptLoader'),
   'kolibri/utils/serverClock': require('kolibri/utils/serverClock'),
   'kolibri/utils/validators': require('kolibri/utils/validators'),

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -67,6 +67,7 @@
     "./utils/objectSpecs": "./utils/objectSpecs",
     "./utils/onboardingSteps": "./utils/onboardingSteps",
     "./utils/redirectBrowser": "./utils/redirectBrowser",
+    "./utils/sanitizeError": "./utils/sanitizeError",
     "./utils/scriptLoader": "./utils/scriptLoader",
     "./utils/serverClock": "./utils/serverClock",
     "./utils/validators": "./utils/validators",

--- a/packages/kolibri/utils/sanitizeError.js
+++ b/packages/kolibri/utils/sanitizeError.js
@@ -1,0 +1,54 @@
+import pickBy from 'lodash/pickBy';
+
+const SENSITIVE_FIELDS = ['password', 'token', 'secret', 'apikey', 'api_key'];
+const SENSITIVE_HEADERS = ['authorization', 'x-api-key', 'x-auth-token'];
+const MASK = '********';
+
+function maskObject(obj, sensitiveKeys) {
+  if (!obj || typeof obj !== 'object') return obj;
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, sensitiveKeys.includes(k.toLowerCase()) ? MASK : v]),
+  );
+}
+
+function _handleData(data) {
+  const dataIsString = typeof data === 'string';
+  if (dataIsString) {
+    try {
+      data = JSON.parse(data);
+    } catch {} // eslint-disable-line no-empty
+  }
+  data = maskObject(data, SENSITIVE_FIELDS);
+  return dataIsString ? JSON.stringify(data) : data;
+}
+
+export default function sanitizeError(error) {
+  if (!error || typeof error !== 'object') return error;
+
+  const result = {
+    message: error.message,
+    name: error.name,
+    code: error.code,
+  };
+
+  if (error.config) {
+    result.config = pickBy({
+      method: error.config.method,
+      url: error.config.url,
+      data: _handleData(error.config.data),
+      params: maskObject(error.config.params, SENSITIVE_FIELDS),
+      headers: maskObject(error.config.headers, SENSITIVE_HEADERS),
+    });
+  }
+
+  if (error.response) {
+    result.response = {
+      status: error.response.status,
+      statusText: error.response.statusText,
+      data: _handleData(error.response.data),
+      config: result.config,
+    };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
Passwords and other sensitive data were being exposed in plaintext in error report dialogs and console logs.
Added a sanitizeError utility that masks sensitive fields in axios error objects before they are displayed or logged.

## References
Fixes #13977

## Reviewer guidance
Add `raise Exception` in `kolibri/core/auth/api.py` just before `login` is called, this will cause a 500 error on what should be a successful login. You should see in the "help us by reporting this error" modal that the password is not set to `*********` instead of the actual password.
