### PR TITLE
Fixes occasional error during pre-commit hook runs where the kolibri package.json was empty

### DIFF
--- a/packages/build_kolibri_package.js
+++ b/packages/build_kolibri_package.js
@@ -46,7 +46,10 @@ function rebuildApiSpec() {
   };
   writeSourceToFile(kolibriPackageJsonFilePath, JSON.stringify(updatedKolibriPackageJson, null, 2));
   const apiSpecFilePath = path.resolve(__dirname, './kolibri/internal/apiSpec.js');
-  const updatedApiKeys = generateApiKeys(updatedKolibriPackageJson.exports);
+  const updatedApiKeys = generateApiKeys(
+    updatedKolibriPackageJson.exports,
+    updatedKolibriPackageJson.exposes || [],
+  );
   let apiSpecContent = apiSpecHeader;
   apiSpecContent += 'export default {\n';
   for (const key of updatedApiKeys) {

--- a/packages/kolibri-build/src/__tests__/webpack.config.plugin.spec.js
+++ b/packages/kolibri-build/src/__tests__/webpack.config.plugin.spec.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 const webpackConfigPlugin = require('../webpack.config.plugin');
 
 jest.mock('../apiSpecExportTools', () => ({
-  coreAliases: () => ({}),
-  coreExternals: () => ({}),
+  getCoreExternals: () => ({}),
 }));
 
 jest.mock('kolibri-logging', () => ({

--- a/packages/kolibri-build/src/apiSpecExportTools.js
+++ b/packages/kolibri-build/src/apiSpecExportTools.js
@@ -1,10 +1,6 @@
-const kolibriPackageJson = require('kolibri/package.json');
-
-const apiSpec = kolibriPackageJson.exports || {};
-
 const { kolibriName } = require('./kolibriName');
 
-function generateApiKeys(apiSpec) {
+function generateApiKeys(apiSpec, exposes) {
   // Generate a list of all the module imports that we need to expose
   // Iterate over all the exports in the kolibri package
   return (
@@ -17,23 +13,30 @@ function generateApiKeys(apiSpec) {
       .map(key => 'kolibri' + key.slice(1))
       // Add the list of modules that are exposed in the kolibri package.json
       // Unmodified, as they are already full import paths, e.g. 'vue'
-      .concat(kolibriPackageJson.exposes)
+      .concat(exposes)
   );
 }
 
-const apiKeys = generateApiKeys(apiSpec);
+function getCoreExternals() {
+  const kolibriPackageJson = require('kolibri/package.json');
 
-const coreExternals = {
-  // The kolibri package itself is a special case, as it is the root of the package
-  // and is not required to be imported in the core bundle, as it is the core bundle.
-  kolibri: kolibriName,
-};
+  const apiSpec = kolibriPackageJson.exports || {};
 
-for (const key of apiKeys) {
-  coreExternals[key] = [kolibriName, key];
+  const apiKeys = generateApiKeys(apiSpec, kolibriPackageJson.exposes || []);
+
+  const coreExternals = {
+    // The kolibri package itself is a special case, as it is the root of the package
+    // and is not required to be imported in the core bundle, as it is the core bundle.
+    kolibri: kolibriName,
+  };
+
+  for (const key of apiKeys) {
+    coreExternals[key] = [kolibriName, key];
+  }
+  return coreExternals;
 }
 
 module.exports = {
-  coreExternals,
+  getCoreExternals,
   generateApiKeys,
 };

--- a/packages/kolibri-build/src/webpack.config.plugin.js
+++ b/packages/kolibri-build/src/webpack.config.plugin.js
@@ -14,7 +14,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const logging = require('kolibri-logging');
 const BundleTracker = require('./webpackBundleTracker');
 const baseConfig = require('./webpack.config.base');
-const { coreExternals } = require('./apiSpecExportTools');
+const { getCoreExternals } = require('./apiSpecExportTools');
 const WebpackRTLPlugin = require('./webpackRtlPlugin');
 const { kolibriName } = require('./kolibriName');
 const WebpackMessages = require('./webpackMessages');
@@ -96,7 +96,7 @@ module.exports = (
   const isCoreBundle = webpackConfig.output && webpackConfig.output.library === kolibriName;
 
   // If this is not the core bundle, then we need to add the external library mappings.
-  const externals = isCoreBundle ? {} : coreExternals;
+  const externals = isCoreBundle ? {} : getCoreExternals();
 
   const alias = {};
   if (kdsPath) {


### PR DESCRIPTION
## Summary
Slightly rejig api spec tools to prevent errors during the core-api-js pre-commit hook.
Previously the kolbiri package package.json was loaded in module scope, which caused weird interactions while running the build_kolibri_package script, which would rewrite the package.json file.

## References
No issue - just observed in multiple pre-commit runs on Github Actions and locally.

## Reviewer guidance
I confirmed this fixed a persistent and recurrent instance of this when running in https://github.com/learningequality/kolibri/pull/13981

The best way to check this works is to make a change within the kolibri NPM package and then try to commit it - then confirm that the hook runs without errors.
