### PR TITLE
Remove Python 2.7 FileNotFoundError compatibility shims

### DIFF
--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -4,16 +4,10 @@ import json
 import logging
 import os
 from collections import namedtuple
+from json import JSONDecodeError
 
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
-
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
-
-from json import JSONDecodeError
 
 
 logger = logging.getLogger(__name__)

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -43,11 +43,6 @@ except BaseException as e:
         raise
     SSLERROR = requests.exceptions.SSLError
 
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
-
 
 RETRY_STATUS_CODE = {502, 503, 504, 521, 522, 523, 524}
 

--- a/kolibri/utils/filesystem.py
+++ b/kolibri/utils/filesystem.py
@@ -1,10 +1,5 @@
 import os
 
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
-
 
 def get_path_permission(path):
     """

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -45,11 +45,6 @@ from kolibri.utils.android import on_android
 from kolibri.utils.logger import cleanup_queue_logging
 from kolibri.utils.logger import setup_queue_logging
 
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
-
 logger = logging.getLogger(__name__)
 
 # Status codes for kolibri
@@ -1081,7 +1076,7 @@ def get_status():  # noqa: max-complexity=16
             response = requests.get(check_url, timeout=3)
         except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
             raise NotRunning(STATUS_NOT_RESPONDING)
-        except (requests.exceptions.RequestException):
+        except requests.exceptions.RequestException:
             raise NotRunning(STATUS_UNCLEAN_SHUTDOWN)
 
         if response.status_code == 404:
@@ -1099,7 +1094,7 @@ def get_status():  # noqa: max-complexity=16
             requests.get(check_url, timeout=3)
         except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError):
             raise NotRunning(STATUS_NOT_RESPONDING)
-        except (requests.exceptions.RequestException):
+        except requests.exceptions.RequestException:
             return pid, "", ""
 
     return (


### PR DESCRIPTION
## Summary
Since Python 2.7 is no longer supported, remove all instances of the FileNotFoundError compatibility shim that was used to map FileNotFoundError to IOError for Python 2.7 compatibility.

Modified files:
- kolibri/utils/file_transfer.py
- kolibri/utils/filesystem.py
- kolibri/utils/server.py
- kolibri/core/content/utils/content_manifest.py

## References
Final bit of Python 2.7 compatibility code, should close #13882

## Reviewer guidance
Are there any other instances of this that have been missed? Any other Python 2.7 compatibility things still extant in the codebase?

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 
