### PR TITLE
Error when no new messages are downloaded from crowdin.

### DIFF
--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -28,6 +28,12 @@ jobs:
           node-version: '20.x'
           cache: 'yarn'
 
+      - name: Setup Java for crowdin-cli
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext
 

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -24,6 +24,12 @@ jobs:
           node-version: '20.x'
           cache: 'yarn'
 
+      - name: Setup Java for crowdin-cli
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ kolibrihome_test/
 # Translations
 kolibri/locale/**/LC_MESSAGES/*.csv
 kolibri/locale/en/LC_MESSAGES/profiles/*
+kolibri/locale/.crowdin-download-marker
 
 # Mr Developer
 .mr.developer.cfg

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,16 @@ i18n-pretranslate-approve-all:
 	yarn exec crowdin pre-translate -- --branch ${CROWDIN_BRANCH} --translate-untranslated-only --method=tm --auto-approve-option=all
 
 i18n-download-translations: i18n-extract-frontend
+	touch kolibri/locale/.crowdin-download-marker
 	yarn exec crowdin download -- --branch ${CROWDIN_BRANCH}
+	@if [ -z "$$(find kolibri/locale/*/LC_MESSAGES -type f \( -name '*.po' -o -name '*.csv' \) -newer kolibri/locale/.crowdin-download-marker 2>/dev/null)" ]; then \
+		echo "❌ ERROR: No translation files were downloaded - Crowdin download may have failed silently"; \
+		echo "Check the output above for errors during the download process"; \
+		rm -f kolibri/locale/.crowdin-download-marker; \
+		exit 1; \
+	fi
+	@echo "✅ Translation files downloaded successfully"
+	rm -f kolibri/locale/.crowdin-download-marker
 	python build_tools/i18n/cleanup_unsupported_languages.py
 	yarn exec kolibri-i18n code-gen -- --output-dir ./packages/kolibri/utils/internal
 	$(MAKE) i18n-django-compilemessages


### PR DESCRIPTION
## Summary
To workaround https://github.com/crowdin/crowdin-cli/issues/965 add an explicit check that downloading from crowdin updates message files and error if not.
Adds a temporary marker file to then compare the message files to make sure they're newer than it.

## References
Fixes issues seen in CI for message download

## Reviewer guidance
I think this will help, but bit hard to test without reproducing the non-deterministic error :/
