### PR TITLE
Update KDS to 5.5.0

### DIFF
--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -84,7 +84,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "kolibri-constants": "0.2.12",
-    "kolibri-design-system": "5.4.2",
+    "kolibri-design-system": "5.5.0",
     "kolibri-logging": "^1.0.0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",

--- a/packages/kolibri/styles/internal/main.scss
+++ b/packages/kolibri/styles/internal/main.scss
@@ -11,6 +11,7 @@
 */
 
 @import '~kolibri-design-system/lib/styles/definitions';
+@import '~kolibri-design-system/lib/styles/common';
 
 // http://www.paulirish.com/2012/box-sizing-border-box-ftw/
 *,
@@ -59,17 +60,6 @@ h6 {
 // https://davidwalsh.name/html5-boilerplate
 svg:not(:root) {
   overflow: hidden;
-}
-
-.visuallyhidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  border: 0;
 }
 
 .rtl-icon {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8249,10 +8249,10 @@ kolibri-constants@0.2.12:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.12.tgz#d858067f5a3159d49bbe9f9ac6d82afbf7a171de"
   integrity sha512-ApVc/KLwEaDJohqKhQTdao4UdWmoyq2pQ5lk8ra+1rDpJvsFWsAOGVC4RTv4YEDlAYJzj2/QZlJQ91u5yUURSQ==
 
-kolibri-design-system@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.4.2.tgz#cbfbab5a86e6132ced8cd18537cfc2d3ad7b694f"
-  integrity sha512-DG/OIsKwE5vKcOFTFniaCv7EjbknuhtKRyzY7I87OeLBGodKajsWOTAHI/kYRCF6ek1uUrQjbJI3jvm21niA5g==
+kolibri-design-system@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.5.0.tgz#ef62adee8a335fac1332d02849c47ed23a401627"
+  integrity sha512-ykLARvIFy6FHoIPfRXk3XHUzmvn2RstDaT2ck8vc7XEawXcZkzt2w9JUVtpnNKdCEnvgg7ufL4cqr0B4Yej0mA==
   dependencies:
     aphrodite "git+https://github.com/learningequality/aphrodite.git"
     autosize "3.0.21"


### PR DESCRIPTION
## Summary

Update KDS to 5.5.0.

- Related release notes:
  - https://github.com/learningequality/kolibri-design-system/releases/tag/v5.4.2
  - https://github.com/learningequality/kolibri-design-system/releases/tag/v5.5.0

- No breaking changes
- Installs the new KDS stylesheet, and removes `visuallyhidden` styles that are not longer needed since the class is provided by KDS (previewed several affected places - no regressions noticed).