### PR TITLE
Fix issue with incorrect filename being used for html file after updating to contenthash

### DIFF
--- a/packages/kolibri-sandbox/h5p_build.json
+++ b/packages/kolibri-sandbox/h5p_build.json
@@ -1,1 +1,1 @@
-{"filename":"h5p-61b56f4fafb8a7df6649.html"}
+{"filename":"h5p-690c3b7bbb77820814ed.html"}

--- a/packages/kolibri-sandbox/webpack.config.h5p.js
+++ b/packages/kolibri-sandbox/webpack.config.h5p.js
@@ -9,18 +9,16 @@ function Plugin() {}
 
 Plugin.prototype.apply = function (compiler) {
   if (compiler.hooks) {
-    compiler.hooks.compilation.tap('H5PHashWriterPlugin', function (compilation) {
+    compiler.hooks.afterEmit.tap('H5PHashWriterPlugin', function (compilation) {
       if (compilation.errors.length > 0) {
         return;
       }
-
-      HtmlWebpackPlugin.getHooks(compilation).afterEmit.tapAsync('H5PWritePlugin', (data, cb) => {
+      // Find the actual emitted HTML file from compilation assets
+      const htmlFile = Object.keys(compilation.assets).find(name => name.endsWith('.html'));
+      if (htmlFile) {
         var outputFilename = path.resolve(__dirname, './h5p_build.json');
-
-        fs.writeFileSync(outputFilename, JSON.stringify({ filename: data.outputName }));
-        // Tell webpack to move on
-        cb(null, data);
-      });
+        fs.writeFileSync(outputFilename, JSON.stringify({ filename: htmlFile }));
+      }
     });
   }
 };


### PR DESCRIPTION
## Summary
* Follow up from https://github.com/learningequality/kolibri/pull/13933 and https://github.com/learningequality/kolibri/pull/13993
* The first PR updated the output HTML file for H5P to use the contenthash for naming to make it stable and deterministic 
* The second PR reran the H5P build and produced the new HTML file
* Unfortunately, there was a hidden bug in the code we use to extract the built HTML file name from the webpack process
* This PR fixes that bug, rebuilds the H5P bundle, and commits the updated h5p_build.json with the correct filename. To be sure, compare the new filename in the diff with the already committed h5p file in kolibri/core/static/assets/h5p

## References
See above

## Reviewer guidance
Check the filename is accurate, as above!
Load an H5P file to confirm

<img width="2872" height="1592" alt="image" src="https://github.com/user-attachments/assets/3d023bb2-7fd2-4866-8550-2d5649eb23e4" />

