### PR TITLE
Fix textColor console warning

### DIFF
--- a/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/AppBar.vue
@@ -14,7 +14,6 @@
       <KToolbar
         :removeNavIcon="showAppNavView"
         type="clear"
-        :textColor="themeConfig.appBar.textColor"
         class="app-bar"
         :style="{
           height: topBarHeight + 'px',


### PR DESCRIPTION
## Summary

Remove invalid prop value in favor of the default '`black'`.

Since `KToolbar` doesn't accept dynamic theme values, it didn't work in the first place, and caused many console warnings.

There's a more robust fix in progress https://github.com/learningequality/kolibri-design-system/pull/1153, but we don't yet know when it will be finished or released.