### PR TITLE
Update .git-blame-ignore-revs for frontend migration changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Reformatted all frontend code using prettier v3
 42efde27bac137734f05057278c4827168d119f2
+
+# Migrated all frontend code from assets/src to frontend
+e59c54a53fe4305700d4ced05134ab95b7436b1e


### PR DESCRIPTION
## Summary
Adds the commit for the recently squash merged PR to the git blame ignore revs.

## Reviewer guidance
Confirm that the commit hash is indeed the hash for the commit of the squash merge of #14009 