### PR TITLE
Update dependabot to monthly schedule with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: "monthly"
       time: "00:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     groups:
       babel:
         patterns:
@@ -23,9 +24,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:


### PR DESCRIPTION
- Change schedule interval from weekly to monthly (1st of each month)
- Added cooldown of 7 days to avoid freshly released versions
- Applied to both npm and github-actions package ecosystems

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 