### PR TITLE
Fix double focus issue in ProfileEditPage by removing autofocus prop

### DIFF
--- a/kolibri/plugins/user_profile/frontend/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfileEditPage.vue
@@ -19,7 +19,7 @@
 
         <FullNameTextbox
           ref="fullNameTextbox"
-          :autofocus="true"
+          
           :disabled="!canEditName || formDisabled"
           :value.sync="fullName"
           :isValid.sync="fullNameValid"


### PR DESCRIPTION

## Summary
This PR fixes the double focus issue on the ProfileEditPage by removing `autoFocus` prop from the input component.

## Problem
When navigating to the ProfileEditPage, the input field was receiving focus twice, causing a flicker and poor user experience.

## Solution
- Removed the `autoFocus` prop from the affected input
- Verified that focus behavior is now consistent and stable

## Testing
- Navigated to ProfileEditPage
- Confirmed the input receives focus only once
- No other functionality is affected

## Screenshots / Recordings
N/A
