### PR TITLE
Refactor: move page visibility tracking to browser info composable

### DIFF
--- a/packages/kolibri/components/error/TechnicalTextBlock.vue
+++ b/packages/kolibri/components/error/TechnicalTextBlock.vue
@@ -112,14 +112,15 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .error-log {
-    width: 100%;
-    padding: 8px;
-    font-family: monospace;
-    line-height: 18px;
-    white-space: pre;
-    resize: none;
-    border-radius: $radius;
-  }
+ .error-log {
+  width: 100%;
+  padding: 8px;
+  font-family: monospace;
+  line-height: 18px;
+  white-space: pre;
+  resize: none;
+  border-radius: $radius;
+  overflow-y: auto;
+}
 
 </style>


### PR DESCRIPTION
### Summary
This PR refactors how Kolibri tracks page visibility. The previous Vuex-based `pageVisibility` state has been removed and replaced with a reactive composable in `browserInfo.js`. This simplifies state management and ensures components can directly react to visibility changes without relying on Vuex actions.

### Changes
- Added `pageVisibilityRef` and `usePageVisibility()` composable in `packages/kolibri/utils/browserInfo.js`
- Removed `setPageVisibility` action and debounce logic from `core/frontend/state/actions.js`
- Removed `store.dispatch('setPageVisibility')` from `core/frontend/index.js`
- Verified that no components rely on Vuex `pageVisibility` anymore

### Testing
- Ran `yarn run devserver` and confirmed components respond correctly when switching tabs or minimizing the window
- Verified visibility state updates via `usePageVisibility()`
- All unit and integration tests pass (`yarn test`, `pytest`)

### Screenshots
N/A