### PR TITLE
Bump version from 0.19.0 to 0.20.0

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -11,7 +11,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 19, 0)
+VERSION = (0, 20, 0)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"


### PR DESCRIPTION
## Summary
Bumps version on develop to 0.20.0

## References
Fixes the first checkbox item in https://github.com/learningequality/kolibri/issues/14045

## Reviewer guidance
Did I type `0.20.0` incorrectly?
