### PR TITLE
Py3.14 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -2,6 +2,7 @@ import logging
 import time
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from itertools import groupby
 from uuid import UUID
 from uuid import uuid4
@@ -1358,7 +1359,7 @@ class SessionViewSet(viewsets.ViewSet):
             }
         )
 
-        visitor_cookie_expiry = datetime.utcnow() + timedelta(days=365)
+        visitor_cookie_expiry = datetime.now(tz=timezone.utc) + timedelta(days=365)
 
         if isinstance(user, AnonymousUser):
             response = Response(session)

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import pytz
 from sqlalchemy import Column
@@ -205,7 +206,7 @@ class Storage(object):
     def enqueue_lifo(
         self, job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
     ):
-        naive_utc_now = datetime.utcnow()
+        naive_utc_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         with self.session_scope() as session:
             soonest_job = (
                 session.query(ORMJob)
@@ -273,7 +274,7 @@ class Storage(object):
         self._update_job(job_id, State.CANCELING)
 
     def _filter_next_query(self, query, priority):
-        naive_utc_now = datetime.utcnow()
+        naive_utc_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         return (
             query.filter(ORMJob.state == State.QUEUED)
             .filter(ORMJob.scheduled_time <= naive_utc_now)

--- a/kolibri/core/tasks/test/taskrunner/test_scheduler.py
+++ b/kolibri/core/tasks/test/taskrunner/test_scheduler.py
@@ -92,7 +92,7 @@ class TestScheduler(object):
     def test_schedule_a_function_gives_value_error_not_timezone_aware_datetime(
         self, job_storage, job
     ):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         with pytest.raises(ValueError) as error:
             job_storage.schedule(now, job)
             assert "timezone aware datetime object" in str(error.value)

--- a/kolibri/plugins/facility/views.py
+++ b/kolibri/plugins/facility/views.py
@@ -82,7 +82,7 @@ def first_log_date(request, facility_id):
         .order_by("start_timestamp")
         .first()
     )
-    first_log_date = first_log.start_timestamp if first_log is not None else dt.utcnow()
+    first_log_date = first_log.start_timestamp if first_log is not None else dt.now(tz=dt.timezone.utc)
     response = {
         "first_log_date": first_log_date.isoformat(),
     }

--- a/kolibri/plugins/facility/views.py
+++ b/kolibri/plugins/facility/views.py
@@ -82,7 +82,11 @@ def first_log_date(request, facility_id):
         .order_by("start_timestamp")
         .first()
     )
-    first_log_date = first_log.start_timestamp if first_log is not None else dt.now(tz=dt.timezone.utc)
+    first_log_date = (
+        first_log.start_timestamp
+        if first_log is not None
+        else dt.now(tz=dt.timezone.utc)
+    )
     response = {
         "first_log_date": first_log_date.isoformat(),
     }

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -133,7 +133,9 @@ def get_git_changeset():
         # This does not fail if git is not available or current dir isn't a git
         # repo - it's safe.
         timestamp = git_log.communicate()[0]
-        timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
+        timestamp = datetime.datetime.fromtimestamp(
+            int(timestamp), tz=datetime.timezone.utc
+        )
         # We have some issues because something normalizes separators to "."
         # From PEP440: With a local version, in addition to the use of . as a
         # separator of segments, the use of - and _ is also acceptable. The

--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     cmdclass={"install_scripts": gen_windows_batch_files},
-    python_requires=">=3.6,  <3.14",
+    python_requires=">=3.6,  <3.15",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13}, postgres
+envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13,3.14}, postgres
 
 [testenv]
 usedevelop = True
@@ -22,6 +22,7 @@ basepython =
     py3.11: python3.11
     py3.12: python3.12
     py3.13: python3.13
+    py3.14: python3.14
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

#### Changes performed by Claude, reviewed & guided by me.

- Bumps Kolibri's support matrix et al to support Python 3.14
- Eagerly updates deprecated datetime uses (this is unnecessary now)

#### :warning: Remaining issues to hash out

Claude noted that Python 3.14 requires new versions of two dependencies `django-filter` and `pytest` where the major version we use currently is incompatible with 3.14.

Claude's solution was to make multiple entries for these where it indicated which Python version should install which library version -- however, this would result in our needing to maintain code in a way that jives with all Python versions.

I've not included a couple of commits that performed some monkey patches while making the two-line dependencies.

#### TODO

- [ ] Create a PR


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#13823 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Draft for now - will return to this in Planned Patch 2!