### PR TITLE
Exclude surveys from quizzes resource selection

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -433,6 +433,10 @@ class CharInFilter(BaseInFilter, CharFilter):
     pass
 
 
+class ChoiceInFilter(BaseInFilter, ChoiceFilter):
+    pass
+
+
 contentnode_filter_fields = [
     "parent",
     "parent__isnull",
@@ -490,6 +494,9 @@ class ContentNodeFilter(FilterSet):
     authors = CharFilter(method="filter_by_authors")
     tags = CharFilter(method="filter_by_tags")
     descendant_of = UUIDFilter(method="filter_descendant_of")
+    exclude_modalities = ChoiceInFilter(
+        field_name="modality", choices=modalities.choices, exclude=True
+    )
 
     class Meta:
         model = models.ContentNode
@@ -950,7 +957,9 @@ class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesVi
                         lft__lt=OuterRef("rght"),
                         kind=content_kinds.EXERCISE,
                         available=True,
-                    ).values_list(
+                    )
+                    .exclude(modality=modalities.SURVEY)
+                    .values_list(
                         "assessmentmetadata__number_of_assessments", flat=True
                     ),
                     field="number_of_assessments",

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1114,6 +1114,58 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
             sibling_assessment_metadata.number_of_assessments,
         )
 
+    def test_contentnode_descendants_assessments_surveys_not_included(self):
+        c1 = content.ContentNode.objects.filter(kind=content_kinds.EXERCISE).first()
+        parent = c1.parent
+        parent_id = parent.id
+        sibling_survey = content.ContentNode.objects.create(
+            pk="6a406ac66b224106aa2e93f73a94333d",
+            channel_id=c1.channel_id,
+            content_id="ded4a083e75f4689b386fd2b706e792a",
+            kind=content_kinds.EXERCISE,
+            parent=parent,
+            title="sibling survey",
+            available=True,
+            modality=modalities.SURVEY,
+        )
+        content.AssessmentMetaData.objects.create(
+            id="6a406ac66b224106aa2e93f73a94333d",
+            contentnode=sibling_survey,
+            # These should not be counted
+            number_of_assessments=5,
+        )
+        sibling_non_survey = content.ContentNode.objects.create(
+            pk="6a406ac66b224106aa2e93f73a94333e",
+            channel_id=c1.channel_id,
+            content_id="ded4a083e75f4689b386fd2b706e792b",
+            kind=content_kinds.EXERCISE,
+            parent=parent,
+            title="sibling exercise",
+            available=True,
+        )
+        sibling_non_survey_assessment_metadata = (
+            content.AssessmentMetaData.objects.create(
+                id="6a406ac66b224106aa2e93f73a94333e",
+                contentnode=sibling_non_survey,
+                number_of_assessments=3,
+            )
+        )
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-descendants-assessments"),
+            data={"ids": parent_id},
+        )
+        self.assertEqual(
+            next(
+                item["num_assessments"]
+                for item in response.data
+                if item["id"] == parent_id
+            ),
+            # Number of assesments for survey sibling should not be taken into account
+            c1.assessmentmetadata.first().number_of_assessments
+            + sibling_non_survey_assessment_metadata.number_of_assessments,
+        )
+
     def test_contentnode_recommendations(self):
         node_id = content.ContentNode.objects.get(title="c2c2").id
         response = self.client.get(
@@ -1491,6 +1543,68 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         )
 
         self.assertEqual(response.data[0]["id"], str(course_topic.id))
+
+    def test_exclude_modalities_filter(self):
+        # Create a node with a specific modality
+        lesson_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).first()
+        course_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).last()
+
+        # Just making sure our fixtures are different so our future assertions are strong
+        self.assertNotEqual(lesson_topic.id, course_topic.id)
+        self.assertGreater(content.ContentNode.objects.count(), 2)
+
+        lesson_topic.modality = modalities.LESSON
+        course_topic.modality = modalities.COURSE
+
+        # Filters will only return available nodes so just to be sure
+        lesson_topic.available = True
+        course_topic.available = True
+
+        lesson_topic.save()
+        course_topic.save()
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"exclude_modalities": f"{modalities.LESSON}"},
+        )
+
+        self.assertNotIn(str(lesson_topic.id), [node["id"] for node in response.data])
+        self.assertIn(str(course_topic.id), [node["id"] for node in response.data])
+
+    def test_exclude_modalities_filter_multiple(self):
+        # Create a node with a specific modality
+        lesson_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).first()
+        course_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).last()
+
+        # Just making sure our fixtures are different so our future assertions are strong
+        self.assertNotEqual(lesson_topic.id, course_topic.id)
+        self.assertGreater(content.ContentNode.objects.count(), 2)
+
+        lesson_topic.modality = modalities.LESSON
+        course_topic.modality = modalities.COURSE
+
+        # Filters will only return available nodes so just to be sure
+        lesson_topic.available = True
+        course_topic.available = True
+
+        lesson_topic.save()
+        course_topic.save()
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"exclude_modalities": f"{modalities.LESSON},{modalities.COURSE}"},
+        )
+
+        self.assertNotIn(str(lesson_topic.id), [node["id"] for node in response.data])
+        self.assertNotIn(str(course_topic.id), [node["id"] for node in response.data])
 
     def _setup_contentnode_progress(self):
         # set up data for testing progress_fraction field on content node endpoint

--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/QuizResourceSelection/index.vue
@@ -164,6 +164,7 @@
   import uniqWith from 'lodash/uniqWith';
   import isEqual from 'lodash/isEqual';
   import { useMemoize } from '@vueuse/core';
+  import Modalities from 'kolibri-constants/Modalities';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import {
     displaySectionTitle,
@@ -393,8 +394,19 @@
         { getKey: content => content.id },
       );
 
+      /**
+       * Practice quizzes should only be included if the resource selection side panel
+       * is in `selectPracticeQuiz` mode.
+       */
       const isPracticeQuiz = item =>
-        !selectPracticeQuiz || get(item, ['options', 'modality'], false) === 'QUIZ';
+        !selectPracticeQuiz || get(item, ['options', 'modality'], false) === Modalities.QUIZ;
+
+      /**
+       * Because survey questions have no 'correct' answer, and in some cases have a
+       * 'correct answer'chosen at random for the sake of having one,
+       * we should not allow them to be included in quizzes.
+       */
+      const isNotSurvey = item => get(item, ['options', 'modality'], false) !== Modalities.SURVEY;
 
       const {
         topic,
@@ -411,7 +423,7 @@
         searchResultsRouteName: PageNames.QUIZ_SELECT_RESOURCES_SEARCH_RESULTS,
         bookmarks: {
           filters: { kind: ContentNodeKinds.EXERCISE },
-          annotator: results => results.filter(isPracticeQuiz),
+          annotator: results => results.filter(isNotSurvey).filter(isPracticeQuiz),
         },
 
         channels: {
@@ -443,6 +455,7 @@
           filters: {
             kind: ContentNodeKinds.EXERCISE,
             contains_quiz: selectPracticeQuiz ? true : null,
+            exclude_modalities: Modalities.SURVEY,
           },
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,6 +1517,13 @@
   dependencies:
     "@sinclair/typebox" "^0.34.0"
 
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@jest/snapshot-utils@30.2.0":
   version "30.2.0"
   resolved "https://registry.yarnpkg.com/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz#387858eb90c2f98f67bff327435a532ac5309fbe"
@@ -1602,6 +1609,18 @@
     "@types/node" "*"
     "@types/yargs" "^17.0.33"
     chalk "^4.1.2"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"
@@ -2202,6 +2221,11 @@
   resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.8.tgz#2eb3c2f72298ce3e53fe16f34ab124cc495cd4fc"
   integrity sha512-9IeBPQM93Ad4qFKUopwuTClzoST/1OId4MaSd/8FB5ScCL2tl25UaOGNR8E2hjiL7xK4LN5+I1Ews6amS7YAiA==
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
 "@sinclair/typebox@^0.34.0":
   version "0.34.33"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.33.tgz#10ab3f1261ed9e754660250fad3e69cca1fa44b2"
@@ -2419,15 +2443,15 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz#79d7a78bad4219f4c03d6557a1c72d9ca6ba62d5"
   integrity sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==
 
+"@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
 "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
   integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
-
-"@types/istanbul-lib-coverage@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
-  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
 
 "@types/istanbul-lib-report@*":
   version "3.0.0"
@@ -2436,7 +2460,7 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^3.0.4":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
@@ -2613,6 +2637,13 @@
   version "17.0.33"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
   integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.8":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -4018,6 +4049,11 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
 ci-info@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.2.0.tgz#cbd21386152ebfe1d56f280a3b5feccbd96764c7"
@@ -4409,6 +4445,18 @@ css-loader@7.1.2:
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
     semver "^7.5.4"
+
+css-minimizer-webpack-plugin@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-7.0.2.tgz#aa1b01c6033f5b2f86ddb60c1f5bddd012b50cac"
+  integrity sha512-nBRWZtI77PBZQgcXMNqiIXVshiQOVLGSf2qX/WZfG8IQfMbeHUMXaBWQmiiSTmPJUflQxHjZjzAmuyO7tpL2Jg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    cssnano "^7.0.4"
+    jest-worker "^29.7.0"
+    postcss "^8.4.40"
+    schema-utils "^4.2.0"
+    serialize-javascript "^6.0.2"
 
 css-minimizer-webpack-plugin@7.0.4:
   version "7.0.4"
@@ -6479,7 +6527,7 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -7883,6 +7931,18 @@ jest-util@30.2.0:
     graceful-fs "^4.2.11"
     picomatch "^4.0.2"
 
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-validate@30.2.0:
   version "30.2.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-30.2.0.tgz#273eaaed4c0963b934b5b31e96289edda6e0a2ef"
@@ -7926,6 +7986,16 @@ jest-worker@^27.4.5:
   integrity sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
   dependencies:
     "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -8170,17 +8240,17 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-kolibri-constants@0.2.12:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.12.tgz#d858067f5a3159d49bbe9f9ac6d82afbf7a171de"
-  integrity sha512-ApVc/KLwEaDJohqKhQTdao4UdWmoyq2pQ5lk8ra+1rDpJvsFWsAOGVC4RTv4YEDlAYJzj2/QZlJQ91u5yUURSQ==
+kolibri-constants@0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.13.tgz#bd41953d5ac59e4eb22468f0a112e0f7c1015634"
+  integrity sha512-9phJBvqHgZI+SsqXju5wo7024aOhP6+ZnKP//MK8EZLl2g4Ns/cob3WtSK0GA2UgQrHN5cbkm+egppzzUOdVVA==
 
 kolibri-design-system@5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-5.5.0.tgz#ef62adee8a335fac1332d02849c47ed23a401627"
   integrity sha512-ykLARvIFy6FHoIPfRXk3XHUzmvn2RstDaT2ck8vc7XEawXcZkzt2w9JUVtpnNKdCEnvgg7ufL4cqr0B4Yej0mA==
   dependencies:
-    aphrodite "git+https://github.com/learningequality/aphrodite.git"
+    aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "3.0.21"
     color "4.2.3"
     css-element-queries "1.2.0"
@@ -9453,7 +9523,7 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-picomatch@^2.3.1:
+picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -11541,7 +11611,7 @@ temp@^0.8.3:
   dependencies:
     rimraf "~2.6.2"
 
-terser-webpack-plugin@^5.3.16:
+terser-webpack-plugin@^5.3.14, terser-webpack-plugin@^5.3.16:
   version "5.3.16"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz#741e448cc3f93d8026ebe4f7ef9e4afacfd56330"
   integrity sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==
@@ -12440,6 +12510,37 @@ webpack-sources@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.3.3.tgz#d4bf7f9909675d7a070ff14d0ef2a4f3c982c723"
   integrity sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==
+
+webpack@^5.103.0:
+  version "5.104.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.104.1.tgz#94bd41eb5dbf06e93be165ba8be41b8260d4fb1a"
+  integrity sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.7"
+    "@types/estree" "^1.0.8"
+    "@types/json-schema" "^7.0.15"
+    "@webassemblyjs/ast" "^1.14.1"
+    "@webassemblyjs/wasm-edit" "^1.14.1"
+    "@webassemblyjs/wasm-parser" "^1.14.1"
+    acorn "^8.15.0"
+    acorn-import-phases "^1.0.3"
+    browserslist "^4.28.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.17.4"
+    es-module-lexer "^2.0.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.11"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.3.1"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^4.3.3"
+    tapable "^2.3.0"
+    terser-webpack-plugin "^5.3.16"
+    watchpack "^2.4.4"
+    webpack-sources "^3.3.3"
 
 webpack@^5.104.0:
   version "5.104.0"


### PR DESCRIPTION
## Summary
* Exclude surveys from quizzes resource selection
* yarn.lock file is updated since I forgot to run `yarn install` on https://github.com/learningequality/kolibri/pull/14042

https://github.com/user-attachments/assets/85a9e06b-9d7f-4630-8cb4-de19e281807e



## References
Closes #13631

## Reviewer guidance
* Import surveys from Kolibri QA Channels.
* Go to coach > quizzes > new quiz > Add resources
* Look for survey resources, and notice that no surveys are displayed.