### PR TITLE
Fix import path for QTI sandbox routes

### DIFF
--- a/kolibri/plugins/learn/frontend/routes/index.js
+++ b/kolibri/plugins/learn/frontend/routes/index.js
@@ -17,7 +17,7 @@ import classesRoutes from './classesRoutes';
 let qtiSandboxRoutes = [];
 if (process.env.NODE_ENV !== 'production') {
   try {
-    const { sandboxRoutes } = require('../../../../qti_viewer/frontend/sandbox');
+    const { sandboxRoutes } = require('../../../qti_viewer/frontend/sandbox');
     qtiSandboxRoutes = sandboxRoutes;
   } catch (e) {
     // QTI viewer plugin may not be available


### PR DESCRIPTION
## Summary
Fixes import path that was one layer too deep that I missed

## References
Follow up from #14009

## Reviewer guidance
I noticed this in the devserver build:
```
[watch] [WARN: Kolibri Build] Compiled 'kolibri.plugins.learn.app' bundle with warnings.
[watch] Module not found: Error: Can't resolve '../../../../qti_viewer/frontend/sandbox' in '/var/home/richard/github/kolibri/kolibri/plugins/learn/frontend/routes'
```

This change resolves it.
