### PR TITLE
Improve performance when filtering by "contains quiz"

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -35,6 +35,7 @@ from django_filters.rest_framework import NumberFilter
 from django_filters.rest_framework import UUIDFilter
 from le_utils.constants import content_kinds
 from le_utils.constants import languages
+from le_utils.constants import modalities
 from rest_framework import filters
 from rest_framework import mixins
 from rest_framework import status
@@ -285,7 +286,7 @@ class ChannelMetadataFilter(FilterSet):
         queryset = queryset.annotate(
             contains_quiz=Exists(
                 models.ContentNode.objects.filter(
-                    options__contains='"modality": "QUIZ"',
+                    modality=modalities.QUIZ,
                     available=True,
                     channel_id=OuterRef("id"),
                 )
@@ -568,7 +569,7 @@ class ContentNodeFilter(FilterSet):
     def filter_contains_quiz(self, queryset, name, value):
         if value:
             quizzes = models.ContentNode.objects.filter(
-                options__contains='"modality": "QUIZ"'
+                modality=modalities.QUIZ
             ).get_ancestors(include_self=True)
             return queryset.filter(pk__in=quizzes.values_list("pk", flat=True))
         return queryset

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -283,17 +283,18 @@ class ChannelMetadataFilter(FilterSet):
         return queryset.filter(contains_exercise=True)
 
     def filter_contains_quiz(self, queryset, name, value):
-        queryset = queryset.annotate(
-            contains_quiz=Exists(
-                models.ContentNode.objects.filter(
-                    modality=modalities.QUIZ,
-                    available=True,
-                    channel_id=OuterRef("id"),
+        if value:
+            queryset = queryset.annotate(
+                contains_quiz=Exists(
+                    models.ContentNode.objects.filter(
+                        modality=modalities.QUIZ,
+                        available=True,
+                        channel_id=OuterRef("id"),
+                    )
                 )
             )
-        )
-
-        return queryset.filter(contains_quiz=True)
+            return queryset.filter(contains_quiz=True)
+        return queryset
 
     def filter_available(self, queryset, name, value):
         return queryset.filter(root__available=value)
@@ -471,7 +472,7 @@ class ContentNodeFilter(FilterSet):
     parent = UUIDFilter("parent")
     parent__isnull = BooleanFilter(field_name="parent", lookup_expr="isnull")
     include_coach_content = BooleanFilter(method="filter_include_coach_content")
-    contains_quiz = CharFilter(method="filter_contains_quiz")
+    contains_quiz = BooleanFilter(method="filter_contains_quiz")
     grade_levels = CharFilter(method="bitmask_contains_and")
     resource_types = CharFilter(method="bitmask_contains_and")
     learning_activities = CharFilter(method="bitmask_contains_and")
@@ -568,10 +569,16 @@ class ContentNodeFilter(FilterSet):
 
     def filter_contains_quiz(self, queryset, name, value):
         if value:
-            quizzes = models.ContentNode.objects.filter(
-                modality=modalities.QUIZ
-            ).get_ancestors(include_self=True)
-            return queryset.filter(pk__in=quizzes.values_list("pk", flat=True))
+            quiz_descendants = models.ContentNode.objects.filter(
+                modality=modalities.QUIZ,
+                available=True,
+                tree_id=OuterRef("tree_id"),
+                lft__gte=OuterRef("lft"),
+                rght__lte=OuterRef("rght"),
+            )
+            return queryset.alias(_has_quiz=Exists(quiz_descendants)).filter(
+                _has_quiz=True
+            )
         return queryset
 
     def filter_keywords(self, queryset, name, value):
@@ -1002,27 +1009,21 @@ class TreeQueryMixin(object):
 
         return depth, next__gt
 
-    def _get_gc_by_parent(self, child_ids):
+    def _get_gc_by_parent(self, qs, child_ids):
         # Use this to keep track of how many grand children we have accumulated per child of the parent node
         gc_by_parent = {}
         # Iterate through the grand children of the parent node in lft order so we follow the tree traversal order
         for gc in (
-            self.filter_queryset(self.get_queryset())
-            .filter(parent_id__in=child_ids)
-            .values("id", "parent_id")
-            .order_by("lft")
+            qs.filter(parent_id__in=child_ids).values("id", "parent_id").order_by("lft")
         ):
-            # If we have not already added a list of nodes to the gc_by_parent map, initialize it here
-            if gc["parent_id"] not in gc_by_parent:
-                gc_by_parent[gc["parent_id"]] = []
-            gc_by_parent[gc["parent_id"]].append(gc["id"])
+            gc_by_parent.setdefault(gc["parent_id"], []).append(gc["id"])
         return gc_by_parent
 
-    def get_grandchild_ids(self, child_ids, depth, page_size):
+    def get_grandchild_ids(self, qs, child_ids, depth, page_size):
         grandchild_ids = []
         if depth == 2:
             # Use this to keep track of how many grand children we have accumulated per child of the parent node
-            gc_by_parent = self._get_gc_by_parent(child_ids)
+            gc_by_parent = self._get_gc_by_parent(qs, child_ids)
             singletons = []
             # Now loop through each of the child_ids we passed in
             # that have any children, check if any of them have only one
@@ -1036,51 +1037,42 @@ class TreeQueryMixin(object):
                 grandchild_ids.extend(gc_ids[:page_size])
             if singletons:
                 grandchild_ids.extend(
-                    self.get_grandchild_ids(singletons, depth, page_size)
+                    self.get_grandchild_ids(qs, singletons, depth, page_size)
                 )
         return grandchild_ids
 
-    def get_child_ids(self, parent_id, next__gt):
+    def get_child_ids(self, qs, parent_id, next__gt):
         # Get a list of child_ids of the parent node up to the pagination limit
-        child_qs = self.get_queryset().filter(parent_id=parent_id)
+        child_qs = qs.filter(parent_id=parent_id)
         if next__gt is not None:
             child_qs = child_qs.filter(lft__gt=next__gt)
         return child_qs.values_list("id", flat=True).order_by("lft")[0:NUM_CHILDREN]
 
     def get_tree_queryset(self, request, pk):
-        # Get the model for the parent node here - we do this so that we trigger a 404 immediately if the node
+        base_qs = self.filter_queryset(self.get_queryset())
+        # Check that the parent node exists - we do this so that we trigger a 404 immediately if the node
         # does not exist (or exists but is not available, or is filtered).
         try:
-            parent_id = (
-                pk
-                if pk
-                and self.filter_queryset(self.get_queryset()).filter(id=pk).exists()
-                else None
-            )
+            if not pk or not base_qs.filter(id=pk).exists():
+                raise Http404
         except ValueError:
-            # If the pk is a badly formed uuid, we will get a ValueError here, so we catch it and set to None
-            # so that it raises a 404 below.
-            parent_id = None
-
-        if parent_id is None:
             raise Http404
+
         depth, next__gt = self.validate_and_return_params(request)
 
-        child_ids = self.get_child_ids(parent_id, next__gt)
+        child_ids = self.get_child_ids(base_qs, pk, next__gt)
 
         ancestor_ids = []
-
         while next__gt is None and len(child_ids) == 1:
             ancestor_ids.extend(child_ids)
-            child_ids = self.get_child_ids(child_ids[0], next__gt)
+            child_ids = self.get_child_ids(base_qs, child_ids[0], next__gt)
 
-        # Get a flat list of ids for grandchildren we will be returning
-        gc_ids = self.get_grandchild_ids(child_ids, depth, NUM_GRANDCHILDREN_PER_CHILD)
-        return self.filter_queryset(self.get_queryset()).filter(
-            Q(id=parent_id)
-            | Q(id__in=ancestor_ids)
-            | Q(id__in=child_ids)
-            | Q(id__in=gc_ids)
+        gc_ids = self.get_grandchild_ids(
+            base_qs, child_ids, depth, NUM_GRANDCHILDREN_PER_CHILD
+        )
+
+        return base_qs.filter(
+            Q(id=pk) | Q(id__in=ancestor_ids) | Q(id__in=child_ids) | Q(id__in=gc_ids)
         )
 
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import re
 from base64 import urlsafe_b64decode
+from collections import defaultdict
 from collections import OrderedDict
 from functools import reduce
 from random import sample
@@ -1011,7 +1012,7 @@ class TreeQueryMixin(object):
 
     def _get_gc_by_parent(self, qs, child_ids):
         # Use this to keep track of how many grand children we have accumulated per child of the parent node
-        gc_by_parent = {}
+        gc_by_parent = defaultdict(list)
         # Iterate through the grand children of the parent node in lft order so we follow the tree traversal order
         for gc in (
             qs.filter(parent_id__in=child_ids).values("id", "parent_id").order_by("lft")

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
+from le_utils.constants import modalities
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -333,24 +334,30 @@ class ContentNodeAPIBase(object):
                 "content_id": expected.content_id,
                 "description": expected.description,
                 "duration": expected.duration,
-                "learning_activities": expected.learning_activities.split(",")
-                if expected.learning_activities
-                else [],
-                "learner_needs": expected.learner_needs.split(",")
-                if expected.learner_needs
-                else [],
-                "grade_levels": expected.grade_levels.split(",")
-                if expected.grade_levels
-                else [],
-                "resource_types": expected.resource_types.split(",")
-                if expected.resource_types
-                else [],
-                "accessibility_labels": expected.accessibility_labels.split(",")
-                if expected.accessibility_labels
-                else [],
-                "categories": expected.categories.split(",")
-                if expected.categories
-                else [],
+                "learning_activities": (
+                    expected.learning_activities.split(",")
+                    if expected.learning_activities
+                    else []
+                ),
+                "learner_needs": (
+                    expected.learner_needs.split(",") if expected.learner_needs else []
+                ),
+                "grade_levels": (
+                    expected.grade_levels.split(",") if expected.grade_levels else []
+                ),
+                "resource_types": (
+                    expected.resource_types.split(",")
+                    if expected.resource_types
+                    else []
+                ),
+                "accessibility_labels": (
+                    expected.accessibility_labels.split(",")
+                    if expected.accessibility_labels
+                    else []
+                ),
+                "categories": (
+                    expected.categories.split(",") if expected.categories else []
+                ),
                 "kind": expected.kind,
                 "lang": self.map_language(expected.lang),
                 "license_description": expected.license_description,
@@ -1261,6 +1268,180 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         self.assertEqual(len(with_filter_response.data), 1)
         self.assertEqual(with_filter_response.data[0]["name"], "testing")
 
+    def test_channelmetadata_contains_quiz_filter(self):
+        no_quiz_channel = content.ContentNode.objects.create(
+            pk="7b406ac66b224106aa2e93f73a94344d",
+            channel_id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            kind="topic",
+            title="no quiz channel",
+        )
+        no_quiz_metadata_id = no_quiz_channel.channel_id
+        content.ChannelMetadata.objects.create(
+            id=no_quiz_metadata_id,
+            name="no quiz channel metadata",
+            root=no_quiz_channel,
+        )
+        content.ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=no_quiz_channel.channel_id,
+            content_id=uuid.uuid4().hex,
+            kind=content_kinds.EXERCISE,
+            title="exercise but not quiz",
+            parent=no_quiz_channel,
+            available=True,
+            modality=modalities.SURVEY,
+        )
+
+        quiz_channel_id = uuid.uuid4().hex
+        quiz_root = content.ContentNode.objects.create(
+            pk=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            content_id=uuid.uuid4().hex,
+            kind="topic",
+            title="quiz root",
+        )
+        content.ChannelMetadata.objects.create(
+            id=quiz_channel_id,
+            name="quiz channel metadata",
+            root=quiz_root,
+        )
+        content.ContentNode.objects.create(
+            content_id=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            description="Quiz content",
+            id=uuid.uuid4().hex,
+            license_name="GNU",
+            license_owner="",
+            license_description=None,
+            lang_id=None,
+            author="",
+            title="quiz node",
+            parent_id=quiz_root.id,
+            kind=content_kinds.EXERCISE,
+            coach_content=False,
+            available=True,
+            modality=modalities.QUIZ,
+        )
+
+        no_filter_response = self.client.get(reverse("kolibri:core:channel-list"))
+        self.assertGreaterEqual(len(no_filter_response.data), 3)
+
+        with_filter_response = self.client.get(
+            reverse("kolibri:core:channel-list"), {"contains_quiz": True}
+        )
+        self.assertEqual(len(with_filter_response.data), 1)
+        returned_ids = {ch["id"] for ch in with_filter_response.data}
+        self.assertIn(quiz_channel_id, returned_ids)
+
+    def test_contentnode_contains_quiz_filter(self):
+        quiz_channel_id = uuid.uuid4().hex
+        quiz_root = content.ContentNode.objects.create(
+            pk=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            content_id=uuid.uuid4().hex,
+            kind="topic",
+            title="quiz root",
+            available=True,
+        )
+        content.ChannelMetadata.objects.create(
+            id=uuid.uuid4().hex,
+            name="quiz channel metadata",
+            root=quiz_root,
+        )
+
+        quiz_node = content.ContentNode.objects.create(
+            content_id=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            description="Blah",
+            id=uuid.uuid4().hex,
+            license_name="GNU",
+            license_owner="",
+            license_description=None,
+            lang_id=None,
+            author="",
+            title="quiz node",
+            parent_id=quiz_root.id,
+            kind=content_kinds.EXERCISE,
+            coach_content=False,
+            available=True,
+            modality=modalities.QUIZ,
+        )
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"contains_quiz": True, "channels": quiz_channel_id},
+        )
+        returned_ids = {n["id"] for n in response.data}
+        self.assertIn(quiz_node.id, returned_ids)
+
+    def test_channelmetadata_contains_quiz_filter_false(self):
+        quiz_channel_id = uuid.uuid4().hex
+        quiz_root = content.ContentNode.objects.create(
+            pk=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            content_id=uuid.uuid4().hex,
+            kind=content_kinds.TOPIC,
+            title="quiz channel root",
+            available=True,
+        )
+        content.ChannelMetadata.objects.create(
+            id=quiz_channel_id, name="quiz channel", root=quiz_root
+        )
+        content.ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=quiz_channel_id,
+            kind=content_kinds.EXERCISE,
+            title="quiz node",
+            parent=quiz_root,
+            available=True,
+            modality=modalities.QUIZ,
+            license_name="GNU",
+            license_owner="",
+        )
+
+        no_quiz_channel_id = uuid.uuid4().hex
+        no_quiz_root = content.ContentNode.objects.create(
+            pk=uuid.uuid4().hex,
+            channel_id=no_quiz_channel_id,
+            content_id=uuid.uuid4().hex,
+            kind=content_kinds.TOPIC,
+            title="no quiz channel root",
+            available=True,
+        )
+        content.ChannelMetadata.objects.create(
+            id=no_quiz_channel_id, name="no quiz channel", root=no_quiz_root
+        )
+        content.ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=no_quiz_channel_id,
+            kind=content_kinds.VIDEO,
+            title="non quiz node",
+            parent=no_quiz_root,
+            available=True,
+            license_name="GNU",
+            license_owner="",
+        )
+
+        baseline = self.client.get(reverse("kolibri:core:channel-list"))
+        self.assertEqual(baseline.status_code, 200)
+        baseline_ids = {c["id"] for c in baseline.data}
+
+        # contains_quiz=false should behave like baseline (no filtering)
+        false_response = self.client.get(
+            reverse("kolibri:core:channel-list"), {"contains_quiz": "false"}
+        )
+        self.assertEqual(false_response.status_code, 200)
+        false_ids = {c["id"] for c in false_response.data}
+
+        self.assertEqual(baseline_ids, false_ids)
+
+        # Check that both channels are in the unfiltered response
+        self.assertIn(quiz_channel_id, baseline_ids)
+        self.assertIn(no_quiz_channel_id, baseline_ids)
+
     def test_file_list(self):
         response = self.client.get(reverse("kolibri:core:file-list"))
         self.assertEqual(len(response.data), 10)
@@ -1933,21 +2114,27 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "content_id": expected.content_id,
                 "description": expected.description,
                 "duration": expected.duration,
-                "learning_activities": expected.learning_activities.split(",")
-                if expected.learning_activities
-                else [],
-                "grade_levels": expected.grade_levels.split(",")
-                if expected.grade_levels
-                else [],
-                "resource_types": expected.resource_types.split(",")
-                if expected.resource_types
-                else [],
-                "accessibility_labels": expected.accessibility_labels.split(",")
-                if expected.accessibility_labels
-                else [],
-                "categories": expected.categories.split(",")
-                if expected.categories
-                else [],
+                "learning_activities": (
+                    expected.learning_activities.split(",")
+                    if expected.learning_activities
+                    else []
+                ),
+                "grade_levels": (
+                    expected.grade_levels.split(",") if expected.grade_levels else []
+                ),
+                "resource_types": (
+                    expected.resource_types.split(",")
+                    if expected.resource_types
+                    else []
+                ),
+                "accessibility_labels": (
+                    expected.accessibility_labels.split(",")
+                    if expected.accessibility_labels
+                    else []
+                ),
+                "categories": (
+                    expected.categories.split(",") if expected.categories else []
+                ),
                 "kind": expected.kind,
                 "lang": self.map_language(expected.lang),
                 "license_description": expected.license_description,

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -1,5 +1,7 @@
 import logging
 
+from le_utils.constants import modalities
+
 from kolibri.core.auth.constants.user_kinds import COACH
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
@@ -48,7 +50,7 @@ class CoachAsset(webpack_hooks.WebpackBundleHook):
         from kolibri.core.content.models import ContentNode
 
         practice_quizzes_exist = ContentNode.objects.filter(
-            available=True, options__contains='"modality": "QUIZ"'
+            available=True, modality=modalities.QUIZ
         ).exists()
         return {
             "practice_quizzes_exist": practice_quizzes_exist,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
This pull request fixes a performance issue where filtering content by "contains quiz" was very slow, due to the inefficient query used to refine the search. Now the check is for the modality field (`modalities.QUIZ`) as a direct field lookup.

- Updated 3 areas of code where quiz filtering occurred to use the new modality field instead of scanning JSON fields.
- Refactored `ContentNodeFilter.filter_contains_quiz` method to use a more efficient database query pattern (top-down approach) that stops searching as soon as it finds a match, instead of ancestor traversal (bottom-up approach).
- Changed the filter type from CharFilter to BooleanFilter because the frontend sometimes sends `contains_quiz=` (empty) or `null`.
- Updated code in `TreeQueryMixin` to reuse the already filtered queryset instead of re-querying from scratch in helper functions to avoid extra work.
- Added test coverage for modality-based quiz filtering for:
     - Channels with quizzes vs. without quizzes
     - Channels that have exercise nodes that are not quizzes 
     - Regression test for contains_quiz=false behavior

https://github.com/user-attachments/assets/e3e7d2d0-2940-40f6-b4f7-cff9066ea8b4

## References
<!--
 * references to related issues and PRs
-->
Fixes #13267 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. With the Kolibri QA channel loaded on your Kolibri device, go to create a quiz and choose the second option from the drop down menu to create it from a practice quiz.
2. Confirm no regressions when navigating the topic tree (channels with quizzes show up, channels without quizzes don’t). 

🤖 Caught the extra query improvements when using Claude Code to review output of the SQLite EXPLAIN QUERY PLAN, and did iterative rounds of updates before getting it ready for review 🤖
