### PR TITLE
Add channel token support to importchannel management command

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1903,9 +1903,9 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             except ValidationError:
                 baseurl = None
         if baseurl is None:
-            client = NetworkClient("/")
+            client = NetworkClient(CENTRAL_CONTENT_BASE_URL)
         url = get_channel_lookup_url(
-            identifier=identifier, baseurl=baseurl, keyword=keyword, language=language
+            identifier=identifier, keyword=keyword, language=language
         )
         try:
             resp = client.get(url)

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -6,6 +6,7 @@ from ...utils import paths
 from kolibri.core.content.constants.transfer_types import COPY_METHOD
 from kolibri.core.content.constants.transfer_types import DOWNLOAD_METHOD
 from kolibri.core.content.utils.channel_transfer import transfer_channel
+from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
@@ -29,9 +30,8 @@ def resolve_channel_token(token, baseurl=None):
     :raises: ValueError if the token is not found or response is invalid
     """
     baseurl = baseurl or CENTRAL_CONTENT_BASE_URL
-    lookup_path = "api/public/v1/channels/lookup/{}?".format(token)
     client = NetworkClient.build_for_address(baseurl)
-    response = client.get(lookup_path)
+    response = client.get(get_channel_lookup_url(identifier=token))
 
     try:
         channels = response.json()

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -6,10 +6,46 @@ from ...utils import paths
 from kolibri.core.content.constants.transfer_types import COPY_METHOD
 from kolibri.core.content.constants.transfer_types import DOWNLOAD_METHOD
 from kolibri.core.content.utils.channel_transfer import transfer_channel
+from kolibri.core.discovery.utils.network.client import NetworkClient
+from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseTimeout
+from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.utils import conf
+from kolibri.utils.uuids import is_valid_uuid
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_channel_token(token, baseurl=None):
+    """
+    Resolve a channel token to a channel ID by querying the channel lookup endpoint.
+
+    :param token: The channel token to resolve
+    :param baseurl: The base URL of the content server (defaults to Studio)
+    :return: Tuple of (channel_id, all_channels) where all_channels is the full list
+    :raises: ValueError if the token is not found or response is invalid
+    """
+    baseurl = baseurl or CENTRAL_CONTENT_BASE_URL
+    lookup_path = "api/public/v1/channels/lookup/{}?".format(token)
+    client = NetworkClient.build_for_address(baseurl)
+    response = client.get(lookup_path)
+
+    try:
+        channels = response.json()
+    except ValueError as e:
+        raise ValueError("Invalid JSON response: {}".format(e))
+
+    if not channels or not isinstance(channels, list):
+        raise ValueError("Token '{}' not found on content server".format(token))
+
+    for channel in channels:
+        if not channel.get("id"):
+            raise ValueError("Invalid response: channel missing ID")
+
+    return channels[0]["id"], channels
 
 
 class Command(AsyncCommand):
@@ -29,7 +65,8 @@ class Command(AsyncCommand):
         network_subparser.add_argument(
             "channel_id",
             type=str,
-            help="Download the database for the given channel_id.",
+            help="Download the database for the given channel_id or channel token. "
+            "Tokens are resolved by querying the content server (e.g., Kolibri Studio).",
         )
 
         default_studio_url = conf.OPTIONS["Urls"]["CENTRAL_CONTENT_BASE_URL"]
@@ -59,7 +96,8 @@ class Command(AsyncCommand):
         local_subparser.add_argument(
             "channel_id",
             type=str,
-            help="Import this channel id from the given directory.",
+            help="Import this channel id from the given directory. "
+            "Note: Only channel IDs (UUIDs) are accepted, not tokens.",
         )
         local_subparser.add_argument(
             "directory", type=str, help="Import content from this directory."
@@ -76,10 +114,50 @@ class Command(AsyncCommand):
             help="Download the database to the given content dir.",
         )
 
+    def _resolve_channel_identifier(self, identifier, baseurl):
+        """
+        Resolve a channel identifier (UUID or token) to a channel_id.
+        """
+        if is_valid_uuid(identifier):
+            return identifier
+
+        try:
+            channel_id, all_channels = resolve_channel_token(
+                identifier, baseurl=baseurl
+            )
+        except (
+            NetworkLocationConnectionFailure,
+            NetworkLocationNotFound,
+            NetworkLocationResponseFailure,
+            NetworkLocationResponseTimeout,
+        ):
+            raise CommandError(
+                "Could not connect to content server at '{}'.".format(
+                    baseurl or "Kolibri Studio"
+                )
+            )
+        except ValueError as e:
+            raise CommandError(str(e))
+
+        if len(all_channels) > 1:
+            channel_list = ", ".join(
+                "{} ({})".format(c.get("name", "Unnamed"), c["id"])
+                for c in all_channels
+            )
+            raise CommandError(
+                "Token '{}' matches multiple channels: {}. "
+                "Use a channel ID instead.".format(identifier, channel_list)
+            )
+
+        return channel_id
+
     def download_channel(self, channel_id, baseurl, no_upgrade, content_dir):
-        logger.info("Downloading data for channel id {}".format(channel_id))
+        # Resolve the identifier (could be channel_id or token)
+        resolved_channel_id = self._resolve_channel_identifier(channel_id, baseurl)
+
+        logger.info("Downloading data for channel id {}".format(resolved_channel_id))
         transfer_channel(
-            channel_id=channel_id,
+            channel_id=resolved_channel_id,
             method=DOWNLOAD_METHOD,
             no_upgrade=no_upgrade,
             content_dir=content_dir,
@@ -87,6 +165,13 @@ class Command(AsyncCommand):
         )
 
     def copy_channel(self, channel_id, source_path, no_upgrade, content_dir):
+        if not is_valid_uuid(channel_id):
+            raise CommandError(
+                "Invalid channel ID '{}'. Disk import requires a UUID, not a token.".format(
+                    channel_id
+                )
+            )
+
         logger.info("Copying in data for channel id {}".format(channel_id))
         transfer_channel(
             channel_id=channel_id,

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -622,10 +622,8 @@ class RemoteChannelDiffStatsValidator(RemoteChannelImportValidator):
         if job_data["kwargs"]["peer_id"]:
             client = NetworkClient.build_for_address(job_data["kwargs"]["baseurl"])
         else:
-            client = NetworkClient("/")
-        url = get_channel_lookup_url(
-            baseurl=job_data["kwargs"]["baseurl"], identifier=data["channel_id"]
-        )
+            client = NetworkClient(conf.OPTIONS["Urls"]["CENTRAL_CONTENT_BASE_URL"])
+        url = get_channel_lookup_url(identifier=data["channel_id"])
         try:
             resp = client.get(url)
         except NetworkLocationResponseFailure as e:

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -23,6 +23,7 @@ from requests.exceptions import ReadTimeout
 from requests.exceptions import SSLError
 
 from kolibri.core.content.errors import InsufficientStorageSpaceError
+from kolibri.core.content.management.commands.importchannel import resolve_channel_token
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
@@ -678,6 +679,200 @@ class ImportChannelTestCase(TestCase):
         import_channel_mock.return_value = True
         call_command("importchannel", "network", self.the_channel_id)
         self.assertTrue(channel_stats_clear_mock.called)
+
+    @patch(
+        "kolibri.core.content.utils.channel_transfer.paths.get_content_database_file_url"
+    )
+    @patch(
+        "kolibri.core.content.utils.channel_transfer.paths.get_content_database_file_path"
+    )
+    @patch("kolibri.core.content.utils.channel_transfer.transfer.FileDownload")
+    @patch("kolibri.core.content.utils.channel_transfer.get_current_job")
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_network_import_with_token(
+        self,
+        mock_network_client_class,
+        get_current_job_mock,
+        FileDownloadMock,
+        local_path_mock,
+        remote_path_mock,
+        start_progress_mock,
+        import_channel_mock,
+    ):
+        """Test that network import resolves tokens to channel IDs"""
+        # Setup mock for token resolution
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": self.the_channel_id,
+                "name": "Test Channel",
+            }
+        ]
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        # Setup mock for the actual import
+        dummy_job = create_dummy_job()
+        get_current_job_mock.return_value = dummy_job
+        fd, local_path = tempfile.mkstemp()
+        os.close(fd)
+        local_path_mock.return_value = local_path
+        remote_path_mock.return_value = "notest"
+        import_channel_mock.return_value = True
+
+        # Call with a token instead of channel ID
+        call_command("importchannel", "network", "test-token")
+
+        # Verify token was resolved (NetworkClient was called)
+        mock_network_client_class.build_for_address.assert_called()
+        # Verify the import proceeded
+        import_channel_mock.assert_called_once()
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_network_import_token_not_found(
+        self,
+        mock_network_client_class,
+        start_progress_mock,
+        import_channel_mock,
+    ):
+        """Test that network import fails gracefully when token is not found"""
+        # Setup mock for token resolution failure
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = []  # Empty list = token not found
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        # Call with an invalid token - should raise CommandError
+        with self.assertRaises(CommandError) as context:
+            call_command("importchannel", "network", "invalid-token")
+
+        self.assertIn("not found", str(context.exception).lower())
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_network_import_token_multiple_channels(
+        self,
+        mock_network_client_class,
+        start_progress_mock,
+        import_channel_mock,
+    ):
+        """Test that token resolving to multiple channels raises an error"""
+        # Setup mock for multiple channel response
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"id": "aa480b60a7f4526f886e7df9f4e9b8ca", "name": "Channel A"},
+            {"id": "bb480b60a7f4526f886e7df9f4e9b8cb", "name": "Channel B"},
+        ]
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        # Should raise CommandError with info about multiple channels
+        with self.assertRaises(CommandError) as context:
+            call_command("importchannel", "network", "multi-token")
+
+        error_msg = str(context.exception)
+        self.assertIn("multiple channels", error_msg.lower())
+
+    def test_disk_import_rejects_token(
+        self,
+        start_progress_mock,
+        import_channel_mock,
+    ):
+        """Test that disk import rejects tokens and only accepts UUIDs"""
+        # Call with a token instead of UUID - should raise CommandError
+        with self.assertRaises(CommandError) as context:
+            call_command("importchannel", "disk", "test-token", tempfile.mkdtemp())
+
+        error_msg = str(context.exception)
+        self.assertIn("invalid channel id", error_msg.lower())
+        self.assertIn("disk", error_msg.lower())
+
+
+class ResolveChannelTokenTest(TestCase):
+    """Test the resolve_channel_token utility function"""
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_resolve_valid_token(self, mock_network_client_class):
+        """Test successful token resolution"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": "aa480b60a7f4526f886e7df9f4e9b8ca",
+                "name": "Test Channel",
+            }
+        ]
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        channel_id, all_channels = resolve_channel_token(
+            "test-token", baseurl="https://studio.example.com"
+        )
+
+        self.assertEqual(channel_id, "aa480b60a7f4526f886e7df9f4e9b8ca")
+        self.assertEqual(len(all_channels), 1)
+        mock_client.get.assert_called_once()
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_resolve_token_not_found(self, mock_network_client_class):
+        """Test token that doesn't exist on the server"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        with self.assertRaises(ValueError):
+            resolve_channel_token("invalid-token", baseurl="https://studio.example.com")
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_resolve_token_missing_id(self, mock_network_client_class):
+        """Test response with missing channel ID"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"name": "Test Channel"}]
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        with self.assertRaises(ValueError) as context:
+            resolve_channel_token("test-token", baseurl="https://studio.example.com")
+
+        self.assertIn("channel missing ID", str(context.exception))
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_resolve_token_multiple_channels(self, mock_network_client_class):
+        """Test token that resolves to multiple channels"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"id": "aa480b60a7f4526f886e7df9f4e9b8ca", "name": "Channel A"},
+            {"id": "bb480b60a7f4526f886e7df9f4e9b8cb", "name": "Channel B"},
+        ]
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        channel_id, all_channels = resolve_channel_token(
+            "test-token", baseurl="https://studio.example.com"
+        )
+
+        self.assertEqual(channel_id, "aa480b60a7f4526f886e7df9f4e9b8ca")
+        self.assertEqual(len(all_channels), 2)
+
+    @patch("kolibri.core.content.management.commands.importchannel.NetworkClient")
+    def test_resolve_token_invalid_json(self, mock_network_client_class):
+        """Test server returning invalid JSON"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_client.get.return_value = mock_response
+        mock_network_client_class.build_for_address.return_value = mock_client
+
+        with self.assertRaises(ValueError) as context:
+            resolve_channel_token("test-token", baseurl="https://studio.example.com")
+
+        self.assertIn("Invalid JSON", str(context.exception))
 
 
 @patch(

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -228,21 +228,19 @@ def get_info_url(baseurl=None):
     return get_content_server_url("api/public/info", baseurl=baseurl)
 
 
-def get_channel_lookup_url(
-    version="1", identifier=None, baseurl=None, keyword=None, language=None
-):
-    content_server_path = "api/public/v{}/channels".format(version)
+def get_channel_lookup_url(version="1", identifier=None, keyword=None, language=None):
+    content_server_path = "/api/public/v{}/channels".format(version)
     if identifier:
         content_server_path += "/lookup/{}".format(identifier)
-    content_server_path += "?"
     query_params = {}
     if keyword:
         query_params["keyword"] = keyword
     if language:
         query_params["language"] = language
-    content_server_path += urlencode(query_params)
+    if query_params:
+        content_server_path += "?" + urlencode(query_params)
 
-    return get_content_server_url(content_server_path, baseurl=baseurl)
+    return content_server_path
 
 
 def get_file_checksums_url(channel_id, baseurl, version="1"):

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -47,9 +47,7 @@ def lookup_channel_listing_status(channel_id, baseurl=None):
     try:
         # prevent trying to fetch a channel from a remote that it is not
         # available from.
-        resp = client.get(
-            get_channel_lookup_url(identifier=channel_id, baseurl=baseurl)
-        )
+        resp = client.get(get_channel_lookup_url(identifier=channel_id))
 
     except NetworkLocationResponseFailure as e:
         if e.response.status_code == 404:

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -154,35 +154,33 @@ class PublicAPITestCase(APITestCase):
         )
 
     def test_public_channel_list(self):
-        response = self.client.get(get_channel_lookup_url(baseurl="/"))
+        response = self.client.get(get_channel_lookup_url())
         data = response.json()
         self.assertEqual(len(data), 2)
 
     def test_public_channel_list_filter_keyword(self):
-        response = self.client.get(get_channel_lookup_url(baseurl="/", keyword="zzz"))
+        response = self.client.get(get_channel_lookup_url(keyword="zzz"))
         self.assertEqual(len(response.json()), 0)
-        response = self.client.get(get_channel_lookup_url(baseurl="/", keyword="math"))
+        response = self.client.get(get_channel_lookup_url(keyword="math"))
         self.assertEqual(len(response.json()), 1)
         self.assertEqual(response.json()[0]["id"], self.channel_id1)
 
     def test_public_channel_list_filter_language(self):
-        response = self.client.get(get_channel_lookup_url(baseurl="/", language="zu"))
+        response = self.client.get(get_channel_lookup_url(language="zu"))
         self.assertEqual(len(response.json()), 0)
         # filter based on contentnode languages
-        response = self.client.get(get_channel_lookup_url(baseurl="/", language="en"))
+        response = self.client.get(get_channel_lookup_url(language="en"))
         self.assertEqual(len(response.json()), 2)
         # filter based on root contentnode language
-        response = self.client.get(get_channel_lookup_url(baseurl="/", language="es"))
+        response = self.client.get(get_channel_lookup_url(language="es"))
         self.assertEqual(len(response.json()), 1)
         self.assertEqual(response.json()[0]["id"], self.channel_id2)
 
     def test_public_channel_list_filter_keyword_language(self):
-        response = self.client.get(
-            get_channel_lookup_url(baseurl="/", keyword="zzz", language="es")
-        )
+        response = self.client.get(get_channel_lookup_url(keyword="zzz", language="es"))
         self.assertEqual(len(response.json()), 0)
         response = self.client.get(
-            get_channel_lookup_url(baseurl="/", keyword="science", language="es")
+            get_channel_lookup_url(keyword="science", language="es")
         )
         self.assertEqual(len(response.json()), 1)
         self.assertEqual(response.json()[0]["id"], self.channel_id2)
@@ -275,7 +273,7 @@ class PublicAPITestCase(APITestCase):
         create_mini_channel(channel_name="math 2", channel_id=unlisted_channel_id)
         set_channel_metadata_fields(unlisted_channel_id, public=False)
 
-        response = self.client.get(get_channel_lookup_url(baseurl="/"))
+        response = self.client.get(get_channel_lookup_url())
         data = response.json()
         self.assertEqual(len(data), 2)
 


### PR DESCRIPTION
## Summary

Adds support for using channel tokens in addition to channel IDs when importing channels via the `importchannel` management command.

**Key features:**
- Token resolution via Kolibri Studio's channel lookup API
- Automatic detection of tokens vs channel IDs using UUID validation
- Clear error when token resolves to multiple channels (lists all options)
- Full backward compatibility with existing channel ID usage

**Example usage:**
```bash
kolibri manage importchannel network tahid-modal
```

* While addressing review comments from rtibblesbot, it became apparent that our existing channel lookup URL function was returning a full path, which was at adds with how it is used as an argument for NetworkClient.get - simplified it to just return the path, not the fully qualified URL.

## References

Fixes #3733

## Reviewer guidance

- Token resolution only applies to the `network` subcommand; `disk` requires UUIDs since tokens need network access to resolve
- Test coverage includes unit tests for `resolve_channel_token()` and integration tests in `test_import_export.py`