### PR TITLE
Add `modality` filter query param in Content API

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -433,6 +433,7 @@ class CharInFilter(BaseInFilter, CharFilter):
 contentnode_filter_fields = [
     "parent",
     "parent__isnull",
+    "modality",
     "prerequisite_for",
     "has_prerequisite",
     "related",

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
+from le_utils.constants import modalities
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -1273,6 +1274,43 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
             )
         )
         self.assertEqual(response.data["preset"], "high_res_video")
+
+    def test_modality_filter(self):
+        # Create a node with a specific modality
+        lesson_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).first()
+        course_topic = content.ContentNode.objects.filter(
+            kind=content_kinds.TOPIC
+        ).last()
+
+        # Just making sure our fixtures are different so our future assertions are strong
+        self.assertNotEqual(lesson_topic.id, course_topic.id)
+        self.assertGreater(content.ContentNode.objects.count(), 2)
+
+        lesson_topic.modality = modalities.LESSON
+        course_topic.modality = modalities.COURSE
+
+        # Filters will only return available nodes so just to be sure
+        lesson_topic.available = True
+        course_topic.available = True
+
+        lesson_topic.save()
+        course_topic.save()
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"modality": modalities.LESSON},
+        )
+
+        self.assertEqual(response.data[0]["id"], str(lesson_topic.id))
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"modality": modalities.COURSE},
+        )
+
+        self.assertEqual(response.data[0]["id"], str(course_topic.id))
 
     def _setup_contentnode_progress(self):
         # set up data for testing progress_fraction field on content node endpoint


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

Adds the line & a test confirming the change allowing the modalities to be filtered by in the content node API.

## References
<!--
 * references to related issues and PRs
-->

Closes #13969 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Is the test sufficient to cover this?
