### PR TITLE
Add courses_exist to the coach's plugin_data

### DIFF
--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -52,6 +52,12 @@ class CoachAsset(webpack_hooks.WebpackBundleHook):
         practice_quizzes_exist = ContentNode.objects.filter(
             available=True, modality=modalities.QUIZ
         ).exists()
+
+        courses_exist = ContentNode.objects.filter(
+            available=True, modality=modalities.COURSE
+        ).exists()
+
         return {
             "practice_quizzes_exist": practice_quizzes_exist,
+            "courses_exist": courses_exist,
         }


### PR DESCRIPTION
## Summary

* Adds courses_exist to the coach's plugin_data.

## References
Closes #13971.

## Reviewer guidance
* Import a channel with course nodes (or override the `modality` field of any ContentNode!)
* Load the coach tab.
* See in its template data-plugin that courses_exist is True.
