### PR TITLE
Fix facility guard redirection on the facility plugin

### DIFF
--- a/kolibri/plugins/facility/frontend/modules/pluginModule.js
+++ b/kolibri/plugins/facility/frontend/modules/pluginModule.js
@@ -67,6 +67,18 @@ export default {
           name: PageNames.USER_MGMT_PAGE,
           params,
         },
+        UsersRootPage: {
+          name: PageNames.USER_MGMT_PAGE,
+          params,
+        },
+        NewUsersPage: {
+          name: PageNames.NEW_USERS_PAGE,
+          params,
+        },
+        UsersTrashPage: {
+          name: PageNames.USERS_TRASH_PAGE,
+          params,
+        },
         ClassEditPage: classId => {
           return {
             name: PageNames.CLASS_EDIT_MGMT_PAGE,


### PR DESCRIPTION
## Summary

* Adds new users page to facilityPageLinks so that they were available to be used on the [AllFacilitiesPage](https://github.com/AlexVelezLl/kolibri/blob/6051c55633c24fb05f7f59ea06dc67dc78ba862f/kolibri/plugins/facility/frontend/views/AllFacilitiesPage.vue#L85) component.


https://github.com/user-attachments/assets/eaa5b579-f2be-4f3c-9cc3-7b67f6a15f21



## References
Closes #13929

## Reviewer guidance

* Navigate through the different facility pages using the side navbar.
