### PR TITLE
Add sync operations and filter utilities for classroom partitioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-all:
 
 %-with-postgres:
 	@echo -e "\e[33mWARNING: for testing purposes only; postgresql database backend is ephemeral\e[0m"
-	@echo -e "\e[36mINFO: run 'docker-compose -v' to remove the database volume\e[0m"
+	@echo -e "\e[36mINFO: run 'docker compose -v' to remove the database volume\e[0m"
 	export KOLIBRI_DATABASE_ENGINE=postgres; \
 	export KOLIBRI_DATABASE_NAME=default; \
 	export KOLIBRI_DATABASE_USER=postgres; \
@@ -109,15 +109,15 @@ test-all:
 	export KOLIBRI_DATABASE_HOST=127.0.0.1; \
 	export KOLIBRI_DATABASE_PORT=15432; \
 	set -ex; \
-	function _on_interrupt() { docker-compose down; }; \
+	function _on_interrupt() { docker compose down; }; \
 	trap _on_interrupt SIGINT SIGTERM SIGKILL ERR; \
-	docker-compose up --detach; \
-	until docker-compose logs --tail=1 postgres | grep -q "database system is ready to accept connections"; do \
+	docker compose up --detach; \
+	until docker compose logs --tail=1 postgres | grep -q "database system is ready to accept connections"; do \
 		echo "$(date) - waiting for postgres..."; \
 		sleep 1; \
 	done; \
 	$(MAKE) -e $(subst -with-postgres,,$@); \
-	docker-compose down -v
+	docker compose down -v
 
 start-foreground:
 	kolibri start --foreground

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM python:3.6
 
 ENV NODE_VERSION=20.19.3
 
@@ -10,10 +10,10 @@ RUN apt-get update && \
     gettext \
     git \
     git-lfs \
-    python3.6 \
-    python-pip \
-    python-sphinx
+    sqlite3 \
+    python3-sphinx
 
+RUN ln -s /usr/bin/python3.6 /usr/bin/python
 # Upgrade pip. Otherwise pip cannot install c extension packages that are not
 # for current platform
 RUN pip install -U pip

--- a/kolibri/core/auth/constants/morango_sync.py
+++ b/kolibri/core/auth/constants/morango_sync.py
@@ -7,6 +7,9 @@ DATA_PORTAL_SYNCING_BASE_URL = conf.OPTIONS["Urls"]["DATA_PORTAL_SYNCING_BASE_UR
 CUSTOM_INSTANCE_INFO = {
     "kolibri": __version__,
 }
+PARTITION_CLASSROOM = "${dataset_id}:classroom:${collection_id}"
+PARTITION_SUFFIX_LEARNER_RW = ":learner-rw"
+PARTITION_SUFFIX_COACH_RW = ":coach-rw"
 
 
 class ScopeDefinitions(object):

--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -5,6 +5,8 @@ from morango.sync.operations import LocalOperation
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Session
+from kolibri.core.auth.sync_operations import KolibriLocalInitializeOperation
+from kolibri.core.auth.sync_operations import KolibriNetworkInitializeOperation
 from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
 from kolibri.core.auth.sync_operations import KolibriSyncOperationMixin
 from kolibri.core.auth.tasks import cleanupsync
@@ -81,6 +83,10 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
 
 @register_hook
 class AuthSyncHook(FacilityDataSyncHook):
+    initializing_operations = [
+        KolibriLocalInitializeOperation(),
+        KolibriNetworkInitializeOperation(),
+    ]
     serializing_operations = [SingleFacilityUserChangeClearingOperation()]
     cleanup_operations = [CleanUpTaskOperation()]
 

--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -67,7 +67,9 @@ class KolibriLocalInitializeOperation(InitializeOperation):
                 ).build_for_user(single_user_id)
 
                 if dynamic_filter:
-                    context.filter += dynamic_filter
+                    context.update(
+                        sync_filter=Filter.add(context.filter, dynamic_filter)
+                    )
 
         return super().handle(context)
 
@@ -108,7 +110,7 @@ class KolibriNetworkInitializeOperation(NetworkInitializeOperation):
         ):
             # receive the modified, dynamic, filter(s) from the server and update the transfer
             # session and context objects to reflect the change
-            context.filter = response_filter
+            context.update(sync_filter=response_filter)
             context.transfer_session.filter = str(response_filter)
             context.transfer_session.save()
 

--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -2,14 +2,19 @@ import json
 import logging
 
 from morango.constants import transfer_stages
+from morango.models.certificates import Filter
 from morango.sync.operations import BaseOperation
+from morango.sync.operations import InitializeOperation
 from morango.sync.operations import LocalOperation
+from morango.sync.operations import NetworkInitializeOperation
 
+from .sync_event_hook_utils import get_dataset_id
 from .sync_event_hook_utils import get_other_side_kolibri_version
 from .sync_event_hook_utils import get_user_id_for_single_user_sync
 from .sync_event_hook_utils import other_side_using_single_user_cert
 from .sync_event_hook_utils import this_side_using_single_user_cert
 from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.core.auth.utils.sync import ClassroomPartitionFilterFactory
 from kolibri.core.upgrade import matches_version
 from kolibri.utils.version import truncate_version
 
@@ -17,6 +22,97 @@ from kolibri.utils.version import truncate_version
 logger = logging.getLogger(__name__)
 SORTED_STAGES = sorted(transfer_stages.ALL, key=lambda s: transfer_stages.precedence(s))
 PREVIOUS_STAGES = dict(zip(SORTED_STAGES, [None] + SORTED_STAGES[:-1]))
+
+
+class KolibriLocalInitializeOperation(InitializeOperation):
+    """
+    Operation for initializing a local sync session. Specifically, this adds functionality to
+    dynamically add filters to a sync when this device is the server during a sync. This
+    functionality could be accomplished by simply adding another operation in the chain before the
+    already extant `InitializeOperation` (which this inherits). Although, since this is important
+    functionality to Kolibri, and Kolibri already has plugins which modify the sync behavior, it's
+    more foolproof to inherit the operation to ensure this functionality is coupled with
+    initialization.
+    """
+
+    def handle(self, context):
+        """
+        Dynamically adds partition filters when one device in the sync is a SoUD (see similar
+        logic in other extant hooks and operations), for syncing classroom partitioned records.
+
+        :param context: The sync context object containing session and filter information.
+        :type context: morango.sync.context.LocalSessionContext
+        """
+        # the server validates that a sync filter is allowed within the certificate's scope, and
+        # since the client initiates the sync, we can't add the dynamic classroom filter to the
+        # context until after the transfer session has been validated. this sync operation will
+        # be invoked before validation on the client, and after validation on the server
+        if context.is_server:
+            is_local = this_side_using_single_user_cert(context)
+            is_remote = other_side_using_single_user_cert(context)
+
+            # server is a full facility device, but syncing with a SoUD, therefore the device has
+            # the 'authority' to dynamically add the classroom partition filter
+            if not is_local and is_remote:
+                filter_factory = ClassroomPartitionFilterFactory(
+                    get_dataset_id(context)
+                )
+                single_user_id = get_user_id_for_single_user_sync(context)
+
+                # when it's a push, since this code block is restricted to the server, the
+                # client's partition filter should be restricted to what is explicitly read/write,
+                # otherwise the user can pull any data for the classroom partition
+                dynamic_filter = filter_factory.set_writeable(
+                    writeable=context.is_push
+                ).build_for_user(single_user_id)
+
+                if dynamic_filter:
+                    context.filter += dynamic_filter
+
+        return super().handle(context)
+
+
+class KolibriNetworkInitializeOperation(NetworkInitializeOperation):
+    """
+    Operation for initializing a sync session with a remote over the network. This specifically adds
+    functionality to handle the result of the above operation that dynamically adds filters.
+    """
+
+    def create_transfer_session(self, context):
+        """
+        Calls the super method which makes a network request to create a transfer session, then
+        updates the local transfer session filters to match the remote's using the response.
+
+        :param context: The sync context object containing session and filter information.
+        :type context: morango.sync.context.NetworkSessionContext
+        :return: The response dictionary from the remote
+        :rtype: dict
+        """
+        response_data = super().create_transfer_session(context)
+
+        is_local = this_side_using_single_user_cert(context)
+        is_remote = other_side_using_single_user_cert(context)
+
+        response_filter = (
+            Filter(response_data["filter"])
+            if response_data.get("filter", None)
+            else None
+        )
+
+        # TODO: morango's sync Filter needs defensiveness against comparing with `None`
+        if (
+            is_local
+            and not is_remote
+            and response_filter is not None
+            and response_filter != context.filter
+        ):
+            # receive the modified, dynamic, filter(s) from the server and update the transfer
+            # session and context objects to reflect the change
+            context.filter = response_filter
+            context.transfer_session.filter = str(response_filter)
+            context.transfer_session.save()
+
+        return response_data
 
 
 class KolibriSyncOperations(BaseOperation):

--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -375,6 +375,14 @@ class KolibriLocalInitializeOperationTestCase(SimpleTestCase):
         self.context.is_push = False
         self.context.filter = Filter("base_filter")
 
+    def assertContextUpdate(self, **kwargs):
+        call_args = self.context.update.call_args[1]
+        for key, value in kwargs.items():
+            self.assertIn(
+                key, call_args, msg=f"Expected argument '{key}' in context update"
+            )
+            self.assertEqual(call_args[key], value)
+
     def test_not_server(self, mock_is_local, mock_is_remote, mock_handle):
         result = self.operation.handle(self.context)
         mock_is_local.assert_not_called()
@@ -451,8 +459,7 @@ class KolibriLocalInitializeOperationTestCase(SimpleTestCase):
                 user_id
             )
 
-        self.assertTrue(self.context.filter.contains_partition("base_filter"))
-        self.assertTrue(self.context.filter.contains_partition("second_filter"))
+        self.assertContextUpdate(sync_filter=Filter("base_filter\nsecond_filter"))
 
         mock_is_local.assert_called_once()
         mock_is_remote.assert_called_once()
@@ -487,8 +494,7 @@ class KolibriLocalInitializeOperationTestCase(SimpleTestCase):
                 user_id
             )
 
-        self.assertTrue(self.context.filter.contains_partition("base_filter"))
-        self.assertTrue(self.context.filter.contains_partition("second_filter"))
+        self.assertContextUpdate(sync_filter=Filter("base_filter\nsecond_filter"))
 
         mock_is_local.assert_called_once()
         mock_is_remote.assert_called_once()
@@ -521,7 +527,7 @@ class KolibriLocalInitializeOperationTestCase(SimpleTestCase):
                 user_id
             )
 
-        self.assertTrue(self.context.filter.contains_partition("base_filter"))
+        self.context.update.assert_not_called()
 
         mock_is_local.assert_called_once()
         mock_is_remote.assert_called_once()
@@ -598,5 +604,5 @@ class KolibriNetworkInitializeOperationTestCase(SimpleTestCase):
         mock_is_remote.assert_called_once()
         self.context.transfer_session.save.assert_called_once()
         self.assertEqual(self.context.transfer_session.filter, "return_filter")
-        self.assertEqual(str(self.context.filter), "return_filter")
+        self.context.update.assert_called_once_with(sync_filter=Filter("return_filter"))
         self.assertEqual(result, mock_create.return_value)

--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -1,14 +1,20 @@
 import json
+import uuid
+from contextlib import contextmanager
 
 import mock
 from django.test import SimpleTestCase
 from morango.constants import transfer_statuses
 from morango.errors import MorangoSkipOperation
+from morango.models import Filter
 from morango.sync.context import LocalSessionContext
+from morango.sync.context import NetworkSessionContext
 from morango.sync.context import SessionContext
 from morango.sync.operations import BaseOperation
 
 from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.core.auth.sync_operations import KolibriLocalInitializeOperation
+from kolibri.core.auth.sync_operations import KolibriNetworkInitializeOperation
 from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
 from kolibri.core.auth.sync_operations import KolibriSyncOperationMixin
 from kolibri.core.auth.sync_operations import KolibriSyncOperations
@@ -355,3 +361,242 @@ class KolibriSingleUserSyncOperationTestCase(SimpleTestCase):
 
         self.handle_remote_user.assert_called_once_with(self.context, "abc123")
         self.handle_local_user.assert_not_called()
+
+
+@mock.patch("kolibri.core.auth.sync_operations.InitializeOperation.handle")
+@mock.patch("kolibri.core.auth.sync_operations.other_side_using_single_user_cert")
+@mock.patch("kolibri.core.auth.sync_operations.this_side_using_single_user_cert")
+class KolibriLocalInitializeOperationTestCase(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.operation = KolibriLocalInitializeOperation()
+        self.context = mock.Mock(spec_set=LocalSessionContext)()
+        self.context.is_server = False
+        self.context.is_push = False
+        self.context.filter = Filter("base_filter")
+
+    def test_not_server(self, mock_is_local, mock_is_remote, mock_handle):
+        result = self.operation.handle(self.context)
+        mock_is_local.assert_not_called()
+        mock_is_remote.assert_not_called()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    def test_server__no_soud(self, mock_is_local, mock_is_remote, mock_handle):
+        self.context.is_server = True
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = False
+        result = self.operation.handle(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    def test_server__is_soud(self, mock_is_local, mock_is_remote, mock_handle):
+        self.context.is_server = True
+        mock_is_local.return_value = True
+        mock_is_remote.return_value = False
+        result = self.operation.handle(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    def test_server__both_soud(self, mock_is_local, mock_is_remote, mock_handle):
+        self.context.is_server = True
+        mock_is_local.return_value = True
+        mock_is_remote.return_value = True
+        result = self.operation.handle(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    @contextmanager
+    def _patch(self, dataset_id, user_id):
+        with mock.patch(
+            "kolibri.core.auth.sync_operations.get_dataset_id", return_value=dataset_id
+        ) as mock_get_dataset_id, mock.patch(
+            "kolibri.core.auth.sync_operations.get_user_id_for_single_user_sync",
+            return_value=user_id,
+        ) as mock_get_user, mock.patch(
+            "kolibri.core.auth.sync_operations.ClassroomPartitionFilterFactory"
+        ) as mock_factory:
+            yield mock_get_dataset_id, mock_get_user, mock_factory
+
+    def test_server__not_the_soud__pull(
+        self, mock_is_local, mock_is_remote, mock_handle
+    ):
+        self.context.is_server = True
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = True
+        dataset_id = uuid.uuid4().hex
+        user_id = uuid.uuid4().hex
+
+        with self._patch(dataset_id, user_id) as (
+            mock_get_dataset_id,
+            mock_get_user,
+            mock_factory,
+        ):
+            factory = mock_factory.return_value
+            factory.set_writeable.return_value.build_for_user.return_value = Filter(
+                "second_filter"
+            )
+            result = self.operation.handle(self.context)
+            mock_get_dataset_id.assert_called_once_with(self.context)
+            mock_factory.assert_called_once_with(dataset_id)
+            mock_get_user.assert_called_once_with(self.context)
+            factory.set_writeable.assert_called_once_with(writeable=False)
+            factory.set_writeable.return_value.build_for_user.assert_called_once_with(
+                user_id
+            )
+
+        self.assertTrue(self.context.filter.contains_partition("base_filter"))
+        self.assertTrue(self.context.filter.contains_partition("second_filter"))
+
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    def test_server__not_the_soud__push(
+        self, mock_is_local, mock_is_remote, mock_handle
+    ):
+        self.context.is_server = True
+        self.context.is_push = True
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = True
+        dataset_id = uuid.uuid4().hex
+        user_id = uuid.uuid4().hex
+
+        with self._patch(dataset_id, user_id) as (
+            mock_get_dataset_id,
+            mock_get_user,
+            mock_factory,
+        ):
+            factory = mock_factory.return_value
+            factory.set_writeable.return_value.build_for_user.return_value = Filter(
+                "second_filter"
+            )
+            result = self.operation.handle(self.context)
+            mock_get_dataset_id.assert_called_once_with(self.context)
+            mock_factory.assert_called_once_with(dataset_id)
+            mock_get_user.assert_called_once_with(self.context)
+            factory.set_writeable.assert_called_once_with(writeable=True)
+            factory.set_writeable.return_value.build_for_user.assert_called_once_with(
+                user_id
+            )
+
+        self.assertTrue(self.context.filter.contains_partition("base_filter"))
+        self.assertTrue(self.context.filter.contains_partition("second_filter"))
+
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+    def test_server__not_the_soud__no_filter(
+        self, mock_is_local, mock_is_remote, mock_handle
+    ):
+        self.context.is_server = True
+        self.context.is_push = True
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = True
+        dataset_id = uuid.uuid4().hex
+        user_id = uuid.uuid4().hex
+
+        with self._patch(dataset_id, user_id) as (
+            mock_get_dataset_id,
+            mock_get_user,
+            mock_factory,
+        ):
+            factory = mock_factory.return_value
+            factory.set_writeable.return_value.build_for_user.return_value = None
+            result = self.operation.handle(self.context)
+            mock_get_dataset_id.assert_called_once_with(self.context)
+            mock_factory.assert_called_once_with(dataset_id)
+            mock_get_user.assert_called_once_with(self.context)
+            factory.set_writeable.assert_called_once_with(writeable=True)
+            factory.set_writeable.return_value.build_for_user.assert_called_once_with(
+                user_id
+            )
+
+        self.assertTrue(self.context.filter.contains_partition("base_filter"))
+
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        mock_handle.assert_called_once_with(self.context)
+        self.assertEqual(result, mock_handle.return_value)
+
+
+@mock.patch(
+    "kolibri.core.auth.sync_operations.NetworkInitializeOperation.create_transfer_session"
+)
+@mock.patch("kolibri.core.auth.sync_operations.other_side_using_single_user_cert")
+@mock.patch("kolibri.core.auth.sync_operations.this_side_using_single_user_cert")
+class KolibriNetworkInitializeOperationTestCase(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.operation = KolibriNetworkInitializeOperation()
+        self.context = mock.Mock(spec_set=NetworkSessionContext)()
+        self.context.is_server = False
+        self.context.is_push = False
+        self.context.transfer_session = mock.Mock()
+        self.context.filter = Filter("base_filter")
+
+    def test_no_soud(self, mock_is_local, mock_is_remote, mock_create):
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = False
+        mock_create.return_value = {"filter": None}
+        result = self.operation.create_transfer_session(self.context)
+        mock_create.assert_called_once_with(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        self.context.transfer_session.save.assert_not_called()
+        self.assertEqual(result, mock_create.return_value)
+
+    def test_no_filter(self, mock_is_local, mock_is_remote, mock_create):
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = False
+        mock_create.return_value = {}
+        result = self.operation.create_transfer_session(self.context)
+        mock_create.assert_called_once_with(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        self.context.transfer_session.save.assert_not_called()
+        self.assertEqual(result, mock_create.return_value)
+
+    def test_remote_soud(self, mock_is_local, mock_is_remote, mock_create):
+        mock_is_local.return_value = False
+        mock_is_remote.return_value = True
+        mock_create.return_value = {"filter": None}
+        result = self.operation.create_transfer_session(self.context)
+        mock_create.assert_called_once_with(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        self.context.transfer_session.save.assert_not_called()
+        self.assertEqual(result, mock_create.return_value)
+
+    def test_both_soud(self, mock_is_local, mock_is_remote, mock_create):
+        mock_is_local.return_value = True
+        mock_is_remote.return_value = True
+        mock_create.return_value = {"filter": None}
+        result = self.operation.create_transfer_session(self.context)
+        mock_create.assert_called_once_with(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        self.context.transfer_session.save.assert_not_called()
+        self.assertEqual(result, mock_create.return_value)
+
+    def test_soud(self, mock_is_local, mock_is_remote, mock_create):
+        mock_is_local.return_value = True
+        mock_is_remote.return_value = False
+        mock_create.return_value = {"filter": "return_filter"}
+        result = self.operation.create_transfer_session(self.context)
+        mock_create.assert_called_once_with(self.context)
+        mock_is_local.assert_called_once()
+        mock_is_remote.assert_called_once()
+        self.context.transfer_session.save.assert_called_once()
+        self.assertEqual(self.context.transfer_session.filter, "return_filter")
+        self.assertEqual(str(self.context.filter), "return_filter")
+        self.assertEqual(result, mock_create.return_value)

--- a/kolibri/core/auth/test/test_sync_utils.py
+++ b/kolibri/core/auth/test/test_sync_utils.py
@@ -1,11 +1,24 @@
+import uuid
+
 from django.test import TestCase
 from mock import Mock
+from morango.models import Filter
 from morango.sync.utils import SyncSignalGroup
 
 from .helpers import create_dummy_facility_data
 from .helpers import provision_device
+from kolibri.core.auth.constants.morango_sync import PARTITION_CLASSROOM
+from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_COACH_RW
+from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_LEARNER_RW
 from kolibri.core.auth.management.utils import MorangoSyncCommand
 from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.utils.sync import ClassroomPartitionFactory
+from kolibri.core.auth.utils.sync import ClassroomPartitionFilterFactory
 from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
@@ -185,3 +198,259 @@ class CanonicalizeAssignmentsTestCase(TestCase):
         ).distinct()
 
         self._assert_assignments("exam", assignments, expected)
+
+
+class ClassroomPartitionFactoryTestCase(TestCase):
+    """
+    Tests for the ClassroomPartitionFactory class.
+    """
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.learner = FacilityUser.objects.create(username="foo", facility=cls.facility)
+        cls.classroom_coach = FacilityUser.objects.create(
+            username="bar", facility=cls.facility
+        )
+
+        cls.classroom = Classroom.objects.create(parent=cls.facility)
+        cls.classroom.add_coach(cls.classroom_coach)
+        cls.classroom.add_member(cls.learner)
+
+        cls.group = LearnerGroup.objects.create(parent=cls.classroom)
+        cls.group.add_learner(cls.learner)
+
+    def setUp(self):
+        self.dataset_id = self.facility.dataset_id
+        self.factory = ClassroomPartitionFactory(self.dataset_id)
+        self.collection_id = uuid.uuid4().hex
+
+    def assertFilter(self, test_filter, expected_suffix=""):
+        self.assertIsInstance(test_filter, Filter)
+        self.assertEqual(
+            str(test_filter),
+            f"{self.dataset_id}:classroom:{self.collection_id}{expected_suffix}",
+        )
+
+    def test_template(self):
+        self.assertEqual(self.factory.filter_template, PARTITION_CLASSROOM)
+
+    def test_set_suffix(self):
+        self.assertEqual(self.factory, self.factory.set_suffix(":test"))
+        self.assertEqual(self.factory.filter_suffix, ":test")
+
+    def test_set_coach_writeable(self):
+        self.assertEqual(self.factory, self.factory.set_coach_writeable())
+        self.assertEqual(self.factory.filter_suffix, PARTITION_SUFFIX_COACH_RW)
+
+    def test_set_learner_writeable(self):
+        self.assertEqual(self.factory, self.factory.set_learner_writeable())
+        self.assertEqual(self.factory.filter_suffix, PARTITION_SUFFIX_LEARNER_RW)
+
+    def test_build__no_suffix(self):
+        test_filter = self.factory.build(self.collection_id)
+        self.assertIsInstance(test_filter, Filter)
+        self.assertFilter(test_filter)
+
+    def test_build__custom_suffix(self):
+        test_filter = self.factory.build(self.collection_id, filter_suffix=":test")
+        self.assertIsInstance(test_filter, Filter)
+        self.assertFilter(test_filter, expected_suffix=":test")
+
+    def test_build__learner_suffix(self):
+        test_filter = self.factory.set_learner_writeable().build(self.collection_id)
+        self.assertIsInstance(test_filter, Filter)
+        self.assertFilter(test_filter, expected_suffix=PARTITION_SUFFIX_LEARNER_RW)
+
+    def test_build__coach_suffix(self):
+        test_filter = self.factory.set_coach_writeable().build(self.collection_id)
+        self.assertIsInstance(test_filter, Filter)
+        self.assertFilter(test_filter, expected_suffix=PARTITION_SUFFIX_COACH_RW)
+
+    def test_get_classroom_collection__no_arg(self):
+        with self.assertRaises(ValueError):
+            self.factory.get_classroom_collection()
+
+    def test_get_classroom_collection__with_classroom_id(self):
+        test_collection = ClassroomPartitionFactory.get_classroom_collection(
+            collection_id=self.classroom.id
+        )
+        self.assertIsInstance(test_collection, Collection)
+        self.assertEqual(test_collection.id, self.classroom.id)
+
+    def test_get_classroom_collection__with_classroom(self):
+        test_collection = ClassroomPartitionFactory.get_classroom_collection(
+            collection=self.classroom
+        )
+        self.assertIsInstance(test_collection, Collection)
+        self.assertEqual(test_collection.id, self.classroom.id)
+
+    def test_get_classroom_collection__with_group_id(self):
+        test_collection = ClassroomPartitionFactory.get_classroom_collection(
+            collection_id=self.group.id,
+        )
+        self.assertIsInstance(test_collection, Collection)
+        self.assertEqual(test_collection.id, self.classroom.id)
+
+    def test_get_classroom_collection__with_group(self):
+        test_collection = ClassroomPartitionFactory.get_classroom_collection(
+            collection=self.group,
+        )
+        self.assertIsInstance(test_collection, Collection)
+        self.assertEqual(test_collection.id, self.classroom.id)
+
+
+class ClassroomPartitionFilterFactoryTestCase(TestCase):
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.learner_a = FacilityUser.objects.create(
+            username="learner_a", facility=cls.facility
+        )
+        cls.learner_b = FacilityUser.objects.create(
+            username="learner_b", facility=cls.facility
+        )
+        cls.learner_c = FacilityUser.objects.create(
+            username="learner_c", facility=cls.facility
+        )
+        cls.learner_d = FacilityUser.objects.create(
+            username="learner_d", facility=cls.facility
+        )
+        cls.classroom_coach_a = FacilityUser.objects.create(
+            username="coach_a", facility=cls.facility
+        )
+        cls.classroom_coach_b = FacilityUser.objects.create(
+            username="coach_b", facility=cls.facility
+        )
+
+        cls.classroom_a = Classroom.objects.create(parent=cls.facility)
+        cls.classroom_a.add_coach(cls.classroom_coach_a)
+        cls.classroom_a.add_member(cls.learner_a)
+        cls.classroom_a.add_member(cls.classroom_coach_b)
+
+        cls.classroom_b = Classroom.objects.create(parent=cls.facility)
+        cls.classroom_b.add_coach(cls.classroom_coach_b)
+        cls.classroom_b.add_member(cls.learner_b)
+        cls.classroom_b.add_member(cls.learner_c)
+
+        cls.group_ba = LearnerGroup.objects.create(parent=cls.classroom_b)
+        cls.group_ba.add_learner(cls.learner_c)
+
+    def setUp(self):
+        self.dataset_id = self.facility.dataset_id
+        self.factory = ClassroomPartitionFilterFactory(self.dataset_id)
+
+    def assertFilter(self, test_filter, collection_id, expected_suffix=""):
+        self.assertIsInstance(test_filter, Filter)
+        self.assertEqual(
+            str(test_filter),
+            f"{self.dataset_id}:classroom:{collection_id}{expected_suffix}",
+        )
+
+    def assertFilterHas(self, test_filter, collection_id, expected_suffix=""):
+        self.assertIsInstance(test_filter, Filter)
+        self.assertTrue(
+            test_filter.contains_partition(
+                f"{self.dataset_id}:classroom:{collection_id}{expected_suffix}"
+            )
+        )
+
+    def test_set_writable(self):
+        self.assertFalse(self.factory.filter_writeable)
+        self.assertEqual(self.factory, self.factory.set_writeable(writeable=True))
+        self.assertTrue(self.factory.filter_writeable)
+
+    def test_build__not_writeable(self):
+        test_filter = self.factory.build(self.classroom_a.id)
+        self.assertFilter(test_filter, self.classroom_a.id)
+
+    def test_build__writeable__no_suffix(self):
+        with self.assertRaises(ValueError):
+            self.factory.set_writeable().build(self.classroom_a.id)
+
+    def test_build__writeable__custom_suffix(self):
+        test_filter = self.factory.set_writeable().build(
+            self.classroom_a.id, filter_suffix=":custom"
+        )
+        self.assertFilter(test_filter, self.classroom_a.id, expected_suffix=":custom")
+
+    def test_build__writeable__learner_suffix(self):
+        test_filter = self.factory.set_learner_writeable().build(self.classroom_b.id)
+        self.assertFilter(
+            test_filter,
+            self.classroom_b.id,
+            expected_suffix=PARTITION_SUFFIX_LEARNER_RW,
+        )
+
+    def test_build__writeable__coach_suffix(self):
+        test_filter = self.factory.set_coach_writeable().build(self.classroom_b.id)
+        self.assertFilter(
+            test_filter, self.classroom_b.id, expected_suffix=PARTITION_SUFFIX_COACH_RW
+        )
+
+    def test_build_for_user__learner(self):
+        test_filter = self.factory.build_for_user(self.learner_a.id)
+        self.assertFilter(test_filter, self.classroom_a.id)
+
+    def test_build_for_user__learner__writeable(self):
+        test_filter = self.factory.set_writeable().build_for_user(self.learner_a.id)
+        self.assertFilter(
+            test_filter,
+            self.classroom_a.id,
+            expected_suffix=PARTITION_SUFFIX_LEARNER_RW,
+        )
+
+    def test_build_for_user__group_learner(self):
+        test_filter = self.factory.build_for_user(self.learner_c.id)
+        self.assertFilter(test_filter, self.classroom_b.id)
+
+    def test_build_for_user__group_learner__writeable(self):
+        test_filter = self.factory.set_writeable().build_for_user(self.learner_c.id)
+        self.assertFilter(
+            test_filter,
+            self.classroom_b.id,
+            expected_suffix=PARTITION_SUFFIX_LEARNER_RW,
+        )
+
+    def test_build_for_user__unrelevant_learner(self):
+        test_filter = self.factory.build_for_user(self.learner_d.id)
+        self.assertIsNone(test_filter)
+
+    def test_build_for_user__unrelevant__writeable(self):
+        test_filter = self.factory.set_writeable().build_for_user(self.learner_d.id)
+        self.assertIsNone(test_filter)
+
+    def test_build_for_user__coach(self):
+        test_filter = self.factory.build_for_user(self.classroom_coach_a.id)
+        self.assertFilter(test_filter, self.classroom_a.id)
+
+    def test_build_for_user__coach__writeable(self):
+        test_filter = self.factory.set_coach_writeable().build_for_user(
+            self.classroom_coach_a.id
+        )
+        self.assertFilter(
+            test_filter, self.classroom_a.id, expected_suffix=PARTITION_SUFFIX_COACH_RW
+        )
+
+    def test_build_for_user__multirole(self):
+        test_filter = self.factory.build_for_user(self.classroom_coach_b.id)
+        self.assertFilterHas(test_filter, self.classroom_a.id)
+        self.assertFilterHas(test_filter, self.classroom_b.id)
+
+    def test_build_for_user__multirole__writeable(self):
+        test_filter = self.factory.set_writeable().build_for_user(
+            self.classroom_coach_b.id
+        )
+        self.assertFilterHas(
+            test_filter,
+            self.classroom_a.id,
+            expected_suffix=PARTITION_SUFFIX_LEARNER_RW,
+        )
+        self.assertFilterHas(
+            test_filter, self.classroom_b.id, expected_suffix=PARTITION_SUFFIX_COACH_RW
+        )

--- a/kolibri/core/auth/utils/sync.py
+++ b/kolibri/core/auth/utils/sync.py
@@ -219,7 +219,7 @@ class ClassroomPartitionFactory(object):
         if filter_suffix:
             filter_template += filter_suffix
 
-        return Filter(
+        return Filter.from_template(
             filter_template,
             params={
                 "dataset_id": self.dataset_id,

--- a/kolibri/core/auth/utils/sync.py
+++ b/kolibri/core/auth/utils/sync.py
@@ -6,19 +6,28 @@ from django.db import connection
 from django.db.models import IntegerField
 from django.db.models.expressions import Case
 from django.db.models.expressions import When
+from morango.models import Filter
 from morango.models import ScopeDefinition
 from morango.models import SyncSession
 from morango.sync.controller import MorangoProfileController
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import PermissionDenied
 
+from kolibri.core.auth.constants import collection_kinds
+from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.constants.collection_kinds import ADHOCLEARNERSGROUP
 from kolibri.core.auth.constants.collection_kinds import CLASSROOM
 from kolibri.core.auth.constants.collection_kinds import LEARNERGROUP
+from kolibri.core.auth.constants.morango_sync import PARTITION_CLASSROOM
+from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_COACH_RW
+from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_LEARNER_RW
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.management.utils import get_client_and_server_certs
 from kolibri.core.auth.management.utils import get_facility_dataset_id
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import Membership
+from kolibri.core.auth.models import Role
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 
 
@@ -157,3 +166,170 @@ def learner_canonicalized_assignments(resource_name, assignments):
             ).distinct()
         ]
     )
+
+
+class ClassroomPartitionFactory(object):
+    """
+    A factory class to create partitions for syncable models related to the classroom partition
+    structure.
+    """
+
+    def __init__(self, dataset_id):
+        """
+        :param dataset_id: The facility dataset id.
+        :type dataset_id: str
+        """
+        self.dataset_id = dataset_id
+        self.filter_template = PARTITION_CLASSROOM
+        self.filter_suffix = None
+
+    def set_suffix(self, suffix):
+        """
+        Sets the partition suffix.
+        :rtype: ClassroomPartitionFactory
+        """
+        self.filter_suffix = suffix
+        return self
+
+    def set_coach_writeable(self):
+        """
+        Sets the writeable permission for the coach role.
+        :rtype: ClassroomPartitionFactory
+        """
+        return self.set_suffix(PARTITION_SUFFIX_COACH_RW)
+
+    def set_learner_writeable(self):
+        """
+        Sets the writeable permission for the learner role.
+        :rtype: ClassroomPartitionFactory
+        """
+        return self.set_suffix(PARTITION_SUFFIX_LEARNER_RW)
+
+    def build(self, collection_id, filter_suffix=None):
+        """
+        Builds the partition and returns it as a Filter instance.
+        :param collection_id: The classroom's collection ID.
+        :param filter_suffix: An optional filter suffix that overrides the factory's.
+        :return: Filter instance
+        :rtype: Filter
+        """
+        filter_template = self.filter_template
+        filter_suffix = filter_suffix or self.filter_suffix
+
+        if filter_suffix:
+            filter_template += filter_suffix
+
+        return Filter(
+            filter_template,
+            params={
+                "dataset_id": self.dataset_id,
+                "collection_id": collection_id,
+            },
+        )
+
+    @classmethod
+    def get_classroom_collection(cls, collection_id=None, collection=None):
+        """
+        Determines the classroom collection of a collection tree.
+        :param collection_id: The ID of a collection.
+        :param collection: A Collection instance.
+        :return: A Collection instance that represents the classroom collection.
+        :rtype: kolibri.core.auth.models.Collection
+        """
+        if collection is None and collection_id is None:
+            raise ValueError("Either a Collection or collection_id is required.")
+
+        if collection is None:
+            collection = Collection.objects.get(pk=collection_id)
+
+        while collection.kind != collection_kinds.CLASSROOM:
+            if not collection.parent:
+                raise ValueError("No classroom was found for the given collection.")
+            collection = collection.parent
+
+        return collection
+
+
+class ClassroomPartitionFilterFactory(ClassroomPartitionFactory):
+    """
+    A factory class to create partition filters for syncing models related to the classroom
+    partition structure.
+    """
+
+    def __init__(self, dataset_id):
+        super().__init__(dataset_id)
+        self.filter_writeable = False
+
+    def set_writeable(self, writeable=True):
+        """
+        Sets the partition with writeable permission.
+        :return: ClassroomPartitionFilterFactory
+        """
+        self.filter_writeable = writeable
+        return self
+
+    def build(self, collection_id, filter_suffix=None):
+        """
+        Builds the partition filter and returns it as a Filter instance, or None if the user
+        is not associated with this classroom.
+
+        :param collection_id: The classroom's collection ID.
+        :param filter_suffix: An optional filter suffix that overrides the factory's.
+        :return: Filter instance
+        :rtype: Filter
+        """
+        filter_suffix = filter_suffix or self.filter_suffix
+
+        if not filter_suffix and self.filter_writeable:
+            raise ValueError(
+                "A filter suffix must be specified for writeable permission"
+            )
+
+        return super().build(
+            collection_id,
+            filter_suffix=filter_suffix,
+        )
+
+    def build_for_user(self, user_id):
+        """
+        Generates a combined syncing partition filter for a user and all their memberships or roles
+        with classroom collections
+
+        :param user_id: The user ID to constrain the permittable partition filter
+        :return: Filter or None
+        :rtype: Filter|None
+        """
+        collection_groups = {
+            PARTITION_SUFFIX_LEARNER_RW: (
+                Membership.objects.filter(
+                    dataset_id=self.dataset_id,
+                    user_id=user_id,
+                    collection__kind=collection_kinds.CLASSROOM,
+                )
+                .values_list("collection_id", flat=True)
+                .distinct()
+            ),
+            PARTITION_SUFFIX_COACH_RW: (
+                Role.objects.filter(
+                    dataset_id=self.dataset_id,
+                    user_id=user_id,
+                    kind__in=[
+                        role_kinds.COACH,
+                        role_kinds.ADMIN,
+                    ],
+                )
+                .values_list("collection_id", flat=True)
+                .distinct()
+            ),
+        }
+        combo_filter = None
+
+        for suffix, collection_ids in collection_groups.items():
+            for collection_id in collection_ids:
+                collection_filter = self.build(
+                    collection_id,
+                    filter_suffix=suffix if self.filter_writeable else None,
+                )
+                combo_filter = Filter.add(combo_filter, collection_filter)
+
+        return combo_filter

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.13
 jsonfield==3.1.0
-morango==0.8.4
+morango==0.8.6
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Fixes `make docker-whl` for local build of wheel and pex files
- Fixes `make %-with-postgres` (e.g. `make test-with-postgres`)  use of `docker-compose` by updating it to new integrated plugin `docker compose`
- Upgrades morango to 0.8.6
- Adds factory classes for building new partitions and partition filters for new classroom based partitioning strategy, which aligns partitions with user assignment, through `Collection`s, to a classroom
- Adds a new sync operation that dynamically modifies the sync filter to include new partition, if-and-only-if:
  - the device is the server and a full-facility device
  - the client is SoUD
 - Adds a new network sync operation for receiving the result, as the client, of the aforementioned sync operation that modifies the sync filter, to save the new filter from the server's response into its local context and transfer session

## References
<!--
 * references to related issues and PRs
-->
Scope: https://github.com/learningequality/morango/issues/283
Supported by: https://github.com/learningequality/morango/pull/284

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- There should be no regressions to full-facility and SoUD syncing behaviors
- The morango integration tests should pass `INTEGRATION_TEST=1 pytest kolibri/core/auth/test/test_morango_integration.py`
- You should be able to use `make docker-whl` to build assets
- You should be able to use `make test-with-postgres` for running tests on postgres
