### PR TITLE
[Hotfix]: Swap untranslated string for fallback in WelcomeModal

### DIFF
--- a/kolibri/plugins/device/frontend/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/frontend/views/WelcomeModal.vue
@@ -34,14 +34,19 @@
     setup() {
       const { isLearnerOnlyImport, isLearner } = useUser();
       const { facilities } = useFacilities();
-      const { onMyOwnWelcomeMessage$, HomePageWelcomeMessage$ } = kolibriOnboardingGuideStrings;
+      const {
+        // TODO Uncomment references to this message obj in 0.20 it
+        // was untranslated by mistake in 0.19, so we used a fallback
+        //onMyOwnWelcomeMessage$,
+        HomePageWelcomeMessage$,
+      } = kolibriOnboardingGuideStrings;
 
       return {
         isLearnerOnlyImport,
         facilities,
         isLearner,
-        onMyOwnWelcomeMessage$,
         HomePageWelcomeMessage$,
+        //onMyOwnWelcomeMessage$,
       };
     },
     props: {
@@ -70,7 +75,8 @@
           return [this.HomePageWelcomeMessage$({ facilityName: '' })];
         }
         if (this.isOnMyOwnUser) {
-          return [this.onMyOwnWelcomeMessage$()];
+          // TODO In 0.20, this should return an array w/ onMyOwnWelcomeMessage$ instead
+          return [this.$tr('learnOnlyDeviceWelcomeMessage1')];
         }
         if (this.importedFacility) {
           return [


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

During QA it was noted that the welcome modal message for "on my own" users was untranslated. The discussion resulted in deciding to, for now, use a suitable and similar message.

#### Before:

Should be in Spanish :disappointed: 

<img width="515" height="341" alt="image" src="https://github.com/user-attachments/assets/f94dd04b-e51a-4554-8d80-1c7ac6f91593" />

#### After:

In English: *The first thing you should do is import some channels to this device.*

<img width="514" height="347" alt="image" src="https://github.com/user-attachments/assets/bf00ad9d-a832-4c88-a3ee-d12f904d5876" />

#### ALSO

~MAKE AN ISSUE FOR REVERTING THIS AFTER MERGE~ (https://github.com/learningequality/kolibri/issues/14081)

## References
<!--
 * references to related issues and PRs
-->

[Original Slack Thread](https://learningequality.slack.com/archives/CB37UM23A/p1768581578200099?thread_ts=1768523527.520549&cid=CB37UM23A)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Does it work?
- Comments look okay? Anything I might have missed?
