### PR TITLE
Fix: Recover jobs stuck in `SELECTED` state after worker failures

### DIFF
--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -182,3 +182,181 @@ class TestWorker:
 
         # Worker must get this job since its a 'high' priority job.
         assert isinstance(job, Job) is True
+
+
+class TestSelectedStateRecovery:
+    """
+    Tests for the fix to recover jobs stuck in SELECTED state.
+
+    Background: When a worker picks up a job from the queue, the job state
+    transitions from QUEUED -> SELECTED. If execute_job() fails before
+    job.execute() is called (e.g., database connection failure, JobNotFound,
+    or any exception), the job remains in SELECTED state forever.
+
+    The fix ensures that:
+    1. requeue_stalled_jobs() requeues jobs in SELECTED state on startup
+    2. handle_finished_future() handles exceptions from execute_job()
+    """
+
+    def test_requeue_stalled_jobs_recovers_selected_state_jobs(self):
+        """
+        Test that jobs stuck in SELECTED state are requeued on worker startup.
+
+        This simulates the scenario where:
+        1. A job is picked up by a worker (state becomes SELECTED)
+        2. The worker crashes before job.execute() is called
+        3. On restart, the job should be requeued (not orphaned)
+        """
+        with connection() as c:
+            from kolibri.core.tasks.storage import Storage
+
+            storage = Storage(c)
+            storage.clear(force=True)
+
+            # Create and enqueue a job
+            job = Job(id, args=(42,))
+            job_id = storage.enqueue_job(job, QUEUE)
+
+            # Simulate the job being picked up by a worker:
+            # get_next_queued_job() marks the job as SELECTED in the state column
+            selected_job = storage.get_next_queued_job()
+            assert selected_job is not None
+            assert selected_job.job_id == job_id
+
+            # Verify the job is now in SELECTED state by checking jobs with that state
+            # (get_next_queued_job updates state column but not saved_job JSON)
+            selected_jobs = storage.get_jobs_by_state(state=State.SELECTED)
+            assert len(selected_jobs) == 1
+            assert selected_jobs[0].job_id == job_id
+
+            # At this point, if the worker crashed before execute_job() completed,
+            # the job would be stuck in SELECTED state forever (without the fix).
+
+            # Now simulate a server restart by creating a new Worker.
+            # The Worker's __init__ calls requeue_stalled_jobs() which should
+            # requeue both RUNNING and SELECTED jobs.
+            worker = Worker(c, regular_workers=1, high_workers=1)
+
+            try:
+                # The job should now be back in QUEUED state (no jobs in SELECTED)
+                selected_jobs_after = storage.get_jobs_by_state(state=State.SELECTED)
+                assert len(selected_jobs_after) == 0, (
+                    "Expected no jobs in SELECTED state after recovery, "
+                    f"but found {len(selected_jobs_after)}. "
+                    "Jobs in SELECTED state should be requeued on startup."
+                )
+
+                # Verify job is now QUEUED
+                queued_jobs = storage.get_jobs_by_state(state=State.QUEUED)
+                job_ids_queued = [j.job_id for j in queued_jobs]
+                assert job_id in job_ids_queued, (
+                    "Expected job to be requeued after recovery"
+                )
+            finally:
+                storage.clear(force=True)
+                worker.shutdown()
+
+    def test_handle_finished_future_handles_execute_job_exception(self):
+        """
+        Test that exceptions in execute_job (before job.execute()) are handled.
+
+        This simulates the scenario where execute_job() raises an exception
+        before job.execute() is called (e.g., database connection failure,
+        JobNotFound). Without proper handling, the job would remain in
+        SELECTED state forever.
+        """
+        from concurrent.futures import Future
+
+        with connection() as c:
+            worker = Worker(c, regular_workers=1, high_workers=1)
+            worker.storage.clear(force=True)
+
+            try:
+                # Create and enqueue a job
+                job = Job(id, args=(42,))
+                job_id = worker.storage.enqueue_job(job, QUEUE)
+
+                # Get the job (simulating it being selected)
+                selected_job = worker.storage.get_next_queued_job()
+
+                # Verify job is in SELECTED state
+                selected_jobs = worker.storage.get_jobs_by_state(state=State.SELECTED)
+                assert len(selected_jobs) == 1
+
+                # Create a future that simulates execute_job raising an exception
+                # (this happens when execute_job fails before job.execute())
+                future = Future()
+                future.set_exception(RuntimeError("Simulated execute_job failure"))
+
+                # Set up the job-future mappings as the worker would
+                worker.job_future_mapping[future] = selected_job
+                worker.future_job_mapping[job_id] = future
+
+                # Call handle_finished_future - this should handle the exception
+                # and mark the job as failed (not leave it in SELECTED state)
+                worker.handle_finished_future(future)
+
+                # The job should now be marked as FAILED, not stuck in SELECTED
+                failed_jobs = worker.storage.get_jobs_by_state(state=State.FAILED)
+                assert len(failed_jobs) == 1, (
+                    f"Expected 1 job in FAILED state after execute_job exception, "
+                    f"but found {len(failed_jobs)}. "
+                    "Exceptions in execute_job should mark the job as failed."
+                )
+                assert failed_jobs[0].job_id == job_id
+
+                # Verify no jobs stuck in SELECTED
+                selected_jobs_after = worker.storage.get_jobs_by_state(state=State.SELECTED)
+                assert len(selected_jobs_after) == 0
+
+                # Check traceback contains useful info
+                final_job = worker.storage.get_job(job_id)
+                assert "worker execution" in final_job.traceback.lower()
+            finally:
+                worker.storage.clear(force=True)
+                worker.shutdown()
+
+    def test_multiple_selected_jobs_all_recovered(self):
+        """
+        Test that multiple jobs stuck in SELECTED state are all recovered.
+        """
+        with connection() as c:
+            from kolibri.core.tasks.storage import Storage
+
+            storage = Storage(c)
+            storage.clear(force=True)
+
+            # Create and enqueue multiple jobs
+            job_ids = []
+            for i in range(3):
+                job = Job(id, args=(i,))
+                job_id = storage.enqueue_job(job, QUEUE)
+                job_ids.append(job_id)
+                # Simulate each job being picked up (state -> SELECTED)
+                storage.get_next_queued_job()
+
+            # Verify all jobs are in SELECTED state
+            selected_jobs = storage.get_jobs_by_state(state=State.SELECTED)
+            assert len(selected_jobs) == 3
+
+            # Create a new worker (simulating server restart)
+            worker = Worker(c, regular_workers=1, high_workers=1)
+
+            try:
+                # All jobs should be recovered - no jobs in SELECTED state
+                selected_jobs_after = storage.get_jobs_by_state(state=State.SELECTED)
+                assert len(selected_jobs_after) == 0, (
+                    f"Expected no jobs in SELECTED state after recovery, "
+                    f"but found {len(selected_jobs_after)}"
+                )
+
+                # All jobs should now be QUEUED
+                queued_jobs = storage.get_jobs_by_state(state=State.QUEUED)
+                queued_job_ids = [j.job_id for j in queued_jobs]
+                for job_id in job_ids:
+                    assert job_id in queued_job_ids, (
+                        f"Job {job_id} should be QUEUED after recovery"
+                    )
+            finally:
+                storage.clear(force=True)
+                worker.shutdown()

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -4,6 +4,7 @@ from concurrent.futures import CancelledError
 from django.db import connection as django_connection
 
 from kolibri.core.tasks.constants import Priority
+from kolibri.core.tasks.job import State
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.utils import db_connection
 from kolibri.core.tasks.utils import InfiniteLoopThread
@@ -91,6 +92,13 @@ class Worker(object):
         for job in self.storage.get_running_jobs():
             logger.info("Requeuing job id {}.".format(job.job_id))
             self.storage.mark_job_as_queued(job.job_id)
+        # Also requeue jobs stuck in SELECTED state - these are jobs that were
+        # picked up by a worker but crashed/failed before transitioning to RUNNING.
+        # This can happen due to database connection failures, server crashes, or
+        # exceptions in execute_job before job.execute() is called.
+        for job in self.storage.get_jobs_by_state(state=State.SELECTED):
+            logger.info("Requeuing selected job id {}.".format(job.job_id))
+            self.storage.mark_job_as_queued(job.job_id)
 
     def shutdown_workers(self, wait=True):
         # First cancel all running jobs
@@ -120,6 +128,25 @@ class Worker(object):
                 future.result()
             except CancelledError:
                 self.storage.mark_job_as_canceled(job.job_id)
+            except Exception as e:
+                # Handle exceptions that occurred in execute_job before job.execute()
+                # was called (e.g., database connection failures, JobNotFound).
+                # Without this, jobs would remain stuck in SELECTED state forever.
+                logger.error(
+                    "Job {} failed during worker execution: {}".format(job.job_id, e)
+                )
+                try:
+                    self.storage.mark_job_as_failed(
+                        job.job_id, e, "Failed during worker execution: {}".format(e)
+                    )
+                except Exception:
+                    # If we can't mark the job as failed (e.g., database unavailable),
+                    # it will be recovered by requeue_stalled_jobs on next restart.
+                    logger.error(
+                        "Could not update job {} state after failure".format(
+                            job.job_id
+                        )
+                    )
         except KeyError:
             pass
 


### PR DESCRIPTION
## Summary

This PR fixes a critical issue in Kolibri’s background task system where jobs could become **permanently stuck in the `SELECTED` state** if a worker failed or the server restarted before the job began execution.

Previously, these jobs were never retried, never marked as failed, and never recovered — resulting in **silent and permanent task loss** in production environments.

---

## Problem

A job is marked as `SELECTED` when it is picked from the queue, before execution starts.

If a failure occurs **before** `job.execute()` is called (for example due to a database error, process crash, or restart), the job remains in `SELECTED` state indefinitely.

On server restart, recovery logic only handled `RUNNING` jobs, leaving `SELECTED` jobs orphaned forever.

---

## Root Cause

- `SELECTED` is a transient state but was not included in recovery logic
- `execute_job()` had no protection against failures before execution begins
- `handle_finished_future()` only handled `CancelledError`, allowing all other exceptions to silently orphan jobs
- The system incorrectly assumed `SELECTED → RUNNING` was an atomic transition

---

## Fix

This PR makes the task system resilient to worker failures by:

1. **Recovering `SELECTED` jobs on startup**
   - `requeue_stalled_jobs()` now requeues jobs stuck in `SELECTED` state

2. **Handling all worker exceptions**
   - Any exception raised during job setup or execution is now caught
   - Jobs are marked as `FAILED`, or requeued if the database is unavailable

3. **Preserving existing behavior**
   - No state changes, schema changes, or architectural modifications
   - Only closes failure gaps that caused permanent job loss

---

## How to Reproduce (Before Fix)

### Scenario 1: Server crash after job selection

1. Start Kolibri
2. Queue a background task (e.g. content import)
3. Kill the server immediately after the job is selected
4. Restart Kolibri
5. Job remains stuck in `SELECTED` state forever

### Scenario 2: Database failure during job startup

1. Queue a task
2. Lock or corrupt the jobs database during worker startup
3. Worker fails before `job.execute()` is called
4. Job is never retried or failed

---

## Behavior After Fix

- Jobs stuck in `SELECTED` are safely requeued on restart
- Worker exceptions properly mark jobs as `FAILED`
- Retryable jobs are retried as expected
- Failed jobs are visible in the task manager UI
- No silent task loss

---

## Why This Matters

Kolibri is commonly deployed on low-resource and unreliable hardware (e.g. Raspberry Pi, school servers) where power loss and restarts are frequent.

This fix ensures the background task system is **crash-safe, observable, and resilient** under real-world conditions.

---

## Risk

- **Low**
- Minimal code change
- No schema or API changes
- Fully backward compatible
