### PR TITLE
Clean up localeCompare usage for proper internationalization (fixes #3888)

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
@@ -54,7 +54,7 @@
 <script>
 
   import { mapState } from 'vuex';
-  import { formatList } from 'kolibri/utils/i18n';
+  import { formatList, localeCompare } from 'kolibri/utils/i18n';
   import PaginatedListContainer from 'kolibri-common/components/PaginatedListContainer';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
@@ -139,7 +139,7 @@
       },
       sortedAllLearners() {
         const allLearners = [...this.allLearners];
-        return allLearners.sort((a, b) => a.name.localeCompare(b.name));
+        return allLearners.sort((a, b) => localeCompare(a.name, b.name));
       },
       currentGroupMap() {
         return this.groupMapFromOtherClass || this.groupMap;

--- a/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
@@ -70,6 +70,7 @@
   import { computed } from 'vue';
   import uniq from 'lodash/uniq';
   import store from 'kolibri/store';
+  import { localeCompare } from 'kolibri/utils/i18n';
 
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { coachStrings } from '../commonCoachStrings';
@@ -132,7 +133,7 @@
 
       const sortedGroups = computed(() => {
         const groupsList = [...groups.value];
-        return groupsList.sort((a, b) => a.name.localeCompare(b.name));
+        return groupsList.sort((a, b) => localeCompare(a.name, b.name));
       });
 
       const ungroupedLearnersIds = computed(() => {

--- a/kolibri/plugins/facility/frontend/composables/useUsersFilters.js
+++ b/kolibri/plugins/facility/frontend/composables/useUsersFilters.js
@@ -3,6 +3,7 @@ import { useRoute, useRouter } from 'vue-router/composables';
 
 import { UserKinds } from 'kolibri/constants';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { localeCompare } from 'kolibri/utils/i18n';
 import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
 import { DateRangeFilters } from '../constants';
@@ -71,7 +72,7 @@ export default function useUsersFilters({ classes }) {
         id: cls.id,
         label: cls.name,
       }))
-      .sort((a, b) => a.label.localeCompare(b.label)),
+      .sort((a, b) => localeCompare(a.label, b.label)),
   );
 
   const creationDateOptions = [

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -118,6 +118,7 @@
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import { localeCompare } from 'kolibri/utils/i18n';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import flatMap from 'lodash/flatMap';
   import CloseConfirmationGuard from '../common/CloseConfirmationGuard.vue';
@@ -187,7 +188,7 @@
       // Computed properties
       const formattedClasses = computed(() => {
         return [...props.classes]
-          .sort((a, b) => a.name.localeCompare(b.name))
+          .sort((a, b) => localeCompare(a.name, b.name))
           .map(({ id, name }) => ({ id, label: name }));
       });
 

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -109,6 +109,7 @@
   import { UserKinds } from 'kolibri/constants';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import { localeCompare } from 'kolibri/utils/i18n';
   import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
@@ -189,7 +190,7 @@
             label: classObj.name,
             id: classObj.id,
           }))
-          .sort((a, b) => a.label.localeCompare(b.label)),
+          .sort((a, b) => localeCompare(a.label, b.label)),
       );
 
       const numCoachesSelected = computed(() => {

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -99,6 +99,7 @@
   import { useRoute } from 'vue-router/composables';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings, { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import { localeCompare } from 'kolibri/utils/i18n';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import MembershipResource from 'kolibri-common/apiResources/MembershipResource';
   import RoleResource from 'kolibri-common/apiResources/RoleResource';
@@ -182,7 +183,7 @@
             label: classObj.name,
             id: classObj.id,
           }))
-          .sort((a, b) => a.label.localeCompare(b.label));
+          .sort((a, b) => localeCompare(a.label, b.label));
       });
 
       const hasRemovedLearners = computed(() => {

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/ClassesSelect.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/ClassesSelect.vue
@@ -24,6 +24,7 @@
 
   import { computed, toRefs } from 'vue';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+  import { localeCompare } from 'kolibri/utils/i18n';
 
   import { ClassesActions } from '../../../../constants';
 
@@ -54,7 +55,7 @@
           value: classItem.id,
         }));
 
-        classesOptions.sort((a, b) => a.label.localeCompare(b.label));
+        classesOptions.sort((a, b) => localeCompare(a.label, b.label));
         classesOptions.unshift(allClassesOption.value);
         return classesOptions;
       });

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/SelectFacility.vue
@@ -86,6 +86,7 @@
   import useDevices from 'kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/useDevices';
   import useDeviceDeletion from 'kolibri-common/components/syncComponentSet/SelectDeviceModalGroup/useDeviceDeletion';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import { localeCompare } from 'kolibri/utils/i18n';
   import commonProfileStrings from '../commonProfileStrings';
 
   export default {
@@ -170,16 +171,10 @@
               }
             }
           }
-          // Sort alphabetically for predictable ordering
-          return Object.values(facilities).sort((facilityA, facilityB) => {
-            if (facilityA.name < facilityB.name) {
-              return -1;
-            }
-            if (facilityA.name > facilityB.name) {
-              return 1;
-            }
-            return 0;
-          });
+          // Sort alphabetically for predictable ordering using locale-aware comparison
+          return Object.values(facilities).sort((facilityA, facilityB) =>
+            localeCompare(facilityA.name, facilityB.name),
+          );
         },
         [],
         { evaluating: isLoading, shallow: false },

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -509,7 +509,13 @@
         }
         // Still no difference?
         // Sort by the URL to ensure consistent ordering
-        return navItemA.url.localeCompare(navItemB.url);
+        if (navItemA.url < navItemB.url) {
+          return -1;
+        }
+        if (navItemA.url > navItemB.url) {
+          return 1;
+        }
+        return 0;
       },
       filterByFullFacilityOnly(item) {
         return !this.isLearnerOnlyImport || !item.fullFacilityOnly;

--- a/packages/kolibri/utils/i18n.js
+++ b/packages/kolibri/utils/i18n.js
@@ -265,11 +265,34 @@ export async function i18nSetup(skipPolyfill = false) {
   }
 }
 
-export function localeCompare(str1, str2) {
-  // Catch if browser does not support extended localeCompare arguments
+/**
+ * Locale-aware string comparison wrapper for proper internationalization.
+ *
+ * This wrapper exists primarily for iOS 9.3 compatibility, which does not
+ * fully support the locale and options parameters of String.prototype.localeCompare.
+ * All other supported browsers (Chrome 49+, Firefox 52+, Safari 11.1+, etc.)
+ * have full support.
+ *
+ * @param {string} str1 - First string to compare
+ * @param {string} str2 - Second string to compare
+ * @param {string} [locale] - BCP 47 locale code (defaults to currentLanguage)
+ * @param {object} [options] - Comparison options
+ * @param {string} [options.usage='sort'] - 'sort' for sorting, 'search' for case-insensitive search
+ * @param {string} [options.sensitivity] - 'base', 'accent', 'case', or 'variant'
+ * @param {boolean} [options.ignorePunctuation] - Whether to ignore punctuation
+ * @param {string} [options.numeric] - Whether numeric collation should be used
+ * @param {string} [options.caseFirst] - Whether upper or lower case should sort first
+ * @returns {number} -1 if str1 < str2, 0 if equal, 1 if str1 > str2
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
+ */
+export function localeCompare(str1, str2, locale, options) {
+  const compareLocale = locale || currentLanguage;
+  const compareOptions = { usage: 'sort', ...options };
+
+  // Catch if browser does not support extended localeCompare arguments (iOS 9.3)
   try {
-    // use 'search' option to ignore case rather than use locale defaults
-    return String(str1).localeCompare(String(str2), 'default', { usage: 'search' });
+    return String(str1).localeCompare(String(str2), compareLocale, compareOptions);
   } catch (e) {
     return String(str1).localeCompare(String(str2));
   }
@@ -313,12 +336,14 @@ export function sortLanguages(availableLanguages, currentLanguageId) {
   return sortedLanguages;
 }
 
+/**
+ * Compares two language objects by their lang_name property using locale-aware comparison.
+ * Used for sorting language lists in the language switcher.
+ *
+ * @param {object} a - First language object with lang_name property
+ * @param {object} b - Second language object with lang_name property
+ * @returns {number} -1 if a < b, 0 if equal, 1 if a > b
+ */
 export function compareLanguages(a, b) {
-  if (a.lang_name.toLowerCase() < b.lang_name.toLowerCase()) {
-    return -1;
-  }
-  if (b.lang_name.toLowerCase() < a.lang_name.toLowerCase()) {
-    return 1;
-  }
-  return 0;
+  return localeCompare(a.lang_name, b.lang_name);
 }


### PR DESCRIPTION
## Summary

Standardizes usage of the `localeCompare` wrapper from `i18n.js` across all sorting operations to ensure proper locale-aware string comparison.

Changes:
- Enhanced the `localeCompare` wrapper in i18n.js to default to `currentLanguage` and `usage: 'sort'`
- Updated 9 files to use the wrapper instead of direct `.localeCompare()` calls
- Fixed `compareLanguages()` to use proper locale-aware comparison
- SideNav URL sorting uses simple string comparison (URLs are technical identifiers)

**Screenshots showing sorted lists work correctly:**

| Classes | Users |
|---------|-------|
| ![Classes](https://i.imgur.com/oyHK6Rc.png) | ![Users](https://i.imgur.com/mnMhY7u.png) |

## References

Fixes #3888

## Reviewer guidance

The changes are mechanical - replacing direct `.localeCompare()` calls with the centralized wrapper. No risky areas (no auth, migrations, or API changes).

To verify: sorting of user/class lists should work correctly for names with accented characters and non-Latin scripts.