### PR TITLE
Replace CSS Variables in favor of theme variable for css styling

### DIFF
--- a/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
@@ -58,9 +58,6 @@
       entry() {
         return (this.options && this.options.entry) || 'index.html';
       },
-      scrollBasedProgress() {
-        return 0.5;
-      },
     },
     async created() {
       const storageUrl = this.defaultFile.storage_url;

--- a/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <div
-    data-testid="safe-html-renderer-container"
-    :style="cssVars"
-  >
+  <div data-testid="safe-html-renderer-container">
     <KCircularLoader
       v-if="loading || !html"
       :delay="false"
@@ -17,7 +14,10 @@
       role="region"
       :aria-label="$tr('articleContent')"
     >
-      <SafeHTML :html="html" />
+      <SafeHTML
+        :html="html"
+        :themeColors="themeColors"
+      />
     </div>
   </div>
 
@@ -61,13 +61,16 @@
       entry() {
         return (this.options && this.options.entry) || 'index.html';
       },
-      cssVars() {
+      scrollBasedProgress() {
+        return 0.5;
+      },
+      themeColors() {
         return {
-          '--color-primary-500': this.$themeBrand.primary.v_500,
-          '--color-primary-100': this.$themeBrand.primary.v_100,
-          '--color-grey-300': this.$themePalette.grey.v_300,
-          '--color-grey-100': this.$themePalette.grey.v_100,
-          '--color-fineline': this.$themeTokens.fineLine,
+          primary500: this.$themeBrand.primary.v_500,
+          primary100: this.$themeBrand.primary.v_100,
+          grey300: this.$themePalette.grey.v_300,
+          grey100: this.$themePalette.grey.v_100,
+          fineLine: this.$themeTokens.fineLine,
         };
       },
     },

--- a/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
@@ -14,10 +14,7 @@
       role="region"
       :aria-label="$tr('articleContent')"
     >
-      <SafeHTML
-        :html="html"
-        :themeColors="themeColors"
-      />
+      <SafeHTML :html="html" />
     </div>
   </div>
 
@@ -63,15 +60,6 @@
       },
       scrollBasedProgress() {
         return 0.5;
-      },
-      themeColors() {
-        return {
-          primary500: this.$themeBrand.primary.v_500,
-          primary100: this.$themeBrand.primary.v_100,
-          grey300: this.$themePalette.grey.v_300,
-          grey100: this.$themePalette.grey.v_100,
-          fineLine: this.$themeTokens.fineLine,
-        };
       },
     },
     async created() {

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -51,10 +51,6 @@
         type: Object,
         default: () => ({}),
       },
-      themeColors: {
-        type: Object,
-        default: () => ({}),
-      },
     },
     data() {
       return {
@@ -64,7 +60,7 @@
     computed: {
       imageStyle() {
         return {
-          border: `1px solid ${this.themeColors.fineLine}`,
+          border: `1px solid ${this.$themeTokens.fineLine}`,
         };
       },
     },

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -8,6 +8,7 @@
       <img
         :src="src"
         :alt="alt"
+        :style="imageStyle"
         v-bind="$attrs"
         @click="openLightbox"
       >
@@ -50,11 +51,22 @@
         type: Object,
         default: () => ({}),
       },
+      themeColors: {
+        type: Object,
+        default: () => ({}),
+      },
     },
     data() {
       return {
         lightboxOpen: false,
       };
+    },
+    computed: {
+      imageStyle() {
+        return {
+          border: `1px solid ${this.themeColors.fineLine}`,
+        };
+      },
     },
     methods: {
       openLightbox() {

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
@@ -26,6 +26,10 @@
         required: true,
         validator: node => node && typeof node.querySelector === 'function',
       },
+      themeColors: {
+        type: Object,
+        default: () => ({}),
+      },
     },
 
     computed: {
@@ -33,11 +37,54 @@
         const firstRow = this.node.querySelector('tr');
         const colCount = firstRow ? firstRow.children.length : 0;
 
+        const styles = {
+          border: `1px solid ${this.themeColors.grey300}`,
+        };
+
         if (colCount <= 3) {
-          return { width: '640px' };
+          styles.width = '640px';
+        } else {
+          styles.width = `${colCount * 200}px`;
         }
 
-        return { width: `${colCount * 200}px` };
+        return styles;
+      },
+    },
+
+    mounted() {
+      this.applyThemeColors();
+    },
+
+    updated() {
+      this.applyThemeColors();
+    },
+
+    methods: {
+      applyThemeColors() {
+        if (!this.$el) return;
+
+        const table = this.$el.querySelector('table');
+        if (!table) return;
+
+        const captions = table.querySelectorAll('caption.safe-html');
+        captions.forEach(caption => {
+          caption.style.color = this.themeColors.primary500;
+        });
+
+        const theads = table.querySelectorAll('thead.safe-html');
+        theads.forEach(thead => {
+          thead.style.backgroundColor = this.themeColors.primary100;
+        });
+
+        const tfoots = table.querySelectorAll('tfoot.safe-html');
+        tfoots.forEach(tfoot => {
+          tfoot.style.backgroundColor = this.themeColors.grey100;
+        });
+
+        const cells = table.querySelectorAll('th.safe-html, td.safe-html');
+        cells.forEach(cell => {
+          cell.style.border = `1px solid ${this.themeColors.grey300}`;
+        });
       },
     },
   };

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
@@ -26,10 +26,6 @@
         required: true,
         validator: node => node && typeof node.querySelector === 'function',
       },
-      themeColors: {
-        type: Object,
-        default: () => ({}),
-      },
     },
 
     computed: {
@@ -38,7 +34,7 @@
         const colCount = firstRow ? firstRow.children.length : 0;
 
         const styles = {
-          border: `1px solid ${this.themeColors.grey300}`,
+          border: `1px solid ${this.$themePalette.grey.v_300}`,
         };
 
         if (colCount <= 3) {
@@ -68,22 +64,22 @@
 
         const captions = table.querySelectorAll('caption.safe-html');
         captions.forEach(caption => {
-          caption.style.color = this.themeColors.primary500;
+          caption.style.color = this.$themeBrand.primary.v_500;
         });
 
         const theads = table.querySelectorAll('thead.safe-html');
         theads.forEach(thead => {
-          thead.style.backgroundColor = this.themeColors.primary100;
+          thead.style.backgroundColor = this.$themeBrand.primary.v_100;
         });
 
         const tfoots = table.querySelectorAll('tfoot.safe-html');
         tfoots.forEach(tfoot => {
-          tfoot.style.backgroundColor = this.themeColors.grey100;
+          tfoot.style.backgroundColor = this.$themePalette.grey.v_100;
         });
 
         const cells = table.querySelectorAll('th.safe-html, td.safe-html');
         cells.forEach(cell => {
-          cell.style.border = `1px solid ${this.themeColors.grey300}`;
+          cell.style.border = `1px solid ${this.$themePalette.grey.v_300}`;
         });
       },
     },

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -24,10 +24,6 @@ export function createSafeHTML(customComponents = {}) {
       html: {
         required: true,
       },
-      themeColors: {
-        type: Object,
-        default: () => ({}),
-      },
     },
     render(h, context) {
       const docFragment = DOMPurify.sanitize(context.props.html, {
@@ -83,10 +79,7 @@ export function createSafeHTML(customComponents = {}) {
             return h(
               SafeHtmlTable,
               {
-                props: {
-                  node,
-                  themeColors: context.props.themeColors,
-                },
+                props: { node },
                 attrs,
               },
               mapChildren(node.childNodes),
@@ -99,7 +92,6 @@ export function createSafeHTML(customComponents = {}) {
               props: {
                 src: attrs.src,
                 alt: attrs.alt,
-                themeColors: context.props.themeColors,
               },
             });
           }

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -24,6 +24,10 @@ export function createSafeHTML(customComponents = {}) {
       html: {
         required: true,
       },
+      themeColors: {
+        type: Object,
+        default: () => ({}),
+      },
     },
     render(h, context) {
       const docFragment = DOMPurify.sanitize(context.props.html, {
@@ -79,7 +83,10 @@ export function createSafeHTML(customComponents = {}) {
             return h(
               SafeHtmlTable,
               {
-                props: { node },
+                props: {
+                  node,
+                  themeColors: context.props.themeColors,
+                },
                 attrs,
               },
               mapChildren(node.childNodes),
@@ -92,6 +99,7 @@ export function createSafeHTML(customComponents = {}) {
               props: {
                 src: attrs.src,
                 alt: attrs.alt,
+                themeColors: context.props.themeColors,
               },
             });
           }

--- a/packages/kolibri-common/components/SafeHTML/style.scss
+++ b/packages/kolibri-common/components/SafeHTML/style.scss
@@ -105,13 +105,11 @@ table.safe-html {
   font-size: 16px;
   table-layout: fixed;
   border-collapse: collapse;
-  border: 1px solid var(--color-grey-300);
 }
 
 caption.safe-html {
   margin: 0 auto 12px;
   font-weight: 600;
-  color: var(--color-primary-500);
 }
 
 caption.safe-html.small-window {
@@ -120,11 +118,6 @@ caption.safe-html.small-window {
 
 thead.safe-html {
   font-weight: 600;
-  background-color: var(--color-primary-100);
-}
-
-tfoot.safe-html {
-  background-color: var(--color-grey-100);
 }
 
 th.safe-html {
@@ -136,7 +129,6 @@ th.safe-html,
 td.safe-html {
   min-width: 200px;
   padding: 16px;
-  border: 1px solid var(--color-grey-300);
 }
 
 .image-container {
@@ -166,7 +158,6 @@ img.safe-html {
   max-width: 100%;
   max-height: 80vh;
   margin: 0 auto;
-  border: 1px solid var(--color-fineline);
 }
 
 .expand-btn {


### PR DESCRIPTION

## Summary

This PR refactors the SafeHTML rendering to compute and apply theme colors styles instead of using CSS variables (var()).
closes [#13851](https://github.com/learningequality/kolibri/issues/13851)

## References

[#13851](https://github.com/learningequality/kolibri/issues/13851)

## Reviewer guidance

- Verify table rendering with proper theme colors (borders, caption, thead/tfoot backgrounds)
- Verify image rendering with proper border color
- Test in browsers with limited CSS variable support
- Confirm no visual regressions