### PR TITLE
Add documentation indicating that APIs are internal

### DIFF
--- a/docs/backend_architecture/index.rst
+++ b/docs/backend_architecture/index.rst
@@ -1,6 +1,21 @@
 Backend architecture
 ====================
 
+.. warning::
+   **API Stability Notice**
+
+   Kolibri has two types of API endpoints:
+
+   **Internal APIs** (most endpoints): These are designed for Kolibri's own frontend and
+   may change without notice between releases. **Do not build external applications** that
+   depend on these APIs. Breaking changes can and will occur as Kolibri evolves.
+
+   **Public APIs** (``/public/`` endpoints only): These endpoints under the ``/public/`` URL
+   namespace are maintained with backwards compatibility for use by other Kolibri instances
+   and authorized integrations. See the public API documentation for details.
+
+   When in doubt, assume an endpoint is internal unless explicitly documented as public.
+
 .. toctree::
   :maxdepth: 1
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,6 +5,9 @@ Getting started
 
 First of all, thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference. The instructions below should get you up and running the code in no time!
 
+.. note::
+  **Planning to integrate with Kolibri?** Most APIs are internal and unstable, designed for Kolibri's own use. Only ``/public/`` endpoints are maintained with backwards compatibility. See the :doc:`backend_architecture/index` for details on API stability.
+
 Prerequisites
 -------------
 

--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -1,3 +1,14 @@
+"""
+Kolibri API base classes and utilities.
+
+IMPORTANT: Most Kolibri APIs are internal and unstable, designed for Kolibri's own use.
+They may change without notice. Do not build external applications that depend on these APIs.
+
+EXCEPTION: Public APIs under /public/ URLs are maintained with backwards compatibility.
+See kolibri/core/public/api_urls.py for the public API definitions.
+
+For more information, see: docs/backend_architecture/index.rst
+"""
 import uuid
 
 from django.http import Http404

--- a/kolibri/core/api_urls.py
+++ b/kolibri/core/api_urls.py
@@ -1,3 +1,14 @@
+"""
+Kolibri Core API URL Configuration.
+
+WARNING: These APIs are internal and designed for Kolibri's own frontend.
+They may change without notice between releases. Do not build external
+applications that depend on these endpoints.
+
+For stable APIs, use only the /public/ endpoints defined in
+kolibri.core.public.api_urls - these are maintained with backwards
+compatibility for external integrations.
+"""
 from django.urls import include
 from django.urls import re_path
 

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -6,6 +6,9 @@ This module defines the "public API" endpoints that we expect to be called exter
 instances of Kolibri, or by 3rd party applications or clients. For this reason, these endpoints
 need to be maintained with backwards compatibility to ensure ongoing support for older clients.
 
+NOTE: These are the ONLY stable API endpoints in Kolibri. All other API endpoints outside
+the /public/ namespace are internal and subject to change without notice.
+
 If breaking changes need to be introduced to an endpoint, a new endpoint should be created
 instead, at a different URL (e.g. with version number v2 instead of v1), leaving the original
 endpoint in place and maintained to the best extent possible so older clients can still use it.

--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -20,7 +20,11 @@ def webpack_redirect_view(request):
 api_info = openapi.Info(
     title="Kolibri API",
     default_version="v0",
-    description="Kolibri Swagger API",
+    description=(
+        "**Warning: Internal API - Do not use for external integrations.**\n\n"
+        "These APIs are designed for Kolibri's own frontend and may change "
+        "without notice. For stable APIs, use only `/api/public/` endpoints."
+    ),
     license=openapi.License(name="MIT"),
 )
 


### PR DESCRIPTION
## Summary

Addresses issue #3306 by adding clear notices that most Kolibri APIs are internal and unstable, with the exception of `/public/` endpoints which are maintained with backwards compatibility.

Changes:
- Add API stability warning to backend architecture documentation
- Add module docstring to `kolibri/core/api.py` (base utilities module)
- Add module docstring to `kolibri/core/api_urls.py` (central routing file)
- Enhance public API documentation to emphasize stability distinction
- Add integration notice to getting started guide
- Update API explorer (Swagger) description with stability warning

Screenshot of API explorer showing the warning:

![API Explorer Warning](https://i.imgur.com/aSnLyf1.png)

## References

Fixes #3306

## Reviewer guidance

- Documentation-only changes with no runtime behavior modifications
- To verify the API explorer change, run in dev mode and visit `/api_explorer/`
- All changes are additive docstrings/comments - no risk to existing functionality