### PR TITLE
Add ESLint rule to prevent RTL-breaking inline styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,8 +136,11 @@ pytest kolibri/path/to/test/                          # Python (directory)
 pytest kolibri/core/auth/test/ -k test_login          # Python (filter by name)
 pnpm run test-jest -- path/to/file.spec.js            # Frontend (single file)
 pnpm run test-jest -- --testPathPattern learn          # Frontend (filter by pattern)
-pre-commit run --all-files                            # Lint
+pre-commit run --all-files                            # Lint (all files)
+pre-commit run --files path/to/File.vue               # Lint (specific file)
 ```
+
+Always use `pre-commit` as the single entry point for linting — do not invoke ESLint or other linters directly.
 
 ## Docs Reference
 

--- a/docs/frontend_architecture/conventions.rst
+++ b/docs/frontend_architecture/conventions.rst
@@ -45,4 +45,34 @@ Styling anti-patterns
 - **Complex pre-processor functionality** - use Vue `computed styles <https://vuejs.org/v2/guide/class-and-style.html>`__ instead
 - **Hard-coded values** - rely on variables defined in the core theme
 - **Left or right alignment on user-generated text** - use ``dir="auto"`` instead for RTL support
-- **Inline directional styles** - put non-dynamic styles in ``<style>`` blocks so that `RTLCSS <https://rtlcss.com/>`__ can automatically flip them for RTL languages. If a directional style must be inline because it is dynamic, it must respond to the ``isRtl`` property. See :doc:`/i18n` for full RTL guidance
+- **Directional inline styles** - avoid using ``style=""`` or ``:style=""`` with properties like ``margin-left``, ``padding-right``, ``text-align: right``, etc. Use CSS classes instead to ensure RTLCSS can flip them for RTL languages. When inline styles are unavoidable, use CSS Logical Properties (``margin-inline-start``, ``padding-inline-end``, etc.). See :doc:`/i18n` for details.
+
+
+RTL-friendly styling quick reference
+------------------------------------
+
+Kolibri supports right-to-left (RTL) languages like Arabic and Hebrew. Follow these guidelines to ensure your styles work in both directions:
+
+**Do:**
+
+✓ Use CSS classes in ``<style>`` blocks for directional properties
+
+✓ Use CSS Logical Properties when available (``margin-inline-start`` instead of ``margin-left``)
+
+✓ Use ``KGrid`` for layouts instead of floats or flexbox
+
+✓ Use the ``isRtl`` property for conditional logic when needed
+
+✓ Test your changes in an RTL language (switch to Arabic in settings)
+
+**Don't:**
+
+✗ Use inline styles with directional properties (``style="margin-left: 8px"``)
+
+✗ Use physical direction properties in inline bindings (``:style="{ marginLeft: '8px' }"``)
+
+✗ Use ``float: left/right`` for layout (use ``KGrid``)
+
+✗ Hard-code text alignment without considering RTL
+
+For comprehensive RTL guidance, see :doc:`/i18n`.

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -160,6 +160,8 @@ Kolibri has full support for right-to-left languages, and all functionality shou
 
 There are a number of important considerations to take into account with RTL content. `Material Design has an excellent article <https://material.io/design/usability/bidirectionality.html>`_ that covers most important topics at a high level.
 
+.. _rtl-warning:
+
 .. warning::
 
   Right-to-left support is broken when running the development server with hot reloading enabled (``pnpm run devserver-hot``)
@@ -176,6 +178,102 @@ A rule of thumb for inline bidirectional text:
 
 * if user-generated text is on its own in a block-level DOM element, it should be aligned based on the text's language using ``dir="auto"`` on the block-level element.
 * if user-generated text is displayed inline with application text (such as "App Label: user text"), it should be aligned using CSS ``text-align`` on the block-level element, and ``dir="auto"`` on a ``span`` wrapping the inline user text.
+
+
+Inline styles and RTL compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Important:** Avoid using inline styles with directional CSS properties, as they cannot be automatically flipped by the RTLCSS framework and will break RTL language support.
+
+The ``kolibri/vue-no-rtl-breaking-inline-styles`` ESLint rule will flag the following patterns:
+
+**Anti-patterns (will break RTL):**
+
+.. code-block:: html
+
+  <!-- Static inline styles -->
+  <div style="margin-left: 8px">...</div>
+  <div style="text-align: right">...</div>
+  <div style="float: left">...</div>
+
+  <!-- Dynamic inline styles -->
+  <div :style="{ marginLeft: '8px' }">...</div>
+  <div :style="{ paddingRight: '16px' }">...</div>
+  <div :style="{ textAlign: 'right' }">...</div>
+
+**RTL-friendly alternatives:**
+
+1. **Use CSS classes (recommended)** - The RTLCSS webpack plugin will automatically flip directional properties in CSS files:
+
+.. code-block:: html
+
+  <!-- In template -->
+  <div class="small-left-margin">...</div>
+
+.. code-block:: scss
+
+  /* In scoped <style> section */
+  .small-left-margin {
+    margin-left: 8px;  // Automatically becomes margin-right: 8px in RTL builds
+  }
+
+2. **Use CSS Logical Properties** - Modern CSS properties that are inherently direction-agnostic:
+
+.. code-block:: scss
+
+  .container {
+    margin-inline-start: 8px;  // Left in LTR, right in RTL
+    margin-inline-end: 16px;   // Right in LTR, left in RTL
+    text-align: start;         // Left in LTR, right in RTL
+  }
+
+3. **Use conditional RTL-aware computed styles** - For truly dynamic values:
+
+.. code-block:: javascript
+
+  computed: {
+    iconStyle() {
+      return {
+        [this.isRtl ? 'marginRight' : 'marginLeft']: '8px'
+      };
+    }
+  }
+
+.. code-block:: html
+
+  <KIcon :style="iconStyle" />
+
+4. **Use non-directional inline styles** - Properties like ``color``, ``opacity``, ``maxWidth``, etc. are safe in inline styles since they are not direction-dependent:
+
+.. code-block:: html
+
+  <div :style="{ maxWidth: calculatedWidth + 'px' }">...</div>
+
+**Directional properties to avoid in inline styles:**
+
+* ``margin-left``, ``margin-right`` (use ``margin-inline-start/end`` or CSS classes)
+* ``padding-left``, ``padding-right`` (use ``padding-inline-start/end`` or CSS classes)
+* ``left``, ``right`` positioning (use ``inset-inline-start/end`` or CSS classes)
+* ``text-align: left/right`` (use ``text-align: start/end`` or CSS classes)
+* ``float: left/right`` (use ``KGrid`` for layout instead)
+* ``border-left``, ``border-right`` (use ``border-inline-start/end`` or CSS classes)
+
+.. note::
+  This restriction only applies to **inline** styles (``style=""`` or ``:style=""``) in templates. The rule does not inspect computed or method-returned style objects in the ``<script>`` section — developers should manually review those for directional properties.
+
+.. note::
+  The linting rule recognises RTL-aware ternary patterns like ``:style="{ [isRtl ? 'marginRight' : 'marginLeft']: '8px' }"`` in templates and will not flag them. However, for cleaner templates, consider using a computed property instead.
+
+**Disabling the rule (rare cases):**
+
+In the rare case where you have a legitimate reason to use inline directional styles, you can disable the linting rule:
+
+.. code-block:: html
+
+  <!-- eslint-disable-next-line kolibri/vue-no-rtl-breaking-inline-styles -->
+  <div :style="{ marginLeft: specialCalculation() }">...</div>
+
+However, this should be avoided whenever possible. Consider whether your use case can be solved with one of the alternatives above.
 
 
 Behavior
@@ -243,6 +341,40 @@ In situations where we are using third-party libraries it might be necessary to 
       });
     },
   };
+
+
+RTL testing checklist
+~~~~~~~~~~~~~~~~~~~~~
+
+When developing or reviewing features, use this checklist to ensure RTL compatibility:
+
+**Pre-commit:**
+
+1. Run ``pnpm run lint-frontend`` and fix any ``kolibri/vue-no-rtl-breaking-inline-styles`` errors
+2. Review your code for directional assumptions (left/right, previous/next navigation)
+3. Ensure layout components use ``KGrid`` instead of floats or manual flexbox
+
+**Manual testing:**
+
+1. Change your Kolibri language to Arabic (العربية) or another RTL language in Settings
+2. Navigate through your feature and verify:
+
+   * All text aligns correctly (interface text to the right, proper margins/padding)
+   * Icons that should flip are flipped (forward/back arrows, directional indicators)
+   * Icons that shouldn't flip are not flipped (time indicators, play buttons)
+   * Layout flows right-to-left (navigation, cards, lists)
+   * User-generated content uses ``dir="auto"`` and displays correctly
+   * No visual overlap or clipping occurs
+   * Scrolling behavior works correctly (horizontal scroll directions)
+
+3. Test mixed content scenarios:
+
+   * RTL interface with LTR content (e.g., English content in Arabic interface)
+   * LTR interface with RTL content (e.g., Arabic content in English interface)
+   * Mixed inline content (app labels with user text)
+
+.. note::
+  See the :ref:`RTL hot-reload warning <rtl-warning>` above regarding development server limitations.
 
 
 .. _crowdin:

--- a/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
@@ -7,10 +7,7 @@
           <KCheckbox
             v-if="isSelectable"
             ref="selectAllCheckbox"
-            class="select-all-box"
-            :style="{
-              marginLeft: isSortable ? '1.5em' : '0',
-            }"
+            :class="['select-all-box', { 'select-all-box-sortable': isSortable }]"
             :label="selectAllLabel$()"
             :disabled="selectAllIsDisabled"
             :checked="selectAllIsChecked"
@@ -377,6 +374,10 @@
     .select-all-box {
       margin-top: 0;
       margin-bottom: 0;
+
+      &.select-all-box-sortable {
+        margin-left: 1.5em;
+      }
 
       // Vertical centering here into the KCheckbox
       /deep/ & label {

--- a/kolibri/plugins/coach/frontend/views/common/resourceSelection/LessonContentCard/BookmarkIcon.vue
+++ b/kolibri/plugins/coach/frontend/views/common/resourceSelection/LessonContentCard/BookmarkIcon.vue
@@ -2,7 +2,7 @@
 
   <KIcon
     icon="bookmark"
-    style="top: 50px; left: 75px; width: 34px; height: 34px"
+    class="bookmark-icon"
   />
 
 </template>
@@ -17,4 +17,13 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .bookmark-icon {
+    top: 50px;
+    left: 75px;
+    width: 34px;
+    height: 34px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/common/status/StatusTestPage.vue
+++ b/kolibri/plugins/coach/frontend/views/common/status/StatusTestPage.vue
@@ -36,7 +36,8 @@
         <tr>
           <th
             rowspan="2"
-            :style="[{ maxWidth: '100px', textAlign: 'left' }, thinBorderStyle]"
+            class="scenario-header"
+            :style="thinBorderStyle"
           >
             {{ tally.name }}
           </th>
@@ -292,6 +293,11 @@
     width: 150px;
     height: 16px;
     margin: auto;
+  }
+
+  .scenario-header {
+    max-width: 100px;
+    text-align: left;
   }
 
   td,

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
@@ -7,14 +7,10 @@
     <template #default>
       <SearchBox
         maxWidth="unset"
+        class="search-box"
         :disabled="isLoading"
         :value="searchKeywords"
         :placeholder="searchByKeyword$()"
-        :style="{
-          marginBottom: '12px',
-          marginRight: '0',
-          marginTop: '8px',
-        }"
         @change="searchKeywords = $event"
       />
       <KCircularLoader
@@ -139,6 +135,12 @@
 
 
 <style lang="scss" scoped>
+
+  .search-box {
+    margin-top: 8px;
+    margin-right: 0;
+    margin-bottom: 12px;
+  }
 
   .bottom-actions {
     display: flex;

--- a/kolibri/plugins/coach/frontend/views/groups/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/groups/GroupMembersPage/index.vue
@@ -42,7 +42,7 @@
 
             <KIconButton
               icon="optionsHorizontal"
-              style="margin-left: 1em"
+              class="options-button"
             >
               <template #menu>
                 <KDropdownMenu
@@ -238,6 +238,10 @@
     height: 1.5em;
     // Space between icon and text
     margin-right: 0.5em;
+  }
+
+  .options-button {
+    margin-left: 1em;
   }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/OverviewBlock.vue
@@ -46,7 +46,7 @@
               :text="coachString('viewLearners')"
               appearance="basic-link"
               :to="classLearnersListRoute"
-              style="margin-left: 24px"
+              class="view-learners-link"
             />
           </template>
         </template>
@@ -145,4 +145,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .view-learners-link {
+    margin-left: 24px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/index.vue
@@ -15,7 +15,7 @@
               :to="lessonSelectionRootPage"
               :text="coachString('manageResourcesAction')"
               appearance="raised-button"
-              style="margin-right: 8px"
+              class="manage-resources-button"
             />
             <LessonOptionsDropdownMenu @select="handleSelectOption" />
           </template>
@@ -382,6 +382,10 @@
   .no-resources-message {
     padding: 48px 0;
     text-align: center;
+  }
+
+  .manage-resources-button {
+    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonsRootPage.vue
@@ -95,8 +95,8 @@
                       <KCircularLoader
                         v-if="show(lesson.id, isUpdatingVisibility(lesson.id), 2000)"
                         :key="`loader-${lesson.id}`"
+                        class="visibility-loader"
                         disableDefaultTransition
-                        :style="{ display: 'inline-block', marginLeft: '6px' }"
                         :size="26"
                       />
                       <KSwitch
@@ -497,6 +497,11 @@
     .lesson-button {
       display: none;
     }
+  }
+
+  .visibility-loader {
+    display: inline-block;
+    margin-left: 6px;
   }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/quizzes/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/QuizSummaryPage/index.vue
@@ -20,7 +20,7 @@
               :to="classRoute(PageNames.QUIZ_PREVIEW, {}, { last: PageNames.EXAM_SUMMARY })"
               :text="coachString('previewAction')"
               appearance="raised-button"
-              style="margin-right: 8px"
+              class="preview-button"
             />
             <QuizOptionsDropdownMenu
               :exam="exam"
@@ -373,6 +373,10 @@
   // over modal overlay and snackbar
   /deep/ .perseus-radio-selected {
     z-index: 0 !important;
+  }
+
+  .preview-button {
+    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/device/frontend/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/frontend/views/DeviceSettingsPage/index.vue
@@ -81,10 +81,7 @@
               @input="handleLandingPageChange"
             />
 
-            <div
-              class="fieldset"
-              style="margin-left: 32px"
-            >
+            <div class="fieldset left-margin">
               <KRadioButton
                 data-test="allowGuestAccessButton"
                 :label="$tr('allowGuestAccess')"

--- a/kolibri/plugins/device/frontend/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/frontend/views/FacilitiesPage/index.vue
@@ -62,7 +62,7 @@
               <tr :key="idx + facilities.length">
                 <td style="padding: 0 0 16px">
                   <!-- Gives most space possible to buttons and aligns them with text -->
-                  <KButtonGroup style="max-width: 100%; margin-right: -16px; margin-left: -16px">
+                  <KButtonGroup class="mobile-button-group">
                     <KButton
                       :text="coreString('syncAction')"
                       :disabled="facilityIsSyncing(facility)"
@@ -496,6 +496,12 @@
     .sync {
       margin-right: 0;
     }
+  }
+
+  .mobile-button-group {
+    max-width: 100%;
+    margin-right: -16px;
+    margin-left: -16px;
   }
 
 </style>

--- a/kolibri/plugins/device/frontend/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/frontend/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -19,7 +19,7 @@
           />
         </ChannelContentsSummary>
 
-        <div style="text-align: right">
+        <div class="import-button-container">
           <KButton
             :text="$tr('importMoreAction')"
             @click="shownModal = 'IMPORT_MORE'"
@@ -367,6 +367,10 @@
 
   .banner {
     margin-bottom: 24px;
+  }
+
+  .import-button-container {
+    text-align: right;
   }
 
 </style>

--- a/kolibri/plugins/device/frontend/views/lodUsers/UsersList.vue
+++ b/kolibri/plugins/device/frontend/views/lodUsers/UsersList.vue
@@ -5,7 +5,7 @@
       v-if="isSearchable"
       v-model="searchQuery"
       :placeholder="searchForUser$()"
-      :style="{ marginBottom: '16px', marginLeft: 'auto', display: 'block' }"
+      class="search-filter"
     />
     <ul
       v-if="filteredUsers.length"
@@ -20,11 +20,7 @@
         <div class="user-info">
           <KIcon
             icon="person"
-            :style="{
-              height: '24px',
-              width: '24px',
-              marginRight: '16px',
-            }"
+            class="user-icon"
           />
           <div>
             <div>
@@ -39,9 +35,7 @@
             <div v-if="isSuperuser(user)">
               <KIcon
                 icon="superadmin"
-                :style="{
-                  marginRight: '4px',
-                }"
+                class="superadmin-icon"
               />
               <span :style="annotationStyle"> {{ superAdminLabel$() }}</span>
             </div>
@@ -54,8 +48,8 @@
         ></slot>
         <KCircularLoader
           v-else-if="user.isImporting"
+          class="importing-loader"
           :size="24"
-          style="margin-right: 0"
         />
         <p
           v-else
@@ -179,6 +173,26 @@
     padding-right: 16px;
     padding-bottom: 4px;
     margin: 0;
+  }
+
+  .search-filter {
+    display: block;
+    margin-bottom: 16px;
+    margin-left: auto;
+  }
+
+  .user-icon {
+    width: 24px;
+    height: 24px;
+    margin-right: 16px;
+  }
+
+  .superadmin-icon {
+    margin-right: 4px;
+  }
+
+  .importing-loader {
+    margin-right: 0;
   }
 
 </style>

--- a/kolibri/plugins/epub_viewer/frontend/views/SearchSideBar.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/SearchSideBar.vue
@@ -18,8 +18,7 @@
           icon="search"
           buttonType="submit"
           :ariaLabel="$tr('submitSearchQuery')"
-          class="d-tc"
-          style="position: relative; top: 4px; left: 8px"
+          class="d-tc search-button"
           size="small"
         />
       </div>
@@ -380,6 +379,12 @@
   .search-input {
     width: 160px;
     vertical-align: middle;
+  }
+
+  .search-button {
+    position: relative;
+    top: 4px;
+    left: 8px;
   }
 
   .search-results-list {

--- a/kolibri/plugins/epub_viewer/frontend/views/TopBar.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/TopBar.vue
@@ -4,7 +4,7 @@
     class="top-bar"
     :style="{ backgroundColor: $themePalette.grey.v_300 }"
   >
-    <KGrid :style="{ marginTop: '2px', marginLeft: '3px', marginRight: '3px' }">
+    <KGrid class="top-bar-grid">
       <KGridItem
         :layout4="{ span: 1 }"
         :layout8="{ span: 2 }"
@@ -126,6 +126,12 @@
 
   .top-bar {
     z-index: 1;
+  }
+
+  .top-bar-grid {
+    margin-top: 2px;
+    margin-right: 3px;
+    margin-left: 3px;
   }
 
   .top-bar-title {

--- a/kolibri/plugins/facility/frontend/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/frontend/views/DataPage/SyncInterface/index.vue
@@ -57,12 +57,12 @@
                 >
                   <template #options>
                     <CoreMenuOption
-                      :style="{ cursor: 'pointer', textAlign: 'left' }"
+                      class="menu-option"
                       :label="coreString('manageSyncAction')"
                       @select="manageSyncAction()"
                     />
                     <CoreMenuOption
-                      :style="{ cursor: 'pointer', textAlign: 'left' }"
+                      class="menu-option"
                       :label="$tr('register')"
                       @select="handleRegister()"
                     />
@@ -109,13 +109,13 @@
 
 <script>
 
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import CoreTable from 'kolibri/components/CoreTable';
   import FacilityNameAndSyncStatus from 'kolibri-common/components/syncComponentSet/FacilityNameAndSyncStatus';
   import ConfirmationRegisterModal from 'kolibri-common/components/syncComponentSet/ConfirmationRegisterModal';
   import RegisterFacilityModal from 'kolibri-common/components/syncComponentSet/RegisterFacilityModal';
   import SyncFacilityModalGroup from 'kolibri-common/components/syncComponentSet/SyncFacilityModalGroup';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import TaskResource from 'kolibri/apiResources/TaskResource';
   import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
@@ -360,6 +360,11 @@
   /deep/ .button-group-item {
     height: max-content;
     margin-bottom: 8px;
+  }
+
+  .menu-option {
+    text-align: left;
+    cursor: pointer;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -128,7 +128,7 @@
           <KButton
             :primary="true"
             appearance="raised-button"
-            :style="{ marginTop: '24px', marginLeft: '-8px' }"
+            class="save-changes-button"
             :text="coreString('saveChangesAction')"
             name="save-settings"
             :disabled="!settingsHaveChanged"
@@ -189,7 +189,6 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
-  import { createTranslator } from 'kolibri/utils/i18n';
 
   import camelCase from 'lodash/camelCase';
   import isEqual from 'lodash/isEqual';
@@ -199,12 +198,13 @@
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import { createTranslator } from 'kolibri/utils/i18n';
   import FacilityAppBarPage from '../FacilityAppBarPage';
-  import EditFacilityNameModal from './EditFacilityNameModal';
-  import CreateManagementPinModal from './CreateManagementPinModal';
-  import ViewPinModal from './ViewPinModal';
-  import ChangePinModal from './ChangePinModal';
   import RemovePinModal from './RemovePinModal';
+  import ChangePinModal from './ChangePinModal';
+  import ViewPinModal from './ViewPinModal';
+  import CreateManagementPinModal from './CreateManagementPinModal';
+  import EditFacilityNameModal from './EditFacilityNameModal';
 
   /**
    * Using the createTranslator to aid concatenation
@@ -505,6 +505,11 @@
   .facility-loader {
     display: inline-block;
     margin-bottom: -0.5em; // To align with the text
+  }
+
+  .save-changes-button {
+    margin-top: 24px;
+    margin-left: -8px;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/ImportCsvPage/Init.vue
+++ b/kolibri/plugins/facility/frontend/views/ImportCsvPage/Init.vue
@@ -57,7 +57,7 @@
         <KButton
           :text="coreString('cancelAction')"
           appearance="raised-button"
-          style="margin-left: 0"
+          class="cancel-button"
           @click="$emit('cancel')"
         />
         <KButton
@@ -179,6 +179,10 @@
 
   .caution {
     font-weight: bold;
+  }
+
+  .cancel-button {
+    margin-left: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/ImportCsvPage/Preview.vue
+++ b/kolibri/plugins/facility/frontend/views/ImportCsvPage/Preview.vue
@@ -168,7 +168,7 @@
         <KButton
           :text="$tr('back')"
           appearance="raised-button"
-          style="margin-left: 0"
+          class="back-button"
           @click="reset"
         />
         <KButton
@@ -339,6 +339,10 @@
 
   .indent {
     margin-left: 16px;
+  }
+
+  .back-button {
+    margin-left: 0;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/users/UsersTrashPage/PermanentDeleteModal.vue
+++ b/kolibri/plugins/facility/frontend/views/users/UsersTrashPage/PermanentDeleteModal.vue
@@ -7,7 +7,7 @@
     <template #actions>
       <KButton
         :disabled="loading"
-        style="margin-right: 16px"
+        class="cancel-button"
         :text="coreStrings.cancelAction$()"
         @click="close"
       />
@@ -29,9 +29,9 @@
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
 
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import DeletedFacilityUserResource from 'kolibri-common/apiResources/DeletedFacilityUserResource';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
@@ -114,6 +114,10 @@
     // Override default global line-height of 1.15 which is not enough
     // space for single lines content modal and makes scrollbar appear.
     line-height: 1.5;
+  }
+
+  .cancel-button {
+    margin-right: 16px;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/users/common/MoveToTrashModal.vue
+++ b/kolibri/plugins/facility/frontend/views/users/common/MoveToTrashModal.vue
@@ -17,19 +17,14 @@
             {{ numAdminsSelected$({ num: adminUsers.length }) }}
           </span>
         </KLabeledIcon>
-        <p
-          :style="{
-            marginLeft: adminUsers.length ? '32px' : '0',
-            margin: 0,
-          }"
-        >
+        <p :class="['trash-warning', { 'trash-warning-indented': adminUsers.length }]">
           {{ moveToTrashWarning$() }}
         </p>
       </div>
       <template #actions>
         <KButton
           :disabled="loading"
-          style="margin-right: 16px"
+          class="cancel-button"
           :text="coreStrings.cancelAction$()"
           @click="close"
         />
@@ -52,16 +47,15 @@
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
 
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { UserKinds } from 'kolibri/constants';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import DeletedFacilityUserResource from 'kolibri-common/apiResources/DeletedFacilityUserResource';
-
-  import { _userState } from '../../../modules/mappers';
   import useActionWithUndo from '../../../composables/useActionWithUndo';
+  import { _userState } from '../../../modules/mappers';
 
   export default {
     name: 'MoveToTrashModal',
@@ -197,6 +191,18 @@
 
   .fix-line-height {
     line-height: 1.5;
+  }
+
+  .trash-warning {
+    margin: 0;
+  }
+
+  .trash-warning-indented {
+    margin-left: 32px;
+  }
+
+  .cancel-button {
+    margin-right: 16px;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/users/common/UsersTableToolbar/SmallWindowLayout.vue
+++ b/kolibri/plugins/facility/frontend/views/users/common/UsersTableToolbar/SmallWindowLayout.vue
@@ -17,12 +17,9 @@
     </div>
     <div
       v-if="hasSelectedUsers"
+      class="divider divider-with-margin"
       :style="{
-        height: '1px',
         backgroundColor: $themeTokens.fineLine,
-        marginBottom: '16px',
-        marginLeft: '-16px',
-        marginRight: '-16px',
       }"
     ></div>
     <div
@@ -45,11 +42,9 @@
     </div>
     <div
       v-if="showUsersTable"
+      class="divider"
       :style="{
-        height: '1px',
         backgroundColor: $themeTokens.fineLine,
-        marginLeft: '-16px',
-        marginRight: '-16px',
       }"
     ></div>
   </div>
@@ -137,6 +132,16 @@
     gap: 8px;
     align-items: center;
     justify-content: space-between;
+    margin-bottom: 16px;
+  }
+
+  .divider {
+    height: 1px;
+    margin-right: -16px;
+    margin-left: -16px;
+  }
+
+  .divider-with-margin {
     margin-bottom: 16px;
   }
 

--- a/kolibri/plugins/learn/frontend/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/frontend/views/BookmarkPage.vue
@@ -68,7 +68,6 @@
         >
           <LearningActivityChip
             class="chip"
-            style="margin-bottom: 8px; margin-left: 8px"
             :kind="activity"
           />
         </div>

--- a/kolibri/plugins/learn/frontend/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/frontend/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -31,7 +31,10 @@
       <CoachContentLabel
         v-if="isUserLoggedIn && !isLearner && contentNode.num_coach_contents"
         :style="coachContentLabelStyles"
-        class="coach-content-label"
+        :class="[
+          'coach-content-label',
+          { 'coach-content-label-topic': isTopic && contentNode.num_coach_contents < 2 },
+        ]"
         :value="contentNode.num_coach_contents"
         :isTopic="isTopic"
       />
@@ -57,12 +60,6 @@
         v-show="isMenuOpen"
         ref="menu"
         class="menu"
-        :style="{
-          left: isRtl ? '16px' : 'auto',
-          right: isRtl ? 'auto' : '16px',
-          position: 'absolute',
-          zIndex: 7,
-        }"
         :raised="true"
         :isOpen="isMenuOpen"
         :containFocus="true"
@@ -191,7 +188,7 @@
         if (this.contentNode.num_coach_contents < 2 && !this.isTopic) {
           return { maxWidth: '24px', marginTop: '4px' };
         } else if (this.contentNode.num_coach_contents < 2 && this.isTopic) {
-          return { maxWidth: '24px', marginTop: '4px', marginRight: '16px' };
+          return { maxWidth: '24px', marginTop: '4px' };
         } else {
           return {};
         }
@@ -286,6 +283,17 @@
 
   .coach-content-label {
     vertical-align: top;
+  }
+
+  .coach-content-label-topic {
+    margin-right: 16px;
+  }
+
+  .menu {
+    position: absolute;
+    right: 16px;
+    left: auto;
+    z-index: 7;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/frontend/views/LearningActivityBar.vue
@@ -80,7 +80,6 @@
           v-show="isTimerOpen"
           ref="timer"
           class="menu"
-          :style="{ left: isRtl ? '16px' : 'auto', right: isRtl ? 'auto' : '16px' }"
           :raised="true"
           :isOpen="isTimerOpen"
           :containFocus="true"
@@ -142,7 +141,6 @@
             v-show="isMenuOpen"
             ref="menu"
             class="menu"
-            :style="{ left: isRtl ? '16px' : 'auto', right: isRtl ? 'auto' : '16px' }"
             :raised="true"
             :isOpen="isMenuOpen"
             :containFocus="true"
@@ -614,6 +612,8 @@
   .menu {
     position: absolute;
     top: 50%;
+    right: 16px;
+    left: auto;
     z-index: 16;
     min-width: 270px;
     transform: translateY(16px);

--- a/kolibri/plugins/learn/frontend/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/frontend/views/LibraryPage/OtherLibraries.vue
@@ -10,7 +10,7 @@
         :layout8="{ span: 4 }"
         :layout4="{ span: 4 }"
       >
-        <h1 :style="{ marginLeft: '-8px' }">
+        <h1 class="section-heading">
           {{ injectedtr('otherLibraries') }}
         </h1>
       </KGridItem>
@@ -74,7 +74,7 @@
     <h2
       v-if="!threeLibrariesOrFewer && pinnedDevicesExist && unpinnedDevicesExist"
       data-test="pinned-label"
-      :style="{ marginLeft: '-8px' }"
+      class="section-heading"
     >
       {{ injectedtr('pinned') }}
     </h2>
@@ -105,7 +105,7 @@
         <h2
           v-if="pinnedDevicesExist"
           data-test="more-label"
-          :style="{ marginTop: '0px', marginLeft: '-8px' }"
+          class="more-heading section-heading"
         >
           {{ injectedtr('moreLibraries') }}
         </h2>
@@ -272,6 +272,14 @@
   .connection-status {
     margin-bottom: 10px;
     margin-left: -8px;
+  }
+
+  .section-heading {
+    margin-left: -8px;
+  }
+
+  .more-heading {
+    margin-top: 0;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/LibraryPage/index.vue
@@ -171,7 +171,6 @@
           >
             <LearningActivityChip
               class="chip"
-              style="margin-bottom: 8px; margin-left: 8px"
               :kind="activity"
             />
           </div>

--- a/kolibri/plugins/learn/frontend/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/frontend/views/TopicsContentPage.vue
@@ -100,7 +100,6 @@
         >
           <LearningActivityChip
             class="chip"
-            style="margin-bottom: 8px; margin-left: 8px"
             :kind="activity"
           />
         </div>

--- a/kolibri/plugins/learn/frontend/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/frontend/views/TopicsPage/ToggleHeaderTabs.vue
@@ -11,15 +11,10 @@
     <router-link
       v-if="topics.length && windowIsLarge"
       :to="foldersLink"
-      class="header-tab"
+      :class="['header-tab', defaultTabStyles, { 'header-tab-spaced': width > 234 }]"
       :activeClass="activeTabClasses"
-      :style="{
-        color: $themeTokens.annotation,
-        marginLeft: width > 234 ? '12px' : '0',
-        marginRight: width > 234 ? '12px' : '0',
-      }"
+      :style="{ color: $themeTokens.annotation }"
       :replace="true"
-      :class="defaultTabStyles"
     >
       <div
         class="inner"
@@ -33,15 +28,10 @@
     <router-link
       v-if="windowIsLarge"
       :to="topics.length ? searchTabLink : {}"
-      class="header-tab"
+      :class="['header-tab', defaultTabStyles, { 'header-tab-spaced': width > 234 }]"
       :activeClass="activeTabClasses"
-      :style="{
-        color: $themeTokens.annotation,
-        marginLeft: width > 234 ? '12px' : '0',
-        marginRight: width > 234 ? '12px' : '0',
-      }"
+      :style="{ color: $themeTokens.annotation }"
       :replace="true"
-      :class="defaultTabStyles"
     >
       <div
         class="inner"
@@ -227,6 +217,11 @@
       padding: 0;
       border-bottom-width: 0;
     }
+  }
+
+  .header-tab-spaced {
+    margin-right: 12px;
+    margin-left: 12px;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
@@ -233,7 +233,6 @@
           >
             <LearningActivityChip
               class="chip"
-              style="margin-bottom: 8px; margin-left: 8px"
               :kind="activity"
             />
           </div>

--- a/kolibri/plugins/setup_wizard/frontend/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/OnboardingStepBase.vue
@@ -66,7 +66,7 @@
         <KIconButton
           v-if="showBackArrow"
           icon="back"
-          style="margin-left: -12px"
+          class="back-button"
           :disabled="backArrowDisabled"
           @click="wizardService.send(eventOnGoBack)"
         />
@@ -425,6 +425,10 @@
 
     /* This will effect the entire onboarding experience */
     white-space: normal;
+  }
+
+  .back-button {
+    margin-left: -12px;
   }
 
 </style>

--- a/kolibri/plugins/user_auth/frontend/views/FacilitySelect.vue
+++ b/kolibri/plugins/user_auth/frontend/views/FacilitySelect.vue
@@ -25,7 +25,7 @@
             <template #icon>
               <KIcon
                 icon="facility"
-                style="margin-right: 16px"
+                class="facility-icon"
               />
             </template>
             {{ facility.name }}
@@ -52,7 +52,7 @@
             <template #icon>
               <KIcon
                 icon="facility"
-                style="margin-right: 16px"
+                class="facility-icon"
               />
             </template>
             {{ facility.name }}
@@ -67,8 +67,8 @@
 
 <script>
 
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import partition from 'lodash/partition';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { ComponentMap } from '../constants';
   import AuthBase from './AuthBase';
@@ -181,6 +181,10 @@
 
   .backlink {
     margin: 24px 0 16px;
+  }
+
+  .facility-icon {
+    margin-right: 16px;
   }
 
 </style>

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/NewPasswordPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/NewPasswordPage.vue
@@ -1,23 +1,19 @@
 <template>
 
   <AuthBase>
-    <div style="text-align: left">
+    <div class="new-password-content">
       <KButton
+        class="go-back-btn"
         appearance="basic-link"
-        style="margin-bottom: 16px"
         data-test="goback"
         @click="goBack"
       >
         <template #icon>
           <KIcon
             icon="back"
+            class="go-back-icon"
             :style="{
               fill: $themeTokens.primary,
-              height: '1.125em',
-              width: '1.125em',
-              position: 'relative',
-              marginRight: '8px',
-              top: '2px',
             }"
           />{{ coreString('goBackAction') }}
         </template>
@@ -55,8 +51,8 @@
   import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
-  import AuthBase from '../AuthBase';
   import { ComponentMap } from '../../constants';
+  import AuthBase from '../AuthBase';
 
   export default {
     name: 'NewPasswordPage',
@@ -139,4 +135,22 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .new-password-content {
+    text-align: left;
+  }
+
+  .go-back-btn {
+    margin-bottom: 16px;
+  }
+
+  .go-back-icon {
+    position: relative;
+    top: 2px;
+    width: 1.125em;
+    height: 1.125em;
+    margin-right: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/SignInHeading.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/SignInHeading.vue
@@ -1,18 +1,12 @@
 <template>
 
   <div class="sign-in-text">
-    <div
-      v-if="showFacilityName && !showPasswordForm"
-      style="margin-top: 24px; margin-bottom: 16px; text-align: left"
-    >
+    <div v-if="showFacilityName && !showPasswordForm">
       {{ userString('signInToFacilityLabel', { facility: selectedFacility.name }) }}
     </div>
 
     <!-- Asking for password, has multiple facilities or is not informal -->
-    <div
-      v-else-if="showFacilityName && showPasswordForm"
-      style="margin-top: 24px; margin-bottom: 16px; text-align: left"
-    >
+    <div v-else-if="showFacilityName && showPasswordForm">
       {{
         userString('signingInToFacilityAsUserLabel', {
           facility: selectedFacility.name,

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/index.vue
@@ -8,28 +8,28 @@
     <div v-if="!needsToCreatePassword">
       <!-- ** Text and Backlinks ** -->
 
-      <div style="display: block; width: 100%; text-align: left">
+      <div class="navigation-links">
         <!-- In MFD show return to facility select when not asking for password -->
         <KRouterLink
           v-if="hasMultipleFacilities && !showPasswordForm"
+          class="back-link"
           icon="back"
           :text="coreString('changeLearningFacility')"
           :to="backToFacilitySelectionRoute"
-          style="margin-top: 24px; margin-left: -4px"
         />
 
         <!-- When password form shows, show a change user link -->
         <!-- Not using v-else here to be more explicit -->
         <KButton
           v-if="showPasswordForm"
+          class="change-user-btn"
           appearance="basic-link"
           :text="$tr('changeUser')"
-          style="margin-top: 24px; margin-left: 4px"
           @click="clearUser"
         >
           <template #icon>
             <KIcon
-              style="top: 6px; right: 8px; width: 24px; height: 24px"
+              class="change-user-icon"
               icon="back"
               :color="$themeTokens.primary"
             />
@@ -159,15 +159,15 @@
 <script>
 
   import { mapState } from 'vuex';
-  import FacilityUsernameResource from 'kolibri-common/apiResources/FacilityUsernameResource';
   import get from 'lodash/get';
-  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { LoginErrors } from 'kolibri/constants';
-  import { validateUsername } from 'kolibri/utils/validators';
   import UiAutocompleteSuggestion from 'kolibri-design-system/lib/keen/UiAutocompleteSuggestion';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import useUser from 'kolibri/composables/useUser';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useUser from 'kolibri/composables/useUser';
+  import { validateUsername } from 'kolibri/utils/validators';
+  import { LoginErrors } from 'kolibri/constants';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import FacilityUsernameResource from 'kolibri-common/apiResources/FacilityUsernameResource';
   import { ComponentMap } from '../../constants';
   import getUrlParameter from '../getUrlParameter';
   import AuthBase from '../AuthBase';
@@ -566,6 +566,29 @@
     // Move up snug against the textbox
     margin-top: -2em;
     list-style-type: none;
+  }
+
+  .back-link {
+    margin-top: 24px;
+    margin-left: -4px;
+  }
+
+  .change-user-btn {
+    margin-top: 24px;
+    margin-left: 4px;
+  }
+
+  .change-user-icon {
+    top: 6px;
+    right: 8px;
+    width: 24px;
+    height: 24px;
+  }
+
+  .navigation-links {
+    display: block;
+    width: 100%;
+    text-align: left;
   }
 
 </style>

--- a/kolibri/plugins/user_auth/frontend/views/UsersList.vue
+++ b/kolibri/plugins/user_auth/frontend/views/UsersList.vue
@@ -5,13 +5,12 @@
       v-for="username in users"
       :key="username"
       class="listed-user"
-      style="width: 100%; margin-left: 0; text-align: left"
       :disabled="busy"
       @click="$emit('userSelected', username)"
     >
       <KIcon
         icon="person"
-        style="margin-right: 8px"
+        class="person-icon"
       />
 
       {{ username }}
@@ -48,6 +47,10 @@
     margin-left: 0;
     text-align: left;
     text-transform: none;
+  }
+
+  .person-icon {
+    margin-right: 8px;
   }
 
 </style>

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-rtl-breaking-inline-styles.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-rtl-breaking-inline-styles.js
@@ -1,0 +1,370 @@
+/**
+ * @fileoverview Prevent RTL-breaking inline styles in Vue components
+ * @author Learning Equality
+ */
+
+const utils = require('eslint-plugin-vue/lib/utils');
+
+// RTL-breaking CSS properties (kebab-case and camelCase variants)
+// Note: text-align, textAlign, float, and clear are NOT included here because
+// they require value-based checking (e.g., 'center' is safe, 'left'/'right' are not)
+const RTL_BREAKING_PROPERTIES = new Set([
+  // Margin
+  'margin-left',
+  'margin-right',
+  'marginLeft',
+  'marginRight',
+  // Padding
+  'padding-left',
+  'padding-right',
+  'paddingLeft',
+  'paddingRight',
+  // Positioning
+  'left',
+  'right',
+  // Border
+  'border-left',
+  'border-right',
+  'borderLeft',
+  'borderRight',
+  'border-left-width',
+  'border-right-width',
+  'borderLeftWidth',
+  'borderRightWidth',
+  'border-left-color',
+  'border-right-color',
+  'borderLeftColor',
+  'borderRightColor',
+  'border-left-style',
+  'border-right-style',
+  'borderLeftStyle',
+  'borderRightStyle',
+  // Border radius
+  'border-top-left-radius',
+  'border-top-right-radius',
+  'border-bottom-left-radius',
+  'border-bottom-right-radius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  // Scroll margin
+  'scroll-margin-left',
+  'scroll-margin-right',
+  'scrollMarginLeft',
+  'scrollMarginRight',
+  // Scroll padding
+  'scroll-padding-left',
+  'scroll-padding-right',
+  'scrollPaddingLeft',
+  'scrollPaddingRight',
+]);
+
+// Directional values for properties like text-align, float, and clear
+const DIRECTIONAL_VALUES = new Set(['left', 'right']);
+
+/**
+ * Check if a CSS property is RTL-breaking
+ * @param {string} property - CSS property name
+ * @returns {boolean}
+ */
+function isRtlBreakingProperty(property) {
+  return RTL_BREAKING_PROPERTIES.has(property);
+}
+
+/**
+ * Check if a value contains directional keywords
+ * @param {string} value - CSS value
+ * @returns {boolean}
+ */
+function hasDirectionalValue(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const normalizedValue = value.toLowerCase().trim();
+
+  // Check exact match first (most common case)
+  if (DIRECTIONAL_VALUES.has(normalizedValue)) {
+    return true;
+  }
+
+  // Check if value contains directional keywords (e.g., "right center" for background-position)
+  const words = normalizedValue.split(/\s+/);
+  return words.some(word => DIRECTIONAL_VALUES.has(word));
+}
+
+/**
+ * Check if a conditional expression is RTL-aware (uses isRtl in the test)
+ * @param {ConditionalExpression} node - AST node
+ * @returns {boolean}
+ */
+function isRtlAwareTernary(node) {
+  if (!node || node.type !== 'ConditionalExpression') {
+    return false;
+  }
+
+  // Check if the test condition references 'isRtl'
+  function containsIsRtl(testNode) {
+    if (!testNode) {
+      return false;
+    }
+
+    if (testNode.type === 'Identifier' && testNode.name === 'isRtl') {
+      return true;
+    }
+
+    if (testNode.type === 'MemberExpression') {
+      // Handle this.isRtl
+      if (testNode.property.type === 'Identifier' && testNode.property.name === 'isRtl') {
+        return true;
+      }
+    }
+
+    if (testNode.type === 'UnaryExpression') {
+      // Handle !isRtl
+      return containsIsRtl(testNode.argument);
+    }
+
+    if (testNode.type === 'LogicalExpression') {
+      // Handle isRtl && ... or isRtl || ...
+      return containsIsRtl(testNode.left) || containsIsRtl(testNode.right);
+    }
+
+    return false;
+  }
+
+  return containsIsRtl(node.test);
+}
+
+/**
+ * Check if static style attribute contains RTL-breaking properties
+ * @param {string} styleValue - The value of the style attribute
+ * @returns {boolean}
+ */
+function hasRtlBreakingStaticStyle(styleValue) {
+  if (!styleValue) {
+    return false;
+  }
+
+  // Split by semicolons to get individual style declarations
+  const declarations = styleValue.split(';').filter(d => d.trim());
+
+  for (const declaration of declarations) {
+    const [property, value] = declaration.split(':').map(s => s.trim());
+
+    if (!property) {
+      continue;
+    }
+
+    // Check if the property itself is RTL-breaking
+    if (isRtlBreakingProperty(property)) {
+      return true;
+    }
+
+    // Check for text-align, float, or clear with directional values
+    if (
+      (property === 'text-align' || property === 'float' || property === 'clear') &&
+      value &&
+      hasDirectionalValue(value)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Extract string literal values from a ConditionalExpression (ternary)
+ * @param {ConditionalExpression} node - AST node
+ * @returns {Array<{value: string, node: Node}>}
+ */
+function extractTernaryStringLiterals(node) {
+  const results = [];
+
+  if (
+    node.consequent &&
+    node.consequent.type === 'Literal' &&
+    typeof node.consequent.value === 'string'
+  ) {
+    results.push({ value: node.consequent.value, node: node.consequent });
+  }
+
+  if (
+    node.alternate &&
+    node.alternate.type === 'Literal' &&
+    typeof node.alternate.value === 'string'
+  ) {
+    results.push({ value: node.alternate.value, node: node.alternate });
+  }
+
+  return results;
+}
+
+/**
+ * Extract property names from an ObjectExpression node
+ * @param {ObjectExpression} node - AST node
+ * @returns {Array<{property: string, node: Node}>}
+ */
+function extractObjectProperties(node) {
+  const properties = [];
+
+  if (!node || node.type !== 'ObjectExpression') {
+    return properties;
+  }
+
+  for (const prop of node.properties) {
+    if (prop.type !== 'Property') {
+      continue;
+    }
+
+    let propertyName = null;
+
+    // Handle both computed and non-computed properties
+    if (prop.key.type === 'Identifier' && !prop.computed) {
+      propertyName = prop.key.name;
+    } else if (prop.key.type === 'Literal') {
+      propertyName = String(prop.key.value);
+    } else if (prop.computed && prop.key.type === 'ConditionalExpression') {
+      // Handle computed keys with ternary expressions
+      // e.g. { [isRtl ? 'marginRight' : 'marginLeft']: '8px' }
+      // If the ternary uses isRtl in the test, this is an RTL-aware pattern - allow it
+      if (isRtlAwareTernary(prop.key)) {
+        continue;
+      }
+      const ternaryLiterals = extractTernaryStringLiterals(prop.key);
+      for (const { value, node: literalNode } of ternaryLiterals) {
+        if (isRtlBreakingProperty(value)) {
+          properties.push({ property: value, node: literalNode });
+        }
+      }
+      // Skip the rest of the loop iteration since we've handled this case
+      continue;
+    }
+
+    if (propertyName && isRtlBreakingProperty(propertyName)) {
+      // Note: isRtl ternary in the VALUE (e.g., marginLeft: isRtl ? 'x' : 'y')
+      // does NOT make it safe - the property name is still directional.
+      // Only isRtl ternary in computed KEYS is RTL-aware (handled above).
+      properties.push({ property: propertyName, node: prop });
+    }
+
+    // Check for text-align, float, or clear with directional values
+    if (
+      propertyName === 'textAlign' ||
+      propertyName === 'text-align' ||
+      propertyName === 'float' ||
+      propertyName === 'clear'
+    ) {
+      if (prop.value.type === 'Literal' && hasDirectionalValue(prop.value.value)) {
+        properties.push({ property: propertyName, node: prop });
+      }
+    }
+  }
+
+  return properties;
+}
+
+/**
+ * Recursively check expressions for RTL-breaking properties
+ * @param {Node} node - AST node
+ * @returns {Array<{property: string, node: Node}>}
+ */
+function checkExpression(node) {
+  if (!node) {
+    return [];
+  }
+
+  // ObjectExpression: { marginLeft: '8px' }
+  if (node.type === 'ObjectExpression') {
+    return extractObjectProperties(node);
+  }
+
+  // ArrayExpression: [style1, { marginLeft: '8px' }]
+  if (node.type === 'ArrayExpression') {
+    const violations = [];
+    for (const element of node.elements) {
+      if (element && element.type !== 'SpreadElement') {
+        violations.push(...checkExpression(element));
+      }
+    }
+    return violations;
+  }
+
+  // ConditionalExpression: condition ? { marginLeft: '8px' } : { marginRight: '8px' }
+  if (node.type === 'ConditionalExpression') {
+    return [...checkExpression(node.consequent), ...checkExpression(node.alternate)];
+  }
+
+  // LogicalExpression: foo && { marginLeft: '8px' }
+  if (node.type === 'LogicalExpression') {
+    return [...checkExpression(node.left), ...checkExpression(node.right)];
+  }
+
+  return [];
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow inline styles with RTL-breaking directional CSS properties in Vue templates',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: null,
+    messages: {
+      noRtlBreakingInlineStyles:
+        'Avoid inline styles with directional properties ({{property}}). Use CSS classes instead for RTL support. See https://kolibri-dev.readthedocs.io/en/develop/i18n.html#inline-styles-and-rtl-compatibility',
+      noRtlBreakingStaticStyles:
+        'Avoid inline styles with directional properties. Use CSS classes instead for RTL support. See https://kolibri-dev.readthedocs.io/en/develop/i18n.html#inline-styles-and-rtl-compatibility',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return utils.defineTemplateBodyVisitor(context, {
+      /**
+       * Check static style attributes: <div style="margin-left: 8px">
+       * @param {VAttribute} node
+       */
+      'VAttribute[directive=false][key.name="style"]'(node) {
+        if (!node.value || !node.value.value) {
+          return;
+        }
+
+        if (hasRtlBreakingStaticStyle(node.value.value)) {
+          context.report({
+            node: node.value || node,
+            messageId: 'noRtlBreakingStaticStyles',
+          });
+        }
+      },
+
+      /**
+       * Check dynamic style bindings: <div :style="{ marginLeft: '8px' }">
+       * @param {VExpressionContainer} node
+       */
+      "VAttribute[directive=true][key.name.name='bind'][key.argument.name='style'] > VExpressionContainer.value"(
+        node,
+      ) {
+        if (!node.expression) {
+          return;
+        }
+
+        const violations = checkExpression(node.expression);
+
+        for (const { property, node: violationNode } of violations) {
+          context.report({
+            node: violationNode,
+            messageId: 'noRtlBreakingInlineStyles',
+            data: {
+              property,
+            },
+          });
+        }
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-rtl-breaking-inline-styles.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-rtl-breaking-inline-styles.spec.js
@@ -1,0 +1,785 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/vue-no-rtl-breaking-inline-styles');
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 },
+});
+
+tester.run('vue-no-rtl-breaking-inline-styles', rule, {
+  valid: [
+    // ===== Valid: No style attributes =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>No styles here</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: CSS classes (recommended approach from docs) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div class="small-left-margin">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Safe CSS properties (non-directional) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="color: red; background: blue; width: 100px; height: 50px">
+            Content
+          </div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Safe dynamic styles (theme tokens from docs) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ color: $themeTokens.primary, width: '100%' }">
+            Content
+          </div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Computed property reference (recommended pattern from docs) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <KIcon :style="iconStyle" />
+        </template>
+        <script>
+          export default {
+            computed: {
+              iconStyle() {
+                return {
+                  [this.isRtl ? 'marginRight' : 'marginLeft']: '8px'
+                };
+              }
+            }
+          }
+        </script>
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
+
+    // ===== Valid: Simple identifier reference =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="dynamicStyles">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Safe positioning properties (top, bottom) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="top: 0; bottom: 0">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Safe dynamic binding with top/bottom =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ top: '0px', bottom: '10px', zIndex: 999 }">
+            Content
+          </div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: text-align with safe values =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="text-align: center">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: textAlign with safe values =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ textAlign: 'center' }">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Method call returning styles =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="getStyles()">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Array with identifier references =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="[baseStyle, extraStyle]">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Margin without directional (margin shorthand) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="margin: 10px">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: v-bind shorthand with safe properties =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ marginTop: '10px', marginBottom: '10px' }">
+            Content
+          </div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: float with safe value (none) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="float: none">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: clear with safe value (both) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="clear: both">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: clear with safe value (none) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ clear: 'none' }">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: Non-directional border-radius =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="border-radius: 5px">Content</div>
+        </template>
+      `,
+    },
+
+    // ===== Valid: isRtl ternary in computed property key (RTL-aware pattern) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <KIcon :style="{ [isRtl ? 'marginRight' : 'marginLeft']: '8px' }" />
+        </template>
+      `,
+    },
+  ],
+
+  invalid: [
+    // ===== Invalid: Static inline styles from documentation examples =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="margin-left: 8px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+          line: 3,
+        },
+      ],
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="text-align: right">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="float: left">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Dynamic bindings from documentation examples =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ marginLeft: '8px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+      ],
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ paddingRight: '16px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'paddingRight' },
+        },
+      ],
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ textAlign: 'right' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'textAlign' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Real-world example from codebase =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <h1 :style="{ marginLeft: '-8px' }">
+            Title
+          </h1>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with margin-right =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="margin-right: 20px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with padding-left =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="padding-left: 15px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with padding-right =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="padding-right: 10px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with left positioning =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="left: 0; top: 0">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with right positioning =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="right: 10px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Dynamic binding with kebab-case property in string =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ 'margin-left': '8px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'margin-left' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Dynamic binding with 'text-align' =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ 'text-align': 'right' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'text-align' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Array with RTL-breaking object =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="[{ marginLeft: '10px' }]">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Ternary with RTL-breaking properties in both branches =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="condition ? { marginLeft: '10px' } : { marginRight: '10px' }">
+            Content
+          </div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginRight' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Logical expression with RTL-breaking property =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="showStyle && { paddingLeft: '20px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'paddingLeft' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Multiple RTL-breaking properties in one object =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ marginLeft: '5px', paddingRight: '10px' }">
+            Content
+          </div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'paddingRight' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Border directional properties =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ borderLeft: '1px solid black' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'borderLeft' },
+        },
+      ],
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ borderRight: '1px solid red' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'borderRight' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Static style with multiple violations =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="margin-left: 8px; padding-right: 10px; text-align: right">
+            Content
+          </div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Float property =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ float: 'right' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'float' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Static text-align left =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="text-align: left">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Dynamic textAlign left =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ textAlign: 'left' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'textAlign' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Computed key ternary WITHOUT isRtl is still flagged =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <KIcon :style="{ [someCondition ? 'marginRight' : 'marginLeft']: '8px' }" />
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+        },
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: isRtl ternary in VALUE does NOT make directional property safe =====
+    // marginLeft is still directional regardless of what value it gets
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ marginLeft: isRtl ? 'auto' : '8px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'marginLeft' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Border-radius directional properties (static) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="border-top-left-radius: 5px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: Border-radius directional properties (dynamic camelCase) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ borderTopRightRadius: '5px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'borderTopRightRadius' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Border-radius bottom-left =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ borderBottomLeftRadius: '8px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'borderBottomLeftRadius' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Border-radius bottom-right =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ 'border-bottom-right-radius': '8px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'border-bottom-right-radius' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Scroll-margin-left =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ scrollMarginLeft: '10px' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'scrollMarginLeft' },
+        },
+      ],
+    },
+
+    // ===== Invalid: Scroll-padding-right (kebab-case) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="scroll-padding-right: 5px">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: clear with directional value (left) =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div style="clear: left">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingStaticStyles',
+        },
+      ],
+    },
+
+    // ===== Invalid: clear with directional value (right) - dynamic =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ clear: 'right' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'clear' },
+        },
+      ],
+    },
+
+    // ===== Invalid: kebab-case text-align with directional value =====
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div :style="{ 'text-align': 'left' }">Content</div>
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'noRtlBreakingInlineStyles',
+          data: { property: 'text-align' },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
@@ -22,9 +22,9 @@
         <div class="filter-list-title">
           <KIcon
             :icon="icon(key)"
+            class="category-icon"
             size="large"
             :color="$themeTokens.primary"
-            :style="{ marginLeft: '8px' }"
           />
           <h3>
             <KButton
@@ -191,6 +191,10 @@
   h3 {
     margin-top: 0;
     margin-bottom: 8px;
+  }
+
+  .category-icon {
+    margin-left: 8px;
   }
 
   /deep/ svg {

--- a/packages/kolibri-format/.eslintrc.js
+++ b/packages/kolibri-format/.eslintrc.js
@@ -266,6 +266,7 @@ module.exports = {
     'kolibri/vue-component-require-img-src': ERROR,
     'kolibri/vue-component-class-name-casing': ERROR,
     'kolibri/vue-component-no-duplicate-ids': ERROR,
+    'kolibri/vue-no-rtl-breaking-inline-styles': ERROR,
 
     'prefer-const': [
       ERROR,

--- a/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
+++ b/packages/kolibri/components/pages/AppBarPage/internal/SideNav.vue
@@ -44,7 +44,7 @@
             >
               <div
                 v-if="showAppNavView"
-                style="margin-bottom: 10px; margin-left: -15px"
+                class="close-button-wrapper"
               >
                 <KIconButton
                   ref="closeButton"
@@ -725,6 +725,11 @@
   .logo {
     max-width: 100%;
     height: auto;
+  }
+
+  .close-button-wrapper {
+    margin-bottom: 10px;
+    margin-left: -15px;
   }
 
 </style>


### PR DESCRIPTION
## Summary

Implements a new ESLint rule `kolibri/vue-no-rtl-breaking-inline-styles` to prevent inline styles with directional CSS properties that break right-to-left (RTL) language support.

**What the rule detects:**
- Static inline styles: `style="margin-left: 8px"`
- Dynamic inline styles: `:style="{ marginLeft: '8px' }"`
- Computed property keys with ternaries: `{ [isRtl ? 'marginRight' : 'marginLeft']: '8px' }`

**Properties covered (48 total):**
- margin/padding left/right
- left/right positioning
- text-align/float/clear with directional values
- border-left/right (and width/color/style variants)
- border-radius corners (top-left, top-right, etc.)
- scroll-margin/padding directional

**Smart value checking:** Allows safe values like `text-align: center`, `float: none`, `clear: both`.

**Documentation updates:**
- Added "Inline styles and RTL compatibility" section to `docs/i18n.rst`
- Added "RTL testing checklist" to `docs/i18n.rst`
- Added RTL anti-patterns to `docs/frontend_architecture/conventions.rst`
- Added "RTL-friendly styling quick reference" to conventions

## References

Fixes #12452

## Reviewer guidance

**To test the rule:**
```bash
pnpm jest packages/eslint-plugin-kolibri/tests/lib/rules/vue-no-rtl-breaking-inline-styles.spec.js
```

### RTL Regression Testing

The second commit fixes existing RTL violations by moving inline styles to CSS classes. To test RTL layout, use \`/ar/\` in the URL (e.g., \`http://localhost:8000/ar/learn/\`).

| Area | What to check | RTL Screenshot |
|------|---------------|----------------|
| **Sign-in Page** | Facility selection buttons, username/password entry fields, "change user" link positioning, back navigation links | ![Sign-in](https://i.imgur.com/SeuoNGC.png) |
| **Learn - Library** | "Other Libraries" section with device cards, channel cards layout, "View all" link positioning | ![Library](https://i.imgur.com/UlcIJU1.png) |
| **Learn - Content Cards** | HybridLearningFooter with progress bar and icon buttons (download, bookmark, info, more options menu) | ![Content Cards](https://i.imgur.com/UbvBk0f.png) |
| **Learn - Content Viewer** | LearningActivityBar with title, activity icon, bookmark and info buttons, options menu | ![Content Viewer](https://i.imgur.com/9G3u4Rm.png) |
| **Learn - Topics/Folders** | Folder/Search tab headers, tab underline positioning, side panel folders | ![Topics/Folders](https://i.imgur.com/b5WGgCB.png) |
| **Learn - Bookmarks** | Bookmarked content list layout, empty state message alignment | ![Bookmarks](https://i.imgur.com/DOmRTM7.png) |
| **Side Navigation** | Menu items alignment, close button position in mobile view, navigation drawer opening from correct side | ![Side Nav](https://i.imgur.com/PqRb3LH.png) |
| **Device Settings** | Radio button group indentation for sign-in page options, checkbox alignment, form labels | ![Device Settings](https://i.imgur.com/OJWzIB0.png) |
| **Device - Channels** | Channel list layout, "Manage" buttons positioning, "Import" button | ![Device Channels](https://i.imgur.com/E6Dd1eg.png) |
| **Device - LOD Users** | User import list, loading spinner positioning | — |
| **Coach - Class Home** | Overview blocks, quiz/lesson progress cards, "View all" links | ![Coach Home](https://i.imgur.com/bfOqH94.png) |
| **Coach - Lessons** | Lessons table layout, "New lesson" button, toggle switches, status icons | ![Coach Lessons](https://i.imgur.com/WXL64eh.png) |
| **Coach - Quizzes** | Quizzes table layout, "New quiz" button, status columns | ![Coach Quizzes](https://i.imgur.com/dlBMsWQ.png) |
| **Coach - Groups** | Group members table, "New group" button, action buttons | ![Coach Groups](https://i.imgur.com/5wObq6W.png) |
| **Coach - Questions** | Quiz summary page, learner list layout, question attempt indicators | ![Coach Questions](https://i.imgur.com/FTDY01P.png) |
| **Facility Config** | Checkbox alignment, form labels, "Save" button positioning | ![Facility Config](https://i.imgur.com/BvsmpKr.png) |
| **Facility - Data/Sync** | Sync interface layout, "Create log" buttons, facility sync section | ![Facility Sync](https://i.imgur.com/bj0bkQk.png) |
| **Facility - Import CSV** | CSV import wizard steps, preview table | ![Import CSV](https://i.imgur.com/cK35osv.png) |
| **Facility - Users Table** | Users table layout, search field, pagination, action buttons | ![Facility Users](https://i.imgur.com/FDM38oA.png) |
| **Setup Wizard** | All onboarding steps - language selector, back/continue buttons, form inputs | ![Setup Wizard](https://i.imgur.com/9ejmree.png) |
| **EPUB Viewer** | Top bar controls, search sidebar layout | — |
| **Category Search Modal** | Category icons positioning in search filters | — |

**Recommended alternatives documented:**
1. CSS classes (processed by RTLCSS webpack plugin)
2. CSS Logical Properties (\`margin-inline-start\`, etc.)
3. Computed properties for dynamic RTL-aware styles
4. Theme tokens from the design system