### PR TITLE
Fix missing dep in Coach

### DIFF
--- a/kolibri/plugins/coach/package.json
+++ b/kolibri/plugins/coach/package.json
@@ -18,6 +18,7 @@
     "markdown-it": "14.1.0",
     "truncate-utf8-bytes": "^1.0.2",
     "vue": "catalog:",
+    "vue-router": "catalog:",
     "vuex": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       vue:
         specifier: 'catalog:'
         version: 2.7.16
+      vue-router:
+        specifier: 'catalog:'
+        version: 3.6.5(vue@2.7.16)
       vuex:
         specifier: 'catalog:'
         version: 3.6.2(vue@2.7.16)


### PR DESCRIPTION
## Overview

The recent #14097 PR showed that there was a missing dependency in coach - so we'll fix it first on 0.19 release branch, and I'll update that PR, then pnpm should be ready to roll on both develop and the release branch.