### PR TITLE
Add select courses and recipients subpages

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -686,6 +686,7 @@ class BaseContentNodeMixin(object):
         "categories",
         "duration",
         "ancestors",
+        "modality",
     )
 
     field_map = {

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -643,6 +643,7 @@ def map_file(file):
 contentnode_previously_omitted_fields = {
     "learner_needs": [],
     "on_device_resources": None,
+    "modality": lambda resource: (resource.get("options", {}).get("modality", None)),
 }
 
 
@@ -827,12 +828,7 @@ class InternalContentNodeMixin(BaseContentNodeMixin):
                 response_data["admin_imported"] = (
                     response_data["id"] in self.locally_admin_imported_ids
                 )
-                # As we evolve the contentnode public API, we use this to backfill
-                # values so that remote responses have consistent structure
-                # regardless of the version of Kolibri exposing the endpoint.
-                for key, default_value in contentnode_previously_omitted_fields.items():
-                    if key not in response_data:
-                        response_data[key] = default_value
+                self._fill_content_previously_omitted_fields(response_data)
                 if "children" in response_data:
                     response_data["children"] = self.update_data(
                         response_data["children"], baseurl
@@ -843,6 +839,17 @@ class InternalContentNodeMixin(BaseContentNodeMixin):
                 data.append(self.update_data(node, baseurl))
             response_data = data
         return response_data
+
+    def _fill_content_previously_omitted_fields(self, response_data):
+        # As we evolve the contentnode public API, we use this to backfill
+        # values so that remote responses have consistent structure
+        # regardless of the version of Kolibri exposing the endpoint.
+        for key, default_value in contentnode_previously_omitted_fields.items():
+            if key not in response_data:
+                if callable(default_value):
+                    response_data[key] = default_value(response_data)
+                else:
+                    response_data[key] = default_value
 
     def add_base_url_to_node(self, node, baseurl):
         baseurl_querystring = "?{}={}".format(REMOTE_URL_PARAM, baseurl)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -383,6 +383,7 @@ class ContentNodeAPIBase(object):
                 "is_leaf": expected.kind != "topic",
                 "files": files,
                 "admin_imported": bool(expected.admin_imported),
+                "modality": expected.modality,
             },
         )
 

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -2226,6 +2226,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
             )
             thumbnail = None
             files = []
+
             for f in expected.files.all():
                 "local_file__id",
                 "local_file__available",
@@ -2257,6 +2258,8 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                     thumbnail = f.get_storage_url()
                     if self.baseurl and thumbnail:
                         thumbnail += "?baseurl={}".format(self.baseurl)
+
+            expected_modality = modalities.COURSE
             expected_old_data = {
                 "id": expected.id,
                 "available": expected.available,
@@ -2293,7 +2296,9 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "license_name": expected.license_name,
                 "license_owner": expected.license_owner,
                 "num_coach_contents": expected.num_coach_contents,
-                "options": expected.options,
+                "options": {
+                    "modality": expected_modality,
+                },
                 "parent": expected.parent_id,
                 "sort_order": expected.sort_order,
                 "title": expected.title,
@@ -2322,6 +2327,128 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
             )
             self.assertEqual(response.data["learner_needs"], [])
             self.assertEqual(response.data["on_device_resources"], None)
+            self.assertEqual(response.data["modality"], modalities.COURSE)
+
+    def test_remote_content_node_missing_modality(self):
+        with mock.patch("kolibri.core.content.api.NetworkClient") as nc:
+            mock_response = mock.Mock()
+            mock_response.headers = {}
+            mock_response.status_code = 200
+            expected = content.ContentNode.objects.get(title="c2c2")
+            assessmentmetadata = (
+                expected.assessmentmetadata.all()
+                .values(
+                    "assessment_item_ids",
+                    "number_of_assessments",
+                    "mastery_model",
+                    "randomize",
+                    "is_manipulable",
+                    "contentnode",
+                )
+                .first()
+            )
+            thumbnail = None
+            files = []
+
+            for f in expected.files.all():
+                "local_file__id",
+                "local_file__available",
+                "local_file__file_size",
+                "local_file__extension",
+                "lang_id",
+                file = {}
+                for field in [
+                    "id",
+                    "priority",
+                    "preset",
+                    "supplementary",
+                    "thumbnail",
+                ]:
+                    file[field] = getattr(f, field)
+                file["checksum"] = f.local_file_id
+                for field in [
+                    "available",
+                    "file_size",
+                    "extension",
+                ]:
+                    file[field] = getattr(f.local_file, field)
+                file["lang"] = self.map_language(f.lang)
+                file["storage_url"] = f.get_storage_url()
+                if self.baseurl and file["storage_url"]:
+                    file["storage_url"] += "?baseurl={}".format(self.baseurl)
+                files.append(file)
+                if f.thumbnail:
+                    thumbnail = f.get_storage_url()
+                    if self.baseurl and thumbnail:
+                        thumbnail += "?baseurl={}".format(self.baseurl)
+
+            expected_old_data = {
+                "id": expected.id,
+                "available": expected.available,
+                "author": expected.author,
+                "channel_id": expected.channel_id,
+                "coach_content": expected.coach_content,
+                "content_id": expected.content_id,
+                "description": expected.description,
+                "duration": expected.duration,
+                "learning_activities": (
+                    expected.learning_activities.split(",")
+                    if expected.learning_activities
+                    else []
+                ),
+                "grade_levels": (
+                    expected.grade_levels.split(",") if expected.grade_levels else []
+                ),
+                "resource_types": (
+                    expected.resource_types.split(",")
+                    if expected.resource_types
+                    else []
+                ),
+                "accessibility_labels": (
+                    expected.accessibility_labels.split(",")
+                    if expected.accessibility_labels
+                    else []
+                ),
+                "categories": (
+                    expected.categories.split(",") if expected.categories else []
+                ),
+                "kind": expected.kind,
+                "lang": self.map_language(expected.lang),
+                "license_description": expected.license_description,
+                "license_name": expected.license_name,
+                "license_owner": expected.license_owner,
+                "num_coach_contents": expected.num_coach_contents,
+                # options is empty, no modality provided
+                "options": {},
+                "parent": expected.parent_id,
+                "sort_order": expected.sort_order,
+                "title": expected.title,
+                "lft": expected.lft,
+                "rght": expected.rght,
+                "tree_id": expected.tree_id,
+                "ancestors": [],
+                "tags": list(
+                    expected.tags.all()
+                    .order_by("tag_name")
+                    .values_list("tag_name", flat=True)
+                ),
+                "thumbnail": thumbnail,
+                "assessmentmetadata": assessmentmetadata,
+                "is_leaf": expected.kind != "topic",
+                "files": files,
+                "admin_imported": bool(expected.admin_imported),
+            }
+            mock_response.json.return_value = expected_old_data
+            mock_client = mock.MagicMock()
+            mock_client.get.return_value = mock_response
+            nc.build_for_address.return_value = mock_client
+            response = self.client.get(
+                reverse("kolibri:core:contentnode-detail", kwargs={"pk": expected.id}),
+                data={"baseurl": "http://example.com/"},
+            )
+            self.assertEqual(response.data["learner_needs"], [])
+            self.assertEqual(response.data["on_device_resources"], None)
+            self.assertEqual(response.data["modality"], None)
 
     def tearDown(self):
         """

--- a/kolibri/plugins/coach/frontend/constants/index.js
+++ b/kolibri/plugins/coach/frontend/constants/index.js
@@ -86,6 +86,10 @@ export const GroupModals = {
   DELETE_GROUP: 'DELETE_GROUP',
 };
 
+export const CoursesModals = {
+  ASSIGN_COURSE_SUCCESS: 'ASSIGN_COURSE_SUCCESS',
+};
+
 export const ViewMoreButtonStates = {
   LOADING: 'LOADING',
   HAS_MORE: 'HAS_MORE',

--- a/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
@@ -1,0 +1,186 @@
+<template>
+
+  <div>
+    <section>
+      <h2 class="mt-0">
+        {{ groupsLabel$() }}
+      </h2>
+      <KCheckbox
+        v-for="group in sortedGroups"
+        :key="group.id"
+        v-model="workingSelectedGroupIds"
+        :value="group.id"
+      >
+        <KLabeledIcon
+          :label="group.name"
+          icon="group"
+          class="font-size-14"
+        />
+      </KCheckbox>
+      <KCheckbox
+        :checked="areAllUngroupedLearnersSelected"
+        :disabled="isAllUngroupedLearnersDisabled"
+        @change="selectAllUngroupedLearners($event)"
+      >
+        <KLabeledIcon
+          :label="allUngroupedLearnersLabel$()"
+          icon="people"
+          class="font-size-14"
+          :color="isAllUngroupedLearnersDisabled ? $themeTokens.textDisabled : null"
+        />
+      </KCheckbox>
+    </section>
+    <section>
+      <h2>{{ individualLearnersLabel$() }}</h2>
+      <div class="font-size-14">
+        {{ onlyShowingEnrolledLabel$() }}
+      </div>
+      <IndividualLearnerSelectorTable
+        searchFieldBlock
+        :selectedGroupIds="workingSelectedGroupIds"
+        :selectedLearnerIds.sync="workingAdHocLearners"
+        :disabled="disabled"
+        :targetClassId="classId"
+        @update:selectedLearnerIds="workingAdHocLearners = $event"
+      />
+    </section>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed } from 'vue';
+  import uniq from 'lodash/uniq';
+  import store from 'kolibri/store';
+
+  import { coachStrings } from '../commonCoachStrings';
+  import IndividualLearnerSelectorTable from './IndividualLearnerSelector/IndividualLearnerSelectorTable.vue';
+
+  export default {
+    name: 'LearnersAndGroupsSelector',
+    components: { IndividualLearnerSelectorTable },
+    setup(props, { emit }) {
+      const workingAdHocLearners = computed({
+        get: () => [...props.adHocLearners],
+        set: value => emit('update:adHocLearners', value),
+      });
+      const workingSelectedGroupIds = computed({
+        get: () => [...props.selectedGroupIds],
+        set: value => emit('update:selectedGroupIds', value),
+      });
+
+      const groups = computed(() => {
+        if (props.groups) {
+          return props.groups;
+        }
+        return store.getters['classSummary/groups'];
+      });
+      const learners = computed(() => store.getters['classSummary/learners']);
+
+      const sortedGroups = computed(() => {
+        const groupsList = [...groups.value];
+        return groupsList.sort((a, b) => a.name.localeCompare(b.name));
+      });
+
+      const ungroupedLearnersIds = computed(() => {
+        return learners.value
+          .filter(learner => {
+            return groups.value.every(group => !group.member_ids.includes(learner.id));
+          })
+          .map(learner => learner.id);
+      });
+
+      const isAllUngroupedLearnersDisabled = computed(() => {
+        return props.disabled || ungroupedLearnersIds.value.length === 0;
+      });
+
+      const areAllUngroupedLearnersSelected = computed(() => {
+        if (ungroupedLearnersIds.value.length === 0) {
+          return false;
+        }
+        return ungroupedLearnersIds.value.every(learnerId =>
+          workingAdHocLearners.value.includes(learnerId),
+        );
+      });
+
+      const selectAllUngroupedLearners = isChecked => {
+        if (isChecked) {
+          workingAdHocLearners.value = uniq([
+            ...workingAdHocLearners.value,
+            ...ungroupedLearnersIds.value,
+          ]);
+        } else {
+          workingAdHocLearners.value = workingAdHocLearners.value.filter(
+            learnerId => !ungroupedLearnersIds.value.includes(learnerId),
+          );
+        }
+      };
+
+      const {
+        groupsLabel$,
+        individualLearnersLabel$,
+        onlyShowingEnrolledLabel$,
+        allUngroupedLearnersLabel$,
+      } = coachStrings;
+
+      return {
+        workingAdHocLearners,
+        workingSelectedGroupIds,
+        sortedGroups,
+        isAllUngroupedLearnersDisabled,
+        areAllUngroupedLearnersSelected,
+        selectAllUngroupedLearners,
+        groupsLabel$,
+        individualLearnersLabel$,
+        onlyShowingEnrolledLabel$,
+        allUngroupedLearnersLabel$,
+      };
+    },
+    props: {
+      groups: {
+        type: Array,
+        required: false,
+        default: null,
+      },
+      adHocLearners: {
+        type: Array,
+        required: false,
+        default: () => [],
+      },
+      selectedGroupIds: {
+        type: Array,
+        required: true,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      classId: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .mt-0 {
+    margin-top: 0;
+  }
+
+  section h2 {
+    margin-top: 24px;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .font-size-14 {
+    font-size: 14px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
@@ -1,14 +1,30 @@
 <template>
 
-  <div>
+  <div class="selector-wrapper">
+    <section v-if="showSelectClassOption">
+      <h2>
+        {{ classLabel$() }}
+      </h2>
+      <KRadioButton
+        v-model="isClassSelected"
+        :buttonValue="SELECT_CLASS_OPTION"
+        :disabled="disabled"
+      >
+        <KLabeledIcon
+          :label="entireClassLabel$()"
+          icon="classes"
+        />
+      </KRadioButton>
+    </section>
     <section>
-      <h2 class="mt-0">
+      <h2>
         {{ groupsLabel$() }}
       </h2>
       <KCheckbox
         v-for="group in sortedGroups"
         :key="group.id"
         v-model="workingSelectedGroupIds"
+        :disabled="disabled"
         :value="group.id"
       >
         <KLabeledIcon
@@ -23,7 +39,7 @@
         @change="selectAllUngroupedLearners($event)"
       >
         <KLabeledIcon
-          :label="allUngroupedLearnersLabel$()"
+          :label="allUngroupedLearnres$()"
           icon="people"
           class="font-size-14"
           :color="isAllUngroupedLearnersDisabled ? $themeTokens.textDisabled : null"
@@ -56,7 +72,10 @@
   import store from 'kolibri/store';
 
   import { coachStrings } from '../commonCoachStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import IndividualLearnerSelectorTable from './IndividualLearnerSelector/IndividualLearnerSelectorTable.vue';
+
+  const SELECT_CLASS_OPTION = 'select_class_option';
 
   export default {
     name: 'LearnersAndGroupsSelector',
@@ -64,11 +83,43 @@
     setup(props, { emit }) {
       const workingAdHocLearners = computed({
         get: () => [...props.adHocLearners],
-        set: value => emit('update:adHocLearners', value),
+        set: value => {
+          emit('update:adHocLearners', value);
+          if (workingSelectedGroupIds.value.includes(props.classId)) {
+            workingSelectedGroupIds.value = workingSelectedGroupIds.value.filter(
+              id => id !== props.classId,
+            );
+          }
+        },
       });
       const workingSelectedGroupIds = computed({
         get: () => [...props.selectedGroupIds],
-        set: value => emit('update:selectedGroupIds', value),
+        set: value => {
+          if (value.includes(props.classId) && value.length > 1) {
+            value = value.filter(id => id !== props.classId);
+          }
+          emit('update:selectedGroupIds', value);
+        },
+      });
+
+      const isClassSelected = computed({
+        get: () => {
+          if (!props.showSelectClassOption) {
+            return '';
+          }
+          if (workingSelectedGroupIds.value.find(group => group === props.classId)) {
+            return SELECT_CLASS_OPTION;
+          }
+          return '';
+        },
+        set: value => {
+          if (value === SELECT_CLASS_OPTION) {
+            workingSelectedGroupIds.value = [props.classId];
+            workingAdHocLearners.value = [];
+          } else {
+            workingSelectedGroupIds.value = [];
+          }
+        },
       });
 
       const groups = computed(() => {
@@ -120,22 +171,31 @@
 
       const {
         groupsLabel$,
+        entireClassLabel$,
         individualLearnersLabel$,
         onlyShowingEnrolledLabel$,
-        allUngroupedLearnersLabel$,
+        allUngroupedLearnres$,
       } = coachStrings;
 
+      const { classLabel$ } = coreStrings;
+
       return {
+        SELECT_CLASS_OPTION,
+        isClassSelected,
         workingAdHocLearners,
         workingSelectedGroupIds,
         sortedGroups,
         isAllUngroupedLearnersDisabled,
         areAllUngroupedLearnersSelected,
+
         selectAllUngroupedLearners,
+
+        classLabel$,
         groupsLabel$,
+        entireClassLabel$,
         individualLearnersLabel$,
         onlyShowingEnrolledLabel$,
-        allUngroupedLearnersLabel$,
+        allUngroupedLearnres$,
       };
     },
     props: {
@@ -161,6 +221,10 @@
         type: String,
         required: true,
       },
+      showSelectClassOption: {
+        type: Boolean,
+        default: false,
+      },
     },
   };
 
@@ -169,12 +233,14 @@
 
 <style lang="scss" scoped>
 
-  .mt-0 {
-    margin-top: 0;
+  .selector-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
   }
 
   section h2 {
-    margin-top: 24px;
+    margin-top: 0;
     font-size: 16px;
     font-weight: 600;
   }

--- a/kolibri/plugins/coach/frontend/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/SidePanelRecipientsSelector/LearnersSelectorSidePanel.vue
@@ -13,50 +13,13 @@
       </h1>
     </template>
     <template #default>
-      <section>
-        <h2 class="mt-0">
-          {{ coachString('groupsLabel') }}
-        </h2>
-        <KCheckbox
-          v-for="group in sortedGroups"
-          :key="group.id"
-          :checked="groupIsSelected(group)"
-          :disabled="disabled"
-          @change="toggleGroup($event, group)"
-        >
-          <KLabeledIcon
-            :label="group.name"
-            icon="group"
-            class="font-size-14"
-          />
-        </KCheckbox>
-        <KCheckbox
-          :checked="allUngroupedLearnresIsSelected"
-          :disabled="isAllUngroupedLearnersDisabled"
-          @change="selectAllUngroupedLearners($event)"
-        >
-          <KLabeledIcon
-            :label="$tr('allUngroupedLearnres')"
-            icon="people"
-            class="font-size-14"
-            :color="isAllUngroupedLearnersDisabled ? $themeTokens.textDisabled : null"
-          />
-        </KCheckbox>
-      </section>
-      <section>
-        <h2>{{ coachString('individualLearnersLabel') }}</h2>
-        <div class="font-size-14">
-          {{ coachString('onlyShowingEnrolledLabel') }}
-        </div>
-        <IndividualLearnerSelectorTable
-          searchFieldBlock
-          :selectedGroupIds="workingSelectedGroupIds"
-          :selectedLearnerIds.sync="workingAdHocLearners"
-          :disabled="disabled"
-          :targetClassId="classId"
-          @update:selectedLearnerIds="updateAdHocLearners"
-        />
-      </section>
+      <LearnersAndGroupsSelector
+        :groups="groups"
+        :adHocLearners.sync="workingAdHocLearners"
+        :selectedGroupIds.sync="workingSelectedGroupIds"
+        :disabled="disabled"
+        :classId="classId"
+      />
     </template>
     <template #bottomNavigation>
       <div class="bottom-nav-container">
@@ -74,18 +37,16 @@
 
 <script>
 
-  import uniq from 'lodash/uniq';
-  import { mapGetters, mapState } from 'vuex';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { coachStringsMixin } from '../../../common/commonCoachStrings';
-  import IndividualLearnerSelectorTable from '../IndividualLearnerSelector/IndividualLearnerSelectorTable';
+  import LearnersAndGroupsSelector from '../LearnersAndGroupsSelector.vue';
 
   export default {
     name: 'LearnersSelectorSidePanel',
     components: {
       SidePanelModal,
-      IndividualLearnerSelectorTable,
+      LearnersAndGroupsSelector,
     },
     mixins: [coachStringsMixin, commonCoreStrings],
     props: {
@@ -117,66 +78,11 @@
         workingSelectedGroupIds: this.selectedGroupIds,
       };
     },
-    computed: {
-      ...mapGetters('classSummary', ['learners']),
-      ...mapState('classSummary', ['groupMap']),
-      sortedGroups() {
-        const groups = [...this.groups];
-        return groups.sort((a, b) => a.name.localeCompare(b.name));
-      },
-      ungroupedLearnersIds() {
-        return this.learners
-          .filter(learner => {
-            return Object.values(this.groupMap).every(
-              group => !group.member_ids.includes(learner.id),
-            );
-          })
-          .map(learner => learner.id);
-      },
-      isAllUngroupedLearnersDisabled() {
-        return this.disabled || this.ungroupedLearnersIds.length === 0;
-      },
-      allUngroupedLearnresIsSelected() {
-        if (this.ungroupedLearnersIds.length === 0) {
-          return false;
-        }
-        return this.ungroupedLearnersIds.every(learnerId =>
-          this.workingAdHocLearners.includes(learnerId),
-        );
-      },
-    },
     methods: {
       focusFirstEl() {
         this.$nextTick(() => {
           this.$el.querySelector('input').focus();
         });
-      },
-      groupIsSelected({ id }) {
-        return this.workingSelectedGroupIds.includes(id);
-      },
-      toggleGroup(isChecked, { id }) {
-        if (isChecked) {
-          this.workingSelectedGroupIds = [...this.workingSelectedGroupIds, id];
-        } else {
-          this.workingSelectedGroupIds = this.workingSelectedGroupIds.filter(
-            groupId => groupId !== id,
-          );
-        }
-      },
-      updateAdHocLearners(learnerIds) {
-        this.workingAdHocLearners = learnerIds;
-      },
-      selectAllUngroupedLearners(isChecked) {
-        if (isChecked) {
-          this.workingAdHocLearners = uniq([
-            ...this.workingAdHocLearners,
-            ...this.ungroupedLearnersIds,
-          ]);
-        } else {
-          this.workingAdHocLearners = this.workingAdHocLearners.filter(
-            learnerId => !this.ungroupedLearnersIds.includes(learnerId),
-          );
-        }
       },
       save() {
         this.$emit('update:adHocLearners', this.workingAdHocLearners);
@@ -185,10 +91,6 @@
       },
     },
     $trs: {
-      allUngroupedLearnres: {
-        message: 'All ungrouped learners',
-        context: 'Option to select all learners that are not in a group',
-      },
       selectGroupsAndIndividualLearnersTitle: {
         message: 'Select groups and individual learners',
         context: 'Title for the side panel to select groups and individual learners',
@@ -201,10 +103,6 @@
 
 <style lang="scss" scoped>
 
-  .mt-0 {
-    margin-top: 0;
-  }
-
   .bottom-nav-container {
     display: flex;
     justify-content: flex-end;
@@ -214,16 +112,6 @@
   .side-panel-title {
     font-size: 18px;
     font-weight: 600;
-  }
-
-  section h2 {
-    margin-top: 24px;
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .font-size-14 {
-    font-size: 14px;
   }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
@@ -687,7 +687,7 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       'Label for the radio button that allows the coach to select groups or individual learners to assign a quiz to.',
   },
-  allUngroupedLearnersLabel: {
+  allUngroupedLearnres: {
     message: 'All ungrouped learners',
     context: 'Option to select all learners that are not in a group',
   },

--- a/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
@@ -687,6 +687,10 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       'Label for the radio button that allows the coach to select groups or individual learners to assign a quiz to.',
   },
+  allUngroupedLearnersLabel: {
+    message: 'All ungrouped learners',
+    context: 'Option to select all learners that are not in a group',
+  },
 });
 
 // Strings for the Missing Content modals, tooltips, alerts, etc.

--- a/kolibri/plugins/coach/frontend/views/common/resourceSelection/UpdatedResourceSelection.vue
+++ b/kolibri/plugins/coach/frontend/views/common/resourceSelection/UpdatedResourceSelection.vue
@@ -58,13 +58,22 @@
         default: false,
       },
       /**
-       * Boolean that determines if the select checkboxes should be rendered.
+       * Boolean that determines if the select checkboxes should be rendered for resources.
        * This is different from `selectionRules` as `selectionRules` just determines
        * whether the checkbox is enabled or not.
        */
       isSelectable: {
         type: Boolean,
         default: true,
+      },
+      /**
+       * Boolean that determines if the select checkboxes should be rendered for topics.
+       * This is different from `selectionRules` as `selectionRules` just determines
+       * whether the checkbox is enabled or not.
+       */
+      isTopicSelectable: {
+        type: Boolean,
+        default: false,
       },
       multi: {
         type: Boolean,
@@ -188,7 +197,8 @@
        */
       getResourceLink: {
         type: Function,
-        required: true,
+        required: false,
+        default: () => {},
       },
       hideBreadcrumbs: {
         type: Boolean,
@@ -292,6 +302,9 @@
         }
       },
       showCheckbox(node) {
+        if (node.kind === ContentNodeKinds.TOPIC) {
+          return this.isTopicSelectable;
+        }
         return this.isSelectable && node.kind !== ContentNodeKinds.TOPIC;
       },
     },

--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -18,7 +18,11 @@
       whose routes are defined in coach/frontend/routes/coursesRoutes.js
       Side panels will only be rendered when their route is active.
     -->
-    <router-view />
+    <router-view @showModal="modelOpen = $event" />
+    <AssignCourseSuccessModal
+      v-if="modelOpen === CoursesModals.ASSIGN_COURSE_SUCCESS"
+      @close="modelOpen = null"
+    />
   </CoachAppBarPage>
 
 </template>
@@ -28,21 +32,24 @@
 
   import store from 'kolibri/store';
   import { useRoute } from 'vue-router/composables';
-  import { computed } from 'vue';
+  import { computed, ref } from 'vue';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
-  import { PageNames } from '../../constants';
+  import { CoursesModals, PageNames } from '../../constants';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
   import CoachHeader from '../common/CoachHeader.vue';
   import { overrideRoute } from '../../utils';
+  import AssignCourseSuccessModal from './modals/AssignCourseSuccess.vue';
 
   export default {
     name: 'CoursesRootPage',
     components: {
       CoachHeader,
       CoachAppBarPage,
+      AssignCourseSuccessModal,
     },
     setup() {
       const route = useRoute();
+      const modelOpen = ref(null);
       const { coursesLabel$, assignCourseAction$ } = coursesStrings;
 
       // Temporarily adding it here, it should be moved to a place after
@@ -57,6 +64,8 @@
         }),
       );
       return {
+        CoursesModals,
+        modelOpen,
         assignCourseRoute,
 
         coursesLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
+++ b/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
@@ -1,0 +1,66 @@
+import Modalities from 'kolibri-constants/Modalities';
+import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+import { ref, computed, provide, inject, watch } from 'vue';
+import useFetch from '../../../composables/useFetch';
+
+/**
+ * Composable for managing the logic for the Assign Course side panel.
+ * This composable will be live during the lifetime of the Assign Course side panel, and
+ * will be used to encapsulate all the logic related to assigning a course to learners.
+ *
+ * This should be instantiated in the parent component of the Assign Course side panel
+ * and its state and methods will be passed down to child components through provide/inject.
+ *
+ * @returns {void}
+ */
+export default function useAssignCourse() {
+  const searchKeywords = ref('');
+  const selectedCourse = ref(null);
+
+  const coursesFetch = useFetch({
+    fetchMethod: () => {
+      return ContentNodeResource.fetchCollection({
+        getParams: {
+          available: true,
+          max_results: 25,
+          modality: Modalities.COURSE,
+          keywords: searchKeywords.value,
+        },
+      });
+    },
+    fetchMoreMethod: moreParams => {
+      return ContentNodeResource.fetchCollection({
+        getParams: moreParams,
+      });
+    },
+  });
+
+  const isLoading = computed(() => coursesFetch.loading.value);
+
+  // Initial fetch of courses
+  coursesFetch.fetchData();
+
+  const selectCourse = course => {
+    selectedCourse.value = course;
+  };
+
+  watch(searchKeywords, () => {
+    coursesFetch.fetchData();
+  });
+
+  provide('assignCourseIsLoading', isLoading);
+  provide('assignCourseSearchKeywords', searchKeywords);
+  provide('assignCourseCoursesFetch', coursesFetch);
+  provide('assignCourseSelectedCourse', selectedCourse);
+  provide('assignCourseSelectCourse', selectCourse);
+}
+
+export function injectAssignCourse() {
+  return {
+    isLoading: inject('assignCourseIsLoading'),
+    searchKeywords: inject('assignCourseSearchKeywords'),
+    coursesFetch: inject('assignCourseCoursesFetch'),
+    selectedCourse: inject('assignCourseSelectedCourse'),
+    selectCourse: inject('assignCourseSelectCourse'),
+  };
+}

--- a/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
+++ b/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
@@ -1,21 +1,27 @@
 import Modalities from 'kolibri-constants/Modalities';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
 import { ref, computed, provide, inject, watch } from 'vue';
 import useFetch from '../../../composables/useFetch';
 
 /**
  * Composable for managing the logic for the Assign Course side panel.
- * This composable will be live during the lifetime of the Assign Course side panel, and
+ * This composable will live during the lifetime of the Assign Course side panel, and
  * will be used to encapsulate all the logic related to assigning a course to learners.
  *
- * This should be instantiated in the parent component of the Assign Course side panel
+ * This is instantiated in the root component of the Assign Course side panel
  * and its state and methods will be passed down to child components through provide/inject.
  *
- * @returns {void}
+ * @param {Object} options **Required** Configuration options for the composable.
+ * @param {import('vue').Ref<string>} options.classId **Required** The id of the class to which
+ *                                                    the course will be assigned.
  */
-export default function useAssignCourse() {
+export default function useAssignCourse({ classId }) {
   const searchKeywords = ref('');
   const selectedCourse = ref(null);
+
+  const selectedGroupIds = ref([]);
+  const selectedLearnerIds = ref([]);
 
   const coursesFetch = useFetch({
     fetchMethod: () => {
@@ -37,30 +43,69 @@ export default function useAssignCourse() {
 
   const isLoading = computed(() => coursesFetch.loading.value);
 
-  // Initial fetch of courses
-  coursesFetch.fetchData();
-
   const selectCourse = course => {
     selectedCourse.value = course;
   };
+
+  const assignCourse = () => {
+    return CourseSessionResource.saveModel({
+      data: {
+        active: false,
+        collection: classId.value,
+        course: selectedCourse.value.id,
+        assignments: selectedGroupIds.value,
+        learner_ids: selectedLearnerIds.value,
+      },
+    });
+  };
+
+  // Initial fetch of courses
+  coursesFetch.fetchData();
 
   watch(searchKeywords, () => {
     coursesFetch.fetchData();
   });
 
+  provide('assignCourseClassId', classId);
   provide('assignCourseIsLoading', isLoading);
   provide('assignCourseSearchKeywords', searchKeywords);
   provide('assignCourseCoursesFetch', coursesFetch);
   provide('assignCourseSelectedCourse', selectedCourse);
+  provide('assignCourseSelectedGroupIds', selectedGroupIds);
+  provide('assignCourseSelectedLearnerIds', selectedLearnerIds);
   provide('assignCourseSelectCourse', selectCourse);
+  provide('assignCourseAssignCourse', assignCourse);
 }
 
+/**
+ * @typedef {import('../../../composables/useFetch').FetchObject} FetchObject
+ *
+ * @typedef {Object} AssignCourseInjectObject
+ * @property {import('vue').Ref<string>} classId The id of the class to which the course will
+ *                                               be assigned.
+ * @property {import('vue').Ref<string>} searchKeywords The keywords used to search for courses.
+ * @property {FetchObject} coursesFetch The useFetch object for fetching courses.
+ * @property {import('vue').Ref<Object|null>} selectedCourse The currently selected course.
+ * @property {import('vue').Ref<Array<string>>} selectedGroupIds The ids of the selected groups
+ *                                                               to assign the course to.
+ * @property {import('vue').Ref<Array<string>>} selectedLearnerIds The ids of the selected learners
+ *                                                                 to assign the course to.
+ * @property {(course: Object) => void} selectCourse Method to set the `selectedCourse` ref.
+ * @property {() => Promise<Object>} assignCourse Method to assign the selected course to the
+ *                                                selected learners and groups.
+ *
+ * @returns {AssignCourseInjectObject} An object with properties and methods for managing
+ *                                     the fetch process.
+ */
 export function injectAssignCourse() {
   return {
-    isLoading: inject('assignCourseIsLoading'),
+    classId: inject('assignCourseClassId'),
     searchKeywords: inject('assignCourseSearchKeywords'),
     coursesFetch: inject('assignCourseCoursesFetch'),
     selectedCourse: inject('assignCourseSelectedCourse'),
+    selectedGroupIds: inject('assignCourseSelectedGroupIds'),
+    selectedLearnerIds: inject('assignCourseSelectedLearnerIds'),
     selectCourse: inject('assignCourseSelectCourse'),
+    assignCourse: inject('assignCourseAssignCourse'),
   };
 }

--- a/kolibri/plugins/coach/frontend/views/courses/modals/AssignCourseSuccess.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/modals/AssignCourseSuccess.vue
@@ -1,0 +1,45 @@
+<template>
+
+  <KModal
+    :title="courseIsAssignedTitle$()"
+    :submitText="closeAction$()"
+    @submit="$emit('close')"
+  >
+    <span class="fix-message-line-height">
+      {{ courseIsAssignedMessage$() }}
+    </span>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+
+  export default {
+    name: 'AssignCourseSuccessModal',
+    setup() {
+      const { closeAction$ } = coreStrings;
+      const { courseIsAssignedTitle$, courseIsAssignedMessage$ } = coursesStrings;
+      return {
+        closeAction$,
+        courseIsAssignedTitle$,
+        courseIsAssignedMessage$,
+      };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .fix-message-line-height {
+    // Override default global line-height of 1.15 which is not enough
+    // space for kmodal and makes scrollbar appear in their parent containers.
+    line-height: 1.5;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
@@ -5,7 +5,10 @@
       Router view for subpages navigation implemented in AssignCourse/subPages/...
       whose routes are defined in coach/frontend/routes/coursesRoutes.js
     -->
-    <router-view @closePanel="closeSidePanel" />
+    <router-view
+      @closePanel="closeSidePanel"
+      @success="onSuccess"
+    />
   </SidePanelModal>
 
 </template>
@@ -14,8 +17,9 @@
 <script>
 
   import { useRoute, useRouter } from 'vue-router/composables';
+  import { computed } from 'vue';
   import SidePanelModal from '../../../common/sidePanel/SidePanelModal.vue';
-  import { PageNames } from '../../../../constants';
+  import { CoursesModals, PageNames } from '../../../../constants';
   import { overrideRoute } from '../../../../utils';
   import useAssignCourse from '../../composables/useAssignCourse';
 
@@ -24,8 +28,9 @@
    * "Assign Course" side panel, providing the SidePanelModal wrapper, and the
    * router-view for the subpages within the side panel.
    *
-   * This component will define the data scope for all subpages within the side panel, and
-   * will make it available to all subpages through the provide/inject pattern.
+   * This component will instantiate the `useAssignCourse` composable to define the data
+   * scope for all subpages within the side panel, and will make it available to all
+   * subpages through the provide/inject pattern.
    * Data Flow:
    * - This component provides shared assignment data to child components
    * - Child components inject the data they need for their specific concerns
@@ -40,15 +45,25 @@
     components: {
       SidePanelModal,
     },
-    setup() {
-      useAssignCourse();
+    setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
+
+      const classId = computed(() => route.params.classId);
+      useAssignCourse({ classId });
+
       const closeSidePanel = () => {
         router.push(overrideRoute(route, { name: PageNames.COURSES_ROOT }));
       };
+
+      const onSuccess = () => {
+        closeSidePanel();
+        emit('showModal', CoursesModals.ASSIGN_COURSE_SUCCESS);
+        emit('refreshData');
+      };
       return {
         closeSidePanel,
+        onSuccess,
       };
     },
   };

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
@@ -17,6 +17,7 @@
   import SidePanelModal from '../../../common/sidePanel/SidePanelModal.vue';
   import { PageNames } from '../../../../constants';
   import { overrideRoute } from '../../../../utils';
+  import useAssignCourse from '../../composables/useAssignCourse';
 
   /**
    * This component will serve as the root component for the
@@ -40,6 +41,7 @@
       SidePanelModal,
     },
     setup() {
+      useAssignCourse();
       const route = useRoute();
       const router = useRouter();
       const closeSidePanel = () => {

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
@@ -5,7 +5,34 @@
     :title="selectCourseLabel$()"
   >
     <template #default>
-      <!-- Content for selecting a course to assign can go here -->
+      <SearchBox
+        maxWidth="unset"
+        :disabled="isLoading"
+        :value="searchKeywords"
+        :placeholder="searchByKeyword$()"
+        :style="{
+          marginBottom: '12px',
+          marginRight: '0',
+          marginTop: '8px',
+        }"
+        @change="searchKeywords = $event"
+      />
+      <KCircularLoader
+        v-if="isLoading"
+        disableDefaultTransition
+      />
+      <UpdatedResourceSelection
+        v-if="!isLoading"
+        isTopicSelectable
+        :multi="false"
+        :contentList="contentList"
+        :hasMore="hasMore"
+        :fetchMore="fetchMore"
+        :loadingMore="loadingMore"
+        :selectedResources="selectedResources"
+        :getTopicLink="getCourseLink"
+        @setSelectedResources="setSelectedResourcesHandler"
+      />
     </template>
     <template #bottomNavigation>
       <div class="bottom-actions">
@@ -15,6 +42,7 @@
         />
         <KButton
           primary
+          :disabled="!selectedCourse"
           :text="selectRecipientsLabel$()"
           @click="selectRecipients"
         />
@@ -30,14 +58,21 @@
   import { useRoute, useRouter } from 'vue-router/composables';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import SearchBox from 'kolibri-common/components/SearchBox';
+  import { computed } from 'vue';
   import SidePanelLayout from '../../../../common/sidePanel/SidePanelLayout.vue';
   import { overrideRoute } from '../../../../../utils';
   import { PageNames } from '../../../../../constants';
 
+  import { injectAssignCourse } from '../../../composables/useAssignCourse';
+  import UpdatedResourceSelection from '../../../../common/resourceSelection/UpdatedResourceSelection.vue';
+
   export default {
     name: 'AssignCourseIndexSubpage',
     components: {
+      SearchBox,
       SidePanelLayout,
+      UpdatedResourceSelection,
     },
     setup(props, { emit }) {
       const route = useRoute();
@@ -46,7 +81,10 @@
         emit('closePanel');
       };
 
-      const { cancelAction$ } = coreStrings;
+      const { isLoading, searchKeywords, coursesFetch, selectedCourse, selectCourse } =
+        injectAssignCourse();
+
+      const { cancelAction$, searchByKeyword$ } = coreStrings;
       const { selectCourseLabel$, selectRecipientsLabel$ } = coursesStrings;
 
       const selectRecipients = () => {
@@ -57,12 +95,41 @@
         );
       };
 
+      const { data, hasMore, fetchMore, loadingMore } = coursesFetch;
+      const selectedResources = computed(() => {
+        return selectedCourse.value ? [selectedCourse.value] : [];
+      });
+
+      const getCourseLink = course => {
+        return overrideRoute(route, {
+          name: PageNames.COURSES_ASSIGN_COURSE_DETAILS,
+          params: { courseId: course.id },
+        });
+      };
+
+      const setSelectedResourcesHandler = resources => {
+        const [course] = resources;
+        selectCourse(course);
+      };
+
       return {
+        isLoading,
+        searchKeywords,
+        contentList: data,
+        hasMore,
+        loadingMore,
+        selectedCourse,
+        selectedResources,
+        setSelectedResourcesHandler,
+
+        fetchMore,
         closePanel,
+        getCourseLink,
         selectRecipients,
 
         cancelAction$,
         selectCourseLabel$,
+        searchByKeyword$,
         selectRecipientsLabel$,
       };
     },

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
@@ -77,12 +77,12 @@
     setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
+
       const closePanel = () => {
         emit('closePanel');
       };
 
-      const { isLoading, searchKeywords, coursesFetch, selectedCourse, selectCourse } =
-        injectAssignCourse();
+      const { searchKeywords, coursesFetch, selectedCourse, selectCourse } = injectAssignCourse();
 
       const { cancelAction$, searchByKeyword$ } = coreStrings;
       const { selectCourseLabel$, selectRecipientsLabel$ } = coursesStrings;
@@ -95,7 +95,7 @@
         );
       };
 
-      const { data, hasMore, fetchMore, loadingMore } = coursesFetch;
+      const { data, hasMore, fetchMore, loading, loadingMore } = coursesFetch;
       const selectedResources = computed(() => {
         return selectedCourse.value ? [selectedCourse.value] : [];
       });
@@ -113,7 +113,7 @@
       };
 
       return {
-        isLoading,
+        isLoading: loading,
         searchKeywords,
         contentList: data,
         hasMore,

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
@@ -3,11 +3,16 @@
   <SidePanelLayout
     :goBack="goBack"
     :title="selectRecipientsLabel$()"
-    :subtitle="courseNameLabel$({ name: 'Course with a name that is super long, test overflow' })"
+    :subtitle="courseNameLabel$({ name: selectedCourse.title })"
   >
-    <!-- TODO: Replace with actual course details content -->
     <template #default>
-      <!-- Content for selecting a course to assign can go here -->
+      <LearnersAndGroupsSelector
+        showSelectClassOption
+        :classId="classId"
+        :disabled="isSaving"
+        :selectedGroupIds.sync="selectedGroupIds"
+        :adHocLearners.sync="selectedLearnerIds"
+      />
     </template>
     <template #bottomNavigation>
       <div>
@@ -16,11 +21,14 @@
       <div class="bottom-actions">
         <KButton
           :text="backAction$()"
+          :disabled="isSaving"
           @click="goBack"
         />
         <KButton
           primary
+          :disabled="isAssignButtonDisabled"
           :text="assignCourseAction$()"
+          @click="handleAssignCourse"
         />
       </div>
     </template>
@@ -34,20 +42,30 @@
   import { useRoute, useRouter } from 'vue-router/composables';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import { computed, onMounted, ref } from 'vue';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
   import SidePanelLayout from '../../../../common/sidePanel/SidePanelLayout.vue';
   import { overrideRoute } from '../../../../../utils';
   import { PageNames } from '../../../../../constants';
+  import { injectAssignCourse } from '../../../composables/useAssignCourse';
+  import LearnersAndGroupsSelector from '../../../../common/assignments/LearnersAndGroupsSelector.vue';
 
   export default {
     name: 'SelectRecipientsSubpage',
     components: {
       SidePanelLayout,
+      LearnersAndGroupsSelector,
     },
-    setup() {
+    setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
+      const isSaving = ref(false);
+      const { createSnackbar } = useSnackbar();
 
-      const { backAction$ } = coreStrings;
+      const { classId, selectedCourse, assignCourse, selectedGroupIds, selectedLearnerIds } =
+        injectAssignCourse();
+
+      const { backAction$, defaultErrorMessage$ } = coreStrings;
       const { courseNameLabel$, assignCourseAction$, selectRecipientsLabel$ } = coursesStrings;
 
       const goBack = () => {
@@ -58,8 +76,41 @@
         );
       };
 
+      const isAssignButtonDisabled = computed(() => {
+        if (isSaving.value) {
+          return true;
+        }
+        return selectedGroupIds.value.length === 0 && selectedLearnerIds.value.length === 0;
+      });
+
+      const handleAssignCourse = async () => {
+        isSaving.value = true;
+        try {
+          await assignCourse();
+          emit('success');
+        } catch (error) {
+          createSnackbar(defaultErrorMessage$());
+        } finally {
+          isSaving.value = false;
+        }
+      };
+
+      onMounted(() => {
+        if (!selectedCourse.value) {
+          goBack();
+        }
+      });
+
       return {
+        isSaving,
+        classId,
+        selectedCourse,
+        selectedGroupIds,
+        selectedLearnerIds,
+        isAssignButtonDisabled,
+
         goBack,
+        handleAssignCourse,
 
         backAction$,
         courseNameLabel$,

--- a/kolibri/plugins/coach/package.json
+++ b/kolibri/plugins/coach/package.json
@@ -18,6 +18,7 @@
     "markdown-it": "14.1.0",
     "truncate-utf8-bytes": "^1.0.2",
     "vue": "catalog:",
+    "vue-router": "catalog:",
     "vuex": "catalog:"
   }
 }

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -1,0 +1,5 @@
+import { Resource } from 'kolibri/apiResource';
+
+export default new Resource({
+  name: 'coursesession',
+});

--- a/packages/kolibri-common/components/SearchBox.vue
+++ b/packages/kolibri-common/components/SearchBox.vue
@@ -48,7 +48,7 @@
           <template #icon>
             <KIcon
               :icon="icon"
-              :style="{ width: '24px', height: '24px', top: '7px' }"
+              :style="{ width: '24px', height: '24px' }"
               :color="$themeTokens.textInverted"
             />
           </template>
@@ -98,6 +98,10 @@
         type: Boolean,
         default: false,
       },
+      maxWidth: {
+        type: String,
+        default: '450px',
+      },
     },
     data() {
       return {
@@ -126,6 +130,7 @@
             color: this.$themeTokens.annotation,
           },
           color: this.$themeTokens.text,
+          backgroundColor: 'transparent',
           textAlign: this.isRtl ? 'right' : '',
         };
       },
@@ -193,7 +198,8 @@
   .search-box-row {
     display: table;
     width: 100%;
-    max-width: 450px;
+    /* stylelint-disable-next-line */
+    max-width: v-bind('maxWidth');
     border: solid 1px;
     border-radius: $radius;
   }

--- a/packages/kolibri-common/components/SearchFiltersPanel/index.vue
+++ b/packages/kolibri-common/components/SearchFiltersPanel/index.vue
@@ -127,7 +127,7 @@
           ref="searchBox"
           style="margin-bottom: 1em"
           :disabled="searchLoading"
-          :placeholder="$tr('searchByKeyword')"
+          :placeholder="coreString('searchByKeyword')"
           :value="value.keywords || ''"
           @change="val => $emit('input', { ...value, keywords: val })"
         />
@@ -427,10 +427,6 @@
       keywords: {
         message: 'Keywords',
         context: 'Section header label in the Library page sidebar.',
-      },
-      searchByKeyword: {
-        message: 'Search by keyword',
-        context: 'Placeholder text in the search box, which is otherwise not labelled',
       },
       categories: {
         message: 'Categories',

--- a/packages/kolibri-common/composables/useCoachMetadataTags.js
+++ b/packages/kolibri-common/composables/useCoachMetadataTags.js
@@ -1,6 +1,8 @@
 import useLearningActivities from 'kolibri-common/composables/useLearningActivities';
+import Modalities from 'kolibri-constants/Modalities';
 import { ActivitiesLookup, ContentNodeKinds, LearningActivities } from 'kolibri/constants';
 import { coreString, coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { coursesStrings } from '../strings/coursesStrings';
 
 /**
  * Create a tag Object that can be used to display metadata
@@ -28,6 +30,9 @@ export function useCoachMetadataTags(contentNode) {
   }
 
   function getKindTag() {
+    if (contentNode.modality === Modalities.COURSE) {
+      return createTag(coursesStrings.$tr('courseLabel'), 'course', 'course');
+    }
     if (contentNode.kind === ContentNodeKinds.CHANNEL) {
       return createTag(coreStrings.$tr('channel'), 'channel');
     }

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -1,6 +1,10 @@
 import { createTranslator } from 'kolibri/utils/i18n';
 
 export const coursesStrings = createTranslator('CoursesStrings', {
+  courseLabel: {
+    message: 'Course',
+    context: 'Label for a single course that contains units and lessons.',
+  },
   coursesLabel: {
     message: 'Courses',
     context: 'Label for courses that contain units and lessons.',

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -25,4 +25,13 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Selected learners',
     context: 'Label for the list of selected learners when assigning a course.',
   },
+  courseIsAssignedTitle: {
+    message: 'Course is assigned!',
+    context: 'Title for the modal that confirms a course has been assigned.',
+  },
+  courseIsAssignedMessage: {
+    message:
+      'Learners in the assigned group will take a pre-test before starting this course. You can adjust assessment availability in the course settings.',
+    context: 'Message for the modal that confirms a course has been assigned.',
+  },
 });

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -1168,6 +1168,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       "Error message a user sees if they've used the wrong username or password when they sign in to Kolibri.",
   },
+  defaultErrorMessage: {
+    message: 'Sorry! Something went wrong, please try again.',
+    context: 'Default error message for API errors.',
+  },
 
   // Formatting
   nameWithIdInParens: {

--- a/packages/kolibri/uiText/commonCoreStrings.js
+++ b/packages/kolibri/uiText/commonCoreStrings.js
@@ -485,6 +485,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Search',
     context: 'Test used to indicate the Kolibri search field.',
   },
+  searchByKeyword: {
+    message: 'Search by keyword',
+    context: 'Text which appears in the search field used to search for resources by keyword.',
+  },
   searchForUser: {
     message: 'Search for a user...',
     context:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       vue:
         specifier: 'catalog:'
         version: 2.7.16
+      vue-router:
+        specifier: 'catalog:'
+        version: 3.6.5(vue@2.7.16)
       vuex:
         specifier: 'catalog:'
         version: 3.6.2(vue@2.7.16)


### PR DESCRIPTION

## Summary
* Implements the SelectCourseIndex subpage.
* Implements SelectRecipients subpage.
  * Refactors `LearnersSelectorSidePanel` to extract the core selection component so that it can be reused in the courses assignment side panel.
  * Adds a "showSelectClassOption" prop to this new component to show select a class option that is now needed in the courses assignment side panel.
* Fixes a couple of style issues in `SearchBox`.

https://github.com/user-attachments/assets/1e821694-7a3e-474f-b024-cef00219ea14




## References
Closes #13976.
Closes #14094.

## Reviewer guidance
* Import a channel with courses. E.g.: `gajif-kudos`
* Go to coach > courses
* Check the basic courses listing and the select recipients sub page.
* Check that coursesessions are created correctly.
* Check that no regression is present on other exam/lessons assignment flows.