### PR TITLE
Removes residue style overrides prop code

### DIFF
--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -77,6 +77,7 @@
 
   import dialogPolyfill from 'dialog-polyfill';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   function supportsDialogClosedBy() {
     if (typeof document === 'undefined') {
@@ -93,6 +94,13 @@
   export default {
     name: 'Lightbox',
     mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
+
+      return {
+        windowIsSmall,
+      };
+    },
     props: {
       open: {
         type: Boolean,
@@ -224,9 +232,8 @@
         this.backdropSize.width = window.innerWidth;
         this.backdropSize.height = window.innerHeight - 40; // action bar height
 
-        const isSmallWindow = this.styleOverrides.windowSizeClass?.includes('small-window');
-        const maxW = this.backdropSize.width - (isSmallWindow ? 32 : 64);
-        const maxH = this.backdropSize.height - (isSmallWindow ? 32 : 64);
+        const maxW = this.backdropSize.width - (this.windowIsSmall ? 32 : 64);
+        const maxH = this.backdropSize.height - (this.windowIsSmall ? 32 : 64);
 
         const img = this.$refs.imageRef;
         if (!img) return;

--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -60,7 +60,7 @@
         :alt="alt"
         tabindex="-1"
         class="expanded-image"
-        :class="styleOverrides.windowSizeClass"
+        :class="windowSizeClass"
         :style="imgStyle"
         @load="calculateSize"
         @mousedown="onMouseDown"
@@ -114,10 +114,6 @@
         type: String,
         default: '',
       },
-      styleOverrides: {
-        type: Object,
-        default: () => ({}),
-      },
     },
     data() {
       return {
@@ -142,6 +138,9 @@
           transform: `translate(${this.delta.x}px, ${this.delta.y}px)`,
           cursor: this.scale > 1 ? (this.isDragging ? 'grabbing' : 'grab') : 'auto',
         };
+      },
+      windowSizeClass() {
+        return this.windowIsSmall ? 'small-window' : '';
       },
       btnHoverStyle() {
         return {

--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -60,7 +60,6 @@
         :alt="alt"
         tabindex="-1"
         class="expanded-image"
-        :class="windowSizeClass"
         :style="imgStyle"
         @load="calculateSize"
         @mousedown="onMouseDown"
@@ -138,9 +137,6 @@
           transform: `translate(${this.delta.x}px, ${this.delta.y}px)`,
           cursor: this.scale > 1 ? (this.isDragging ? 'grabbing' : 'grab') : 'auto',
         };
-      },
-      windowSizeClass() {
-        return this.windowIsSmall ? 'small-window' : '';
       },
       btnHoverStyle() {
         return {
@@ -473,5 +469,4 @@
   .action-bar {
     user-select: none;
   }
-
 </style>

--- a/packages/kolibri-common/components/SafeHTML/Lightbox.vue
+++ b/packages/kolibri-common/components/SafeHTML/Lightbox.vue
@@ -469,4 +469,5 @@
   .action-bar {
     user-select: none;
   }
+
 </style>

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -26,7 +26,6 @@
       :open="lightboxOpen"
       :src="src"
       :alt="alt"
-      :styleOverrides="styleOverrides"
       @closeLightbox="closeLightbox"
     />
   </div>
@@ -47,10 +46,6 @@
     props: {
       src: { type: String, required: true },
       alt: { type: String, default: '' },
-      styleOverrides: {
-        type: Object,
-        default: () => ({}),
-      },
     },
     data() {
       return {

--- a/packages/kolibri-common/components/SafeHTML/__tests__/Lightbox.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/Lightbox.spec.js
@@ -5,7 +5,6 @@ import Lightbox from '../Lightbox.vue';
 const sampleOpen = true;
 const sampleSrc = 'test_img.jpg';
 const sampleAlt = 'Test img alt text';
-const sampleStyleOverrides = { windowSizeClass: '' };
 
 const renderComponent = () => {
   return render(Lightbox, {
@@ -13,7 +12,6 @@ const renderComponent = () => {
       open: sampleOpen,
       src: sampleSrc,
       alt: sampleAlt,
-      styleOverrides: sampleStyleOverrides,
     },
   });
 };

--- a/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlImage.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlImage.spec.js
@@ -4,14 +4,12 @@ import SafeHtmlImage from '../SafeHtmlImage.vue';
 
 const sampleSrc = 'test_img.jpg';
 const sampleAlt = 'Test img alt text';
-const sampleStyleOverrides = { windowSizeClass: '' };
 
 const renderComponent = () => {
   return render(SafeHtmlImage, {
     props: {
       src: sampleSrc,
       alt: sampleAlt,
-      styleOverrides: sampleStyleOverrides,
     },
   });
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
This pr removes all residual code from the remove of the `styleOverrides` prop.

## References
<!--
 * references to related issues and PRs
-->
Closes #13852

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Install the Safe Html5 plugin by running `kolibri plugin enable kolibri.plugins.safe_html5_viewer`
- Run Kolibri and view HTML5 content
- Ensure no regressions
