### PR TITLE
Learn Course Assignments API Endpoints

### DIFF
--- a/kolibri/plugins/learn/api_urls.py
+++ b/kolibri/plugins/learn/api_urls.py
@@ -3,6 +3,7 @@ from django.urls import re_path
 from rest_framework import routers
 
 from .viewsets import LearnerClassroomViewset
+from .viewsets import LearnerCourseViewset
 from .viewsets import LearnerLessonViewset
 from .viewsets import LearnHomePageHydrationView
 from .viewsets import LearnStateView
@@ -12,6 +13,7 @@ router.register(
     r"learnerclassroom", LearnerClassroomViewset, basename="learnerclassroom"
 )
 router.register(r"learnerlesson", LearnerLessonViewset, basename="learnerlesson")
+router.register(r"learnercourse", LearnerCourseViewset, basename="learnercourse")
 
 
 urlpatterns = [

--- a/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
+++ b/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
@@ -71,7 +71,6 @@ const TEST_CLASSES = [
   {
     id: 'class-1',
     name: 'Class 1',
-    assignments: {
       exams: [
         {
           id: 'class-1-active-quiz-in-progress',
@@ -153,11 +152,9 @@ const TEST_CLASSES = [
         },
       ],
     },
-  },
   {
     id: 'class-2',
     name: 'Class 2',
-    assignments: {
       exams: [
         {
           id: 'class-2-active-quiz-in-progress',
@@ -205,7 +202,6 @@ const TEST_CLASSES = [
           },
         },
       ],
-    },
   },
 ];
 
@@ -215,10 +211,10 @@ const TEST_CLASSES = [
 function finishClasses(classes) {
   const finishedClasses = cloneDeep(classes);
   return finishedClasses.map(c => {
-    c.assignments.exams.forEach(quiz => {
+    c.exams.forEach(quiz => {
       quiz.progress.closed = true;
     });
-    c.assignments.lessons.forEach(lesson => {
+    c.lessons.forEach(lesson => {
       lesson.progress.resource_progress = lesson.progress.total_resources;
     });
     return c;

--- a/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
@@ -47,7 +47,7 @@ function _cacheLessonResources(lesson) {
 }
 
 function setClassData(classroom) {
-  for (const lesson of classroom.assignments.lessons) {
+  for (const lesson of classroom.lessons) {
     _cacheLessonResources(lesson);
   }
 }
@@ -65,7 +65,7 @@ export default function useLearnerResources() {
    * @private
    */
   const _classesQuizzes = computed(() => {
-    return flatMap(get(classes), c => c.assignments.exams);
+    return flatMap(get(classes), c => c.exams);
   });
 
   /**
@@ -74,7 +74,7 @@ export default function useLearnerResources() {
    * @public
    */
   const activeClassesLessons = computed(() => {
-    return flatMap(get(classes), c => c.assignments.lessons);
+    return flatMap(get(classes), c => c.lessons);
   });
 
   /**
@@ -86,7 +86,7 @@ export default function useLearnerResources() {
     return flatMapDepth(
       get(classes),
       c =>
-        c.assignments.lessons.map(l =>
+        c.lessons.map(l =>
           l.resources.map(r => ({
             contentNodeId: r.contentnode_id,
             progress: r.progress,
@@ -158,10 +158,10 @@ export default function useLearnerResources() {
    */
   function getClassActiveLessons(classId) {
     const classroom = getClass(classId);
-    if (!classroom || !classroom.assignments || !classroom.assignments.lessons) {
+    if (!classroom || !classroom.lessons) {
       return [];
     }
-    return classroom.assignments.lessons.filter(lesson => lesson.active);
+    return classroom.lessons.filter(lesson => lesson.active);
   }
 
   /**
@@ -171,10 +171,10 @@ export default function useLearnerResources() {
    */
   function getClassActiveQuizzes(classId) {
     const classroom = getClass(classId);
-    if (!classroom || !classroom.assignments || !classroom.assignments.exams) {
+    if (!classroom || !classroom.exams) {
       return [];
     }
-    return classroom.assignments.exams.filter(exam => exam.active);
+    return classroom.exams.filter(exam => exam.active);
   }
 
   /**

--- a/kolibri/plugins/learn/test/test_learner_classroom.py
+++ b/kolibri/plugins/learn/test/test_learner_classroom.py
@@ -1,6 +1,9 @@
+import uuid
+
 from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
+from le_utils.constants import modalities
 from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Classroom
@@ -9,6 +12,9 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.lessons.models import Lesson
@@ -81,7 +87,7 @@ class LearnerClassroomTestCase(APITestCase):
         get_response = self.client.get(
             reverse(self.basename + "-detail", kwargs={"pk": self.own_classroom.id})
         )
-        self.assertEqual(len(get_response.data["assignments"]["exams"]), 1)
+        self.assertEqual(len(get_response.data["exams"]), 1)
 
     def test_correct_number_of_attempted_exams(self):
         # One active exam and two inactive exams, but one attempted
@@ -137,7 +143,7 @@ class LearnerClassroomTestCase(APITestCase):
         get_response = self.client.get(
             reverse(self.basename + "-detail", kwargs={"pk": self.own_classroom.id})
         )
-        self.assertEqual(len(get_response.data["assignments"]["exams"]), 2)
+        self.assertEqual(len(get_response.data["exams"]), 2)
 
     def test_correct_number_of_lessons(self):
         # One active and inactive lesson
@@ -167,7 +173,7 @@ class LearnerClassroomTestCase(APITestCase):
         get_response = self.client.get(
             reverse(self.basename + "-detail", kwargs={"pk": self.own_classroom.id})
         )
-        self.assertEqual(len(get_response.data["assignments"]["lessons"]), 1)
+        self.assertEqual(len(get_response.data["lessons"]), 1)
 
     def test_learner_only_sees_lessons_for_enrolled_classroom(self):
         classroom = Classroom.objects.create(
@@ -184,7 +190,7 @@ class LearnerClassroomTestCase(APITestCase):
         )
         self.client.login(username="learner", password="password")
         get_response = self.client.get(reverse(self.basename + "-list"))
-        self.assertEqual(len(get_response.data[0]["assignments"]["lessons"]), 0)
+        self.assertEqual(len(get_response.data[0]["lessons"]), 0)
 
     def test_learner_only_sees_lessons_for_single_classroom_when_enrolled_in_multiple(
         self,
@@ -204,7 +210,73 @@ class LearnerClassroomTestCase(APITestCase):
         )
         self.client.login(username="learner", password="password")
         get_response = self.client.get(reverse(self.basename + "-list"))
-        total_lessons = len(get_response.data[0]["assignments"]["lessons"]) + len(
-            get_response.data[1]["assignments"]["lessons"]
+        total_lessons = len(get_response.data[0]["lessons"]) + len(
+            get_response.data[1]["lessons"]
         )
         self.assertEqual(total_lessons, Lesson.objects.count())
+
+    def test_learner_only_sees_courses_for_enrolled_classroom(self):
+        channel_id = uuid.uuid4().hex
+        course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course Title 1",
+            description="Course description 1",
+        )
+        active_own_course = CourseSession.objects.create(
+            collection=self.own_classroom,
+            is_active=True,
+            created_by=self.coach_user,
+            course=course.id,
+            title=course.title,
+            description=course.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach_user,
+            collection=self.own_classroom,
+        )
+        self.client.login(username="learner", password="password")
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": self.own_classroom.id})
+        )
+        self.assertEqual(len(get_request.data["courses"]), 1)
+
+    def test_learner_assigned_same_course_multiple_times_only_sees_single_course(self):
+        channel_id = uuid.uuid4().hex
+        course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course Title 1",
+            description="Course description 1",
+        )
+        active_own_course = CourseSession.objects.create(
+            collection=self.own_classroom,
+            is_active=True,
+            created_by=self.coach_user,
+            course=course.id,
+            title=course.title,
+            description=course.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach_user,
+            collection=self.own_classroom,
+        )
+        group = LearnerGroup.objects.create(name="Own Group", parent=self.own_classroom)
+        group.add_member(self.learner_user)
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach_user,
+            collection=group,
+        )
+        self.client.login(username="learner", password="password")
+        list_request = self.client.get(reverse(self.basename + "-list"))
+        self.assertEqual(len(list_request.data), 1)
+        self.assertEqual(len(list_request.data[0]["courses"]), 1)

--- a/kolibri/plugins/learn/test/test_learner_course.py
+++ b/kolibri/plugins/learn/test/test_learner_course.py
@@ -1,6 +1,8 @@
 import uuid
 
 from django.urls import reverse
+from django.utils.timezone import now
+from le_utils.constants import content_kinds
 from le_utils.constants import modalities
 from rest_framework.test import APITestCase
 
@@ -13,6 +15,8 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.courses.models import CourseSessionAssignment
+from kolibri.core.logger.models import ContentSummaryLog
+
 
 DUMMY_PASSWORD = "password"
 
@@ -190,3 +194,127 @@ class LearnerCourseTestCase(APITestCase):
         self.assertEqual(get_request.status_code, 200)
         list_request = self.client.get(reverse(self.basename + "-list"))
         self.assertEqual(len(list_request.data), 1)
+
+    def test_learner_course_progress_calculated_correctly(self):
+        channel_id = uuid.uuid4().hex
+        # Create a course with 1 unit, 2 lessons, and 2 exercises
+        course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course With Units",
+            description="",
+        )
+
+        unit1 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=course,
+            available=True,
+            kind=content_kinds.TOPIC,
+            modality=modalities.UNIT,
+            title="Unit 1",
+            description="",
+        )
+
+        lesson1 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=unit1,
+            available=True,
+            kind=content_kinds.TOPIC,
+            modality=modalities.LESSON,
+            title="Lesson 1",
+            description="",
+        )
+
+        ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=lesson1,
+            available=True,
+            kind=content_kinds.EXERCISE,
+            title="Exercise 1",
+            description="",
+        )
+
+        lesson2 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=unit1,
+            available=True,
+            kind=content_kinds.TOPIC,
+            modality=modalities.LESSON,
+            title="Lesson 2",
+            description="",
+        )
+
+        ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=lesson2,
+            available=True,
+            kind=content_kinds.EXERCISE,
+            title="Exercise 2",
+            description="",
+        )
+
+        # Create and assign the course session
+        active_own_course = CourseSession.objects.create(
+            collection=self.classroom,
+            is_active=True,
+            created_by=self.coach,
+            course=course.id,
+            title=course.title,
+            description=course.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach,
+            collection=self.classroom,
+        )
+
+        # Ensure the course has two non-topic descendants (the exercises)
+        content_qs = list(
+            course.get_descendants()
+            .exclude(kind=content_kinds.TOPIC)
+            .values_list("content_id", flat=True)
+        )
+        self.assertEqual(len(content_qs), 2)
+
+        # Mark 1 resource as completed (progress == 1.0) and one as in-progress
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=content_qs[0],
+            kind=content_kinds.EXERCISE,
+            progress=1.0,
+            start_timestamp=now(),
+            completion_timestamp=now(),
+        )
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=content_qs[1],
+            kind=content_kinds.EXERCISE,
+            progress=0.5,
+            start_timestamp=now(),
+            completion_timestamp=now(),
+        )
+
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": active_own_course.id})
+        )
+        self.assertEqual(get_request.data["id"], active_own_course.id)
+        self.assertEqual(get_request.status_code, 200)
+        # progress should be completed(1) / total(2) == 0.5
+        self.assertEqual(get_request.data["progress"], 0.5)
+        # Ensure unit and lesson counts are annotated correctly
+        self.assertEqual(get_request.data.get("unit_count"), 1)
+        self.assertEqual(get_request.data.get("lesson_count"), 2)

--- a/kolibri/plugins/learn/test/test_learner_course.py
+++ b/kolibri/plugins/learn/test/test_learner_course.py
@@ -1,0 +1,192 @@
+import uuid
+
+from django.urls import reverse
+from le_utils.constants import modalities
+from rest_framework.test import APITestCase
+
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import clear_process_cache
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
+
+DUMMY_PASSWORD = "password"
+
+
+class LearnerCourseTestCase(APITestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        clear_process_cache()
+        provision_device()
+        self.facility = Facility.objects.create(name="My Facility")
+        self.classroom = Classroom.objects.create(
+            name="Classroom", parent=self.facility
+        )
+        self.coach = FacilityUser.objects.create(
+            username="coach", facility=self.facility
+        )
+        self.coach.set_password(DUMMY_PASSWORD)
+        self.coach.save()
+        self.classroom.add_coach(self.coach)
+
+        self.learner = FacilityUser.objects.create(
+            username="learner", facility=self.facility
+        )
+        self.learner.set_password(DUMMY_PASSWORD)
+        self.learner.save()
+        self.classroom.add_member(self.learner)
+        self.basename = "kolibri:kolibri.plugins.learn:learnercourse"
+
+        channel_id = uuid.uuid4().hex
+        self.course_1 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course Title 1",
+            description="Course description 1",
+        )
+
+        channel_id_2 = uuid.uuid4().hex
+        self.course_2 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id_2,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course Title 2",
+            description="Course description 2",
+        )
+
+        channel_id_3 = uuid.uuid4().hex
+        self.course_3 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id_3,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Course Title 3",
+            description="Course description 3",
+        )
+
+    def test_must_be_authenticated(self):
+        get_request = self.client.get(reverse(self.basename + "-list"))
+        self.assertEqual(get_request.status_code, 403)
+
+    def test_learner_can_access_assigned_courses(self):
+        active_own_course = CourseSession.objects.create(
+            is_active=True,
+            collection=self.classroom,
+            created_by=self.coach,
+            course=self.course_1.id,
+            title=self.course_1.title,
+            description=self.course_1.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach,
+            collection=self.classroom,
+        )
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": active_own_course.id})
+        )
+        self.assertEqual(get_request.data["id"], active_own_course.id)
+
+    def test_learner_cannot_access_not_own_courses(self):
+        # Course created in Classroom, but not assigned
+        other_classroom = Classroom.objects.create(
+            name="Other Classroom", parent=self.facility
+        )
+        other_classroom.add_coach(self.coach)
+        other_course = CourseSession.objects.create(
+            is_active=True,
+            collection=other_classroom,
+            created_by=self.coach,
+            course=self.course_2.id,
+            title=self.course_2.title,
+            description=self.course_2.description,
+        )
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": other_course.id})
+        )
+        self.assertEqual(get_request.status_code, 404)
+
+        # Course assigned to different LearnerGroup that does not include learner
+        different_group = LearnerGroup.objects.create(
+            name="Different Group", parent=self.classroom
+        )
+        different_course = CourseSession.objects.create(
+            title=self.course_3.title,
+            description=self.course_3.description,
+            course=self.course_3.id,
+            is_active=True,
+            collection=self.classroom,
+            created_by=self.coach,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=different_course,
+            assigned_by=self.coach,
+            collection=different_group,
+        )
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": different_course.id})
+        )
+        self.assertEqual(get_request.status_code, 404)
+
+    def test_learner_cannot_access_own_inactive_courses(self):
+        inactive_own_course = CourseSession.objects.create(
+            collection=self.classroom,
+            is_active=False,
+            created_by=self.coach,
+            course=self.course_1.id,
+            title=self.course_1.title,
+            description=self.course_1.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=inactive_own_course,
+            assigned_by=self.coach,
+            collection=self.classroom,
+        )
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": inactive_own_course.id})
+        )
+        self.assertEqual(get_request.status_code, 404)
+
+    def test_learner_assigned_same_course_multiple_times_only_return_one(self):
+        active_own_course = CourseSession.objects.create(
+            collection=self.classroom,
+            is_active=True,
+            created_by=self.coach,
+            course=self.course_1.id,
+            title=self.course_1.title,
+            description=self.course_1.description,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach,
+            collection=self.classroom,
+        )
+        group = LearnerGroup.objects.create(name="Own Group", parent=self.classroom)
+        group.add_member(self.learner)
+        CourseSessionAssignment.objects.create(
+            course_session=active_own_course,
+            assigned_by=self.coach,
+            collection=group,
+        )
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        get_request = self.client.get(
+            reverse(self.basename + "-detail", kwargs={"pk": active_own_course.id})
+        )
+        self.assertEqual(get_request.data["id"], active_own_course.id)
+        self.assertEqual(get_request.status_code, 200)
+        list_request = self.client.get(reverse(self.basename + "-list"))
+        self.assertEqual(len(list_request.data), 1)

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -4,6 +4,8 @@ from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import Sum
 from django.db.models.fields import IntegerField
+from le_utils.constants import content_kinds
+from le_utils.constants import modalities
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -15,10 +17,12 @@ from kolibri.core.content.api import ContentNodeProgressViewset
 from kolibri.core.content.api import ContentNodeViewset
 from kolibri.core.content.api import UserContentNodeViewset
 from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import exam_assignment_lookup
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
 
 
@@ -104,6 +108,63 @@ def _consolidate_lessons_data(request, lessons):
             missing_resource = missing_resource or not resource["contentnode"]
         lesson["missing_resource"] = missing_resource
         lesson["active"] = lesson.pop("is_active")
+
+
+def _consolidate_courses_data(request, courses):
+    if not courses:
+        return courses
+
+    course_content_ids = {course["course"] for course in courses}
+
+    course_nodes = ContentNode.objects.filter(id__in=course_content_ids).annotate(
+        unit_count=Count(
+            "children", filter=Q(children__modality=modalities.UNIT), distinct=True
+        ),
+        lesson_count=Count(
+            "children__children",
+            filter=Q(
+                children__modality=modalities.UNIT,
+                children__children__modality=modalities.LESSON,
+            ),
+            distinct=True,
+        ),
+    )
+
+    course_data_map = {}
+
+    for course_node in course_nodes:
+        content_qs = (
+            course_node.get_descendants()
+            .exclude(kind=content_kinds.TOPIC)
+            .values_list("content_id", flat=True)
+        )
+
+        total_content = content_qs.count()
+
+        user_completed_content = 0
+        if total_content:
+            user_completed_content = ContentSummaryLog.objects.filter(
+                user=request.user, progress=1, content_id__in=content_qs
+            ).count()
+            progress = user_completed_content / total_content
+        else:
+            progress = 0
+
+        course_data_map[course_node.id] = {
+            "unit_count": course_node.unit_count,
+            "lesson_count": course_node.lesson_count,
+            "progress": progress,
+        }
+
+    for course in courses:
+        course_id = course["course"]
+        data = course_data_map.get(
+            course_id, {"unit_count": 0, "lesson_count": 0, "progress": 0}
+        )
+        course.update(data)
+        course["course_id"] = course.pop("course")
+
+    return courses
 
 
 class LearnerClassroomViewset(ReadOnlyValuesViewset):
@@ -238,14 +299,28 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                     missing_resource = True
                     break
             exam["missing_resource"] = missing_resource
+
+        courses = (
+            CourseSession.objects.filter(
+                assignments__collection__membership__user=self.request.user,
+                collection__in=(c["id"] for c in items),
+                is_active=True,
+            )
+            .distinct()
+            .values("id", "course", "title", "description", "is_active", "collection")
+        )
+
+        courses = _consolidate_courses_data(self.request, courses) if courses else []
+
         out_items = []
         for item in items:
-            item["assignments"] = {
-                "exams": [exam for exam in exams if exam["collection"] == item["id"]],
-                "lessons": [
-                    lesson for lesson in lessons if lesson["collection"] == item["id"]
-                ],
-            }
+            item["exams"] = [exam for exam in exams if exam["collection"] == item["id"]]
+            item["lessons"] = [
+                lesson for lesson in lessons if lesson["collection"] == item["id"]
+            ]
+            item["courses"] = [
+                course for course in courses if course["collection"] == item["id"]
+            ]
             out_items.append(item)
         return out_items
 
@@ -255,7 +330,7 @@ learner_classroom_viewset = LearnerClassroomViewset()
 
 def _resumable_resources(classrooms):
     for classroom in classrooms:
-        for lesson in classroom["assignments"]["lessons"]:
+        for lesson in classroom["lessons"]:
             for resource in lesson["resources"]:
                 yield 0 < resource["progress"] < 1
 
@@ -263,10 +338,13 @@ def _resumable_resources(classrooms):
 class LearnHomePageHydrationView(APIView):
     def get(self, request, format=None):
         classrooms = []
+        courses = []
         resumable_resources = []
         resumable_resources_progress = []
         if not request.user.is_anonymous:
             classrooms = learner_classroom_viewset.serialize_list(request)
+            for classroom in classrooms:
+                courses.extend(classroom.get("courses", []))
             if not classrooms or not any(_resumable_resources(classrooms)):
                 resumable_resources = user_contentnode_viewset.serialize_list(
                     request,
@@ -286,6 +364,7 @@ class LearnHomePageHydrationView(APIView):
         return Response(
             {
                 "classrooms": classrooms,
+                "courses": courses,
                 "resumable_resources": resumable_resources,
                 "resumable_resources_progress": resumable_resources_progress,
             }
@@ -335,5 +414,48 @@ class LearnerLessonViewset(ReadOnlyValuesViewset):
             return items
 
         _consolidate_lessons_data(self.request, items)
+
+        return items
+
+
+class LearnerCourseViewset(ReadOnlyValuesViewset):
+    """
+    Special Viewset for Learners to view Course Sessions to which they are assigned.
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    values = (
+        "id",
+        "course",
+        "title",
+        "description",
+        "is_active",
+        "collection__id",
+        "collection__name",
+        "collection__parent_id",
+    )
+
+    field_map = {
+        "classroom": lambda item: {
+            "id": item.pop("collection__id"),
+            "name": item.pop("collection__name"),
+            "parent": item.pop("collection__parent_id"),
+        },
+    }
+
+    def get_queryset(self):
+        if self.request.user.is_anonymous:
+            return CourseSession.objects.none()
+        return CourseSession.objects.filter(
+            assignments__collection__membership__user=self.request.user,
+            is_active=True,
+        ).distinct()
+
+    def consolidate(self, items, queryset):
+        if not items:
+            return items
+
+        items = _consolidate_courses_data(self.request, items)
 
         return items


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds new `LearnerCourseViewset` to return course assignments for learners, following the existing patterns for lessons and exams.
- Updates `LearnerClassroomViewset` to return `exams`, `lessons`, `courses` directly on classroom object, removing the assignments wrapper and updates corresponding tests
- Updates `LearnHomePageHydrationView` to return courses in the hydrated response
- Adds python tests for `LearnerCourseViewset` to test that learners can only access their assigned active courses, not other assigned courses, and learners assigned to the same course multiple times can only see one course.

## References
<!--
 * references to related issues and PRs
-->
Closes #14061 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- No regressions when viewing assigned lessons and exams on the learner homepage.
