### PR TITLE
Add Course Session Context to Progress Tracking

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -44,6 +44,7 @@ from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.models import dataset_cache
 from kolibri.core.auth.models import Facility
 from kolibri.core.content.api import OptionalPageNumberPagination
+from kolibri.core.courses.models import CourseSession
 from kolibri.core.decorators import query_params_required
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
@@ -85,43 +86,60 @@ class StartSessionSerializer(serializers.Serializer):
     channel_id = HexStringUUIDField(required=False)
     kind = serializers.ChoiceField(choices=content_kinds.choices, required=False)
     mastery_model = MasteryModelSerializer(required=False)
+    course_session_id = HexStringUUIDField(required=False)
     # Do this as a special way of handling our coach generated quizzes
     quiz_id = HexStringUUIDField(required=False)
     # A flag to indicate whether to start the session over again
     repeat = serializers.BooleanField(required=False, default=False)
 
     def validate(self, data):
-        if "quiz_id" in data and ("lesson_id" in data or "node_id" in data):
-            raise ValidationError("quiz_id must not be mixed with other context")
+        self._validate_required_fields(data)
+        self._validate_context_exclusivity(data)
+        self._validate_node_id_fields(data)
+        return data
+
+    def _validate_required_fields(self, data):
         if "node_id" not in data and "quiz_id" not in data:
             raise ValidationError("node_id is required if not a coach assigned quiz")
-        if "node_id" in data:
-            errors = {}
-            if "kind" not in data:
-                errors["kind"] = ValidationError("kind is required for any node_id")
-            else:
-                if (
-                    data["kind"] == content_kinds.EXERCISE
-                    and "mastery_model" not in data
-                ):
-                    errors["mastery_model"] = ValidationError(
-                        "mastery model must be specified for exercise kinds"
-                    )
-                elif data["kind"] != content_kinds.EXERCISE and "mastery_model" in data:
-                    errors["mastery_model"] = ValidationError(
-                        "mastery model must not be specified for non-exercise kinds"
-                    )
-            if "content_id" not in data:
-                errors["content_id"] = ValidationError(
-                    "content_id is required for any node_id"
-                )
-            if "channel_id" not in data:
-                errors["channel_id"] = ValidationError(
-                    "channel_id is required for any node_id"
-                )
-            if errors:
-                raise ValidationError(errors)
-        return data
+
+    def _validate_context_exclusivity(self, data):
+        if "quiz_id" in data and ("lesson_id" in data or "node_id" in data):
+            raise ValidationError("quiz_id must not be mixed with other context")
+        if "course_session_id" in data and "lesson_id" in data:
+            raise ValidationError(
+                "The course_session_id and lesson_id are mutually exclusive identifiers"
+            )
+
+    def _validate_node_id_fields(self, data):
+        if "node_id" not in data:
+            return
+        errors = {}
+        if "kind" not in data:
+            errors["kind"] = ValidationError("kind is required for any node_id")
+        else:
+            self._validate_mastery_model(data, errors)
+        if "content_id" not in data:
+            errors["content_id"] = ValidationError(
+                "content_id is required for any node_id"
+            )
+        if "channel_id" not in data:
+            errors["channel_id"] = ValidationError(
+                "channel_id is required for any node_id"
+            )
+        if errors:
+            raise ValidationError(errors)
+
+    def _validate_mastery_model(self, data, errors):
+        is_exercise = data["kind"] == content_kinds.EXERCISE
+        has_mastery_model = "mastery_model" in data
+        if is_exercise and not has_mastery_model:
+            errors["mastery_model"] = ValidationError(
+                "mastery model must be specified for exercise kinds"
+            )
+        elif not is_exercise and has_mastery_model:
+            errors["mastery_model"] = ValidationError(
+                "mastery model must not be specified for non-exercise kinds"
+            )
 
 
 class InteractionSerializer(serializers.Serializer):
@@ -191,14 +209,15 @@ class LogContext(object):
     mastery_level - represents the current 'try' at an assessment, whether an exercise
     a practice quiz or a coach assigned quiz. Different mastery_level values
     indicate a different try at the assessment.
-
+    course_session_id - represents the id of the CourseSession model object that this
+    session is regarding (if any).
     This is used to encode the values that are sent when initializing a session
     (see its use in the _get_context method below)
     and then also used to hold the values from an existing sessionlog when
     updating a session (see _update_session method).
     """
 
-    __slots__ = "node_id", "quiz_id", "lesson_id", "mastery_level"
+    __slots__ = "node_id", "quiz_id", "lesson_id", "mastery_level", "course_session_id"
 
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
@@ -274,10 +293,22 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
         ).exists():
             raise ValidationError("Invalid lesson_id")
 
+    def _check_course_session_permissions(self, user, course_session_id):
+        if user.is_anonymous:
+            raise PermissionDenied("Cannot access a course if not logged in")
+        if not CourseSession.objects.filter(
+            assignments__collection_id__in=user.memberships.all().values(
+                "collection_id"
+            ),
+            id=course_session_id,
+        ).exists():
+            raise ValidationError("Invalid course_session_id")
+
     def _get_context(self, user, validated_data):
         node_id = validated_data.get("node_id")
         quiz_id = validated_data.get("quiz_id")
         lesson_id = validated_data.get("lesson_id")
+        course_session_id = validated_data.get("course_session_id")
 
         context = LogContext()
 
@@ -290,6 +321,9 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
             if lesson_id:
                 self._check_lesson_permissions(user, lesson_id)
                 context["lesson_id"] = lesson_id
+            if course_session_id:
+                self._check_course_session_permissions(user, course_session_id)
+                context["course_session_id"] = course_session_id
         elif quiz_id is not None:
             self._check_quiz_permissions(user, quiz_id)
             mastery_model = {"type": exercises.QUIZ, "coach_assigned": True}

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -27,6 +27,8 @@ from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.lessons.models import Lesson
@@ -64,6 +66,42 @@ def create_assigned_lesson_for_user(user):
         lesson=lesson, collection=classroom, assigned_by=coach
     )
     return lesson
+
+
+def create_assigned_course_for_user(user, channel_id, content_id):
+    coach = FacilityUserFactory.create(facility=user.facility)
+    classroom = Classroom.objects.create(name="classroom", parent=user.facility)
+    classroom.add_coach(coach)
+    classroom.add_member(user)
+    course = CourseSession.objects.create(
+        course=uuid.uuid4().hex,
+        title="course",
+        collection=classroom,
+        created_by=coach,
+    )
+    course = ContentNode.objects.create(
+        id=uuid.uuid4().hex,
+        channel_id=channel_id,
+        content_id=content_id,
+        available=True,
+        modality=modalities.COURSE,
+        title="Course 1",
+        description="A course",
+    )
+    course_session = CourseSession.objects.create(
+        is_active=True,
+        collection=classroom,
+        created_by=coach,
+        course=course.id,
+        title=course.title,
+        description=course.description,
+    )
+    CourseSessionAssignment.objects.create(
+        course_session=course_session,
+        collection=classroom,
+        assigned_by=coach,
+    )
+    return course_session
 
 
 class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
@@ -436,6 +474,73 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
             facility=self.facility,
         )
         response = self._make_request({}, delete_keys=["content_id"])
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_session_node_id_course_session_id_and_lesson_id_fails(self):
+        course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self._make_request(
+            {
+                "course_session_id": course_session.id,
+                "lesson_id": uuid.uuid4().hex,
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_session_node_id_course_session_id_succeeds(self):
+        course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self._make_request(
+            {
+                "course_session_id": course_session.id,
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_start_session_node_id_course_session_id_not_assigned_fails(self):
+        _ = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        other_classroom = Classroom.objects.create(
+            name="other_classroom", parent=self.facility
+        )
+        other_coach = FacilityUserFactory.create(facility=self.facility)
+        wrong_course_session = CourseSession.objects.create(
+            course=uuid.uuid4().hex,
+            title="course",
+            collection=other_classroom,
+            created_by=other_coach,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=wrong_course_session,
+            collection=other_classroom,
+            assigned_by=other_coach,
+        )
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self._make_request(
+            {
+                "course_session_id": wrong_course_session.id,
+            }
+        )
 
         self.assertEqual(response.status_code, 400)
 

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -477,6 +477,28 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_start_session_node_id_course_session_id_anonymous_fails(self):
+        course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        response = self._make_request({"course_session_id": course_session.id})
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_start_session_node_id_course_session_id_non_existent_fails(self):
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self._make_request(
+            {
+                "course_session_id": uuid.uuid4().hex,
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_start_session_node_id_course_session_id_and_lesson_id_fails(self):
         course_session = create_assigned_course_for_user(
             self.user, channel_id=self.channel_id, content_id=self.content_id

--- a/kolibri/plugins/learn/frontend/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/frontend/composables/__tests__/useProgressTracking.spec.js
@@ -74,6 +74,20 @@ describe('useProgressTracking composable', () => {
         );
       }
     });
+    it('should throw an error if lessonId and courseSessionId provided', async () => {
+      const { initContentSession } = setUp();
+      try {
+        await initContentSession({
+          node,
+          lessonId: 'test_lesson',
+          courseSessionId: 'test_course_session',
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          new TypeError('only course_session_id or lessonId can be defined, not both'),
+        );
+      }
+    });
     it.each(['id', 'content_id', 'channel_id', 'kind'])(
       'should throw an error if %s is missing from node',
       async property => {
@@ -274,6 +288,27 @@ describe('useProgressTracking composable', () => {
       });
       expect(client).toHaveBeenCalled();
     });
+    it('should not make a backend request when the session for course_session_id and node_id is already active', async () => {
+      const { initContentSession } = setUp();
+      const session_id = 'test_session_id';
+      const node_id = node.id;
+      const course_session_id = 'test_course_session_id';
+      const progress = 0.5;
+      const time_spent = 15;
+      const extra_fields = { extra: true };
+      client.__setPayload({
+        session_id,
+        context: { node_id, course_session_id },
+        progress,
+        time_spent,
+        extra_fields,
+        complete: false,
+      });
+      await initContentSession({ node, courseSessionId: course_session_id });
+      client.__reset();
+      await initContentSession({ node, courseSessionId: course_session_id });
+      expect(client).not.toHaveBeenCalled();
+    });
     it('should not make a backend request when the session for quiz_id is already active', async () => {
       const { initContentSession } = setUp();
       const session_id = 'test_session_id';
@@ -385,6 +420,24 @@ describe('useProgressTracking composable', () => {
       });
       await expect(initContentSession({ node })).rejects.toMatchObject(error);
       expect(client).toHaveBeenCalledTimes(5);
+    });
+    it('should set course_session_id when provided', async () => {
+      const { initContentSession } = setUp();
+      const session_id = 'test_session_id';
+      const node_id = node.id;
+      const course_session_id = 'test_course_session_id';
+      client.__setPayload({
+        session_id,
+        context: { node_id, course_session_id },
+      });
+      await initContentSession({ node, courseSessionId: course_session_id });
+      expect(client.mock.calls[0][0].data).toEqual({
+        node_id: node.id,
+        kind: node.kind,
+        content_id: node.content_id,
+        channel_id: node.channel_id,
+        course_session_id: course_session_id,
+      });
     });
   });
   describe('updateContentSession', () => {

--- a/kolibri/plugins/learn/frontend/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/frontend/composables/useProgressTracking.js
@@ -177,13 +177,16 @@ export default function useProgressTracking(store) {
    * Initialize a content session for progress tracking
    * To be called on page load for content viewers
    */
-  function initContentSession({ node, lessonId, quizId, repeat = false } = {}) {
+  function initContentSession({ node, lessonId, quizId, repeat = false, courseSessionId } = {}) {
     const data = {};
     if (!node && !quizId) {
       throw TypeError('Must define either node or quizId');
     }
     if ((node || lessonId) && quizId) {
       throw TypeError('quizId must be the only defined parameter if defined');
+    }
+    if (lessonId && courseSessionId) {
+      throw TypeError('only course_session_id or lessonId can be defined, not both');
     }
     let sessionStarted = false;
 
@@ -210,6 +213,10 @@ export default function useProgressTracking(store) {
       data.content_id = node.content_id;
       data.channel_id = node.channel_id;
       data.kind = node.kind;
+      if (courseSessionId) {
+        sessionStarted = sessionStarted && get(context) && get(context).course_session_id === courseSessionId;
+        data.course_session_id = courseSessionId;
+      }
       if (lessonId) {
         sessionStarted = sessionStarted && get(context) && get(context).lesson_id === lessonId;
         data.lesson_id = lessonId;

--- a/kolibri/plugins/learn/frontend/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/frontend/composables/useProgressTracking.js
@@ -190,9 +190,23 @@ export default function useProgressTracking(store) {
     }
     let sessionStarted = false;
 
+    // Helper to check and set session context
+    function setSessionContext(sessionType, value, isFirst = false) {
+      if (!value) return;
+
+      const contextKey = `${sessionType}_id`;
+      const matches = get(context) && get(context)[contextKey] === value;
+      data[contextKey] = value;
+
+      if (isFirst) {
+        sessionStarted = matches;
+      } else {
+        sessionStarted = sessionStarted && matches;
+      }
+    }
+
     if (quizId) {
-      sessionStarted = get(context) && get(context).quiz_id === quizId;
-      data.quiz_id = quizId;
+      setSessionContext('quiz', quizId, true);
     }
 
     if (node) {
@@ -208,18 +222,15 @@ export default function useProgressTracking(store) {
       if (!node.kind) {
         throw TypeError('node must have kind property');
       }
-      sessionStarted = get(context) && get(context).node_id === node.id;
-      data.node_id = node.id;
+      setSessionContext('node', node.id, !quizId);
       data.content_id = node.content_id;
       data.channel_id = node.channel_id;
       data.kind = node.kind;
       if (courseSessionId) {
-        sessionStarted = sessionStarted && get(context) && get(context).course_session_id === courseSessionId;
-        data.course_session_id = courseSessionId;
+        setSessionContext('course_session', courseSessionId);
       }
       if (lessonId) {
-        sessionStarted = sessionStarted && get(context) && get(context).lesson_id === lessonId;
-        data.lesson_id = lessonId;
+        setSessionContext('lesson', lessonId);
       }
       if (node.kind === 'exercise') {
         if (!node.assessmentmetadata) {


### PR DESCRIPTION


## Summary
Backend:
- `course_session_id` added to `LogContext.__slots__` and `StartSessionSerializer`
- Validation rejects requests with both `course_session_id` and `lesson_id` are provided
- `_check_course_session_permissions` method created to reject users not assigned to the course session along with added tests
- `ProgressTrackingViewSet._get_context` includes `course_session_id` in context when provided
- Context with `course_session_id` stored in session log `extra_fields`
- Simplified `StartSessionSerializer.validate` by using helper methods to validate individual aspects at once due to Flake8 complexity error

Frontend:
- Update `initContentSession` to accept `courseSessionId` param so that it is passed in request data when provided
- Included course session context in session comparison logic
- Added unit tests for `course_session_id` validation field and `course_session_id` mutual exclusivity with `lesson_id`

## References
#14105 

## Reviewer guidance
- Ensure changes align with the issue acceptance criteria and thorough testing has been added
