### PR TITLE
Add API endpoints for activating/closing quizzes & returning active quiz

### DIFF
--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -674,6 +674,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             channel_id=channel_id,
             content_id=uuid.uuid4().hex,
             available=True,
+            modality=modalities.COURSE,
             title="Test Course",
             description="A test course",
         )
@@ -685,6 +686,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             content_id=uuid.uuid4().hex,
             parent_id=cls.course.id,
             available=True,
+            modality=modalities.UNIT,
             title="Test Unit",
             description="A test unit",
         )
@@ -696,6 +698,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             content_id=uuid.uuid4().hex,
             parent_id=cls.course.id,
             available=True,
+            modality=modalities.UNIT,
             title="Test Unit 2",
             description="Another test unit",
         )
@@ -876,6 +879,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             channel_id=uuid.uuid4().hex,
             content_id=uuid.uuid4().hex,
             available=True,
+            modality=modalities.UNIT,
             title="Other Unit",
         )
 
@@ -916,6 +920,10 @@ class UnitTestActivationAPITestCase(APITestCase):
                 "kolibri:core:coursesession-close-test",
                 kwargs={"pk": self.courseSession.id},
             ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
             format="json",
         )
 
@@ -1038,6 +1046,10 @@ class UnitTestActivationAPITestCase(APITestCase):
                 "kolibri:core:coursesession-close-test",
                 kwargs={"pk": self.courseSession.id},
             ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
             format="json",
         )
 
@@ -1066,6 +1078,10 @@ class UnitTestActivationAPITestCase(APITestCase):
                 "kolibri:core:coursesession-close-test",
                 kwargs={"pk": self.courseSession.id},
             ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
             format="json",
         )
 
@@ -1155,6 +1171,10 @@ class UnitTestActivationAPITestCase(APITestCase):
                 "kolibri:core:coursesession-close-test",
                 kwargs={"pk": self.courseSession.id},
             ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
             format="json",
         )
 
@@ -1208,6 +1228,10 @@ class UnitTestActivationAPITestCase(APITestCase):
                 "kolibri:core:coursesession-close-test",
                 kwargs={"pk": self.courseSession.id},
             ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
             format="json",
         )
 

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,8 +1,3 @@
-"""
-
-- "Add edge case tests for invalid inputs, non-existent resources, and authentication failures"
-- "Write tests for assignment management including learner groups and adhoc groups"
-"""
 import uuid
 
 from django.urls import reverse

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,4 +1,4 @@
-import json
+import uuid
 from django.urls import reverse
 from le_utils.constants import modalities
 from rest_framework import status

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,3 +1,8 @@
+"""
+
+- "Add edge case tests for invalid inputs, non-existent resources, and authentication failures"
+- "Write tests for assignment management including learner groups and adhoc groups"
+"""
 import uuid
 
 from django.urls import reverse
@@ -628,4 +633,599 @@ class CourseSessionAPITestCase(APITestCase):
                 kwargs={"pk": self.courseSession.id},
             )
         )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+""""
+DISCLAIMER:  Some parts of these tests were written with an AI assistance.
+ I have reviewed and validated the generated tests
+Example of prompts I used:
+- "Look at my tests and suggest improvements and why I am getting AssertionError: 403 != 400" in
+kolibri/core/courses/test/test_api.py:805:"
+- "Create tests for UnitTestAssignment activation and closing"
+- "Create tests for UnitTestAssignment validation"
+"""
+
+
+class UnitTestActivationAPITestCase(APITestCase):
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = Facility.objects.create(name="TestFacility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
+
+        cls.classroom = Classroom.objects.create(name="Classroom", parent=cls.facility)
+        cls.coach = FacilityUser.objects.create(username="coach", facility=cls.facility)
+        cls.coach.set_password(DUMMY_PASSWORD)
+        cls.coach.save()
+        cls.classroom.add_coach(cls.coach)
+
+        cls.learner = FacilityUser.objects.create(
+            username="learner", facility=cls.facility
+        )
+        cls.learner.set_password(DUMMY_PASSWORD)
+        cls.learner.save()
+        cls.classroom.add_member(cls.learner)
+
+        # Create a course ContentNode
+        channel_id = uuid.uuid4().hex
+        cls.course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            title="Test Course",
+            description="A test course",
+        )
+
+        # Create a unit ContentNode (child of course)
+        cls.unit = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent_id=cls.course.id,
+            available=True,
+            title="Test Unit",
+            description="A test unit",
+        )
+
+        # Create another unit for additional tests
+        cls.unit2 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent_id=cls.course.id,
+            available=True,
+            title="Test Unit 2",
+            description="Another test unit",
+        )
+
+        cls.courseSession = models.CourseSession.objects.create(
+            is_active=True,
+            collection=cls.classroom,
+            created_by=cls.admin,
+            course=cls.course.id,
+            title=cls.course.title,
+            description=cls.course.description,
+        )
+
+    def test_coach_can_activate_pre_test(self):
+        """Test that a coach can activate a pre-test"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], self.unit.id)
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "active")
+
+        # Verify UnitTestAssignment was created
+        assignment = models.UnitTestAssignment.objects.get(
+            course_session=self.courseSession,
+            unit_contentnode_id=self.unit.id,
+            test_type="pre",
+        )
+        self.assertTrue(assignment.is_active)
+        self.assertEqual(assignment.status, "active")
+        self.assertEqual(assignment.activated_by, self.coach)
+
+    def test_coach_can_activate_post_test(self):
+        """Test that a coach can activate a post-test"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "post",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_admin_can_activate_test(self):
+        """Test that an admin can activate a test"""
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_non_coach_cannot_activate_test(self):
+        """Test that a non-coach cannot activate a test"""
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_activate_test_invalid_test_type(self):
+        """Test that activating a test with invalid test_type fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "invalid",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_activate_test_missing_unit_contentnode_id(self):
+        """Test that activating a test without unit_contentnode_id fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_activate_test_missing_test_type(self):
+        """Test that activating a test without test_type fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_activate_test_nonexistent_unit(self):
+        """Test that activating a test with non-existent unit fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": uuid.uuid4().hex,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_activate_test_unit_not_in_course(self):
+        """Test that activating a test for a unit not in the course fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # Create a unit that's not part of this course
+        other_unit = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            title="Other Unit",
+        )
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": other_unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_coach_can_close_active_test(self):
+        """Test that a coach can close an active test"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # First activate a test
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # Now close it
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], self.unit.id)
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "ended")
+
+        # Verify the test is no longer active
+        assignment = models.UnitTestAssignment.objects.get(
+            course_session=self.courseSession,
+            unit_contentnode_id=self.unit.id,
+            test_type="pre",
+        )
+        self.assertFalse(assignment.is_active)
+        self.assertEqual(assignment.status, "ended")
+
+    def test_close_test_with_validation_parameters(self):
+        """Test closing a test with validation parameters"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # Activate a test
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # Close it with validation parameters
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_close_test_validation_mismatch_unit(self):
+        """Test that closing a test with mismatched unit_contentnode_id fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # Activate a test
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # Try to close with different unit_contentnode_id
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit2.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_close_test_validation_mismatch_type(self):
+        """Test that closing a test with mismatched test_type fails"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # Activate a pre-test
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # Try to close as post-test
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "post",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_close_test_when_no_active_test_returns_404(self):
+        """Test that closing when no test is active returns 404"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_non_coach_cannot_close_test(self):
+        """Test that a non-coach cannot close a test"""
+        # First, coach activates a test
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # learner can not close it
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_active_test_returns_test_details(self):
+        """Test that active_test endpoint returns full test details"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        response = self.client.get(
+            reverse(
+                "kolibri:core:coursesession-active-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("id", response.data)
+        self.assertEqual(response.data["unit_contentnode_id"], self.unit.id)
+        self.assertEqual(response.data["unit_title"], "Test Unit")
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "active")
+        self.assertIsNotNone(response.data["activated_by"])
+        self.assertEqual(response.data["activated_by"]["username"], "coach")
+        self.assertEqual(response.data["activated_by"]["id"], self.coach.id)
+
+    def test_get_active_test_returns_null_when_no_active_test(self):
+        """Test that active_test returns null when no test is active"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.get(
+            reverse(
+                "kolibri:core:coursesession-active-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["active_test"])
+
+    def test_non_coach_cannot_get_active_test(self):
+        """Test that a non-coach cannot get active test details"""
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+
+        response = self.client.get(
+            reverse(
+                "kolibri:core:coursesession-active-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_activate_test_updates_existing_assignment(self):
+        """Test that activating a test updates an existing assignment"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # Activate a test
+        response1 = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+        assignment_id_1 = response1.data["id"]
+
+        # Close it
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            format="json",
+        )
+
+        # Activate it again
+        response2 = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+        assignment_id_2 = response2.data["id"]
+
+        # Should be the same assignment updated
+        self.assertEqual(assignment_id_1, assignment_id_2)
+
+        # Verify only one assignment exists
+        self.assertEqual(
+            models.UnitTestAssignment.objects.filter(
+                course_session=self.courseSession,
+                unit_contentnode_id=self.unit.id,
+                test_type="pre",
+            ).count(),
+            1,
+        )
+
+    def test_unauthenticated_user_cannot_activate_test(self):
+        """Test that unauthenticated users cannot activate tests"""
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_user_cannot_close_test(self):
+        """Test that unauthenticated users cannot close tests"""
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_user_cannot_get_active_test(self):
+        """Test that unauthenticated users cannot get active test"""
+        response = self.client.get(
+            reverse(
+                "kolibri:core:coursesession-active-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -942,38 +942,6 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.assertFalse(assignment.is_active)
         self.assertEqual(assignment.status, "ended")
 
-    def test_close_test_with_validation_parameters(self):
-        """Test closing a test with validation parameters"""
-        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-
-        # Activate a test
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
-
-        # Close it with validation parameters
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
     def test_close_test_validation_mismatch_unit(self):
         """Test that closing a test with mismatched unit_contentnode_id fails"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,5 +1,5 @@
 import uuid
-
+import json
 from django.urls import reverse
 from le_utils.constants import modalities
 from rest_framework import status

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,4 +1,3 @@
-import uuid
 import json
 from django.urls import reverse
 from le_utils.constants import modalities

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1,4 +1,5 @@
 import uuid
+
 from django.urls import reverse
 from le_utils.constants import modalities
 from rest_framework import status
@@ -1145,7 +1146,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_activate_test_updates_existing_assignment(self):
         """Test that activating a test updates an existing assignment"""
@@ -1246,4 +1247,4 @@ class UnitTestActivationAPITestCase(APITestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -1,9 +1,9 @@
-import uuid
 from collections import OrderedDict
 
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django_filters.rest_framework import DjangoFilterBackend
+from le_utils.constants import modalities
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.serializers import BooleanField
@@ -12,7 +12,6 @@ from rest_framework.serializers import ListField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import Serializer
-from rest_framework.serializers import UUIDField
 from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_200_OK
 from rest_framework.status import HTTP_404_NOT_FOUND
@@ -41,7 +40,9 @@ class UnitTestValidationSerializer(Serializer):
     for activate_test and close_test actions
     """
 
-    unit_contentnode_id = UUIDField(required=True)
+    unit_contentnode_id = PrimaryKeyRelatedField(
+        queryset=ContentNode.objects.filter(modality=modalities.UNIT), required=True
+    )
     test_type = CharField(required=True)
 
     def validate_test_type(self, value):
@@ -57,66 +58,25 @@ class UnitTestValidationSerializer(Serializer):
 
     def validate(self, attrs):
         """
-        Validate that the unit exists and belongs to the course
+        Validate that the unit belongs to the course
         """
-        course_session = self._get_course_session()
-        unit = self._get_unit(attrs.get("unit_contentnode_id"))
-        self._ensure_unit_belongs_to_course(unit, course_session)
-        return attrs
-
-    def _get_course_session(self):
         course_session = self.context.get("course_session")
         if not course_session:
             raise ValidationError(
                 "Course session not found in context", code=error_constants.INVALID
             )
-        return course_session
 
-    def _get_unit(self, unit_contentnode_id):
-        try:
-            return ContentNode.objects.get(id=unit_contentnode_id)
-        except ContentNode.DoesNotExist:
+        if attrs["unit_contentnode_id"].parent_id != course_session.course:
             raise ValidationError(
-                "Unit with the specified unit_contentnode_id does not exist",
+                "Unit does not belong to this course",
                 code=error_constants.INVALID,
             )
-
-    def _ensure_unit_belongs_to_course(self, unit, course_session):
-        try:
-            course = ContentNode.objects.get(id=course_session.course)
-        except ContentNode.DoesNotExist:
-            raise ValidationError("Course not found", code=error_constants.INVALID)
-
-        if unit.channel_id != course.channel_id:
-            raise ValidationError(
-                "Unit does not belong to the same channel as the course",
-                code=error_constants.INVALID,
-            )
-
-        if unit.parent_id == course.id:
-            return
-
-        max_depth = 50
-        current_id = unit.parent_id
-        depth = 0
-        while current_id and depth < max_depth:
-            if str(current_id) == str(course.id):
-                return
-            try:
-                parent = ContentNode.objects.get(id=current_id)
-                current_id = parent.parent_id
-                depth += 1
-            except ContentNode.DoesNotExist:
-                break
-
-        raise ValidationError(
-            "Unit does not belong to this course", code=error_constants.INVALID
-        )
+        return attrs
 
 
 class CourseSessionSerializer(ModelSerializer):
     course = PrimaryKeyRelatedField(
-        queryset=ContentNode.objects.all(),
+        queryset=ContentNode.objects.filter(modality=modalities.COURSE),
         required=True,
     )
     assignments = ListField(
@@ -296,14 +256,6 @@ def _ensure_raw_dict(d):
     return dict(d)
 
 
-def _uuid_to_hex(value):
-
-    try:
-        return uuid.UUID(str(value)).hex
-    except (TypeError, ValueError, AttributeError):
-        return str(value)
-
-
 class CourseSessionPermissions(KolibriAuthPermissions):
     # Overrides the default validator to sanitize the CourseSession POST Payload
     # before user.can_create validation. This is needed because can_create
@@ -440,7 +392,8 @@ class CourseSessionViewset(ValuesViewset):
         )
         serializer.is_valid(raise_exception=True)
 
-        unit_contentnode_id = serializer.validated_data["unit_contentnode_id"]
+        unit = serializer.validated_data["unit_contentnode_id"]
+        unit_contentnode_id = unit.id
         test_type = serializer.validated_data["test_type"]
 
         # Get or create the UnitTestAssignment
@@ -460,7 +413,7 @@ class CourseSessionViewset(ValuesViewset):
         return Response(
             {
                 "id": unit_test_assignment.id,
-                "unit_contentnode_id": _uuid_to_hex(unit_contentnode_id),
+                "unit_contentnode_id": str(unit_contentnode_id),
                 "test_type": test_type,
                 "status": unit_test_assignment.status,
             },
@@ -475,6 +428,16 @@ class CourseSessionViewset(ValuesViewset):
         """
         course_session = self.get_object()
 
+        # Validate request parameters (both are required)
+        serializer = UnitTestValidationSerializer(
+            data=request.data, context={"course_session": course_session}
+        )
+        serializer.is_valid(raise_exception=True)
+
+        unit = serializer.validated_data["unit_contentnode_id"]
+        unit_contentnode_id = unit.id
+        test_type = serializer.validated_data["test_type"]
+
         # Find the currently active test
         try:
             active_test = UnitTestAssignment.objects.get(
@@ -486,30 +449,18 @@ class CourseSessionViewset(ValuesViewset):
                 status=HTTP_404_NOT_FOUND,
             )
 
-        # If request includes validation parameters,  we can validate them
-        if "unit_contentnode_id" in request.data or "test_type" in request.data:
-            serializer = UnitTestValidationSerializer(
-                data=request.data, context={"course_session": course_session}
+        # Validate that the provided parameters match the active test
+        if str(active_test.unit_contentnode_id) != str(unit_contentnode_id):
+            raise ValidationError(
+                "The provided unit_contentnode_id does not match the active test",
+                code=error_constants.INVALID,
             )
-            serializer.is_valid(raise_exception=True)
 
-            unit_contentnode_id = serializer.validated_data.get("unit_contentnode_id")
-            test_type = serializer.validated_data.get("test_type")
-
-            # And then we can validate that the provided parameters match the active test
-            if unit_contentnode_id and _uuid_to_hex(
-                active_test.unit_contentnode_id
-            ) != _uuid_to_hex(unit_contentnode_id):
-                raise ValidationError(
-                    "The provided unit_contentnode_id does not match the active test",
-                    code=error_constants.INVALID,
-                )
-
-            if test_type and active_test.test_type != test_type:
-                raise ValidationError(
-                    "The provided test_type does not match the active test",
-                    code=error_constants.INVALID,
-                )
+        if active_test.test_type != test_type:
+            raise ValidationError(
+                "The provided test_type does not match the active test",
+                code=error_constants.INVALID,
+            )
 
         # Close the active test
         active_test.is_active = False
@@ -519,7 +470,7 @@ class CourseSessionViewset(ValuesViewset):
         return Response(
             {
                 "id": active_test.id,
-                "unit_contentnode_id": _uuid_to_hex(active_test.unit_contentnode_id),
+                "unit_contentnode_id": str(active_test.unit_contentnode_id),
                 "test_type": active_test.test_type,
                 "status": active_test.status,
             },
@@ -542,7 +493,7 @@ class CourseSessionViewset(ValuesViewset):
         except UnitTestAssignment.DoesNotExist:
             return Response({"active_test": None}, status=HTTP_200_OK)
 
-        #  then tetch the unit's ContentNode
+        #  then fetch the unit's ContentNode
         try:
             unit = ContentNode.objects.get(id=active_test.unit_contentnode_id)
             unit_title = unit.title
@@ -561,7 +512,7 @@ class CourseSessionViewset(ValuesViewset):
         return Response(
             {
                 "id": active_test.id,
-                "unit_contentnode_id": _uuid_to_hex(active_test.unit_contentnode_id),
+                "unit_contentnode_id": str(active_test.unit_contentnode_id),
                 "unit_title": unit_title,
                 "test_type": active_test.test_type,
                 "status": active_test.status,

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -7,7 +7,7 @@ from le_utils.constants import modalities
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.serializers import BooleanField
-from rest_framework.serializers import CharField
+from rest_framework.serializers import ChoiceField
 from rest_framework.serializers import ListField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import PrimaryKeyRelatedField
@@ -43,18 +43,7 @@ class UnitTestValidationSerializer(Serializer):
     unit_contentnode_id = PrimaryKeyRelatedField(
         queryset=ContentNode.objects.filter(modality=modalities.UNIT), required=True
     )
-    test_type = CharField(required=True)
-
-    def validate_test_type(self, value):
-        """
-        Validate that test_type is either 'pre' or 'post'
-        """
-        if value not in [TestType.Pre, TestType.Post]:
-            raise ValidationError(
-                "test_type must be either 'pre' or 'post'",
-                code=error_constants.INVALID,
-            )
-        return value
+    test_type = ChoiceField(choices=[TestType.Pre, TestType.Post], required=True)
 
     def validate(self, attrs):
         """

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -310,19 +310,6 @@ class CourseSessionViewset(ValuesViewset):
         "assignments": "course_session_assignment_collections",
     }
 
-    def filter_queryset(self, queryset):
-        if getattr(self, "action", None) == "active_test":
-            # we can skip the permissions filter so unauthorized users get a 403 via object permissions instead of a 404
-            backends = [
-                backend
-                for backend in self.filter_backends
-                if backend is not KolibriAuthPermissionsFilter
-            ]
-            for backend in backends:
-                queryset = backend().filter_queryset(self.request, queryset, self)
-            return queryset
-        return super().filter_queryset(queryset)
-
     def consolidate(self, items, queryset):
         if items:
             course_session_ids = [l["id"] for l in items]

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -1,5 +1,7 @@
+import logging
 from collections import OrderedDict
 
+from django.db import transaction
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django_filters.rest_framework import DjangoFilterBackend
@@ -32,6 +34,8 @@ from kolibri.core.auth.models import Membership
 from kolibri.core.auth.utils.users import create_adhoc_group_for_learners
 from kolibri.core.content.models import ContentNode
 from kolibri.core.query import annotate_array_aggregate
+
+logger = logging.getLogger(__name__)
 
 
 class UnitTestValidationSerializer(Serializer):
@@ -254,7 +258,6 @@ class CourseSessionPermissions(KolibriAuthPermissions):
     # we would lose the assigments and learner_ids fields
     def has_object_permission(self, request, view, obj):
         if view.action in ["activate_test", "close_test", "active_test"]:
-            # Custom actions should be allowed for users who can update the course session
             return request.user.can_update(obj)
         return super().has_object_permission(request, view, obj)
 
@@ -372,19 +375,27 @@ class CourseSessionViewset(ValuesViewset):
         unit_contentnode_id = unit.id
         test_type = serializer.validated_data["test_type"]
 
-        # Get or create the UnitTestAssignment
-        unit_test_assignment, created = UnitTestAssignment.objects.get_or_create(
-            course_session=course_session,
-            unit_contentnode_id=unit_contentnode_id,
-            test_type=test_type,
-            collection=course_session.collection,
-        )
+        with transaction.atomic():
+            UnitTestAssignment.objects.filter(
+                course_session=course_session, is_active=True
+            ).exclude(
+                unit_contentnode_id=unit_contentnode_id, test_type=test_type
+            ).update(
+                is_active=False, status=TestStatus.Ended
+            )
 
-        # Set as active
-        unit_test_assignment.is_active = True
-        unit_test_assignment.status = TestStatus.Active
-        unit_test_assignment.activated_by = request.user
-        unit_test_assignment.save()
+            unit_test_assignment, created = UnitTestAssignment.objects.get_or_create(
+                course_session=course_session,
+                unit_contentnode_id=unit_contentnode_id,
+                test_type=test_type,
+                collection=course_session.collection,
+            )
+
+            # Set as active
+            unit_test_assignment.is_active = True
+            unit_test_assignment.status = TestStatus.Active
+            unit_test_assignment.activated_by = request.user
+            unit_test_assignment.save()
 
         return Response(
             {
@@ -474,6 +485,11 @@ class CourseSessionViewset(ValuesViewset):
             unit = ContentNode.objects.get(id=active_test.unit_contentnode_id)
             unit_title = unit.title
         except ContentNode.DoesNotExist:
+            logger.error(
+                "UnitTestAssignment {} references non-existent ContentNode {}. This is orphaned data.".format(
+                    active_test.id, active_test.unit_contentnode_id
+                )
+            )
             unit_title = None
 
         # then get the details about the user who activated the test

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -1,17 +1,27 @@
+import uuid
 from collections import OrderedDict
 
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django_filters.rest_framework import DjangoFilterBackend
-from le_utils.constants import modalities
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from rest_framework.serializers import BooleanField
+from rest_framework.serializers import CharField
 from rest_framework.serializers import ListField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.serializers import PrimaryKeyRelatedField
+from rest_framework.serializers import Serializer
+from rest_framework.serializers import UUIDField
 from rest_framework.serializers import ValidationError
+from rest_framework.status import HTTP_200_OK
+from rest_framework.status import HTTP_404_NOT_FOUND
 
 from .models import CourseSession
 from .models import CourseSessionAssignment
+from .models import TestStatus
+from .models import TestType
+from .models import UnitTestAssignment
 from kolibri.core import error_constants
 from kolibri.core.api import ValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
@@ -25,9 +35,88 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.query import annotate_array_aggregate
 
 
+class UnitTestValidationSerializer(Serializer):
+    """
+    Serializer to validate unit_contentnode_id and test_type parameters
+    for activate_test and close_test actions
+    """
+
+    unit_contentnode_id = UUIDField(required=True)
+    test_type = CharField(required=True)
+
+    def validate_test_type(self, value):
+        """
+        Validate that test_type is either 'pre' or 'post'
+        """
+        if value not in [TestType.Pre, TestType.Post]:
+            raise ValidationError(
+                "test_type must be either 'pre' or 'post'",
+                code=error_constants.INVALID,
+            )
+        return value
+
+    def validate(self, attrs):
+        """
+        Validate that the unit exists and belongs to the course
+        """
+        course_session = self._get_course_session()
+        unit = self._get_unit(attrs.get("unit_contentnode_id"))
+        self._ensure_unit_belongs_to_course(unit, course_session)
+        return attrs
+
+    def _get_course_session(self):
+        course_session = self.context.get("course_session")
+        if not course_session:
+            raise ValidationError(
+                "Course session not found in context", code=error_constants.INVALID
+            )
+        return course_session
+
+    def _get_unit(self, unit_contentnode_id):
+        try:
+            return ContentNode.objects.get(id=unit_contentnode_id)
+        except ContentNode.DoesNotExist:
+            raise ValidationError(
+                "Unit with the specified unit_contentnode_id does not exist",
+                code=error_constants.INVALID,
+            )
+
+    def _ensure_unit_belongs_to_course(self, unit, course_session):
+        try:
+            course = ContentNode.objects.get(id=course_session.course)
+        except ContentNode.DoesNotExist:
+            raise ValidationError("Course not found", code=error_constants.INVALID)
+
+        if unit.channel_id != course.channel_id:
+            raise ValidationError(
+                "Unit does not belong to the same channel as the course",
+                code=error_constants.INVALID,
+            )
+
+        if unit.parent_id == course.id:
+            return
+
+        max_depth = 50
+        current_id = unit.parent_id
+        depth = 0
+        while current_id and depth < max_depth:
+            if str(current_id) == str(course.id):
+                return
+            try:
+                parent = ContentNode.objects.get(id=current_id)
+                current_id = parent.parent_id
+                depth += 1
+            except ContentNode.DoesNotExist:
+                break
+
+        raise ValidationError(
+            "Unit does not belong to this course", code=error_constants.INVALID
+        )
+
+
 class CourseSessionSerializer(ModelSerializer):
     course = PrimaryKeyRelatedField(
-        queryset=ContentNode.objects.filter(modality=modalities.COURSE),
+        queryset=ContentNode.objects.all(),
         required=True,
     )
     assignments = ListField(
@@ -207,6 +296,14 @@ def _ensure_raw_dict(d):
     return dict(d)
 
 
+def _uuid_to_hex(value):
+
+    try:
+        return uuid.UUID(str(value)).hex
+    except (TypeError, ValueError, AttributeError):
+        return str(value)
+
+
 class CourseSessionPermissions(KolibriAuthPermissions):
     # Overrides the default validator to sanitize the CourseSession POST Payload
     # before user.can_create validation. This is needed because can_create
@@ -214,7 +311,18 @@ class CourseSessionPermissions(KolibriAuthPermissions):
     # that the payload is in the correct format.
     # We do this here because if we do it in the serializer,
     # we would lose the assigments and learner_ids fields
+    def has_object_permission(self, request, view, obj):
+        if view.action in ["activate_test", "close_test", "active_test"]:
+            # Custom actions should be allowed for users who can update the course session
+            return request.user.can_update(obj)
+        return super().has_object_permission(request, view, obj)
+
     def validator(self, request, view, datum):
+        # we skip validation for custom actions (activate_test, close_test)
+        # Note:these actions have their own serializers and validation logic
+        if view.action in ["activate_test", "close_test"]:
+            return True
+
         model = view.get_serializer_class().Meta.model
         validated_data = view.get_serializer().to_internal_value(
             _ensure_raw_dict(datum)
@@ -261,6 +369,19 @@ class CourseSessionViewset(ValuesViewset):
         "assignments": "course_session_assignment_collections",
     }
 
+    def filter_queryset(self, queryset):
+        if getattr(self, "action", None) == "active_test":
+            # we can skip the permissions filter so unauthorized users get a 403 via object permissions instead of a 404
+            backends = [
+                backend
+                for backend in self.filter_backends
+                if backend is not KolibriAuthPermissionsFilter
+            ]
+            for backend in backends:
+                queryset = backend().filter_queryset(self.request, queryset, self)
+            return queryset
+        return super().filter_queryset(queryset)
+
     def consolidate(self, items, queryset):
         if items:
             course_session_ids = [l["id"] for l in items]
@@ -305,4 +426,146 @@ class CourseSessionViewset(ValuesViewset):
                     available=True,
                 )
             )
+        )
+
+    @action(detail=True, methods=["post"])
+    def activate_test(self, request, pk=None):
+        """
+        Activates a pre-test or post-test for a unit within the course session.
+        """
+        course_session = self.get_object()
+
+        serializer = UnitTestValidationSerializer(
+            data=request.data, context={"course_session": course_session}
+        )
+        serializer.is_valid(raise_exception=True)
+
+        unit_contentnode_id = serializer.validated_data["unit_contentnode_id"]
+        test_type = serializer.validated_data["test_type"]
+
+        # Get or create the UnitTestAssignment
+        unit_test_assignment, created = UnitTestAssignment.objects.get_or_create(
+            course_session=course_session,
+            unit_contentnode_id=unit_contentnode_id,
+            test_type=test_type,
+            collection=course_session.collection,
+        )
+
+        # Set as active
+        unit_test_assignment.is_active = True
+        unit_test_assignment.status = TestStatus.Active
+        unit_test_assignment.activated_by = request.user
+        unit_test_assignment.save()
+
+        return Response(
+            {
+                "id": unit_test_assignment.id,
+                "unit_contentnode_id": _uuid_to_hex(unit_contentnode_id),
+                "test_type": test_type,
+                "status": unit_test_assignment.status,
+            },
+            status=HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=["post"])
+    def close_test(self, request, pk=None):
+        """
+        Closes the currently active test for the course session.
+        Sets is_active=False and status='ended' for the active test.
+        """
+        course_session = self.get_object()
+
+        # Find the currently active test
+        try:
+            active_test = UnitTestAssignment.objects.get(
+                course_session=course_session, is_active=True
+            )
+        except UnitTestAssignment.DoesNotExist:
+            return Response(
+                {"error": "No active test exists for this course session"},
+                status=HTTP_404_NOT_FOUND,
+            )
+
+        # If request includes validation parameters,  we can validate them
+        if "unit_contentnode_id" in request.data or "test_type" in request.data:
+            serializer = UnitTestValidationSerializer(
+                data=request.data, context={"course_session": course_session}
+            )
+            serializer.is_valid(raise_exception=True)
+
+            unit_contentnode_id = serializer.validated_data.get("unit_contentnode_id")
+            test_type = serializer.validated_data.get("test_type")
+
+            # And then we can validate that the provided parameters match the active test
+            if unit_contentnode_id and _uuid_to_hex(
+                active_test.unit_contentnode_id
+            ) != _uuid_to_hex(unit_contentnode_id):
+                raise ValidationError(
+                    "The provided unit_contentnode_id does not match the active test",
+                    code=error_constants.INVALID,
+                )
+
+            if test_type and active_test.test_type != test_type:
+                raise ValidationError(
+                    "The provided test_type does not match the active test",
+                    code=error_constants.INVALID,
+                )
+
+        # Close the active test
+        active_test.is_active = False
+        active_test.status = TestStatus.Ended
+        active_test.save()
+
+        return Response(
+            {
+                "id": active_test.id,
+                "unit_contentnode_id": _uuid_to_hex(active_test.unit_contentnode_id),
+                "test_type": active_test.test_type,
+                "status": active_test.status,
+            },
+            status=HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=["get"])
+    def active_test(self, request, pk=None):
+        """
+        We get the details about the currently active test for the course session.
+        If no active test exists, returns { "active_test": null }.
+        """
+        course_session = self.get_object()
+
+        # but first, find the currently active test
+        try:
+            active_test = UnitTestAssignment.objects.get(
+                course_session=course_session, is_active=True
+            )
+        except UnitTestAssignment.DoesNotExist:
+            return Response({"active_test": None}, status=HTTP_200_OK)
+
+        #  then tetch the unit's ContentNode
+        try:
+            unit = ContentNode.objects.get(id=active_test.unit_contentnode_id)
+            unit_title = unit.title
+        except ContentNode.DoesNotExist:
+            unit_title = None
+
+        # then get the details about the user who activated the test
+        activated_by_info = None
+        if active_test.activated_by:
+            activated_by_info = {
+                "id": active_test.activated_by.id,
+                "username": active_test.activated_by.username,
+                "full_name": active_test.activated_by.full_name,
+            }
+
+        return Response(
+            {
+                "id": active_test.id,
+                "unit_contentnode_id": _uuid_to_hex(active_test.unit_contentnode_id),
+                "unit_title": unit_title,
+                "test_type": active_test.test_type,
+                "status": active_test.status,
+                "activated_by": activated_by_info,
+            },
+            status=HTTP_200_OK,
         )


### PR DESCRIPTION


## Summary

This PR adds API endpoints for activating and closing pre-tests and post-tests for units within course sessions using  the UnitTestAssignment model. 

1. Activates a pre or post test for a specific unit
2. Validates unit existence and course relationship
3. Creates or updates UnitTestAssignment record
4. Sets test status to active and tracks activating user
6. Fetches unit title from ContentNode
7. Returns full test details or null if no active test
8. Includes test id, unit info, test type, status, and activating user
9. Validates unit_contentnode_id (UUID format)
10. Validates test_type (must be "pre" or "post")


  closes #14100

## References
#14100

## Reviewer guidance
Do the changes make sense?
And confirm if:
 `activate_test/close_test/active_test` wired on `CourseSessionViewset` and use `UnitTestAssignment`
 `UnitTestValidationSerializer` enforces u`nit_contentnode_id `existence and course lineage, `test_type in {pre, post}.`
