### PR TITLE
Add linting to prevent non-scoped lodash/dateFn imports.

### DIFF
--- a/packages/kolibri-format/.eslintrc.js
+++ b/packages/kolibri-format/.eslintrc.js
@@ -71,7 +71,7 @@ module.exports = {
     'plugin:jest-dom/recommended',
     resolveConfig('eslint-config-prettier'),
   ],
-  plugins: ['import', 'vue', 'kolibri', 'jest-dom', 'jest'],
+  plugins: ['import', 'vue', 'kolibri', 'jest-dom', 'jest', 'small-import'],
   settings: {
     "import/resolver": {
       node: {
@@ -250,6 +250,8 @@ module.exports = {
     'import/no-duplicates': ERROR,
     'import/newline-after-import': ERROR,
     'import/order': ERROR,
+
+    'small-import/no-full-import': ERROR,
 
     // Custom vue rules
     'kolibri/vue-no-unused-vuex-properties': ERROR,

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-jest": "^29.5.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-kolibri": "workspace:*",
+    "eslint-plugin-small-import": "^1.0.0",
     "eslint-plugin-vue": "^9.33.0",
     "fast-glob": "3.3.3",
     "kolibri-logging": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1242,6 +1242,9 @@ importers:
       eslint-plugin-kolibri:
         specifier: workspace:*
         version: link:../eslint-plugin-kolibri
+      eslint-plugin-small-import:
+        specifier: ^1.0.0
+        version: 1.0.0(eslint@8.57.1)
       eslint-plugin-vue:
         specifier: ^9.33.0
         version: 9.33.0(eslint@8.57.1)
@@ -5006,6 +5009,11 @@ packages:
         optional: true
       jest:
         optional: true
+
+  eslint-plugin-small-import@1.0.0:
+    resolution: {integrity: sha512-udQ1Eh3hP1PtAtgk5B4ie9jp4nSJjGF2ytl4OuHw8zhTBnxQ0aFCsGdY0s9RKEignYVjqtJslv8z/VQZxDziQA==}
+    peerDependencies:
+      eslint: ^6.1.0
 
   eslint-plugin-vue@9.33.0:
     resolution: {integrity: sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==}
@@ -12919,6 +12927,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-plugin-small-import@1.0.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
 
   eslint-plugin-vue@9.33.0(eslint@8.57.1):
     dependencies:


### PR DESCRIPTION
## Summary
Adds linting rule to prevent importing all of lodash and dateFn

## References
Adds this rule: https://www.npmjs.com/package/eslint-plugin-small-import

## Reviewer guidance
Is it properly configured?
