### PR TITLE
Prevent traversal of symlinks in node_modules during egg info generation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include README.md
 include kolibri/VERSION
 recursive-include kolibri/locale *.mo
 recursive-include kolibri/locale *.json
-recursive-include kolibri/core *
+graft kolibri/core
 recursive-include kolibri/deployment *
 recursive-include kolibri/dist *
 
@@ -25,7 +25,7 @@ recursive-exclude kolibri/dist/django/contrib/flatpages/locale *
 recursive-exclude kolibri/dist/django/contrib/sessions/locale *
 recursive-exclude kolibri/dist/django/contrib/admin/locale *
 
-recursive-include kolibri/plugins *
+graft kolibri/plugins
 recursive-include kolibri/utils *
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/*/build/ *.json


### PR DESCRIPTION
## Summary
`recursive-include` ended up traversing symlinks in the node_modules inside `core` and the `plugins` sub folders - this made the egg info generation traverse the entirety of node_modules
using `graft` prevents this behaviour, and doesn't impact the files included (SOURCES.txt before and after were identical)

## References
Fixes regression for `pip install -e .` speed since pnpm migration

## Reviewer guidance
Run `pip install -e .` see that it is performant again
Check the size of the resultant WHL file, check that it has not drastically changed.