### PR TITLE
Exclude Courses in Search, Resume, Library & plugin_data flag for courses

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -58,6 +58,7 @@ from kolibri.core.bookmarks.models import Bookmark
 from kolibri.core.content import models
 from kolibri.core.content import serializers
 from kolibri.core.content.models import ContentDownloadRequest
+from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import ContentRemovalRequest
 from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
@@ -109,6 +110,20 @@ REMOTE_URL_PARAM = "baseurl"
 
 def get_cache_key(*args, **kwargs):
     return str(ContentCacheKey.get_cache_key())
+
+
+def get_course_ids():
+    cache_key = "COURSE_IDS_{}".format(get_cache_key())
+    cached_data = cache.get(cache_key)
+    if cached_data is not None:
+        return cached_data
+    updated_data = list(
+        ContentNode.objects.filter(
+            available=True, modality=modalities.COURSE
+        ).values_list("id", flat=True)
+    )
+    cache.set(cache_key, updated_data, 3600)
+    return updated_data
 
 
 def metadata_cache(view_func, cache_key_func=get_cache_key):
@@ -465,6 +480,7 @@ contentnode_filter_fields = [
     "tree_id",
     "lft__gt",
     "rght__lt",
+    "exclude_course_ancestry",
 ]
 
 
@@ -498,10 +514,29 @@ class ContentNodeFilter(FilterSet):
     exclude_modalities = ChoiceInFilter(
         field_name="modality", choices=modalities.choices, exclude=True
     )
+    exclude_course_ancestry = BooleanFilter(method="filter_exclude_course_ancestry")
 
     class Meta:
         model = models.ContentNode
         fields = contentnode_filter_fields
+
+    def filter_exclude_course_ancestry(self, queryset, name, value):
+        """
+        Exclude any resources that are descended from a Course.
+        :param queryset: ContentNode queryset to filter
+        :param name: filter field name
+        :param value: boolean indicating whether to apply the exclusion
+        :return: filtered queryset excluding course descendants if value is True
+        """
+        if not value:
+            return queryset
+        has_course_ancestor = ContentNode.objects.filter(
+            id__in=get_course_ids(),
+            lft__lt=OuterRef("lft"),
+            rght__gt=OuterRef("rght"),
+            tree_id=OuterRef("tree_id"),
+        )
+        return queryset.exclude(Exists(has_course_ancestor))
 
     def filter_ids(self, queryset, name, value):
         return queryset.filter_by_uuids(value)
@@ -570,7 +605,10 @@ class ContentNodeFilter(FilterSet):
         return queryset.filter(kind__in=kinds).order_by("lft")
 
     def filter_exclude_content_ids(self, queryset, name, value):
-        return queryset.exclude_by_content_ids(value.split(","))
+        if not value:
+            return queryset
+        else:
+            return queryset.exclude_by_content_ids(value.split(","))
 
     def filter_include_coach_content(self, queryset, name, value):
         if value:
@@ -1278,7 +1316,6 @@ class ContentNodeSearchViewset(ContentNodeViewset):
 
         # iterate over each query type, and build up search results
         for query in all_queries:
-
             # in each pass, don't take any items already in the result set
             matches = (
                 queryset.exclude_by_content_ids(list(content_ids), validate=False)
@@ -1700,7 +1737,10 @@ class UserContentNodeFilter(ContentNodeFilter):
 
     class Meta:
         model = models.ContentNode
-        fields = contentnode_filter_fields + ["resume", "lesson"]
+        fields = contentnode_filter_fields + [
+            "resume",
+            "lesson",
+        ]
 
 
 class UserContentNodeViewset(
@@ -1868,7 +1908,6 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             identifier=identifier, baseurl=baseurl, keyword=keyword, language=language
         )
         try:
-
             resp = client.get(url)
             # map the channel list into the format the Kolibri client-side expects
             channels = list(map(self._studio_response_to_kolibri_response, resp.json()))

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1607,6 +1607,67 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         self.assertNotIn(str(lesson_topic.id), [node["id"] for node in response.data])
         self.assertNotIn(str(course_topic.id), [node["id"] for node in response.data])
 
+    def test_exclude_course_ancestry_filter(self):
+        # Mark c2 (a topic with children) as a Course
+        course_node = content.ContentNode.objects.get(title="c2")
+        course_node.modality = modalities.COURSE
+        course_node.available = True
+        course_node.save()
+
+        # Get the descendants of the course node
+        descendant_ids = set(
+            str(pk)
+            for pk in content.ContentNode.objects.filter(
+                tree_id=course_node.tree_id,
+                lft__gt=course_node.lft,
+                rght__lt=course_node.rght,
+            )
+            .filter(available=True)
+            .values_list("id", flat=True)
+        )
+        self.assertGreater(len(descendant_ids), 0)
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"exclude_course_ancestry": True},
+        )
+
+        result_ids = {node["id"] for node in response.data}
+
+        # Course descendants should be excluded
+        self.assertTrue(descendant_ids.isdisjoint(result_ids))
+
+        # The course node itself should still be present
+        self.assertIn(str(course_node.id), result_ids)
+
+    def test_exclude_course_ancestry_filter_false(self):
+        # Mark c2 as a Course
+        course_node = content.ContentNode.objects.get(title="c2")
+        course_node.modality = modalities.COURSE
+        course_node.available = True
+        course_node.save()
+
+        descendant_ids = set(
+            str(pk)
+            for pk in content.ContentNode.objects.filter(
+                tree_id=course_node.tree_id,
+                lft__gt=course_node.lft,
+                rght__lt=course_node.rght,
+            )
+            .filter(available=True)
+            .values_list("id", flat=True)
+        )
+
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"exclude_course_ancestry": False},
+        )
+
+        result_ids = {node["id"] for node in response.data}
+
+        # With false, descendants should NOT be excluded
+        self.assertTrue(descendant_ids.issubset(result_ids))
+
     def _setup_contentnode_progress(self):
         # set up data for testing progress_fraction field on content node endpoint
         facility = Facility.objects.create(name="MyFac")

--- a/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
+++ b/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
@@ -618,7 +618,7 @@ describe(`useLearnerResources`, () => {
 
   describe('fetchResumableContentNodes', () => {
     it('should set resumable content nodes and the more value', async () => {
-      const more = { test: 1 };
+      const more = { test: 1, exclude_course_ancestry: true };
       ContentNodeResource.fetchResume = jest
         .fn()
         .mockResolvedValue({ results: TEST_RESUMABLE_CONTENT_NODES, more });

--- a/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
@@ -328,7 +328,12 @@ export default function useLearnerResources() {
    * @public
    */
   function fetchResumableContentNodes() {
-    const params = { resume: true, max_results: 12, ordering: '-last_interacted' };
+    const params = {
+      resume: true,
+      max_results: 12,
+      ordering: '-last_interacted',
+      exclude_course_ancestry: true,
+    };
     fetchContentNodeProgress(params);
     return ContentNodeResource.fetchResume(params).then(({ results, more }) => {
       if (!results || !results.length) {

--- a/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
@@ -264,6 +264,7 @@
   import useUser from 'kolibri/composables/useUser';
   import { ContentNodeKinds } from 'kolibri/constants';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import Modalities from 'kolibri-constants/Modalities';
   import { throttle } from 'frame-throttle';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import samePageCheckGenerator from 'kolibri-common/utils/samePageCheckGenerator';
@@ -303,7 +304,7 @@
   }
 
   function _getChildren(id, topic, skip) {
-    let children = topic.children.results || [];
+    let children = topic?.children?.results || [];
     let skipped = false;
     // If there is only one child, and that child is a topic, then display that instead
     while (skip && children.length === 1 && !children[0].is_leaf) {
@@ -432,6 +433,9 @@
         const skip = route.query && route.query.skip === 'true';
         const params = {
           include_coach_content: get(isAdmin) || get(isCoach) || get(isSuperuser),
+          // Only hide COURSE from Learners in the library view
+          exclude_modalities:
+            get(isAdmin) || get(isCoach) || get(isSuperuser) ? null : Modalities.COURSE,
           baseurl,
         };
         if (get(isUserLoggedIn) && !baseurl) {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from le_utils.constants import modalities
 
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.auth.constants.user_kinds import LEARNER
@@ -58,6 +59,11 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
     def plugin_data(self):
         from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
         from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
+        from kolibri.core.content.models import ContentNode
+
+        courses_exist = ContentNode.objects.filter(
+            available=True, modality=modalities.COURSE
+        ).exists()
 
         return {
             "allowDownloadOnMeteredConnection": get_device_setting(
@@ -75,6 +81,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
                 "base_url": CENTRAL_CONTENT_BASE_URL,
                 "instance_id": CENTRAL_CONTENT_BASE_INSTANCE_ID,
             },
+            "courses_exist": courses_exist,
         }
 
 

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -350,7 +350,12 @@ class LearnHomePageHydrationView(APIView):
             if not classrooms or not any(_resumable_resources(classrooms)):
                 resumable_resources = user_contentnode_viewset.serialize_list(
                     request,
-                    {"resume": True, "max_results": 12, "ordering": "-last_interacted"},
+                    {
+                        "resume": True,
+                        "max_results": 12,
+                        "ordering": "-last_interacted",
+                        "exclude_course_ancestry": True,
+                    },
                 )
                 resumable_resources_progress = (
                     contentnode_progress_viewset.serialize_list(
@@ -359,6 +364,7 @@ class LearnHomePageHydrationView(APIView):
                             "resume": True,
                             "max_results": 12,
                             "ordering": "-last_interacted",
+                            "exclude_course_ancestry": True,
                         },
                     )
                 )

--- a/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
@@ -5,6 +5,7 @@ import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource
 import { coreStoreFactory } from 'kolibri/store';
 import { AllCategories, ContentNodeKinds, NoCategories } from 'kolibri/constants';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
+import Modalities from 'kolibri-constants/Modalities';
 import useBaseSearch from '../useBaseSearch';
 import coreModule from '../../../../kolibri/core/frontend/state/modules/core';
 
@@ -204,6 +205,8 @@ describe(`useBaseSearch`, () => {
           categories: ['test1', 'test2'],
           max_results: 25,
           include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
         },
       });
     });
@@ -233,6 +236,8 @@ describe(`useBaseSearch`, () => {
           rght__lt: 20,
           max_results: 1,
           include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
         },
       });
     });
@@ -245,6 +250,8 @@ describe(`useBaseSearch`, () => {
           kind: ContentNodeKinds.EXERCISE,
           max_results: 1,
           include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
         },
       });
     });
@@ -270,6 +277,8 @@ describe(`useBaseSearch`, () => {
           categories: ['test1', 'test2'],
           max_results: 25,
           include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
         },
       });
     });
@@ -278,7 +287,13 @@ describe(`useBaseSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories__isnull: false, max_results: 25, include_coach_content: false },
+        getParams: {
+          categories__isnull: false,
+          max_results: 25,
+          include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
+        },
       });
     });
     it('should ignore other categories when NoCategories is set and search for isnull true', () => {
@@ -286,7 +301,13 @@ describe(`useBaseSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories__isnull: true, max_results: 25, include_coach_content: false },
+        getParams: {
+          categories__isnull: true,
+          max_results: 25,
+          include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
+        },
       });
     });
     it('should set keywords when defined', () => {
@@ -298,6 +319,8 @@ describe(`useBaseSearch`, () => {
           keywords: `this is just a test`,
           max_results: 25,
           include_coach_content: false,
+          exclude_modalities: Modalities.COURSE,
+          exclude_course_ancestry: true,
         },
       });
     });

--- a/packages/kolibri-common/composables/useBaseSearch.js
+++ b/packages/kolibri-common/composables/useBaseSearch.js
@@ -16,6 +16,7 @@ import {
 } from 'kolibri/constants';
 import useUser from 'kolibri/composables/useUser';
 
+import Modalities from 'kolibri-constants/Modalities';
 import { deduplicateResources } from '../utils/contentNode';
 
 export const logging = logger.getLogger(__filename);
@@ -242,6 +243,9 @@ export default function useBaseSearch({
 
   function createBaseSearchGetParams() {
     const getParams = {
+      exclude_modalities:
+        get(isAdmin) || get(isCoach) || get(isSuperuser) ? null : Modalities.COURSE,
+      exclude_course_ancestry: !(get(isAdmin) || get(isCoach) || get(isSuperuser)),
       include_coach_content: get(isAdmin) || get(isCoach) || get(isSuperuser),
       baseurl: get(baseurl),
     };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

- Adds a helper function to `content/api.py` `get_course_ids()` that returns a flat list of the IDs for every course on the device - then it caches that data against the `ContentCacheKey`
- Adds `exclude_course_ancestry` BooleanFilter field to the `ContentNodeFilter` allowing us to pass a query param `exclude_course_ancestry: true` to exclude all resources that are within a Course
- Uses previously added `exclude_modalities` filter to filter out the Courses themselves in Search
- Exclude all Course descendants from the "recent/resume" recommendations

#### Potential concerns

- The demo channel only has courses so when you open it up it's just an empty channel, **but there is no messaging to say as much** -- should we a) steal a "No resources available" string or similar and put it in the empty channel page?, b) Hide all channels that exclusively have Courses as direct chidlren from the channels list?, c) other?
- I called the plugin_data flag `courses_exist` for consistency as this is what it is called in the Coach plugin (just noting I didn't call it `courses_active` like the issue said to).


## References
<!--
 * references to related issues and PRs
-->

Closes #14108


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

#### Code

- I'm feeling like I should add a test for the exclude_course_ancestry maybe? 
- Is any of the other added code worth putting under test?

#### Performance

- It would be good to get a sense of how quickly/slowly the filtering query is when excluding descendants. Open the `/profile` to see Silk's outputs and do some investigation on how long calls to get recommendations and searches.

#### QA Testing

You will need to have the courses channel imported and to go onto base `release-v0.19.x` and interact with some of the courses' descendants (ie, take a couple of the exercises about hummingbirds). *This gives your user progress on the course-descended resource so you can see how it's hidden in this PR.*

After that, checkout this PR and:

- Try searching for the resources that you saw previously and see that you cannot find anything from the courses
- See that the resources you made progress on last time aren't shown on the Home or Library pages
- In the console do `document.querySelector('template[data-plugin="kolibri.plugins.learn.app"]').content.textContent.includes("courses_exist")` to see that the key is set 
- Run `JSON.parse(document.querySelector('template[data-plugin="kolibri.plugins.learn.app"]').content.textContent).courses_exist` to see the value of it - when you have Course content it should be `true`, otherwise, `false`.

