### PR TITLE
Pre/Post-Tests Activation UI

### DIFF
--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -26,6 +26,14 @@ class TestStatus(ChoicesEnum):
     Ended = "ended"
 
 
+class UnitPhase(ChoicesEnum):
+    PreTestPending = "pre_test_pending"
+    PreTestActive = "pre_test_active"
+    PostTestPending = "post_test_pending"
+    PostTestActive = "post_test_active"
+    Complete = "complete"
+
+
 class CourseSession(AbstractFacilityDataModel):
 
     # UUID reference to the course ContentNode (not FK due to sync constraints)

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1155,6 +1155,60 @@ class UnitTestActivationAPITestCase(APITestCase):
             1,
         )
 
+    def test_activate_test_returns_unit_phase(self):
+        """activate_test should return unit_phase and active_unit_index"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_phase"], "pre_test_active")
+        self.assertIn("active_unit_index", response.data)
+
+    def test_close_test_returns_unit_phase(self):
+        """close_test should return unit_phase and active_unit_index"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        # First activate a test
+        self.client.post(
+            reverse(
+                "kolibri:core:coursesession-activate-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        # Then close it
+        response = self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {
+                "unit_contentnode_id": self.unit.id,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_phase"], "post_test_pending")
+        self.assertIn("active_unit_index", response.data)
+
     def test_unauthenticated_user_cannot_activate_test(self):
         """Test that unauthenticated users cannot activate tests"""
         response = self.client.post(
@@ -1616,3 +1670,84 @@ class LastUnitTestAPITestCase(APITestCase):
         self.assertIn("status", response.data)
         self.assertIn("activated_by", response.data)
         self.assertEqual(response.data["id"], str(test.id))
+
+    # --- unit_phase and active_unit_index tests ---
+
+    def test_unit_phase_pre_test_active(self):
+        """unit_phase should be pre_test_active when a pre-test is running"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["unit_phase"], "pre_test_active")
+        self.assertEqual(response.data["active_unit_index"], 0)
+
+    def test_unit_phase_post_test_pending(self):
+        """unit_phase should be post_test_pending after pre-test ends"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["unit_phase"], "post_test_pending")
+        self.assertEqual(response.data["active_unit_index"], 0)
+
+    def test_unit_phase_post_test_active(self):
+        """unit_phase should be post_test_active when a post-test is running"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["unit_phase"], "post_test_active")
+        self.assertEqual(response.data["active_unit_index"], 0)
+
+    def test_unit_phase_pre_test_pending_after_post_test_ends(self):
+        """unit_phase should be pre_test_pending for next unit after post-test ends"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["unit_phase"], "pre_test_pending")
+        self.assertEqual(response.data["active_unit_index"], 1)
+
+    def test_unit_phase_complete_when_last_unit_post_test_ends(self):
+        """unit_phase should be complete when last unit's post-test ends"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+        self._create_test(self.unit3, "pre", "ended")
+        self._create_test(self.unit3, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["unit_phase"], "complete")
+        self.assertEqual(response.data["active_unit_index"], -1)
+
+    def test_active_unit_index_mid_course(self):
+        """active_unit_index should reflect the current unit position"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["active_unit_index"], 1)
+        self.assertEqual(response.data["unit_phase"], "pre_test_active")
+
+    def test_response_structure_includes_new_fields(self):
+        """Verify response includes unit_phase and active_unit_index"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertIn("unit_phase", response.data)
+        self.assertIn("active_unit_index", response.data)

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -65,6 +65,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_user_course_session_no_delete(self):
+
         user = FacilityUser.objects.create(username="learner", facility=self.facility)
         user.set_password("pass")
         user.save()
@@ -80,6 +81,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_logged_in_admin_course_session_delete(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.delete(
@@ -91,6 +93,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_logged_in_admin_course_session_create(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -107,6 +110,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(created_by, self.admin.id)
 
     def test_logged_in_admin_course_session_create_with_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -128,6 +132,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_no_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -157,6 +162,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_different_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -193,6 +199,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_additional_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -235,6 +242,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_create_learner_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         user = FacilityUser.objects.create(username="u", facility=self.facility)
@@ -272,6 +280,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(adhoc_group.kind, collection_kinds.ADHOCLEARNERSGROUP)
 
     def test_logged_in_admin_course_session_update_learner_assignments(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -321,6 +330,7 @@ class CourseSessionAPITestCase(APITestCase):
     def test_logged_in_admin_course_session_update_learner_assignments_wrong_collection(
         self,
     ):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -357,6 +367,7 @@ class CourseSessionAPITestCase(APITestCase):
             AdHocGroup.objects.get(parent=self.classroom)
 
     def test_logged_in_user_course_session_no_create(self):
+
         # user without admin nor coach rights
         user = FacilityUser.objects.create(username="learner", facility=self.facility)
         user.set_password("pass")
@@ -376,6 +387,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_logged_in_admin_course_session_update_basic(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.put(
@@ -418,6 +430,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_can_get_course_session_list(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.get(
@@ -440,6 +453,7 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_coach_can_see_only_allowed_course_sessions(self):
+
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse("kolibri:core:coursesession-list"))
 
@@ -453,6 +467,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertIn(self.courseSession_2.id, course_session_ids)
 
     def test_cannot_create_course_session_with_non_existent_course_id(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -467,6 +482,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_cannot_create_course_session_with_non_course_modality(self):
+
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         # Create a content node that is not a COURSE
@@ -524,6 +540,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertNotIn(other_course_session.id, course_session_ids)
 
     def test_coach_can_create_course_session(self):
+
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -538,6 +555,7 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 201)
 
     def test_learner_cannot_create_course_session(self):
+
         learner = FacilityUser.objects.create(
             username="learner", facility=self.facility
         )
@@ -625,6 +643,7 @@ kolibri/core/courses/test/test_api.py:805:"
 
 
 class UnitTestActivationAPITestCase(APITestCase):
+
     databases = "__all__"
 
     @classmethod
@@ -694,21 +713,39 @@ class UnitTestActivationAPITestCase(APITestCase):
             description=cls.course.description,
         )
 
-    def test_coach_can_activate_pre_test(self):
-        """Test that a coach can activate a pre-test"""
-        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-
-        response = self.client.post(
+    def _activate_test(self, unit_id, test_type, **kwargs):
+        return self.client.post(
             reverse(
                 "kolibri:core:coursesession-activate-test",
                 kwargs={"pk": self.courseSession.id},
             ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
+            {"unit_contentnode_id": unit_id, "test_type": test_type, **kwargs},
             format="json",
         )
+
+    def _close_test(self, unit_id, test_type):
+        return self.client.post(
+            reverse(
+                "kolibri:core:coursesession-close-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+            {"unit_contentnode_id": unit_id, "test_type": test_type},
+            format="json",
+        )
+
+    def _get_active_test(self):
+        return self.client.get(
+            reverse(
+                "kolibri:core:coursesession-active-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
+    def test_coach_can_activate_pre_test(self):
+        """Test that a coach can activate a pre-test"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+
+        response = self._activate_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_contentnode_id"], self.unit.id)
@@ -729,17 +766,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that a coach can activate a post-test"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "post",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "post")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["test_type"], "post")
@@ -749,17 +776,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that an admin can activate a test"""
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -767,17 +784,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that a non-coach cannot activate a test"""
         self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -785,17 +792,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that activating a test with invalid test_type fails"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "invalid",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "invalid")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -837,17 +834,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that activating a test with non-existent unit fails"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": uuid.uuid4().hex,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(uuid.uuid4().hex, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -865,17 +852,7 @@ class UnitTestActivationAPITestCase(APITestCase):
             title="Other Unit",
         )
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": other_unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(other_unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -884,30 +861,10 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # First activate a test
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
         # Now close it
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_contentnode_id"], self.unit.id)
@@ -928,30 +885,10 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # Activate a test
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
         # Try to close with different unit_contentnode_id
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit2.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit2.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -960,30 +897,10 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # Activate a pre-test
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
         # Try to close as post-test
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "post",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "post")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -991,17 +908,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that closing when no test is active returns 404"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1009,31 +916,11 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that a non-coach cannot close a test"""
         # First, coach activates a test
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
         # learner can not close it
         self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1041,24 +928,9 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that active_test endpoint returns full test details"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
-        response = self.client.get(
-            reverse(
-                "kolibri:core:coursesession-active-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-        )
+        response = self._get_active_test()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("id", response.data)
@@ -1074,12 +946,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that active_test returns null when no test is active"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.get(
-            reverse(
-                "kolibri:core:coursesession-active-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-        )
+        response = self._get_active_test()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data["active_test"])
@@ -1088,12 +955,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """Test that a non-coach cannot get active test details"""
         self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
 
-        response = self.client.get(
-            reverse(
-                "kolibri:core:coursesession-active-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-        )
+        response = self._get_active_test()
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1102,44 +964,14 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # Activate a test
-        response1 = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response1 = self._activate_test(self.unit.id, "pre")
         assignment_id_1 = response1.data["id"]
 
         # Close it
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._close_test(self.unit.id, "pre")
 
         # Activate it again
-        response2 = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response2 = self._activate_test(self.unit.id, "pre")
         assignment_id_2 = response2.data["id"]
 
         # Should be the same assignment updated
@@ -1159,17 +991,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         """activate_test should return unit_phase and active_unit_id"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_phase"], "pre_test_active")
@@ -1180,30 +1002,10 @@ class UnitTestActivationAPITestCase(APITestCase):
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # First activate a test
-        self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        self._activate_test(self.unit.id, "pre")
 
         # Then close it
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_phase"], "post_test_pending")
@@ -1211,44 +1013,19 @@ class UnitTestActivationAPITestCase(APITestCase):
 
     def test_unauthenticated_user_cannot_activate_test(self):
         """Test that unauthenticated users cannot activate tests"""
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-activate-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._activate_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_unauthenticated_user_cannot_close_test(self):
         """Test that unauthenticated users cannot close tests"""
-        response = self.client.post(
-            reverse(
-                "kolibri:core:coursesession-close-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-            {
-                "unit_contentnode_id": self.unit.id,
-                "test_type": "pre",
-            },
-            format="json",
-        )
+        response = self._close_test(self.unit.id, "pre")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_unauthenticated_user_cannot_get_active_test(self):
         """Test that unauthenticated users cannot get active test"""
-        response = self.client.get(
-            reverse(
-                "kolibri:core:coursesession-active-test",
-                kwargs={"pk": self.courseSession.id},
-            ),
-        )
+        response = self._get_active_test()
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1156,7 +1156,7 @@ class UnitTestActivationAPITestCase(APITestCase):
         )
 
     def test_activate_test_returns_unit_phase(self):
-        """activate_test should return unit_phase and active_unit_index"""
+        """activate_test should return unit_phase and active_unit_id"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -1173,10 +1173,10 @@ class UnitTestActivationAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_phase"], "pre_test_active")
-        self.assertIn("active_unit_index", response.data)
+        self.assertIn("active_unit_id", response.data)
 
     def test_close_test_returns_unit_phase(self):
-        """close_test should return unit_phase and active_unit_index"""
+        """close_test should return unit_phase and active_unit_id"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         # First activate a test
@@ -1207,7 +1207,7 @@ class UnitTestActivationAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["unit_phase"], "post_test_pending")
-        self.assertIn("active_unit_index", response.data)
+        self.assertIn("active_unit_id", response.data)
 
     def test_unauthenticated_user_cannot_activate_test(self):
         """Test that unauthenticated users cannot activate tests"""
@@ -1427,7 +1427,7 @@ class LastUnitTestAPITestCase(APITestCase):
         self.assertIsNone(response.data["status"])
         self.assertIsNone(response.data["activated_by"])
         self.assertEqual(response.data["unit_phase"], "pre_test_pending")
-        self.assertEqual(response.data["active_unit_index"], 0)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit1.id))
 
     # --- Unit 1 progression ---
 
@@ -1687,7 +1687,7 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertEqual(response.data["unit_phase"], "pre_test_active")
-        self.assertEqual(response.data["active_unit_index"], 0)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit1.id))
 
     def test_unit_phase_post_test_pending(self):
         """unit_phase should be post_test_pending after pre-test ends"""
@@ -1697,7 +1697,7 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertEqual(response.data["unit_phase"], "post_test_pending")
-        self.assertEqual(response.data["active_unit_index"], 0)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit1.id))
 
     def test_unit_phase_post_test_active(self):
         """unit_phase should be post_test_active when a post-test is running"""
@@ -1708,7 +1708,7 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertEqual(response.data["unit_phase"], "post_test_active")
-        self.assertEqual(response.data["active_unit_index"], 0)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit1.id))
 
     def test_unit_phase_pre_test_pending_after_post_test_ends(self):
         """unit_phase should be pre_test_pending for next unit after post-test ends"""
@@ -1719,7 +1719,7 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertEqual(response.data["unit_phase"], "pre_test_pending")
-        self.assertEqual(response.data["active_unit_index"], 1)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit2.id))
 
     def test_unit_phase_complete_when_last_unit_post_test_ends(self):
         """unit_phase should be complete when last unit's post-test ends"""
@@ -1734,7 +1734,7 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertEqual(response.data["unit_phase"], "complete")
-        self.assertEqual(response.data["active_unit_index"], -1)
+        self.assertIsNone(response.data["active_unit_id"])
 
     def test_active_unit_index_mid_course(self):
         """active_unit_index should reflect the current unit position"""
@@ -1745,7 +1745,7 @@ class LastUnitTestAPITestCase(APITestCase):
 
         response = self._get_last_unit_test()
 
-        self.assertEqual(response.data["active_unit_index"], 1)
+        self.assertEqual(response.data["active_unit_id"], str(self.unit2.id))
         self.assertEqual(response.data["unit_phase"], "pre_test_active")
 
     def test_response_structure_includes_new_fields(self):
@@ -1756,4 +1756,4 @@ class LastUnitTestAPITestCase(APITestCase):
         response = self._get_last_unit_test()
 
         self.assertIn("unit_phase", response.data)
-        self.assertIn("active_unit_index", response.data)
+        self.assertIn("active_unit_id", response.data)

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -65,7 +65,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_user_course_session_no_delete(self):
-
         user = FacilityUser.objects.create(username="learner", facility=self.facility)
         user.set_password("pass")
         user.save()
@@ -81,7 +80,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_logged_in_admin_course_session_delete(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.delete(
@@ -93,7 +91,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_logged_in_admin_course_session_create(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -110,7 +107,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(created_by, self.admin.id)
 
     def test_logged_in_admin_course_session_create_with_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -132,7 +128,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_no_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -162,7 +157,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_different_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -199,7 +193,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_update_additional_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -242,7 +235,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_logged_in_admin_course_session_create_learner_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         user = FacilityUser.objects.create(username="u", facility=self.facility)
@@ -280,7 +272,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(adhoc_group.kind, collection_kinds.ADHOCLEARNERSGROUP)
 
     def test_logged_in_admin_course_session_update_learner_assignments(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -330,7 +321,6 @@ class CourseSessionAPITestCase(APITestCase):
     def test_logged_in_admin_course_session_update_learner_assignments_wrong_collection(
         self,
     ):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -367,7 +357,6 @@ class CourseSessionAPITestCase(APITestCase):
             AdHocGroup.objects.get(parent=self.classroom)
 
     def test_logged_in_user_course_session_no_create(self):
-
         # user without admin nor coach rights
         user = FacilityUser.objects.create(username="learner", facility=self.facility)
         user.set_password("pass")
@@ -387,7 +376,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_logged_in_admin_course_session_update_basic(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.put(
@@ -430,7 +418,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_can_get_course_session_list(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.get(
@@ -453,7 +440,6 @@ class CourseSessionAPITestCase(APITestCase):
         )
 
     def test_coach_can_see_only_allowed_course_sessions(self):
-
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse("kolibri:core:coursesession-list"))
 
@@ -467,7 +453,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertIn(self.courseSession_2.id, course_session_ids)
 
     def test_cannot_create_course_session_with_non_existent_course_id(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -482,7 +467,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_cannot_create_course_session_with_non_course_modality(self):
-
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
 
         # Create a content node that is not a COURSE
@@ -540,7 +524,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertNotIn(other_course_session.id, course_session_ids)
 
     def test_coach_can_create_course_session(self):
-
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(
@@ -555,7 +538,6 @@ class CourseSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 201)
 
     def test_learner_cannot_create_course_session(self):
-
         learner = FacilityUser.objects.create(
             username="learner", facility=self.facility
         )
@@ -643,7 +625,6 @@ kolibri/core/courses/test/test_api.py:805:"
 
 
 class UnitTestActivationAPITestCase(APITestCase):
-
     databases = "__all__"
 
     @classmethod
@@ -1216,3 +1197,422 @@ class UnitTestActivationAPITestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class LastUnitTestAPITestCase(APITestCase):
+    """
+    Tests for the last_unit_test endpoint which returns the most recent test
+    based on unit ordering and test type (post > pre within each unit).
+
+    For a course with 3 units, the ordering priority (highest to lowest) is:
+    unit3.post > unit3.pre > unit2.post > unit2.pre > unit1.post > unit1.pre
+    """
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = Facility.objects.create(name="TestFacility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
+
+        cls.classroom = Classroom.objects.create(name="Classroom", parent=cls.facility)
+        cls.coach = FacilityUser.objects.create(username="coach", facility=cls.facility)
+        cls.coach.set_password(DUMMY_PASSWORD)
+        cls.coach.save()
+        cls.classroom.add_coach(cls.coach)
+
+        cls.learner = FacilityUser.objects.create(
+            username="learner", facility=cls.facility
+        )
+        cls.learner.set_password(DUMMY_PASSWORD)
+        cls.learner.save()
+        cls.classroom.add_member(cls.learner)
+
+        # Create a course ContentNode
+        channel_id = uuid.uuid4().hex
+        cls.course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Test Course",
+            description="A test course with 3 units",
+        )
+
+        # Create 3 units (children of course) - order matters for lft/rght tree
+        cls.unit1 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent_id=cls.course.id,
+            available=True,
+            modality=modalities.UNIT,
+            title="Unit 1: Introduction",
+            description="First unit",
+        )
+
+        cls.unit2 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent_id=cls.course.id,
+            available=True,
+            modality=modalities.UNIT,
+            title="Unit 2: Fundamentals",
+            description="Second unit",
+        )
+
+        cls.unit3 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent_id=cls.course.id,
+            available=True,
+            modality=modalities.UNIT,
+            title="Unit 3: Advanced",
+            description="Third unit",
+        )
+
+        cls.courseSession = models.CourseSession.objects.create(
+            is_active=True,
+            collection=cls.classroom,
+            created_by=cls.admin,
+            course=cls.course.id,
+            title=cls.course.title,
+            description=cls.course.description,
+        )
+
+        # Course with no units for edge case testing
+        cls.empty_course = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            modality=modalities.COURSE,
+            title="Empty Course",
+            description="A course with no units",
+        )
+
+        cls.empty_course_session = models.CourseSession.objects.create(
+            is_active=True,
+            collection=cls.classroom,
+            created_by=cls.admin,
+            course=cls.empty_course.id,
+            title=cls.empty_course.title,
+            description=cls.empty_course.description,
+        )
+
+    def setUp(self):
+        # Clean up any UnitTestAssignments between tests
+        models.UnitTestAssignment.objects.filter(
+            course_session=self.courseSession
+        ).delete()
+
+    def _get_last_unit_test(self):
+        """Helper to call the last_unit_test endpoint"""
+        return self.client.get(
+            reverse(
+                "kolibri:core:coursesession-last-unit-test",
+                kwargs={"pk": self.courseSession.id},
+            ),
+        )
+
+    def _create_test(self, unit, test_type, status_val="active"):
+        """Helper to create a UnitTestAssignment directly"""
+        return models.UnitTestAssignment.objects.create(
+            course_session=self.courseSession,
+            collection=self.classroom,
+            unit_contentnode_id=unit.id,
+            test_type=test_type,
+            status=status_val,
+            is_active=(status_val == "active"),
+            activated_by=self.coach,
+        )
+
+    # --- Permission tests ---
+
+    def test_coach_can_get_last_unit_test(self):
+        """Test that a coach can access the last_unit_test endpoint"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        response = self._get_last_unit_test()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_can_get_last_unit_test(self):
+        """Test that an admin can access the last_unit_test endpoint"""
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self._get_last_unit_test()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_learner_cannot_get_last_unit_test(self):
+        """Test that a learner cannot access the last_unit_test endpoint"""
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self._get_last_unit_test()
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_unauthenticated_user_cannot_get_last_unit_test(self):
+        """Test that unauthenticated users cannot access the endpoint"""
+        response = self._get_last_unit_test()
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- Edge cases ---
+
+    def test_returns_null_when_no_tests_taken(self):
+        """Test that endpoint returns null when no tests have been taken"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data)
+
+    # --- Unit 1 progression ---
+
+    def test_returns_unit1_pre_test_when_active(self):
+        """Starting point: Unit 1 pre-test is active"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit1.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit1_pre_test_when_ended(self):
+        """Unit 1 pre-test completed, lessons phase"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit1.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "ended")
+
+    def test_returns_unit1_post_test_when_active(self):
+        """Unit 1 post-test active (pre-test already done)"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit1.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit1_post_test_when_ended(self):
+        """Unit 1 complete - both tests ended"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit1.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "ended")
+
+    # --- Unit 2 progression (unit 1 complete) ---
+
+    def test_returns_unit2_pre_test_when_active(self):
+        """Unit 2 pre-test active after unit 1 is complete"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Unit 1 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        # Unit 2 starting
+        self._create_test(self.unit2, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit2.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit2_pre_test_when_ended(self):
+        """Unit 2 pre-test ended, in lessons phase"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Unit 1 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        # Unit 2 pre-test done
+        self._create_test(self.unit2, "pre", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit2.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "ended")
+
+    def test_returns_unit2_post_test_when_active(self):
+        """Unit 2 post-test active"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Unit 1 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        # Unit 2 pre done, post active
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit2.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit2_post_test_when_ended(self):
+        """Unit 2 complete"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Unit 1 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        # Unit 2 complete
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit2.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "ended")
+
+    # --- Unit 3 progression (units 1 and 2 complete) ---
+
+    def test_returns_unit3_pre_test_when_active(self):
+        """Unit 3 pre-test active after units 1 and 2 complete"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Units 1 and 2 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+        # Unit 3 starting
+        self._create_test(self.unit3, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit3.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit3_pre_test_when_ended(self):
+        """Unit 3 pre-test ended, in lessons phase"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Units 1 and 2 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+        # Unit 3 pre done
+        self._create_test(self.unit3, "pre", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit3.id))
+        self.assertEqual(response.data["test_type"], "pre")
+        self.assertEqual(response.data["status"], "ended")
+
+    def test_returns_unit3_post_test_when_active(self):
+        """Unit 3 post-test active"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Units 1 and 2 complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+        # Unit 3 pre done, post active
+        self._create_test(self.unit3, "pre", "ended")
+        self._create_test(self.unit3, "post", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit3.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "active")
+
+    def test_returns_unit3_post_test_when_course_complete(self):
+        """Course complete - all 3 units finished"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # All units complete
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+        self._create_test(self.unit2, "post", "ended")
+        self._create_test(self.unit3, "pre", "ended")
+        self._create_test(self.unit3, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit3.id))
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["status"], "ended")
+
+    # --- Ordering verification tests ---
+
+    def test_post_takes_precedence_over_pre_within_same_unit(self):
+        """Verify that post-test is returned over pre-test for the same unit"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Create both tests for unit 1, post should win
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+
+        response = self._get_last_unit_test()
+
+        self.assertEqual(response.data["test_type"], "post")
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit1.id))
+
+    def test_later_unit_takes_precedence_over_earlier_unit(self):
+        """Verify that unit 2 pre-test is returned over unit 1 post-test"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        # Unit 1 complete, unit 2 just started
+        self._create_test(self.unit1, "pre", "ended")
+        self._create_test(self.unit1, "post", "ended")
+        self._create_test(self.unit2, "pre", "ended")
+
+        response = self._get_last_unit_test()
+
+        # Unit 2 pre-test should be returned (higher unit position)
+        self.assertEqual(response.data["unit_contentnode_id"], str(self.unit2.id))
+        self.assertEqual(response.data["test_type"], "pre")
+
+    def test_response_includes_activated_by_info(self):
+        """Verify that the response includes activated_by user info"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        self._create_test(self.unit1, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertIn("activated_by", response.data)
+        self.assertEqual(response.data["activated_by"]["id"], self.coach.id)
+        self.assertEqual(response.data["activated_by"]["username"], "coach")
+
+    def test_response_structure(self):
+        """Verify the response contains all expected fields"""
+        self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
+        test = self._create_test(self.unit1, "pre", "active")
+
+        response = self._get_last_unit_test()
+
+        self.assertIn("id", response.data)
+        self.assertIn("unit_contentnode_id", response.data)
+        self.assertIn("test_type", response.data)
+        self.assertIn("status", response.data)
+        self.assertIn("activated_by", response.data)
+        self.assertEqual(response.data["id"], str(test.id))

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1415,13 +1415,19 @@ class LastUnitTestAPITestCase(APITestCase):
 
     # --- Edge cases ---
 
-    def test_returns_null_when_no_tests_taken(self):
-        """Test that endpoint returns null when no tests have been taken"""
+    def test_returns_initial_state_when_no_tests_taken(self):
+        """Test that endpoint returns initial course state when no tests have been taken"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
         response = self._get_last_unit_test()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIsNone(response.data)
+        self.assertIsNone(response.data["id"])
+        self.assertIsNone(response.data["unit_contentnode_id"])
+        self.assertIsNone(response.data["test_type"])
+        self.assertIsNone(response.data["status"])
+        self.assertIsNone(response.data["activated_by"])
+        self.assertEqual(response.data["unit_phase"], "pre_test_pending")
+        self.assertEqual(response.data["active_unit_index"], 0)
 
     # --- Unit 1 progression ---
 

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -1165,6 +1165,33 @@ class LastUnitTestAPITestCase(APITestCase):
             activated_by=self.coach,
         )
 
+    def _create_tests_to(self, unit, test_type, status_val="active"):
+        """Create all UnitTestAssignments up to and including the given step.
+
+        All steps before the target are created as "ended"; the target step
+        is created with ``status_val``.  Returns the last created assignment.
+
+        e.g. _create_tests_to(self.unit2, "post", "active") creates:
+          unit1/pre=ended, unit1/post=ended, unit2/pre=ended, unit2/post=active
+        """
+        steps = [
+            (self.unit1, "pre"),
+            (self.unit1, "post"),
+            (self.unit2, "pre"),
+            (self.unit2, "post"),
+            (self.unit3, "pre"),
+            (self.unit3, "post"),
+        ]
+        result = None
+        for step_unit, step_type in steps:
+            is_target = step_unit == unit and step_type == test_type
+            result = self._create_test(
+                step_unit, step_type, status_val if is_target else "ended"
+            )
+            if is_target:
+                break
+        return result
+
     # --- Permission tests ---
 
     def test_coach_can_get_last_unit_test(self):
@@ -1211,7 +1238,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit1_pre_test_when_active(self):
         """Starting point: Unit 1 pre-test is active"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "active")
+        self._create_tests_to(self.unit1, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1223,7 +1250,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit1_pre_test_when_ended(self):
         """Unit 1 pre-test completed, lessons phase"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
+        self._create_tests_to(self.unit1, "pre", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1235,8 +1262,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit1_post_test_when_active(self):
         """Unit 1 post-test active (pre-test already done)"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "active")
+        self._create_tests_to(self.unit1, "post", "active")
 
         response = self._get_last_unit_test()
 
@@ -1248,8 +1274,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit1_post_test_when_ended(self):
         """Unit 1 complete - both tests ended"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
+        self._create_tests_to(self.unit1, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1263,11 +1288,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit2_pre_test_when_active(self):
         """Unit 2 pre-test active after unit 1 is complete"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Unit 1 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        # Unit 2 starting
-        self._create_test(self.unit2, "pre", "active")
+        self._create_tests_to(self.unit2, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1279,11 +1300,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit2_pre_test_when_ended(self):
         """Unit 2 pre-test ended, in lessons phase"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Unit 1 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        # Unit 2 pre-test done
-        self._create_test(self.unit2, "pre", "ended")
+        self._create_tests_to(self.unit2, "pre", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1295,12 +1312,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit2_post_test_when_active(self):
         """Unit 2 post-test active"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Unit 1 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        # Unit 2 pre done, post active
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "active")
+        self._create_tests_to(self.unit2, "post", "active")
 
         response = self._get_last_unit_test()
 
@@ -1312,12 +1324,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit2_post_test_when_ended(self):
         """Unit 2 complete"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Unit 1 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        # Unit 2 complete
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
+        self._create_tests_to(self.unit2, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1331,13 +1338,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit3_pre_test_when_active(self):
         """Unit 3 pre-test active after units 1 and 2 complete"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Units 1 and 2 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
-        # Unit 3 starting
-        self._create_test(self.unit3, "pre", "active")
+        self._create_tests_to(self.unit3, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1349,13 +1350,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit3_pre_test_when_ended(self):
         """Unit 3 pre-test ended, in lessons phase"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Units 1 and 2 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
-        # Unit 3 pre done
-        self._create_test(self.unit3, "pre", "ended")
+        self._create_tests_to(self.unit3, "pre", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1367,14 +1362,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit3_post_test_when_active(self):
         """Unit 3 post-test active"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Units 1 and 2 complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
-        # Unit 3 pre done, post active
-        self._create_test(self.unit3, "pre", "ended")
-        self._create_test(self.unit3, "post", "active")
+        self._create_tests_to(self.unit3, "post", "active")
 
         response = self._get_last_unit_test()
 
@@ -1386,13 +1374,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_returns_unit3_post_test_when_course_complete(self):
         """Course complete - all 3 units finished"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # All units complete
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
-        self._create_test(self.unit3, "pre", "ended")
-        self._create_test(self.unit3, "post", "ended")
+        self._create_tests_to(self.unit3, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1406,9 +1388,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_post_takes_precedence_over_pre_within_same_unit(self):
         """Verify that post-test is returned over pre-test for the same unit"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Create both tests for unit 1, post should win
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
+        self._create_tests_to(self.unit1, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1418,10 +1398,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_later_unit_takes_precedence_over_earlier_unit(self):
         """Verify that unit 2 pre-test is returned over unit 1 post-test"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        # Unit 1 complete, unit 2 just started
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
+        self._create_tests_to(self.unit2, "pre", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1432,7 +1409,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_response_includes_activated_by_info(self):
         """Verify that the response includes activated_by user info"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "active")
+        self._create_tests_to(self.unit1, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1443,7 +1420,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_response_structure(self):
         """Verify the response contains all expected fields"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        test = self._create_test(self.unit1, "pre", "active")
+        test = self._create_tests_to(self.unit1, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1459,7 +1436,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_unit_phase_pre_test_active(self):
         """unit_phase should be pre_test_active when a pre-test is running"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "active")
+        self._create_tests_to(self.unit1, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1469,7 +1446,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_unit_phase_post_test_pending(self):
         """unit_phase should be post_test_pending after pre-test ends"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
+        self._create_tests_to(self.unit1, "pre", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1479,8 +1456,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_unit_phase_post_test_active(self):
         """unit_phase should be post_test_active when a post-test is running"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "active")
+        self._create_tests_to(self.unit1, "post", "active")
 
         response = self._get_last_unit_test()
 
@@ -1490,8 +1466,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_unit_phase_pre_test_pending_after_post_test_ends(self):
         """unit_phase should be pre_test_pending for next unit after post-test ends"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
+        self._create_tests_to(self.unit1, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1501,12 +1476,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_unit_phase_complete_when_last_unit_post_test_ends(self):
         """unit_phase should be complete when last unit's post-test ends"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "ended")
-        self._create_test(self.unit2, "post", "ended")
-        self._create_test(self.unit3, "pre", "ended")
-        self._create_test(self.unit3, "post", "ended")
+        self._create_tests_to(self.unit3, "post", "ended")
 
         response = self._get_last_unit_test()
 
@@ -1516,9 +1486,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_active_unit_index_mid_course(self):
         """active_unit_index should reflect the current unit position"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "ended")
-        self._create_test(self.unit1, "post", "ended")
-        self._create_test(self.unit2, "pre", "active")
+        self._create_tests_to(self.unit2, "pre", "active")
 
         response = self._get_last_unit_test()
 
@@ -1528,7 +1496,7 @@ class LastUnitTestAPITestCase(APITestCase):
     def test_response_structure_includes_new_fields(self):
         """Verify response includes unit_phase and active_unit_index"""
         self.client.login(username=self.coach.username, password=DUMMY_PASSWORD)
-        self._create_test(self.unit1, "pre", "active")
+        self._create_tests_to(self.unit1, "pre", "active")
 
         response = self._get_last_unit_test()
 

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -286,6 +286,17 @@ def _map_course_session_classroom(item):
     }
 
 
+def _activated_by_info(user):
+    """Return a dict of user info for the activated_by field, or None."""
+    if user:
+        return {
+            "id": user.id,
+            "username": user.username,
+            "full_name": user.full_name,
+        }
+    return None
+
+
 def _compute_course_state(course_id, test):
     """
     Compute the unit phase and active unit index from the most recent test
@@ -293,7 +304,7 @@ def _compute_course_state(course_id, test):
 
     Args:
         course_id: UUID of the course ContentNode
-        test: The most recent UnitTestAssignment (with b_lft annotated), or None
+        test: The most recent UnitTestAssignment, or None
 
     Returns:
         dict with 'unit_phase' and 'active_unit_index'
@@ -304,14 +315,23 @@ def _compute_course_state(course_id, test):
     )
     total_units = unit_qs.count()
 
-    if not test:
-        return {
-            "unit_phase": UnitPhase.PreTestPending,
-            "active_unit_index": 0 if total_units > 0 else -1,
-        }
+    initial_state = {
+        "unit_phase": UnitPhase.PreTestPending,
+        "active_unit_index": 0 if total_units > 0 else -1,
+    }
+
+    if not test or test.status == TestStatus.NotStarted:
+        return initial_state
+
+    # Look up the unit's tree position for ordering
+    unit_lft = (
+        ContentNode.objects.filter(id=test.unit_contentnode_id)
+        .values_list("lft", flat=True)
+        .first()
+    )
 
     # 0-based index of the test's unit within the course
-    test_unit_index = unit_qs.filter(lft__lt=test.b_lft).count()
+    test_unit_index = unit_qs.filter(lft__lt=unit_lft).count()
 
     if test.status == TestStatus.Active:
         unit_phase = (
@@ -459,12 +479,6 @@ class CourseSessionViewset(ValuesViewset):
             unit_test_assignment.activated_by = request.user
             unit_test_assignment.save()
 
-        # Annotate with b_lft for course state computation
-        unit_test_assignment.b_lft = (
-            ContentNode.objects.filter(id=unit_contentnode_id)
-            .values_list("lft", flat=True)
-            .first()
-        )
         course_state = _compute_course_state(
             course_session.course, unit_test_assignment
         )
@@ -475,6 +489,7 @@ class CourseSessionViewset(ValuesViewset):
                 "unit_contentnode_id": str(unit_contentnode_id),
                 "test_type": test_type,
                 "status": unit_test_assignment.status,
+                "activated_by": _activated_by_info(unit_test_assignment.activated_by),
                 **course_state,
             },
             status=HTTP_200_OK,
@@ -527,12 +542,6 @@ class CourseSessionViewset(ValuesViewset):
         active_test.status = TestStatus.Ended
         active_test.save()
 
-        # Annotate with b_lft for course state computation
-        active_test.b_lft = (
-            ContentNode.objects.filter(id=active_test.unit_contentnode_id)
-            .values_list("lft", flat=True)
-            .first()
-        )
         course_state = _compute_course_state(course_session.course, active_test)
 
         return Response(
@@ -541,6 +550,7 @@ class CourseSessionViewset(ValuesViewset):
                 "unit_contentnode_id": str(active_test.unit_contentnode_id),
                 "test_type": active_test.test_type,
                 "status": active_test.status,
+                "activated_by": _activated_by_info(active_test.activated_by),
                 **course_state,
             },
             status=HTTP_200_OK,
@@ -617,18 +627,20 @@ class CourseSessionViewset(ValuesViewset):
             .first()
         )
 
-        if not test:
-            return Response(None, status=HTTP_200_OK)
-
-        def activated_by_info(test):
-            if test.activated_by:
-                return {
-                    "id": test.activated_by.id,
-                    "username": test.activated_by.username,
-                    "full_name": test.activated_by.full_name,
-                }
-
         course_state = _compute_course_state(course_session.course, test)
+
+        if not test:
+            return Response(
+                {
+                    "id": None,
+                    "unit_contentnode_id": None,
+                    "test_type": None,
+                    "status": None,
+                    "activated_by": None,
+                    **course_state,
+                },
+                status=HTTP_200_OK,
+            )
 
         return Response(
             {
@@ -636,7 +648,7 @@ class CourseSessionViewset(ValuesViewset):
                 "unit_contentnode_id": str(test.unit_contentnode_id),
                 "test_type": test.test_type,
                 "status": test.status,
-                "activated_by": activated_by_info(test),
+                "activated_by": _activated_by_info(test.activated_by),
                 **course_state,
             },
             status=HTTP_200_OK,

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -23,6 +23,7 @@ from .models import CourseSession
 from .models import CourseSessionAssignment
 from .models import TestStatus
 from .models import TestType
+from .models import UnitPhase
 from .models import UnitTestAssignment
 from kolibri.core import error_constants
 from kolibri.core.api import ValuesViewset
@@ -285,6 +286,66 @@ def _map_course_session_classroom(item):
     }
 
 
+def _compute_course_state(course_id, test):
+    """
+    Compute the unit phase and active unit index from the most recent test
+    and the course's unit structure.
+
+    Args:
+        course_id: UUID of the course ContentNode
+        test: The most recent UnitTestAssignment (with b_lft annotated), or None
+
+    Returns:
+        dict with 'unit_phase' and 'active_unit_index'
+    """
+    unit_qs = ContentNode.objects.filter(
+        parent_id=course_id,
+        modality=modalities.UNIT,
+    )
+    total_units = unit_qs.count()
+
+    if not test:
+        return {
+            "unit_phase": UnitPhase.PreTestPending,
+            "active_unit_index": 0 if total_units > 0 else -1,
+        }
+
+    # 0-based index of the test's unit within the course
+    test_unit_index = unit_qs.filter(lft__lt=test.b_lft).count()
+
+    if test.status == TestStatus.Active:
+        unit_phase = (
+            UnitPhase.PreTestActive
+            if test.test_type == TestType.Pre
+            else UnitPhase.PostTestActive
+        )
+        return {
+            "unit_phase": unit_phase,
+            "active_unit_index": test_unit_index,
+        }
+
+    # Test is ended
+    if test.test_type == TestType.Pre:
+        # Pre-test ended = still on this unit (lessons/post-test phase)
+        return {
+            "unit_phase": UnitPhase.PostTestPending,
+            "active_unit_index": test_unit_index,
+        }
+
+    # Post-test ended = unit complete
+    next_index = test_unit_index + 1
+    if next_index >= total_units:
+        return {
+            "unit_phase": UnitPhase.Complete,
+            "active_unit_index": -1,
+        }
+
+    return {
+        "unit_phase": UnitPhase.PreTestPending,
+        "active_unit_index": next_index,
+    }
+
+
 class CourseSessionViewset(ValuesViewset):
     serializer_class = CourseSessionSerializer
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend)
@@ -398,12 +459,23 @@ class CourseSessionViewset(ValuesViewset):
             unit_test_assignment.activated_by = request.user
             unit_test_assignment.save()
 
+        # Annotate with b_lft for course state computation
+        unit_test_assignment.b_lft = (
+            ContentNode.objects.filter(id=unit_contentnode_id)
+            .values_list("lft", flat=True)
+            .first()
+        )
+        course_state = _compute_course_state(
+            course_session.course, unit_test_assignment
+        )
+
         return Response(
             {
                 "id": unit_test_assignment.id,
                 "unit_contentnode_id": str(unit_contentnode_id),
                 "test_type": test_type,
                 "status": unit_test_assignment.status,
+                **course_state,
             },
             status=HTTP_200_OK,
         )
@@ -455,12 +527,21 @@ class CourseSessionViewset(ValuesViewset):
         active_test.status = TestStatus.Ended
         active_test.save()
 
+        # Annotate with b_lft for course state computation
+        active_test.b_lft = (
+            ContentNode.objects.filter(id=active_test.unit_contentnode_id)
+            .values_list("lft", flat=True)
+            .first()
+        )
+        course_state = _compute_course_state(course_session.course, active_test)
+
         return Response(
             {
                 "id": active_test.id,
                 "unit_contentnode_id": str(active_test.unit_contentnode_id),
                 "test_type": active_test.test_type,
                 "status": active_test.status,
+                **course_state,
             },
             status=HTTP_200_OK,
         )
@@ -547,6 +628,8 @@ class CourseSessionViewset(ValuesViewset):
                     "full_name": test.activated_by.full_name,
                 }
 
+        course_state = _compute_course_state(course_session.course, test)
+
         return Response(
             {
                 "id": test.id,
@@ -554,6 +637,7 @@ class CourseSessionViewset(ValuesViewset):
                 "test_type": test.test_type,
                 "status": test.status,
                 "activated_by": activated_by_info(test),
+                **course_state,
             },
             status=HTTP_200_OK,
         )

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -512,3 +512,41 @@ class CourseSessionViewset(ValuesViewset):
             },
             status=HTTP_200_OK,
         )
+
+    @action(detail=True, methods=["get"])
+    def test_history(self, request, pk=None):
+        """
+        We get the details about the currently active test for the course session.
+        If no active test exists, returns { "active_test": null }.
+        """
+        course_session = self.get_object()
+
+        # but first, find the tests that have been completed
+        try:
+            tests = UnitTestAssignment.objects.filter(
+                course_session=course_session, is_active=False
+            )
+        except UnitTestAssignment.DoesNotExist:
+            return Response({"test_history": list()}, status=HTTP_200_OK)
+
+        def activated_by_info(test):
+            if test.activated_by:
+                return {
+                    "id": test.activated_by.id,
+                    "username": test.activated_by.username,
+                    "full_name": test.activated_by.full_name,
+                }
+        return Response(
+            [
+                {
+                    "id": test.id,
+                    "unit_contentnode_id": str(test.unit_contentnode_id),
+                    "test_type": test.test_type,
+                    "status": test.status,
+                    "activated_by": activated_by_info(test),
+                }
+                for test
+                in tests
+            ],
+            status=HTTP_200_OK,
+        )

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -2,13 +2,9 @@ import logging
 from collections import OrderedDict
 
 from django.db import transaction
-from django.db.models import Case
 from django.db.models import Exists
-from django.db.models import IntegerField
 from django.db.models import OuterRef
 from django.db.models import Subquery
-from django.db.models import Value
-from django.db.models import When
 from django_filters.rest_framework import DjangoFilterBackend
 from le_utils.constants import modalities
 from rest_framework.decorators import action
@@ -21,7 +17,6 @@ from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import Serializer
 from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_200_OK
-from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.status import HTTP_404_NOT_FOUND
 
 from .models import CourseSession
@@ -523,68 +518,6 @@ class CourseSessionViewset(ValuesViewset):
     def last_unit_test(self, request, pk=None):
         """
         Returns the most recent test, active or not, for the given course session
-        """
-        course_session = self.get_object()
-        unit_ids = ContentNode.objects.filter(parent=course_session.course).values_list(
-            "id", flat=True
-        )
-
-        if not len(unit_ids):
-            return Response(
-                "Units must be given in order to get the last unit test",
-                status=HTTP_400_BAD_REQUEST,
-            )
-        # Create position annotation: unit_ids[0] -> 0, unit_ids[1] -> 1, etc.
-        position_cases = [
-            When(unit_contentnode_id=uid, then=Value(i))
-            for i, uid in enumerate(unit_ids)
-        ]
-
-        # test_type ordering: post=1, pre=0 (so post sorts after pre in descending)
-        test_type_order = Case(
-            When(test_type="post", then=Value(1)),
-            When(test_type="pre", then=Value(0)),
-            output_field=IntegerField(),
-        )
-
-        test = (
-            UnitTestAssignment.objects.filter(
-                course_session=course_session, unit_contentnode_id__in=unit_ids
-            )
-            .annotate(
-                unit_position=Case(*position_cases, output_field=IntegerField()),
-                test_type_order=test_type_order,
-            )
-            .order_by("-unit_position", "-test_type_order")
-            .first()
-        )
-
-        def activated_by_info(test):
-            if test.activated_by:
-                return {
-                    "id": test.activated_by.id,
-                    "username": test.activated_by.username,
-                    "full_name": test.activated_by.full_name,
-                }
-
-        if not test:
-            return Response(None, status=HTTP_200_OK)
-
-        return Response(
-            {
-                "id": test.id,
-                "unit_contentnode_id": str(test.unit_contentnode_id),
-                "test_type": test.test_type,
-                "status": test.status,
-                "activated_by": activated_by_info(test),
-            },
-            status=HTTP_200_OK,
-        )
-
-    @action(detail=True, methods=["get"])
-    def other_last_unit_test(self, request, pk=None):
-        """
-        Returns the most recent test, active or not, for the given course session
         with consideration for the order of the units and the natural order in which
         tests are started & ended
         """
@@ -594,12 +527,12 @@ class CourseSessionViewset(ValuesViewset):
             UnitTestAssignment.objects.filter(course_session=course_session)
             .annotate(
                 b_lft=Subquery(
-                    ContentNode.objects.filter(parent=course_session.course).values(
-                        "lft"
-                    )
+                    ContentNode.objects.filter(
+                        id=OuterRef("unit_contentnode_id")
+                    ).values("lft")[:1]
                 )
             )
-            .order_by("b_lft")
+            .order_by("-b_lft", "test_type")
             .first()
         )
 

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -299,7 +299,7 @@ def _activated_by_info(user):
 
 def _compute_course_state(course_id, test):
     """
-    Compute the unit phase and active unit index from the most recent test
+    Compute the unit phase and active unit ID from the most recent test
     and the course's unit structure.
 
     Args:
@@ -307,17 +307,18 @@ def _compute_course_state(course_id, test):
         test: The most recent UnitTestAssignment, or None
 
     Returns:
-        dict with 'unit_phase' and 'active_unit_index'
+        dict with 'unit_phase' and 'active_unit_id'
     """
     unit_qs = ContentNode.objects.filter(
         parent_id=course_id,
         modality=modalities.UNIT,
     )
-    total_units = unit_qs.count()
+
+    first_unit_id = unit_qs.order_by("lft").values_list("id", flat=True).first()
 
     initial_state = {
         "unit_phase": UnitPhase.PreTestPending,
-        "active_unit_index": 0 if total_units > 0 else -1,
+        "active_unit_id": str(first_unit_id) if first_unit_id else None,
     }
 
     if not test or test.status == TestStatus.NotStarted:
@@ -330,9 +331,6 @@ def _compute_course_state(course_id, test):
         .first()
     )
 
-    # 0-based index of the test's unit within the course
-    test_unit_index = unit_qs.filter(lft__lt=unit_lft).count()
-
     if test.status == TestStatus.Active:
         unit_phase = (
             UnitPhase.PreTestActive
@@ -341,7 +339,7 @@ def _compute_course_state(course_id, test):
         )
         return {
             "unit_phase": unit_phase,
-            "active_unit_index": test_unit_index,
+            "active_unit_id": str(test.unit_contentnode_id),
         }
 
     # Test is ended
@@ -349,20 +347,26 @@ def _compute_course_state(course_id, test):
         # Pre-test ended = still on this unit (lessons/post-test phase)
         return {
             "unit_phase": UnitPhase.PostTestPending,
-            "active_unit_index": test_unit_index,
+            "active_unit_id": str(test.unit_contentnode_id),
         }
 
     # Post-test ended = unit complete
-    next_index = test_unit_index + 1
-    if next_index >= total_units:
+    next_unit_id = (
+        unit_qs.filter(lft__gt=unit_lft)
+        .order_by("lft")
+        .values_list("id", flat=True)
+        .first()
+    )
+
+    if not next_unit_id:
         return {
             "unit_phase": UnitPhase.Complete,
-            "active_unit_index": -1,
+            "active_unit_id": None,
         }
 
     return {
         "unit_phase": UnitPhase.PreTestPending,
-        "active_unit_index": next_index,
+        "active_unit_id": str(next_unit_id),
     }
 
 

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -2,8 +2,13 @@ import logging
 from collections import OrderedDict
 
 from django.db import transaction
+from django.db.models import Case
 from django.db.models import Exists
+from django.db.models import IntegerField
 from django.db.models import OuterRef
+from django.db.models import Subquery
+from django.db.models import Value
+from django.db.models import When
 from django_filters.rest_framework import DjangoFilterBackend
 from le_utils.constants import modalities
 from rest_framework.decorators import action
@@ -16,6 +21,7 @@ from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import Serializer
 from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_200_OK
+from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.status import HTTP_404_NOT_FOUND
 
 from .models import CourseSession
@@ -514,20 +520,44 @@ class CourseSessionViewset(ValuesViewset):
         )
 
     @action(detail=True, methods=["get"])
-    def test_history(self, request, pk=None):
+    def last_unit_test(self, request, pk=None):
         """
-        We get the details about the currently active test for the course session.
-        If no active test exists, returns { "active_test": null }.
+        Returns the most recent test, active or not, for the given course session
         """
         course_session = self.get_object()
+        unit_ids = ContentNode.objects.filter(parent=course_session.course).values_list(
+            "id", flat=True
+        )
 
-        # but first, find the tests that have been completed
-        try:
-            tests = UnitTestAssignment.objects.filter(
-                course_session=course_session, is_active=False
+        if not len(unit_ids):
+            return Response(
+                "Units must be given in order to get the last unit test",
+                status=HTTP_400_BAD_REQUEST,
             )
-        except UnitTestAssignment.DoesNotExist:
-            return Response({"test_history": list()}, status=HTTP_200_OK)
+        # Create position annotation: unit_ids[0] -> 0, unit_ids[1] -> 1, etc.
+        position_cases = [
+            When(unit_contentnode_id=uid, then=Value(i))
+            for i, uid in enumerate(unit_ids)
+        ]
+
+        # test_type ordering: post=1, pre=0 (so post sorts after pre in descending)
+        test_type_order = Case(
+            When(test_type="post", then=Value(1)),
+            When(test_type="pre", then=Value(0)),
+            output_field=IntegerField(),
+        )
+
+        test = (
+            UnitTestAssignment.objects.filter(
+                course_session=course_session, unit_contentnode_id__in=unit_ids
+            )
+            .annotate(
+                unit_position=Case(*position_cases, output_field=IntegerField()),
+                test_type_order=test_type_order,
+            )
+            .order_by("-unit_position", "-test_type_order")
+            .first()
+        )
 
         def activated_by_info(test):
             if test.activated_by:
@@ -536,17 +566,61 @@ class CourseSessionViewset(ValuesViewset):
                     "username": test.activated_by.username,
                     "full_name": test.activated_by.full_name,
                 }
+
+        if not test:
+            return Response(None, status=HTTP_200_OK)
+
         return Response(
-            [
-                {
-                    "id": test.id,
-                    "unit_contentnode_id": str(test.unit_contentnode_id),
-                    "test_type": test.test_type,
-                    "status": test.status,
-                    "activated_by": activated_by_info(test),
+            {
+                "id": test.id,
+                "unit_contentnode_id": str(test.unit_contentnode_id),
+                "test_type": test.test_type,
+                "status": test.status,
+                "activated_by": activated_by_info(test),
+            },
+            status=HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=["get"])
+    def other_last_unit_test(self, request, pk=None):
+        """
+        Returns the most recent test, active or not, for the given course session
+        with consideration for the order of the units and the natural order in which
+        tests are started & ended
+        """
+        course_session = self.get_object()
+
+        test = (
+            UnitTestAssignment.objects.filter(course_session=course_session)
+            .annotate(
+                b_lft=Subquery(
+                    ContentNode.objects.filter(parent=course_session.course).values(
+                        "lft"
+                    )
+                )
+            )
+            .order_by("b_lft")
+            .first()
+        )
+
+        if not test:
+            return Response(None, status=HTTP_200_OK)
+
+        def activated_by_info(test):
+            if test.activated_by:
+                return {
+                    "id": test.activated_by.id,
+                    "username": test.activated_by.username,
+                    "full_name": test.activated_by.full_name,
                 }
-                for test
-                in tests
-            ],
+
+        return Response(
+            {
+                "id": test.id,
+                "unit_contentnode_id": str(test.unit_contentnode_id),
+                "test_type": test.test_type,
+                "status": test.status,
+                "activated_by": activated_by_info(test),
+            },
             status=HTTP_200_OK,
         )

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -1,7 +1,8 @@
 import { nextTick } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
-import useCourseSession, { UnitPhase } from '../useCourseSession';
+import { UnitPhase } from '../../constants/courseConstants';
+import useCourseSession from '../useCourseSession';
 
 jest.mock('kolibri-common/apiResources/ContentNodeResource');
 jest.mock('kolibri-common/apiResources/CourseSessionResource');

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -88,13 +88,24 @@ describe('useCourseSession', () => {
     active_unit_index: 1,
   };
 
+  // Server response when no tests have been taken
+  const mockNoTests = {
+    id: null,
+    unit_contentnode_id: null,
+    test_type: null,
+    status: null,
+    activated_by: null,
+    unit_phase: UnitPhase.PRE_TEST_PENDING,
+    active_unit_index: 0,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
 
     // Default mock implementations - no tests taken yet
     CourseSessionResource.fetchModel.mockResolvedValue(mockCourseSession);
     ContentNodeResource.fetchTree.mockResolvedValue(mockCourse);
-    CourseSessionResource.lastUnitTest.mockResolvedValue(null);
+    CourseSessionResource.lastUnitTest.mockResolvedValue(mockNoTests);
   });
 
   describe('initialization', () => {
@@ -172,7 +183,7 @@ describe('useCourseSession', () => {
   });
 
   describe('activeTest computed', () => {
-    it('should return null when no lastUnitTest', async () => {
+    it('should return null when no tests taken', async () => {
       const { activeTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -267,6 +278,10 @@ describe('useCourseSession', () => {
         id: 'course-456',
         children: { results: [] },
       });
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        ...mockNoTests,
+        active_unit_index: -1,
+      });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
 
@@ -295,10 +310,14 @@ describe('useCourseSession', () => {
       expect(activeUnitIndex.value).toBe(1);
     });
 
-    it('should return -1 when activeUnit is null', async () => {
+    it('should return -1 when no units exist', async () => {
       ContentNodeResource.fetchTree.mockResolvedValue({
         id: 'course-456',
         children: { results: [] },
+      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        ...mockNoTests,
+        active_unit_index: -1,
       });
 
       const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
@@ -441,6 +460,10 @@ describe('useCourseSession', () => {
         id: 'course-456',
         children: { results: [] },
       });
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        ...mockNoTests,
+        active_unit_index: -1,
+      });
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
 
@@ -451,12 +474,14 @@ describe('useCourseSession', () => {
   });
 
   describe('lastUnitTest state', () => {
-    it('should be null when no tests taken', async () => {
+    it('should have null test fields when no tests taken', async () => {
       const { lastUnitTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(lastUnitTest.value).toBe(null);
+      expect(lastUnitTest.value.id).toBe(null);
+      expect(lastUnitTest.value.unit_phase).toBe(UnitPhase.PRE_TEST_PENDING);
+      expect(lastUnitTest.value.active_unit_index).toBe(0);
     });
 
     it('should contain the last test data', async () => {
@@ -471,7 +496,7 @@ describe('useCourseSession', () => {
   });
 
   describe('unitPhase computed', () => {
-    it('should return PRE_TEST_PENDING when no lastUnitTest', async () => {
+    it('should return PRE_TEST_PENDING when no tests taken', async () => {
       const { unitPhase } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -1,0 +1,586 @@
+import { nextTick } from 'vue';
+import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
+import useCourseSession, { UnitPhase } from '../useCourseSession';
+
+jest.mock('kolibri-common/apiResources/ContentNodeResource');
+jest.mock('kolibri-common/apiResources/CourseSessionResource');
+jest.mock('kolibri-common/strings/coursesStrings', () => ({
+  coursesStrings: {
+    unitNLabel$: ({ num }) => `Unit ${num}:`,
+  },
+}));
+
+describe('useCourseSession', () => {
+  const mockCourseSessionId = 'session-123';
+
+  const mockCourseSession = {
+    id: mockCourseSessionId,
+    course: 'course-456',
+    title: 'Test Course Session',
+    collection: 'class-789',
+  };
+
+  const mockCourse = {
+    id: 'course-456',
+    title: 'Test Course',
+    children: {
+      results: [
+        { id: 'unit-1', title: 'Introduction' },
+        { id: 'unit-2', title: 'Fundamentals' },
+        { id: 'unit-3', title: 'Advanced Topics' },
+      ],
+    },
+  };
+
+  const mockActiveTestPre = {
+    id: 'test-1',
+    unit_contentnode_id: 'unit-1',
+    test_type: 'pre',
+    status: 'active',
+  };
+
+  const mockActiveTestPost = {
+    id: 'test-2',
+    unit_contentnode_id: 'unit-1',
+    test_type: 'post',
+    status: 'active',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    CourseSessionResource.fetchModel.mockResolvedValue(mockCourseSession);
+    ContentNodeResource.fetchTree.mockResolvedValue(mockCourse);
+    CourseSessionResource.activeTest.mockResolvedValue({ active_test: null });
+    CourseSessionResource.testHistory.mockResolvedValue({ data: [] });
+  });
+
+  describe('initialization', () => {
+    it('should start with loading=true', () => {
+      const { loading } = useCourseSession(mockCourseSessionId);
+      expect(loading.value).toBe(true);
+    });
+
+    it('should fetch course session on initialization', () => {
+      useCourseSession(mockCourseSessionId);
+      expect(CourseSessionResource.fetchModel).toHaveBeenCalledWith({ id: mockCourseSessionId });
+    });
+
+    it('should fetch course, active test, and history after session is loaded', async () => {
+      useCourseSession(mockCourseSessionId);
+      await nextTick();
+
+      expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({ id: mockCourseSession.course });
+      expect(CourseSessionResource.activeTest).toHaveBeenCalledWith({ id: mockCourseSessionId });
+      expect(CourseSessionResource.testHistory).toHaveBeenCalledWith({ id: mockCourseSessionId });
+    });
+
+    it('should set loading=false after all data is loaded', async () => {
+      const { loading } = useCourseSession(mockCourseSessionId);
+
+      // Wait for all promises to resolve
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(loading.value).toBe(false);
+    });
+
+    it('should populate courseSession after fetch', async () => {
+      const { courseSession } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(courseSession.value).toEqual(mockCourseSession);
+    });
+
+    it('should populate course after fetch', async () => {
+      const { course } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(course.value).toEqual(mockCourse);
+    });
+  });
+
+  describe('units computed', () => {
+    it('should return empty array when course is null', () => {
+      const { units } = useCourseSession(mockCourseSessionId);
+      expect(units.value).toEqual([]);
+    });
+
+    it('should return units with numberedTitle', async () => {
+      const { units } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(units.value).toHaveLength(3);
+      expect(units.value[0].numberedTitle).toBe('Unit 1: Introduction');
+      expect(units.value[1].numberedTitle).toBe('Unit 2: Fundamentals');
+      expect(units.value[2].numberedTitle).toBe('Unit 3: Advanced Topics');
+    });
+
+    it('should preserve original title and other properties', async () => {
+      const { units } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(units.value[0].id).toBe('unit-1');
+      expect(units.value[0].title).toBe('Introduction');
+      expect(units.value[1].id).toBe('unit-2');
+      expect(units.value[1].title).toBe('Fundamentals');
+    });
+  });
+
+  describe('activeUnit computed', () => {
+    it('should return first unit when no history and no active test', async () => {
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value.id).toBe('unit-1');
+    });
+
+    it('should return unit of active test when test is running', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: { ...mockActiveTestPre, unit_contentnode_id: 'unit-2' },
+      });
+
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value.id).toBe('unit-2');
+    });
+
+    it('should stay on same unit after pre-test is completed', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
+      });
+
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value.id).toBe('unit-1');
+    });
+
+    it('should advance to next unit after post-test is completed', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value.id).toBe('unit-2');
+    });
+
+    it('should stay on last unit when course is complete', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // Should stay on unit-3 since there's no unit-4
+      expect(activeUnit.value.id).toBe('unit-3');
+    });
+
+    it('should return null when no units exist', async () => {
+      ContentNodeResource.fetchTree.mockResolvedValue({
+        id: 'course-456',
+        children: { results: [] },
+      });
+
+      const { activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value).toBe(null);
+    });
+  });
+
+  describe('activeUnitIndex computed', () => {
+    it('should return 0 for first unit', async () => {
+      const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnitIndex.value).toBe(0);
+    });
+
+    it('should return correct index after advancing', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnitIndex.value).toBe(1);
+    });
+
+    it('should return -1 when activeUnit is null', async () => {
+      ContentNodeResource.fetchTree.mockResolvedValue({
+        id: 'course-456',
+        children: { results: [] },
+      });
+
+      const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnitIndex.value).toBe(-1);
+    });
+  });
+
+  describe('completedUnits computed', () => {
+    it('should return empty array when on first unit', async () => {
+      const { completedUnits } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(completedUnits.value).toEqual([]);
+    });
+
+    it('should return completed units when advanced', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
+          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { completedUnits } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(completedUnits.value).toHaveLength(2);
+      expect(completedUnits.value[0].id).toBe('unit-1');
+      expect(completedUnits.value[1].id).toBe('unit-2');
+    });
+  });
+
+  describe('upcomingUnits computed', () => {
+    it('should return all units except first when starting', async () => {
+      const { upcomingUnits } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(upcomingUnits.value).toHaveLength(2);
+      expect(upcomingUnits.value[0].id).toBe('unit-2');
+      expect(upcomingUnits.value[1].id).toBe('unit-3');
+    });
+
+    it('should return fewer units as course progresses', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { upcomingUnits } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(upcomingUnits.value).toHaveLength(1);
+      expect(upcomingUnits.value[0].id).toBe('unit-3');
+    });
+
+    it('should return empty array on last unit', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { upcomingUnits } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(upcomingUnits.value).toEqual([]);
+    });
+  });
+
+  describe('lastCompletedTest computed', () => {
+    it('should return null when no history', async () => {
+      const { lastCompletedTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(lastCompletedTest.value).toBe(null);
+    });
+
+    it('should return last test from history', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { lastCompletedTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(lastCompletedTest.value.id).toBe('test-2');
+      expect(lastCompletedTest.value.test_type).toBe('post');
+    });
+  });
+
+  describe('unitPhase computed', () => {
+    it('should return PRE_TEST_PENDING when no history and no active test', async () => {
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_PENDING);
+    });
+
+    it('should return PRE_TEST_ACTIVE when pre-test is running', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPre,
+      });
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_ACTIVE);
+    });
+
+    it('should return POST_TEST_PENDING after pre-test is completed', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
+      });
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.POST_TEST_PENDING);
+    });
+
+    it('should return POST_TEST_ACTIVE when post-test is running', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPost,
+      });
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
+      });
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.POST_TEST_ACTIVE);
+    });
+
+    it('should return COMPLETE when post-test is completed for active unit', async () => {
+      // Set history so we're on unit-3 (last unit) with post-test completed
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
+          { id: 'test-3', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
+          { id: 'test-4', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.COMPLETE);
+    });
+
+    it('should return null when no units exist', async () => {
+      ContentNodeResource.fetchTree.mockResolvedValue({
+        id: 'course-456',
+        children: { results: [] },
+      });
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(null);
+    });
+  });
+
+  describe('activateTest action', () => {
+    it('should call CourseSessionResource.activateTest with correct params', async () => {
+      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+
+      const { activateTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await activateTest('pre');
+
+      expect(CourseSessionResource.activateTest).toHaveBeenCalledWith({
+        id: mockCourseSessionId,
+        data: {
+          unit_contentnode_id: 'unit-1',
+          test_type: 'pre',
+        },
+      });
+    });
+
+    it('should update activeTest ref after activation', async () => {
+      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+
+      const { activateTest, activeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeTest.value).toBe(null);
+
+      await activateTest('pre');
+
+      expect(activeTest.value).toEqual(mockActiveTestPre);
+    });
+
+    it('should update unitPhase after activation', async () => {
+      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+
+      const { activateTest, unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_PENDING);
+
+      await activateTest('pre');
+
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_ACTIVE);
+    });
+  });
+
+  describe('closeTest action', () => {
+    it('should call CourseSessionResource.closeTest with correct params', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPre,
+      });
+      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+
+      const { closeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await closeTest();
+
+      expect(CourseSessionResource.closeTest).toHaveBeenCalledWith({
+        id: mockCourseSessionId,
+        data: {
+          unit_contentnode_id: 'unit-1',
+          test_type: 'pre',
+        },
+      });
+    });
+
+    it('should clear activeTest after closing', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPre,
+      });
+      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+
+      const { closeTest, activeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeTest.value).toEqual(mockActiveTestPre);
+
+      await closeTest();
+
+      expect(activeTest.value).toBe(null);
+    });
+
+    it('should add closed test to history', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPre,
+      });
+      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+
+      const { closeTest, testHistory } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(testHistory.value).toHaveLength(0);
+
+      await closeTest();
+
+      expect(testHistory.value).toHaveLength(1);
+      expect(testHistory.value[0].id).toBe('test-1');
+      expect(testHistory.value[0].status).toBe('ended');
+    });
+
+    it('should update unitPhase after closing pre-test', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPre,
+      });
+      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+
+      const { closeTest, unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_ACTIVE);
+
+      await closeTest();
+
+      expect(unitPhase.value).toBe(UnitPhase.POST_TEST_PENDING);
+    });
+
+    it('should advance activeUnit after closing post-test', async () => {
+      CourseSessionResource.activeTest.mockResolvedValue({
+        active_test: mockActiveTestPost,
+      });
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
+      });
+      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+
+      const { closeTest, activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value.id).toBe('unit-1');
+
+      await closeTest();
+
+      expect(activeUnit.value.id).toBe('unit-2');
+    });
+  });
+
+  describe('UnitPhase constants', () => {
+    it('should export all phase constants', () => {
+      expect(UnitPhase.PRE_TEST_PENDING).toBe('pre_test_pending');
+      expect(UnitPhase.PRE_TEST_ACTIVE).toBe('pre_test_active');
+      expect(UnitPhase.POST_TEST_PENDING).toBe('post_test_pending');
+      expect(UnitPhase.POST_TEST_ACTIVE).toBe('post_test_active');
+      expect(UnitPhase.COMPLETE).toBe('complete');
+    });
+
+    it('should be frozen', () => {
+      expect(Object.isFrozen(UnitPhase)).toBe(true);
+    });
+  });
+});

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -1,7 +1,6 @@
-import { nextTick } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
-import { UnitPhase } from '../../constants/courseConstants';
+import { TestStatus, TestType, UnitPhase } from '../../constants/courseConstants';
 import useCourseSession from '../useCourseSession';
 
 jest.mock('kolibri-common/apiResources/ContentNodeResource');
@@ -19,6 +18,11 @@ jest.mock('kolibri-common/strings/coursesStrings', () => ({
     postTestStartedForUnit$: jest.fn(),
     preTestEndedForUnit$: jest.fn(),
     postTestEndedForUnit$: jest.fn(),
+  },
+}));
+jest.mock('kolibri/uiText/commonCoreStrings', () => ({
+  coreStrings: {
+    defaultErrorMessage$: jest.fn(),
   },
 }));
 
@@ -44,34 +48,51 @@ describe('useCourseSession', () => {
     },
   };
 
-  const mockActiveTestPre = {
+  // Active pre-test on unit 1
+  const mockActivePreTest = {
     id: 'test-1',
     unit_contentnode_id: 'unit-1',
-    test_type: 'pre',
-    status: 'active',
+    test_type: TestType.PRE,
+    status: TestStatus.ACTIVE,
   };
 
-  const mockActiveTestPost = {
+  // Active post-test on unit 1
+  const mockActivePostTest = {
     id: 'test-2',
     unit_contentnode_id: 'unit-1',
-    test_type: 'post',
-    status: 'active',
+    test_type: TestType.POST,
+    status: TestStatus.ACTIVE,
+  };
+
+  // Completed pre-test on unit 1
+  const mockCompletedPreTest = {
+    id: 'test-1',
+    unit_contentnode_id: 'unit-1',
+    test_type: TestType.PRE,
+    status: TestStatus.ENDED,
+  };
+
+  // Completed post-test on unit 1
+  const mockCompletedPostTest = {
+    id: 'test-2',
+    unit_contentnode_id: 'unit-1',
+    test_type: TestType.POST,
+    status: TestStatus.ENDED,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Default mock implementations
+    // Default mock implementations - no tests taken yet
     CourseSessionResource.fetchModel.mockResolvedValue(mockCourseSession);
     ContentNodeResource.fetchTree.mockResolvedValue(mockCourse);
-    CourseSessionResource.activeTest.mockResolvedValue({ active_test: null });
-    CourseSessionResource.testHistory.mockResolvedValue({ data: [] });
+    CourseSessionResource.lastUnitTest.mockResolvedValue(null);
   });
 
   describe('initialization', () => {
-    it('should start with loading=true', () => {
-      const { loading } = useCourseSession(mockCourseSessionId);
-      expect(loading.value).toBe(true);
+    it('should start with pageLoading=true', () => {
+      const { pageLoading } = useCourseSession(mockCourseSessionId);
+      expect(pageLoading.value).toBe(true);
     });
 
     it('should fetch course session on initialization', () => {
@@ -79,22 +100,21 @@ describe('useCourseSession', () => {
       expect(CourseSessionResource.fetchModel).toHaveBeenCalledWith({ id: mockCourseSessionId });
     });
 
-    it('should fetch course, active test, and history after session is loaded', async () => {
+    it('should fetch course and lastUnitTest after session is loaded', async () => {
       useCourseSession(mockCourseSessionId);
-      await nextTick();
 
-      expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({ id: mockCourseSession.course });
-      expect(CourseSessionResource.activeTest).toHaveBeenCalledWith({ id: mockCourseSessionId });
-      expect(CourseSessionResource.testHistory).toHaveBeenCalledWith({ id: mockCourseSessionId });
-    });
-
-    it('should set loading=false after all data is loaded', async () => {
-      const { loading } = useCourseSession(mockCourseSessionId);
-
-      // Wait for all promises to resolve
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(loading.value).toBe(false);
+      expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({ id: mockCourseSession.course });
+      expect(CourseSessionResource.lastUnitTest).toHaveBeenCalledWith({ id: mockCourseSessionId });
+    });
+
+    it('should set pageLoading=false after all data is loaded', async () => {
+      const { pageLoading } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(pageLoading.value).toBe(false);
     });
 
     it('should populate courseSession after fetch', async () => {
@@ -143,8 +163,38 @@ describe('useCourseSession', () => {
     });
   });
 
+  describe('activeTest computed', () => {
+    it('should return null when no lastUnitTest', async () => {
+      const { activeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeTest.value).toBe(null);
+    });
+
+    it('should return null when lastUnitTest status is not active', async () => {
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPreTest);
+
+      const { activeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeTest.value).toBe(null);
+    });
+
+    it('should return lastUnitTest when status is active', async () => {
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockActivePreTest);
+
+      const { activeTest } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeTest.value).toEqual(mockActivePreTest);
+    });
+  });
+
   describe('activeUnit computed', () => {
-    it('should return first unit when no history and no active test', async () => {
+    it('should return first unit when no lastUnitTest', async () => {
       const { activeUnit } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -153,8 +203,9 @@ describe('useCourseSession', () => {
     });
 
     it('should return unit of active test when test is running', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: { ...mockActiveTestPre, unit_contentnode_id: 'unit-2' },
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        ...mockActivePreTest,
+        unit_contentnode_id: 'unit-2',
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -165,9 +216,7 @@ describe('useCourseSession', () => {
     });
 
     it('should stay on same unit after pre-test is completed', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPreTest);
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
 
@@ -177,12 +226,7 @@ describe('useCourseSession', () => {
     });
 
     it('should advance to next unit after post-test is completed', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-        ],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPostTest);
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
 
@@ -192,18 +236,18 @@ describe('useCourseSession', () => {
     });
 
     it('should return null when course is complete', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
-        ],
+      // Last unit's post-test is completed
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-6',
+        unit_contentnode_id: 'unit-3',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      // Should be null since all units are complete
       expect(activeUnit.value).toBe(null);
     });
 
@@ -231,12 +275,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return correct index after advancing', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-        ],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPostTest);
 
       const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
 
@@ -269,13 +308,12 @@ describe('useCourseSession', () => {
     });
 
     it('should return completed units when advanced', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
-          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
-        ],
+      // On unit 3 (units 1 and 2 completed)
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-4',
+        unit_contentnode_id: 'unit-2',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { completedUnits } = useCourseSession(mockCourseSessionId);
@@ -288,15 +326,11 @@ describe('useCourseSession', () => {
     });
 
     it('should return all units when course is complete', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
-          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
-          { id: 'test-5', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
-          { id: 'test-6', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
-        ],
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-6',
+        unit_contentnode_id: 'unit-3',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { completedUnits, activeUnit } = useCourseSession(mockCourseSessionId);
@@ -323,12 +357,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return fewer units as course progresses', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-        ],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPostTest);
 
       const { upcomingUnits } = useCourseSession(mockCourseSessionId);
 
@@ -339,11 +368,11 @@ describe('useCourseSession', () => {
     });
 
     it('should return empty array on last unit', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
-        ],
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-4',
+        unit_contentnode_id: 'unit-2',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { upcomingUnits } = useCourseSession(mockCourseSessionId);
@@ -364,12 +393,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return false when some units remain', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-        ],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPostTest);
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
 
@@ -379,15 +403,11 @@ describe('useCourseSession', () => {
     });
 
     it('should return true when all units are complete', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
-          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
-          { id: 'test-5', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
-          { id: 'test-6', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
-        ],
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-6',
+        unit_contentnode_id: 'unit-3',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
@@ -411,34 +431,28 @@ describe('useCourseSession', () => {
     });
   });
 
-  describe('lastCompletedTest computed', () => {
-    it('should return null when no history', async () => {
-      const { lastCompletedTest } = useCourseSession(mockCourseSessionId);
+  describe('lastUnitTest state', () => {
+    it('should be null when no tests taken', async () => {
+      const { lastUnitTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(lastCompletedTest.value).toBe(null);
+      expect(lastUnitTest.value).toBe(null);
     });
 
-    it('should return last test from history', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-        ],
-      });
+    it('should contain the last test data', async () => {
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPreTest);
 
-      const { lastCompletedTest } = useCourseSession(mockCourseSessionId);
+      const { lastUnitTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(lastCompletedTest.value.id).toBe('test-2');
-      expect(lastCompletedTest.value.test_type).toBe('post');
+      expect(lastUnitTest.value).toEqual(mockCompletedPreTest);
     });
   });
 
   describe('unitPhase computed', () => {
-    it('should return PRE_TEST_PENDING when no history and no active test', async () => {
+    it('should return PRE_TEST_PENDING when no lastUnitTest', async () => {
       const { unitPhase } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
@@ -447,9 +461,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return PRE_TEST_ACTIVE when pre-test is running', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPre,
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockActivePreTest);
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -459,9 +471,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return POST_TEST_PENDING after pre-test is completed', async () => {
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPreTest);
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -471,12 +481,7 @@ describe('useCourseSession', () => {
     });
 
     it('should return POST_TEST_ACTIVE when post-test is running', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPost,
-      });
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
-      });
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockActivePostTest);
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -485,15 +490,23 @@ describe('useCourseSession', () => {
       expect(unitPhase.value).toBe(UnitPhase.POST_TEST_ACTIVE);
     });
 
-    it('should return COMPLETE when post-test is completed for active unit', async () => {
-      // Set history so we're on unit-3 (last unit) with post-test completed
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [
-          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
-          { id: 'test-2', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
-          { id: 'test-3', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
-          { id: 'test-4', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
-        ],
+    it('should return PRE_TEST_PENDING after post-test is completed (next unit)', async () => {
+      CourseSessionResource.lastUnitTest.mockResolvedValue(mockCompletedPostTest);
+
+      const { unitPhase } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // After completing post-test, we advance to next unit which needs pre-test
+      expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_PENDING);
+    });
+
+    it('should return COMPLETE when course is complete', async () => {
+      CourseSessionResource.lastUnitTest.mockResolvedValue({
+        id: 'test-6',
+        unit_contentnode_id: 'unit-3',
+        test_type: TestType.POST,
+        status: TestStatus.ENDED,
       });
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);
@@ -502,42 +515,35 @@ describe('useCourseSession', () => {
 
       expect(unitPhase.value).toBe(UnitPhase.COMPLETE);
     });
-
-    it('should return null when no units exist', async () => {
-      ContentNodeResource.fetchTree.mockResolvedValue({
-        id: 'course-456',
-        children: { results: [] },
-      });
-
-      const { unitPhase } = useCourseSession(mockCourseSessionId);
-
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(unitPhase.value).toBe(null);
-    });
   });
 
   describe('activateTest action', () => {
     it('should call CourseSessionResource.activateTest with correct params', async () => {
-      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+      CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
+      CourseSessionResource.lastUnitTest
+        .mockResolvedValueOnce(null) // Initial load
+        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await activateTest('pre');
+      await activateTest(TestType.PRE);
 
       expect(CourseSessionResource.activateTest).toHaveBeenCalledWith({
         id: mockCourseSessionId,
         data: {
           unit_contentnode_id: 'unit-1',
-          test_type: 'pre',
+          test_type: TestType.PRE,
         },
       });
     });
 
-    it('should update activeTest ref after activation', async () => {
-      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+    it('should update activeTest after activation', async () => {
+      CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
+      CourseSessionResource.lastUnitTest
+        .mockResolvedValueOnce(null) // Initial load
+        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest, activeTest } = useCourseSession(mockCourseSessionId);
 
@@ -545,13 +551,16 @@ describe('useCourseSession', () => {
 
       expect(activeTest.value).toBe(null);
 
-      await activateTest('pre');
+      await activateTest(TestType.PRE);
 
-      expect(activeTest.value).toEqual(mockActiveTestPre);
+      expect(activeTest.value).toEqual(mockActivePreTest);
     });
 
     it('should update unitPhase after activation', async () => {
-      CourseSessionResource.activateTest.mockResolvedValue(mockActiveTestPre);
+      CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
+      CourseSessionResource.lastUnitTest
+        .mockResolvedValueOnce(null) // Initial load
+        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest, unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -559,7 +568,7 @@ describe('useCourseSession', () => {
 
       expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_PENDING);
 
-      await activateTest('pre');
+      await activateTest(TestType.PRE);
 
       expect(unitPhase.value).toBe(UnitPhase.PRE_TEST_ACTIVE);
     });
@@ -567,10 +576,12 @@ describe('useCourseSession', () => {
 
   describe('closeTest action', () => {
     it('should call CourseSessionResource.closeTest with correct params', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPre,
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
+      CourseSessionResource.closeTest.mockResolvedValue({
+        ...mockActivePreTest,
+        status: TestStatus.ENDED,
       });
-      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
 
       const { closeTest } = useCourseSession(mockCourseSessionId);
 
@@ -582,52 +593,39 @@ describe('useCourseSession', () => {
         id: mockCourseSessionId,
         data: {
           unit_contentnode_id: 'unit-1',
-          test_type: 'pre',
+          test_type: TestType.PRE,
         },
       });
     });
 
     it('should clear activeTest after closing', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPre,
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
+      CourseSessionResource.closeTest.mockResolvedValue({
+        ...mockActivePreTest,
+        status: TestStatus.ENDED,
+        test_type: TestType.PRE,
       });
-      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
 
       const { closeTest, activeTest } = useCourseSession(mockCourseSessionId);
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(activeTest.value).toEqual(mockActiveTestPre);
+      expect(activeTest.value).toEqual(mockActivePreTest);
 
       await closeTest();
 
       expect(activeTest.value).toBe(null);
     });
 
-    it('should add closed test to history', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPre,
-      });
-      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
-
-      const { closeTest, testHistory } = useCourseSession(mockCourseSessionId);
-
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(testHistory.value).toHaveLength(0);
-
-      await closeTest();
-
-      expect(testHistory.value).toHaveLength(1);
-      expect(testHistory.value[0].id).toBe('test-1');
-      expect(testHistory.value[0].status).toBe('ended');
-    });
-
     it('should update unitPhase after closing pre-test', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPre,
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
+      CourseSessionResource.closeTest.mockResolvedValue({
+        ...mockActivePreTest,
+        status: TestStatus.ENDED,
+        test_type: TestType.PRE,
       });
-      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
 
       const { closeTest, unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -641,13 +639,13 @@ describe('useCourseSession', () => {
     });
 
     it('should advance activeUnit after closing post-test', async () => {
-      CourseSessionResource.activeTest.mockResolvedValue({
-        active_test: mockActiveTestPost,
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePostTest);
+      CourseSessionResource.closeTest.mockResolvedValue({
+        ...mockActivePostTest,
+        status: TestStatus.ENDED,
+        test_type: TestType.POST,
       });
-      CourseSessionResource.testHistory.mockResolvedValue({
-        data: [{ id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' }],
-      });
-      CourseSessionResource.closeTest.mockResolvedValue({ status: 'ended' });
+      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPostTest);
 
       const { closeTest, activeUnit } = useCourseSession(mockCourseSessionId);
 
@@ -669,8 +667,6 @@ describe('useCourseSession', () => {
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      // mockCourseSession doesn't have active, so it starts as undefined (falsy)
-      // toggling should set it to true
       courseSession.value = { ...courseSession.value, active: true };
 
       await toggleCourseActive();
@@ -740,6 +736,20 @@ describe('useCourseSession', () => {
 
     it('should be frozen', () => {
       expect(Object.isFrozen(UnitPhase)).toBe(true);
+    });
+  });
+
+  describe('TestType constants', () => {
+    it('should export test type constants', () => {
+      expect(TestType.PRE).toBe('pre');
+      expect(TestType.POST).toBe('post');
+    });
+  });
+
+  describe('TestStatus constants', () => {
+    it('should export test status constants', () => {
+      expect(TestStatus.ACTIVE).toBe('active');
+      expect(TestStatus.ENDED).toBe('ended');
     });
   });
 });

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -54,6 +54,8 @@ describe('useCourseSession', () => {
     unit_contentnode_id: 'unit-1',
     test_type: TestType.PRE,
     status: TestStatus.ACTIVE,
+    unit_phase: UnitPhase.PRE_TEST_ACTIVE,
+    active_unit_index: 0,
   };
 
   // Active post-test on unit 1
@@ -62,6 +64,8 @@ describe('useCourseSession', () => {
     unit_contentnode_id: 'unit-1',
     test_type: TestType.POST,
     status: TestStatus.ACTIVE,
+    unit_phase: UnitPhase.POST_TEST_ACTIVE,
+    active_unit_index: 0,
   };
 
   // Completed pre-test on unit 1
@@ -70,6 +74,8 @@ describe('useCourseSession', () => {
     unit_contentnode_id: 'unit-1',
     test_type: TestType.PRE,
     status: TestStatus.ENDED,
+    unit_phase: UnitPhase.POST_TEST_PENDING,
+    active_unit_index: 0,
   };
 
   // Completed post-test on unit 1
@@ -78,6 +84,8 @@ describe('useCourseSession', () => {
     unit_contentnode_id: 'unit-1',
     test_type: TestType.POST,
     status: TestStatus.ENDED,
+    unit_phase: UnitPhase.PRE_TEST_PENDING,
+    active_unit_index: 1,
   };
 
   beforeEach(() => {
@@ -206,6 +214,7 @@ describe('useCourseSession', () => {
       CourseSessionResource.lastUnitTest.mockResolvedValue({
         ...mockActivePreTest,
         unit_contentnode_id: 'unit-2',
+        active_unit_index: 1,
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -242,6 +251,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-3',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.COMPLETE,
+        active_unit_index: -1,
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -314,6 +325,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-2',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.PRE_TEST_PENDING,
+        active_unit_index: 2,
       });
 
       const { completedUnits } = useCourseSession(mockCourseSessionId);
@@ -331,6 +344,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-3',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.COMPLETE,
+        active_unit_index: -1,
       });
 
       const { completedUnits, activeUnit } = useCourseSession(mockCourseSessionId);
@@ -373,6 +388,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-2',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.PRE_TEST_PENDING,
+        active_unit_index: 2,
       });
 
       const { upcomingUnits } = useCourseSession(mockCourseSessionId);
@@ -408,6 +425,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-3',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.COMPLETE,
+        active_unit_index: -1,
       });
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
@@ -507,6 +526,8 @@ describe('useCourseSession', () => {
         unit_contentnode_id: 'unit-3',
         test_type: TestType.POST,
         status: TestStatus.ENDED,
+        unit_phase: UnitPhase.COMPLETE,
+        active_unit_index: -1,
       });
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);
@@ -520,9 +541,6 @@ describe('useCourseSession', () => {
   describe('activateTest action', () => {
     it('should call CourseSessionResource.activateTest with correct params', async () => {
       CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
-      CourseSessionResource.lastUnitTest
-        .mockResolvedValueOnce(null) // Initial load
-        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest } = useCourseSession(mockCourseSessionId);
 
@@ -541,9 +559,6 @@ describe('useCourseSession', () => {
 
     it('should update activeTest after activation', async () => {
       CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
-      CourseSessionResource.lastUnitTest
-        .mockResolvedValueOnce(null) // Initial load
-        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest, activeTest } = useCourseSession(mockCourseSessionId);
 
@@ -558,9 +573,6 @@ describe('useCourseSession', () => {
 
     it('should update unitPhase after activation', async () => {
       CourseSessionResource.activateTest.mockResolvedValue(mockActivePreTest);
-      CourseSessionResource.lastUnitTest
-        .mockResolvedValueOnce(null) // Initial load
-        .mockResolvedValueOnce(mockActivePreTest); // After activation
 
       const { activateTest, unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -577,11 +589,7 @@ describe('useCourseSession', () => {
   describe('closeTest action', () => {
     it('should call CourseSessionResource.closeTest with correct params', async () => {
       CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
-      CourseSessionResource.closeTest.mockResolvedValue({
-        ...mockActivePreTest,
-        status: TestStatus.ENDED,
-      });
-      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
+      CourseSessionResource.closeTest.mockResolvedValue(mockCompletedPreTest);
 
       const { closeTest } = useCourseSession(mockCourseSessionId);
 
@@ -600,12 +608,7 @@ describe('useCourseSession', () => {
 
     it('should clear activeTest after closing', async () => {
       CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
-      CourseSessionResource.closeTest.mockResolvedValue({
-        ...mockActivePreTest,
-        status: TestStatus.ENDED,
-        test_type: TestType.PRE,
-      });
-      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
+      CourseSessionResource.closeTest.mockResolvedValue(mockCompletedPreTest);
 
       const { closeTest, activeTest } = useCourseSession(mockCourseSessionId);
 
@@ -620,12 +623,7 @@ describe('useCourseSession', () => {
 
     it('should update unitPhase after closing pre-test', async () => {
       CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePreTest);
-      CourseSessionResource.closeTest.mockResolvedValue({
-        ...mockActivePreTest,
-        status: TestStatus.ENDED,
-        test_type: TestType.PRE,
-      });
-      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPreTest);
+      CourseSessionResource.closeTest.mockResolvedValue(mockCompletedPreTest);
 
       const { closeTest, unitPhase } = useCourseSession(mockCourseSessionId);
 
@@ -640,12 +638,7 @@ describe('useCourseSession', () => {
 
     it('should advance activeUnit after closing post-test', async () => {
       CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockActivePostTest);
-      CourseSessionResource.closeTest.mockResolvedValue({
-        ...mockActivePostTest,
-        status: TestStatus.ENDED,
-        test_type: TestType.POST,
-      });
-      CourseSessionResource.lastUnitTest.mockResolvedValueOnce(mockCompletedPostTest);
+      CourseSessionResource.closeTest.mockResolvedValue(mockCompletedPostTest);
 
       const { closeTest, activeUnit } = useCourseSession(mockCourseSessionId);
 

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -55,7 +55,7 @@ describe('useCourseSession', () => {
     test_type: TestType.PRE,
     status: TestStatus.ACTIVE,
     unit_phase: UnitPhase.PRE_TEST_ACTIVE,
-    active_unit_index: 0,
+    active_unit_id: 'unit-1',
   };
 
   // Active post-test on unit 1
@@ -65,7 +65,7 @@ describe('useCourseSession', () => {
     test_type: TestType.POST,
     status: TestStatus.ACTIVE,
     unit_phase: UnitPhase.POST_TEST_ACTIVE,
-    active_unit_index: 0,
+    active_unit_id: 'unit-1',
   };
 
   // Completed pre-test on unit 1
@@ -75,7 +75,7 @@ describe('useCourseSession', () => {
     test_type: TestType.PRE,
     status: TestStatus.ENDED,
     unit_phase: UnitPhase.POST_TEST_PENDING,
-    active_unit_index: 0,
+    active_unit_id: 'unit-1',
   };
 
   // Completed post-test on unit 1
@@ -85,7 +85,7 @@ describe('useCourseSession', () => {
     test_type: TestType.POST,
     status: TestStatus.ENDED,
     unit_phase: UnitPhase.PRE_TEST_PENDING,
-    active_unit_index: 1,
+    active_unit_id: 'unit-2',
   };
 
   // Server response when no tests have been taken
@@ -96,7 +96,7 @@ describe('useCourseSession', () => {
     status: null,
     activated_by: null,
     unit_phase: UnitPhase.PRE_TEST_PENDING,
-    active_unit_index: 0,
+    active_unit_id: 'unit-1',
   };
 
   beforeEach(() => {
@@ -225,7 +225,7 @@ describe('useCourseSession', () => {
       CourseSessionResource.lastUnitTest.mockResolvedValue({
         ...mockActivePreTest,
         unit_contentnode_id: 'unit-2',
-        active_unit_index: 1,
+        active_unit_id: 'unit-2',
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -263,7 +263,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.COMPLETE,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -280,7 +280,7 @@ describe('useCourseSession', () => {
       });
       CourseSessionResource.lastUnitTest.mockResolvedValue({
         ...mockNoTests,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { activeUnit } = useCourseSession(mockCourseSessionId);
@@ -317,7 +317,7 @@ describe('useCourseSession', () => {
       });
       CourseSessionResource.lastUnitTest.mockResolvedValue({
         ...mockNoTests,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { activeUnitIndex } = useCourseSession(mockCourseSessionId);
@@ -345,7 +345,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.PRE_TEST_PENDING,
-        active_unit_index: 2,
+        active_unit_id: 'unit-3',
       });
 
       const { completedUnits } = useCourseSession(mockCourseSessionId);
@@ -364,7 +364,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.COMPLETE,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { completedUnits, activeUnit } = useCourseSession(mockCourseSessionId);
@@ -408,7 +408,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.PRE_TEST_PENDING,
-        active_unit_index: 2,
+        active_unit_id: 'unit-3',
       });
 
       const { upcomingUnits } = useCourseSession(mockCourseSessionId);
@@ -445,7 +445,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.COMPLETE,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
@@ -462,7 +462,7 @@ describe('useCourseSession', () => {
       });
       CourseSessionResource.lastUnitTest.mockResolvedValue({
         ...mockNoTests,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { isCourseComplete } = useCourseSession(mockCourseSessionId);
@@ -481,7 +481,7 @@ describe('useCourseSession', () => {
 
       expect(lastUnitTest.value.id).toBe(null);
       expect(lastUnitTest.value.unit_phase).toBe(UnitPhase.PRE_TEST_PENDING);
-      expect(lastUnitTest.value.active_unit_index).toBe(0);
+      expect(lastUnitTest.value.active_unit_id).toBe('unit-1');
     });
 
     it('should contain the last test data', async () => {
@@ -552,7 +552,7 @@ describe('useCourseSession', () => {
         test_type: TestType.POST,
         status: TestStatus.ENDED,
         unit_phase: UnitPhase.COMPLETE,
-        active_unit_index: -1,
+        active_unit_id: null,
       });
 
       const { unitPhase } = useCourseSession(mockCourseSessionId);

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
 import { TestStatus, TestType, UnitPhase } from '../../constants/courseConstants';
@@ -27,10 +28,10 @@ jest.mock('kolibri/uiText/commonCoreStrings', () => ({
 }));
 
 describe('useCourseSession', () => {
-  const mockCourseSessionId = 'session-123';
+  const mockCourseSessionId = ref('session-123');
 
   const mockCourseSession = {
-    id: mockCourseSessionId,
+    id: mockCourseSessionId.value,
     course: 'course-456',
     title: 'Test Course Session',
     collection: 'class-789',
@@ -116,7 +117,9 @@ describe('useCourseSession', () => {
 
     it('should fetch course session on initialization', () => {
       useCourseSession(mockCourseSessionId);
-      expect(CourseSessionResource.fetchModel).toHaveBeenCalledWith({ id: mockCourseSessionId });
+      expect(CourseSessionResource.fetchModel).toHaveBeenCalledWith({
+        id: mockCourseSessionId.value,
+      });
     });
 
     it('should fetch course and lastUnitTest after session is loaded', async () => {
@@ -125,7 +128,9 @@ describe('useCourseSession', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({ id: mockCourseSession.course });
-      expect(CourseSessionResource.lastUnitTest).toHaveBeenCalledWith({ id: mockCourseSessionId });
+      expect(CourseSessionResource.lastUnitTest).toHaveBeenCalledWith({
+        id: mockCourseSessionId.value,
+      });
     });
 
     it('should set pageLoading=false after all data is loaded', async () => {
@@ -574,7 +579,7 @@ describe('useCourseSession', () => {
       await activateTest(TestType.PRE);
 
       expect(CourseSessionResource.activateTest).toHaveBeenCalledWith({
-        id: mockCourseSessionId,
+        id: mockCourseSessionId.value,
         data: {
           unit_contentnode_id: 'unit-1',
           test_type: TestType.PRE,
@@ -623,7 +628,7 @@ describe('useCourseSession', () => {
       await closeTest();
 
       expect(CourseSessionResource.closeTest).toHaveBeenCalledWith({
-        id: mockCourseSessionId,
+        id: mockCourseSessionId.value,
         data: {
           unit_contentnode_id: 'unit-1',
           test_type: TestType.PRE,
@@ -690,7 +695,7 @@ describe('useCourseSession', () => {
       await toggleCourseActive();
 
       expect(CourseSessionResource.saveModel).toHaveBeenCalledWith({
-        id: mockCourseSessionId,
+        id: mockCourseSessionId.value,
         data: { active: false },
       });
     });
@@ -721,14 +726,14 @@ describe('useCourseSession', () => {
       await toggleCourseActive();
 
       expect(CourseSessionResource.saveModel).toHaveBeenCalledWith({
-        id: mockCourseSessionId,
+        id: mockCourseSessionId.value,
         data: { active: true },
       });
       expect(courseSession.value.active).toBe(true);
     });
 
     it('should return the result from saveModel', async () => {
-      const mockResult = { id: mockCourseSessionId, active: true, title: 'Test' };
+      const mockResult = { id: mockCourseSessionId.value, active: true, title: 'Test' };
       CourseSessionResource.saveModel.mockResolvedValue(mockResult);
 
       const { toggleCourseActive, courseSession } = useCourseSession(mockCourseSessionId);

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -6,9 +6,19 @@ import useCourseSession from '../useCourseSession';
 
 jest.mock('kolibri-common/apiResources/ContentNodeResource');
 jest.mock('kolibri-common/apiResources/CourseSessionResource');
+jest.mock('kolibri/composables/useSnackbar', () => ({
+  __esModule: true,
+  default: () => ({ createSnackbar: jest.fn() }),
+}));
 jest.mock('kolibri-common/strings/coursesStrings', () => ({
   coursesStrings: {
     unitNLabel$: ({ num }) => `Unit ${num}:`,
+    courseVisible$: jest.fn(),
+    courseNotVisible$: jest.fn(),
+    preTestStartedForUnit$: jest.fn(),
+    postTestStartedForUnit$: jest.fn(),
+    preTestEndedForUnit$: jest.fn(),
+    postTestEndedForUnit$: jest.fn(),
   },
 }));
 
@@ -181,7 +191,7 @@ describe('useCourseSession', () => {
       expect(activeUnit.value.id).toBe('unit-2');
     });
 
-    it('should stay on last unit when course is complete', async () => {
+    it('should return null when course is complete', async () => {
       CourseSessionResource.testHistory.mockResolvedValue({
         data: [
           { id: 'test-1', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
@@ -193,8 +203,8 @@ describe('useCourseSession', () => {
 
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      // Should stay on unit-3 since there's no unit-4
-      expect(activeUnit.value.id).toBe('unit-3');
+      // Should be null since all units are complete
+      expect(activeUnit.value).toBe(null);
     });
 
     it('should return null when no units exist', async () => {
@@ -276,6 +286,29 @@ describe('useCourseSession', () => {
       expect(completedUnits.value[0].id).toBe('unit-1');
       expect(completedUnits.value[1].id).toBe('unit-2');
     });
+
+    it('should return all units when course is complete', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
+          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
+          { id: 'test-5', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
+          { id: 'test-6', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { completedUnits, activeUnit } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(activeUnit.value).toBe(null);
+      expect(completedUnits.value).toHaveLength(3);
+      expect(completedUnits.value[0].id).toBe('unit-1');
+      expect(completedUnits.value[1].id).toBe('unit-2');
+      expect(completedUnits.value[2].id).toBe('unit-3');
+    });
   });
 
   describe('upcomingUnits computed', () => {
@@ -318,6 +351,63 @@ describe('useCourseSession', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(upcomingUnits.value).toEqual([]);
+    });
+  });
+
+  describe('isCourseComplete computed', () => {
+    it('should return false when on first unit', async () => {
+      const { isCourseComplete } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(isCourseComplete.value).toBe(false);
+    });
+
+    it('should return false when some units remain', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { isCourseComplete } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(isCourseComplete.value).toBe(false);
+    });
+
+    it('should return true when all units are complete', async () => {
+      CourseSessionResource.testHistory.mockResolvedValue({
+        data: [
+          { id: 'test-1', unit_contentnode_id: 'unit-1', test_type: 'pre', status: 'ended' },
+          { id: 'test-2', unit_contentnode_id: 'unit-1', test_type: 'post', status: 'ended' },
+          { id: 'test-3', unit_contentnode_id: 'unit-2', test_type: 'pre', status: 'ended' },
+          { id: 'test-4', unit_contentnode_id: 'unit-2', test_type: 'post', status: 'ended' },
+          { id: 'test-5', unit_contentnode_id: 'unit-3', test_type: 'pre', status: 'ended' },
+          { id: 'test-6', unit_contentnode_id: 'unit-3', test_type: 'post', status: 'ended' },
+        ],
+      });
+
+      const { isCourseComplete } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(isCourseComplete.value).toBe(true);
+    });
+
+    it('should return false when no units exist', async () => {
+      ContentNodeResource.fetchTree.mockResolvedValue({
+        id: 'course-456',
+        children: { results: [] },
+      });
+
+      const { isCourseComplete } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(isCourseComplete.value).toBe(false);
     });
   });
 
@@ -568,6 +658,74 @@ describe('useCourseSession', () => {
       await closeTest();
 
       expect(activeUnit.value.id).toBe('unit-2');
+    });
+  });
+
+  describe('toggleCourseActive action', () => {
+    it('should call CourseSessionResource.saveModel with toggled active state', async () => {
+      CourseSessionResource.saveModel.mockResolvedValue({ active: false });
+
+      const { toggleCourseActive, courseSession } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // mockCourseSession doesn't have active, so it starts as undefined (falsy)
+      // toggling should set it to true
+      courseSession.value = { ...courseSession.value, active: true };
+
+      await toggleCourseActive();
+
+      expect(CourseSessionResource.saveModel).toHaveBeenCalledWith({
+        id: mockCourseSessionId,
+        data: { active: false },
+      });
+    });
+
+    it('should update courseSession.active after toggle', async () => {
+      CourseSessionResource.saveModel.mockResolvedValue({ active: false });
+
+      const { toggleCourseActive, courseSession } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      courseSession.value = { ...courseSession.value, active: true };
+
+      await toggleCourseActive();
+
+      expect(courseSession.value.active).toBe(false);
+    });
+
+    it('should toggle from false to true', async () => {
+      CourseSessionResource.saveModel.mockResolvedValue({ active: true });
+
+      const { toggleCourseActive, courseSession } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      courseSession.value = { ...courseSession.value, active: false };
+
+      await toggleCourseActive();
+
+      expect(CourseSessionResource.saveModel).toHaveBeenCalledWith({
+        id: mockCourseSessionId,
+        data: { active: true },
+      });
+      expect(courseSession.value.active).toBe(true);
+    });
+
+    it('should return the result from saveModel', async () => {
+      const mockResult = { id: mockCourseSessionId, active: true, title: 'Test' };
+      CourseSessionResource.saveModel.mockResolvedValue(mockResult);
+
+      const { toggleCourseActive, courseSession } = useCourseSession(mockCourseSessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      courseSession.value = { ...courseSession.value, active: false };
+
+      const result = await toggleCourseActive();
+
+      expect(result).toEqual(mockResult);
     });
   });
 

--- a/kolibri/plugins/coach/frontend/composables/useClassSummary.js
+++ b/kolibri/plugins/coach/frontend/composables/useClassSummary.js
@@ -1,0 +1,17 @@
+import { computed, getCurrentInstance } from 'vue';
+
+export default function useClassSummary(store) {
+  store = store || getCurrentInstance().proxy.$store;
+  /**
+   * Return array of learner names given a course session object.
+   * @returns {Function} - Function that takes a course session object
+   * and returns an array of learner names.
+   */
+  const getRecipientNamesForCourseSession = computed(() => {
+    return store.getters['classSummary/getRecipientNamesForExam'];
+  });
+
+  return {
+    getRecipientNamesForCourseSession,
+  };
+}

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -231,7 +231,7 @@ export default function useCourseSession(courseSessionId) {
       .then(result => {
         // If we activate the course and the pre-test for the first unit hasn't been started,
         // start it automatically to make things easier for the coach
-        if (!activeTest.value && activeUnitIndex.value === 0) {
+        if (result?.active && !activeTest.value && activeUnitIndex.value === 0) {
           // Can fire it off and move on as it will handle dataLoading
           // and such internally
           activateTest(TestType.PRE);

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -2,19 +2,9 @@ import { computed, ref } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+import { UnitPhase } from '../constants/courseConstants';
 
 const { unitNLabel$ } = coursesStrings;
-
-/**
- * Unit phase constants representing the state machine for a unit's test lifecycle.
- */
-export const UnitPhase = Object.freeze({
-  PRE_TEST_PENDING: 'pre_test_pending',
-  PRE_TEST_ACTIVE: 'pre_test_active',
-  POST_TEST_PENDING: 'post_test_pending',
-  POST_TEST_ACTIVE: 'post_test_active',
-  COMPLETE: 'complete',
-});
 
 /**
  * A composable for managing course session state.
@@ -251,8 +241,5 @@ export default function useCourseSession(courseSessionId) {
     // Actions
     activateTest,
     closeTest,
-
-    // Constants
-    UnitPhase,
   };
 }

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -1,9 +1,10 @@
 import { computed, ref } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
-import { UnitPhase } from '../constants/courseConstants';
+import { TestStatus, TestType, UnitPhase } from '../constants/courseConstants';
 
 const {
   unitNLabel$,
@@ -14,6 +15,8 @@ const {
   preTestEndedForUnit$,
   postTestEndedForUnit$,
 } = coursesStrings;
+
+const { defaultErrorMessage$ } = coreStrings;
 
 /**
  * A composable for managing course session state.
@@ -30,9 +33,14 @@ export default function useCourseSession(courseSessionId) {
   // -----------
   const courseSession = ref(null);
   const course = ref(null);
-  const activeTest = ref(null);
-  const testHistory = ref([]);
-  const loading = ref(true);
+  const lastUnitTest = ref(null);
+  const activeTest = computed(() =>
+    lastUnitTest?.value?.status === TestStatus.ACTIVE ? lastUnitTest.value : null,
+  );
+  // UI blocking loading state
+  const pageLoading = ref(true);
+  // Informative loading state (ie, we're re-fetching the last unit test, activating/closing)
+  const dataLoading = ref(false);
 
   // -----------
   // Data fetching
@@ -40,19 +48,22 @@ export default function useCourseSession(courseSessionId) {
   CourseSessionResource.fetchModel({ id: courseSessionId })
     .then(session => {
       courseSession.value = session;
-      return Promise.all([
-        ContentNodeResource.fetchTree({ id: session.course }),
-        CourseSessionResource.activeTest({ id: courseSessionId }),
-        CourseSessionResource.testHistory({ id: courseSessionId }),
-      ]);
+      return ContentNodeResource.fetchTree({ id: session.course });
     })
-    .then(([courseData, activeTestData, historyData]) => {
+    .then(courseData => {
       course.value = courseData;
-      activeTest.value = activeTestData.active_test;
-      testHistory.value = historyData.data;
+      return CourseSessionResource.lastUnitTest({ id: courseSessionId });
+    })
+    .then(testData => {
+      lastUnitTest.value = testData;
+    })
+    .catch(e => {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      createSnackbar(defaultErrorMessage$());
     })
     .finally(() => {
-      loading.value = false;
+      pageLoading.value = false;
     });
 
   // -----------
@@ -72,14 +83,6 @@ export default function useCourseSession(courseSessionId) {
   });
 
   /**
-   * The most recently completed test from history.
-   */
-  const lastCompletedTest = computed(() => {
-    if (!testHistory.value?.length) return null;
-    return testHistory.value[testHistory.value.length - 1];
-  });
-
-  /**
    * The unit currently being worked on, derived from activeTest and testHistory.
    *
    * Logic:
@@ -92,22 +95,22 @@ export default function useCourseSession(courseSessionId) {
   const activeUnit = computed(() => {
     if (!units.value.length) return null;
 
+    if (!activeTest.value && !lastUnitTest.value) {
+      // No active test and no last test taken, we're at the very beginning
+      return units.value[0];
+    }
+
     // Active test tells us exactly which unit we're on
     if (activeTest.value) {
       return units.value.find(u => u.id === activeTest.value.unit_contentnode_id);
     }
 
-    // No active test - derive from history
-    if (!lastCompletedTest.value) {
-      // No history = starting fresh at unit 0
-      return units.value[0];
-    }
-
+    // We don't have an active test, so we'll use the lastUnitTest to work out which is active
     const lastTestUnitIndex = units.value.findIndex(
-      u => u.id === lastCompletedTest.value.unit_contentnode_id,
+      u => u.id === lastUnitTest.value?.unit_contentnode_id,
     );
 
-    if (lastCompletedTest.value.test_type === 'post') {
+    if (lastUnitTest.value?.test_type === TestType.POST) {
       // Post-test done = unit complete, move to next (or null if course complete)
       return units.value[lastTestUnitIndex + 1] || null;
     }
@@ -163,32 +166,27 @@ export default function useCourseSession(courseSessionId) {
     // Course complete - all units finished
     if (isCourseComplete.value) return UnitPhase.COMPLETE;
 
-    if (!activeUnit.value) return null;
-
     // Is there a test running right now?
     if (activeTest.value) {
-      return activeTest.value.test_type === 'pre'
+      return activeTest.value.test_type === TestType.PRE
         ? UnitPhase.PRE_TEST_ACTIVE
         : UnitPhase.POST_TEST_ACTIVE;
     }
 
     // No active test - what was the last thing completed for this unit?
-    const lastTestForActiveUnit = [...(testHistory.value || [])]
-      .reverse()
-      .find(t => t.unit_contentnode_id === activeUnit.value.id);
-
-    if (!lastTestForActiveUnit) {
-      // No tests done for this unit yet
+    if (!lastUnitTest.value) {
+      // No tests done for this whole course session, so we're at the very start
       return UnitPhase.PRE_TEST_PENDING;
     }
 
-    if (lastTestForActiveUnit.test_type === 'pre') {
+    if (lastUnitTest.value.test_type === TestType.PRE) {
       // Pre-test done, ready for post-test (lessons phase)
       return UnitPhase.POST_TEST_PENDING;
+    } else {
+      // If the last unit test is a post test, we already know we have no active test
+      // so, we're pending the pre-test for the next unit
+      return UnitPhase.PRE_TEST_PENDING;
     }
-
-    // Post-test done for this unit
-    return UnitPhase.COMPLETE;
   });
 
   // -----------
@@ -202,20 +200,29 @@ export default function useCourseSession(courseSessionId) {
    * @returns {Promise} Resolves when the test is activated
    */
   function activateTest(testType) {
+    dataLoading.value = true;
     return CourseSessionResource.activateTest({
       id: courseSession.value.id,
       data: {
         unit_contentnode_id: activeUnit.value.id,
         test_type: testType,
       },
-    }).then(result => {
-      activeTest.value = result;
-      if (testType === 'pre') {
-        createSnackbar(preTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
-      } else {
-        createSnackbar(postTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
-      }
-    });
+    })
+      .then(() => {
+        if (testType === TestType.PRE) {
+          createSnackbar(preTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
+        } else {
+          createSnackbar(postTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
+        }
+        return CourseSessionResource.lastUnitTest({ id: courseSessionId });
+      })
+      .then(results => (lastUnitTest.value = results))
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        createSnackbar(defaultErrorMessage$());
+      })
+      .finally(() => (dataLoading.value = false));
   }
 
   /**
@@ -231,26 +238,26 @@ export default function useCourseSession(courseSessionId) {
         unit_contentnode_id: activeTest.value.unit_contentnode_id,
         test_type: activeTest.value.test_type,
       },
-    }).then(result => {
-      // Get this now because activeUnit will change before we trigger snackbars
-      // if we closed the post-test
-      const title = activeUnit.value.numberedTitle;
+    })
+      .then(result => {
+        // Get this now because activeUnit will change before we trigger snackbars
+        // if we closed the post-test
+        const title = activeUnit.value.numberedTitle;
 
-      // Move the closed test to history
-      testHistory.value = [
-        ...testHistory.value,
-        {
-          ...activeTest.value,
-          status: result.status,
-        },
-      ];
-      activeTest.value = null;
-      if (result.test_type === 'pre') {
-        createSnackbar(preTestEndedForUnit$({ title }));
-      } else {
-        createSnackbar(postTestEndedForUnit$({ title }));
-      }
-    });
+        if (result.test_type === TestType.PRE) {
+          createSnackbar(preTestEndedForUnit$({ title }));
+        } else {
+          createSnackbar(postTestEndedForUnit$({ title }));
+        }
+        return CourseSessionResource.lastUnitTest({ id: courseSessionId });
+      })
+      .then(results => (lastUnitTest.value = results))
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        createSnackbar(defaultErrorMessage$());
+      })
+      .finally(() => (dataLoading.value = false));
   }
 
   /**
@@ -259,29 +266,30 @@ export default function useCourseSession(courseSessionId) {
    *
    * @returns {Promise} Resolves with the updated course session
    */
-  async function toggleCourseActive() {
-    const result = await CourseSessionResource.saveModel({
+  function toggleCourseActive() {
+    return CourseSessionResource.saveModel({
       id: courseSession.value.id,
       data: { active: !courseSession.value.active },
+    }).then(result => {
+      courseSession.value = { ...courseSession.value, active: result.active };
+      if (result.active) {
+        createSnackbar(courseVisible$());
+      } else {
+        createSnackbar(courseNotVisible$());
+      }
+      return result;
     });
-    courseSession.value = { ...courseSession.value, active: result.active };
-    if (result.active) {
-      createSnackbar(courseVisible$());
-    } else {
-      createSnackbar(courseNotVisible$());
-    }
-    return result;
   }
 
   return {
     // Loading state
-    loading,
+    pageLoading,
+    dataLoading,
 
     // Raw data
     courseSession,
     course,
     activeTest,
-    testHistory,
 
     // Derived unit state
     units,
@@ -292,8 +300,8 @@ export default function useCourseSession(courseSessionId) {
     isCourseComplete,
 
     // Derived test state
-    lastCompletedTest,
     unitPhase,
+    lastUnitTest,
 
     // Actions
     activateTest,

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -1,0 +1,258 @@
+import { computed, ref } from 'vue';
+import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
+import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+
+const { unitNLabel$ } = coursesStrings;
+
+/**
+ * Unit phase constants representing the state machine for a unit's test lifecycle.
+ */
+export const UnitPhase = Object.freeze({
+  PRE_TEST_PENDING: 'pre_test_pending',
+  PRE_TEST_ACTIVE: 'pre_test_active',
+  POST_TEST_PENDING: 'post_test_pending',
+  POST_TEST_ACTIVE: 'post_test_active',
+  COMPLETE: 'complete',
+});
+
+/**
+ * A composable for managing course session state.
+ * Handles fetching course session data, course content, active tests, and test history.
+ * Provides derived state for units and unit phase.
+ *
+ * @param {string} courseSessionId - The ID of the course session to load
+ * @returns {Object} Reactive state and methods for managing the course session
+ */
+export default function useCourseSession(courseSessionId) {
+  // -----------
+  // Raw state
+  // -----------
+  const courseSession = ref(null);
+  const course = ref(null);
+  const activeTest = ref(null);
+  const testHistory = ref([]);
+  const loading = ref(true);
+
+  // -----------
+  // Data fetching
+  // -----------
+  CourseSessionResource.fetchModel({ id: courseSessionId })
+    .then(session => {
+      courseSession.value = session;
+      return Promise.all([
+        ContentNodeResource.fetchTree({ id: session.course }),
+        CourseSessionResource.activeTest({ id: courseSessionId }),
+        CourseSessionResource.testHistory({ id: courseSessionId }),
+      ]);
+    })
+    .then(([courseData, activeTestData, historyData]) => {
+      course.value = courseData;
+      activeTest.value = activeTestData.active_test;
+      testHistory.value = historyData.data;
+    })
+    .finally(() => {
+      loading.value = false;
+    });
+
+  // -----------
+  // Derived unit state
+  // -----------
+
+  /**
+   * All units from the course content tree, with numbered titles.
+   * Original title is preserved, numberedTitle adds the "Unit N:" prefix.
+   */
+  const units = computed(() => {
+    const children = course.value?.children?.results || [];
+    return children.map((unit, i) => ({
+      ...unit,
+      numberedTitle: `${unitNLabel$({ num: i + 1 })} ${unit.title}`,
+    }));
+  });
+
+  /**
+   * The most recently completed test from history.
+   */
+  const lastCompletedTest = computed(() => {
+    if (!testHistory.value?.length) return null;
+    return testHistory.value[testHistory.value.length - 1];
+  });
+
+  /**
+   * The unit currently being worked on, derived from activeTest and testHistory.
+   *
+   * Logic:
+   * - If there's an active test, that determines the active unit
+   * - If no active test, derive from test history:
+   *   - If last completed test was a post-test, advance to next unit
+   *   - If last completed test was a pre-test, stay on that unit
+   * - If no history, start at the first unit
+   */
+  const activeUnit = computed(() => {
+    if (!units.value.length) return null;
+
+    // Active test tells us exactly which unit we're on
+    if (activeTest.value) {
+      return units.value.find(u => u.id === activeTest.value.unit_contentnode_id);
+    }
+
+    // No active test - derive from history
+    if (!lastCompletedTest.value) {
+      // No history = starting fresh at unit 0
+      return units.value[0];
+    }
+
+    const lastTestUnitIndex = units.value.findIndex(
+      u => u.id === lastCompletedTest.value.unit_contentnode_id,
+    );
+
+    if (lastCompletedTest.value.test_type === 'post') {
+      // Post-test done = unit complete, move to next (or stay on last if course complete)
+      return units.value[lastTestUnitIndex + 1] || units.value[lastTestUnitIndex];
+    }
+
+    // Pre-test done = still on this unit (lessons phase)
+    return units.value[lastTestUnitIndex];
+  });
+
+  /**
+   * Index of the active unit within the units array.
+   */
+  const activeUnitIndex = computed(() => {
+    if (!activeUnit.value) return -1;
+    return units.value.findIndex(u => u.id === activeUnit.value.id);
+  });
+
+  /**
+   * Units that have been completed (before the active unit).
+   */
+  const completedUnits = computed(() => {
+    if (activeUnitIndex.value <= 0) return [];
+    return units.value.slice(0, activeUnitIndex.value);
+  });
+
+  /**
+   * Units that are upcoming (after the active unit).
+   */
+  const upcomingUnits = computed(() => {
+    if (activeUnitIndex.value < 0) return [];
+    return units.value.slice(activeUnitIndex.value + 1);
+  });
+
+  // -----------
+  // Derived test state
+  // -----------
+
+  /**
+   * The current phase of the active unit in the test lifecycle.
+   *
+   * State machine:
+   * PRE_TEST_PENDING → PRE_TEST_ACTIVE → POST_TEST_PENDING → POST_TEST_ACTIVE → COMPLETE
+   */
+  const unitPhase = computed(() => {
+    if (!activeUnit.value) return null;
+
+    // Is there a test running right now?
+    if (activeTest.value) {
+      return activeTest.value.test_type === 'pre'
+        ? UnitPhase.PRE_TEST_ACTIVE
+        : UnitPhase.POST_TEST_ACTIVE;
+    }
+
+    // No active test - what was the last thing completed for this unit?
+    const lastTestForActiveUnit = [...(testHistory.value || [])]
+      .reverse()
+      .find(t => t.unit_contentnode_id === activeUnit.value.id);
+
+    if (!lastTestForActiveUnit) {
+      // No tests done for this unit yet
+      return UnitPhase.PRE_TEST_PENDING;
+    }
+
+    if (lastTestForActiveUnit.test_type === 'pre') {
+      // Pre-test done, ready for post-test (lessons phase)
+      return UnitPhase.POST_TEST_PENDING;
+    }
+
+    // Post-test done for this unit
+    return UnitPhase.COMPLETE;
+  });
+
+  // -----------
+  // Actions
+  // -----------
+
+  /**
+   * Activates a test for the current active unit.
+   *
+   * @param {string} testType - Either 'pre' or 'post'
+   * @returns {Promise} Resolves when the test is activated
+   */
+  function activateTest(testType) {
+    return CourseSessionResource.activateTest({
+      id: courseSession.value.id,
+      data: {
+        unit_contentnode_id: activeUnit.value.id,
+        test_type: testType,
+      },
+    }).then(result => {
+      activeTest.value = result;
+    });
+  }
+
+  /**
+   * Closes the currently active test.
+   * Moves the closed test to history and clears activeTest.
+   *
+   * @returns {Promise} Resolves when the test is closed
+   */
+  function closeTest() {
+    return CourseSessionResource.closeTest({
+      id: courseSession.value.id,
+      data: {
+        unit_contentnode_id: activeTest.value.unit_contentnode_id,
+        test_type: activeTest.value.test_type,
+      },
+    }).then(result => {
+      // Move the closed test to history
+      testHistory.value = [
+        ...testHistory.value,
+        {
+          ...activeTest.value,
+          status: result.status,
+        },
+      ];
+      activeTest.value = null;
+    });
+  }
+
+  return {
+    // Loading state
+    loading,
+
+    // Raw data
+    courseSession,
+    course,
+    activeTest,
+    testHistory,
+
+    // Derived unit state
+    units,
+    activeUnit,
+    activeUnitIndex,
+    completedUnits,
+    upcomingUnits,
+
+    // Derived test state
+    lastCompletedTest,
+    unitPhase,
+
+    // Actions
+    activateTest,
+    closeTest,
+
+    // Constants
+    UnitPhase,
+  };
+}

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -83,7 +83,7 @@ export default function useCourseSession(courseSessionId) {
   });
 
   /**
-   * The unit currently being worked on, derived from activeTest and testHistory.
+   * The unit currently being worked on, derived from activeTest and lastUnitTest
    *
    * Logic:
    * - If there's an active test, that determines the active unit

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -232,6 +232,7 @@ export default function useCourseSession(courseSessionId) {
    * @returns {Promise} Resolves when the test is closed
    */
   function closeTest() {
+    dataLoading.value = true;
     return CourseSessionResource.closeTest({
       id: courseSession.value.id,
       data: {

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -218,15 +218,29 @@ export default function useCourseSession(courseSessionId) {
     return CourseSessionResource.saveModel({
       id: courseSession.value.id,
       data: { active: !courseSession.value.active },
-    }).then(result => {
-      courseSession.value = { ...courseSession.value, active: result.active };
-      if (result.active) {
-        createSnackbar(courseVisible$());
-      } else {
-        createSnackbar(courseNotVisible$());
-      }
-      return result;
-    });
+    })
+      .then(result => {
+        courseSession.value = { ...courseSession.value, active: result.active };
+        if (result.active) {
+          createSnackbar(courseVisible$());
+        } else {
+          createSnackbar(courseNotVisible$());
+        }
+        return result;
+      })
+      .then(result => {
+        // If we activate the course and the pre-test for the first unit hasn't been started,
+        // start it automatically to make things easier for the coach
+        if (!activeTest.value && activeUnitIndex.value === 0) {
+          // Can fire it off and move on as it will handle dataLoading
+          // and such internally
+          activateTest(TestType.PRE);
+        }
+        return result; // pipe the original CourseSession result back out
+      })
+      .catch(() => {
+        createSnackbar(defaultErrorMessage$());
+      });
   }
 
   return {

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -4,7 +4,7 @@ import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionReso
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import useSnackbar from 'kolibri/composables/useSnackbar';
-import { TestStatus, TestType, UnitPhase } from '../constants/courseConstants';
+import { TestStatus, TestType } from '../constants/courseConstants';
 
 const {
   unitNLabel$,
@@ -86,8 +86,7 @@ export default function useCourseSession(courseSessionId) {
    * The unit currently being worked on, derived from server-provided active_unit_index.
    */
   const activeUnit = computed(() => {
-    if (!units.value.length) return null;
-    if (!lastUnitTest.value) return units.value[0];
+    if (!units.value.length || !lastUnitTest.value) return null;
     const index = lastUnitTest.value.active_unit_index;
     if (index < 0 || index >= units.value.length) return null;
     return units.value[index];
@@ -97,9 +96,7 @@ export default function useCourseSession(courseSessionId) {
    * Index of the active unit within the units array.
    */
   const activeUnitIndex = computed(() => {
-    if (!lastUnitTest.value) {
-      return units.value.length > 0 ? 0 : -1;
-    }
+    if (!lastUnitTest.value) return -1;
     return lastUnitTest.value.active_unit_index;
   });
 
@@ -137,7 +134,7 @@ export default function useCourseSession(courseSessionId) {
    * Read directly from the server-provided unit_phase field.
    */
   const unitPhase = computed(() => {
-    if (!lastUnitTest.value) return UnitPhase.PRE_TEST_PENDING;
+    if (!lastUnitTest.value) return null;
     return lastUnitTest.value.unit_phase;
   });
 

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
@@ -23,7 +23,7 @@ const { defaultErrorMessage$ } = coreStrings;
  * Handles fetching course session data, course content, active tests, and test history.
  * Provides derived state for units and unit phase.
  *
- * @param {string} courseSessionId - The ID of the course session to load
+ * @param {Ref<string>} courseSessionId - The ID of the course session to load
  * @returns {Object} Reactive state and methods for managing the course session
  */
 export default function useCourseSession(courseSessionId) {
@@ -45,26 +45,42 @@ export default function useCourseSession(courseSessionId) {
   // -----------
   // Data fetching
   // -----------
-  CourseSessionResource.fetchModel({ id: courseSessionId })
-    .then(session => {
-      courseSession.value = session;
-      return ContentNodeResource.fetchTree({ id: session.course });
-    })
-    .then(courseData => {
-      course.value = courseData;
-      return CourseSessionResource.lastUnitTest({ id: courseSessionId });
-    })
-    .then(testData => {
-      lastUnitTest.value = testData;
-    })
-    .catch(e => {
-      // eslint-disable-next-line no-console
-      console.error(e);
-      createSnackbar(defaultErrorMessage$());
-    })
-    .finally(() => {
+  function fetchCourseSession() {
+    pageLoading.value = true;
+    if (!courseSessionId.value) {
+      // Reset to avoid stale data
+      courseSession.value = null;
+      course.value = null;
+      lastUnitTest.value = null;
       pageLoading.value = false;
-    });
+      return;
+    }
+    CourseSessionResource.fetchModel({ id: courseSessionId.value })
+      .then(session => {
+        courseSession.value = session;
+        return ContentNodeResource.fetchTree({ id: session.course });
+      })
+      .then(courseData => {
+        course.value = courseData;
+        return CourseSessionResource.lastUnitTest({ id: courseSessionId.value });
+      })
+      .then(testData => {
+        lastUnitTest.value = testData;
+      })
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        createSnackbar(defaultErrorMessage$());
+      })
+      .finally(() => {
+        pageLoading.value = false;
+      });
+  }
+
+  fetchCourseSession();
+
+  // When courseSessionId changes, we update all of our data
+  watch(courseSessionId, () => fetchCourseSession());
 
   // -----------
   // Derived unit state
@@ -75,6 +91,7 @@ export default function useCourseSession(courseSessionId) {
    * Original title is preserved, numberedTitle adds the "Unit N:" prefix.
    */
   const units = computed(() => {
+    if (!courseSessionId.value) return [];
     const children = course.value?.children?.results || [];
     return children.map((unit, i) => ({
       ...unit,
@@ -122,6 +139,7 @@ export default function useCourseSession(courseSessionId) {
    * Whether the entire course is complete (all units finished).
    */
   const isCourseComplete = computed(() => {
+    if (!courseSessionId.value) return null;
     return units.value.length > 0 && completedUnits.value.length === units.value.length;
   });
 

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -83,21 +83,21 @@ export default function useCourseSession(courseSessionId) {
   });
 
   /**
-   * The unit currently being worked on, derived from server-provided active_unit_index.
+   * The unit currently being worked on, derived from server-provided active_unit_id.
    */
   const activeUnit = computed(() => {
     if (!units.value.length || !lastUnitTest.value) return null;
-    const index = lastUnitTest.value.active_unit_index;
-    if (index < 0 || index >= units.value.length) return null;
-    return units.value[index];
+    const id = lastUnitTest.value.active_unit_id;
+    if (!id) return null;
+    return units.value.find(u => u.id === id) || null;
   });
 
   /**
    * Index of the active unit within the units array.
    */
   const activeUnitIndex = computed(() => {
-    if (!lastUnitTest.value) return -1;
-    return lastUnitTest.value.active_unit_index;
+    if (!activeUnit.value) return -1;
+    return units.value.findIndex(u => u.id === activeUnit.value.id);
   });
 
   /**

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -83,48 +83,24 @@ export default function useCourseSession(courseSessionId) {
   });
 
   /**
-   * The unit currently being worked on, derived from activeTest and lastUnitTest
-   *
-   * Logic:
-   * - If there's an active test, that determines the active unit
-   * - If no active test, derive from test history:
-   *   - If last completed test was a post-test, advance to next unit
-   *   - If last completed test was a pre-test, stay on that unit
-   * - If no history, start at the first unit
+   * The unit currently being worked on, derived from server-provided active_unit_index.
    */
   const activeUnit = computed(() => {
     if (!units.value.length) return null;
-
-    if (!activeTest.value && !lastUnitTest.value) {
-      // No active test and no last test taken, we're at the very beginning
-      return units.value[0];
-    }
-
-    // Active test tells us exactly which unit we're on
-    if (activeTest.value) {
-      return units.value.find(u => u.id === activeTest.value.unit_contentnode_id);
-    }
-
-    // We don't have an active test, so we'll use the lastUnitTest to work out which is active
-    const lastTestUnitIndex = units.value.findIndex(
-      u => u.id === lastUnitTest.value?.unit_contentnode_id,
-    );
-
-    if (lastUnitTest.value?.test_type === TestType.POST) {
-      // Post-test done = unit complete, move to next (or null if course complete)
-      return units.value[lastTestUnitIndex + 1] || null;
-    }
-
-    // Pre-test done = still on this unit (lessons phase)
-    return units.value[lastTestUnitIndex];
+    if (!lastUnitTest.value) return units.value[0];
+    const index = lastUnitTest.value.active_unit_index;
+    if (index < 0 || index >= units.value.length) return null;
+    return units.value[index];
   });
 
   /**
    * Index of the active unit within the units array.
    */
   const activeUnitIndex = computed(() => {
-    if (!activeUnit.value) return -1;
-    return units.value.findIndex(u => u.id === activeUnit.value.id);
+    if (!lastUnitTest.value) {
+      return units.value.length > 0 ? 0 : -1;
+    }
+    return lastUnitTest.value.active_unit_index;
   });
 
   /**
@@ -158,35 +134,11 @@ export default function useCourseSession(courseSessionId) {
 
   /**
    * The current phase of the active unit in the test lifecycle.
-   *
-   * State machine:
-   * PRE_TEST_PENDING → PRE_TEST_ACTIVE → POST_TEST_PENDING → POST_TEST_ACTIVE → COMPLETE
+   * Read directly from the server-provided unit_phase field.
    */
   const unitPhase = computed(() => {
-    // Course complete - all units finished
-    if (isCourseComplete.value) return UnitPhase.COMPLETE;
-
-    // Is there a test running right now?
-    if (activeTest.value) {
-      return activeTest.value.test_type === TestType.PRE
-        ? UnitPhase.PRE_TEST_ACTIVE
-        : UnitPhase.POST_TEST_ACTIVE;
-    }
-
-    // No active test - what was the last thing completed for this unit?
-    if (!lastUnitTest.value) {
-      // No tests done for this whole course session, so we're at the very start
-      return UnitPhase.PRE_TEST_PENDING;
-    }
-
-    if (lastUnitTest.value.test_type === TestType.PRE) {
-      // Pre-test done, ready for post-test (lessons phase)
-      return UnitPhase.POST_TEST_PENDING;
-    } else {
-      // If the last unit test is a post test, we already know we have no active test
-      // so, we're pending the pre-test for the next unit
-      return UnitPhase.PRE_TEST_PENDING;
-    }
+    if (!lastUnitTest.value) return UnitPhase.PRE_TEST_PENDING;
+    return lastUnitTest.value.unit_phase;
   });
 
   // -----------
@@ -208,15 +160,14 @@ export default function useCourseSession(courseSessionId) {
         test_type: testType,
       },
     })
-      .then(() => {
+      .then(result => {
         if (testType === TestType.PRE) {
           createSnackbar(preTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
         } else {
           createSnackbar(postTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
         }
-        return CourseSessionResource.lastUnitTest({ id: courseSessionId });
+        lastUnitTest.value = result;
       })
-      .then(results => (lastUnitTest.value = results))
       .catch(e => {
         // eslint-disable-next-line no-console
         console.error(e);
@@ -250,9 +201,8 @@ export default function useCourseSession(courseSessionId) {
         } else {
           createSnackbar(postTestEndedForUnit$({ title }));
         }
-        return CourseSessionResource.lastUnitTest({ id: courseSessionId });
+        lastUnitTest.value = result;
       })
-      .then(results => (lastUnitTest.value = results))
       .catch(e => {
         // eslint-disable-next-line no-console
         console.error(e);

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -2,9 +2,18 @@ import { computed, ref } from 'vue';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+import useSnackbar from 'kolibri/composables/useSnackbar';
 import { UnitPhase } from '../constants/courseConstants';
 
-const { unitNLabel$ } = coursesStrings;
+const {
+  unitNLabel$,
+  courseVisible$,
+  courseNotVisible$,
+  preTestStartedForUnit$,
+  postTestStartedForUnit$,
+  preTestEndedForUnit$,
+  postTestEndedForUnit$,
+} = coursesStrings;
 
 /**
  * A composable for managing course session state.
@@ -15,6 +24,7 @@ const { unitNLabel$ } = coursesStrings;
  * @returns {Object} Reactive state and methods for managing the course session
  */
 export default function useCourseSession(courseSessionId) {
+  const { createSnackbar } = useSnackbar();
   // -----------
   // Raw state
   // -----------
@@ -98,8 +108,8 @@ export default function useCourseSession(courseSessionId) {
     );
 
     if (lastCompletedTest.value.test_type === 'post') {
-      // Post-test done = unit complete, move to next (or stay on last if course complete)
-      return units.value[lastTestUnitIndex + 1] || units.value[lastTestUnitIndex];
+      // Post-test done = unit complete, move to next (or null if course complete)
+      return units.value[lastTestUnitIndex + 1] || null;
     }
 
     // Pre-test done = still on this unit (lessons phase)
@@ -115,9 +125,11 @@ export default function useCourseSession(courseSessionId) {
   });
 
   /**
-   * Units that have been completed (before the active unit).
+   * Units that have been completed (before the active unit, or all units if course complete).
    */
   const completedUnits = computed(() => {
+    // Course complete - all units are completed
+    if (!activeUnit.value) return units.value;
     if (activeUnitIndex.value <= 0) return [];
     return units.value.slice(0, activeUnitIndex.value);
   });
@@ -128,6 +140,13 @@ export default function useCourseSession(courseSessionId) {
   const upcomingUnits = computed(() => {
     if (activeUnitIndex.value < 0) return [];
     return units.value.slice(activeUnitIndex.value + 1);
+  });
+
+  /**
+   * Whether the entire course is complete (all units finished).
+   */
+  const isCourseComplete = computed(() => {
+    return units.value.length > 0 && completedUnits.value.length === units.value.length;
   });
 
   // -----------
@@ -141,6 +160,9 @@ export default function useCourseSession(courseSessionId) {
    * PRE_TEST_PENDING → PRE_TEST_ACTIVE → POST_TEST_PENDING → POST_TEST_ACTIVE → COMPLETE
    */
   const unitPhase = computed(() => {
+    // Course complete - all units finished
+    if (isCourseComplete.value) return UnitPhase.COMPLETE;
+
     if (!activeUnit.value) return null;
 
     // Is there a test running right now?
@@ -188,6 +210,11 @@ export default function useCourseSession(courseSessionId) {
       },
     }).then(result => {
       activeTest.value = result;
+      if (testType === 'pre') {
+        createSnackbar(preTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
+      } else {
+        createSnackbar(postTestStartedForUnit$({ title: activeUnit.value.numberedTitle }));
+      }
     });
   }
 
@@ -205,6 +232,10 @@ export default function useCourseSession(courseSessionId) {
         test_type: activeTest.value.test_type,
       },
     }).then(result => {
+      // Get this now because activeUnit will change before we trigger snackbars
+      // if we closed the post-test
+      const title = activeUnit.value.numberedTitle;
+
       // Move the closed test to history
       testHistory.value = [
         ...testHistory.value,
@@ -214,7 +245,32 @@ export default function useCourseSession(courseSessionId) {
         },
       ];
       activeTest.value = null;
+      if (result.test_type === 'pre') {
+        createSnackbar(preTestEndedForUnit$({ title }));
+      } else {
+        createSnackbar(postTestEndedForUnit$({ title }));
+      }
     });
+  }
+
+  /**
+   * Toggles the active state of the course session.
+   * Updates the courseSession ref with the new state on success.
+   *
+   * @returns {Promise} Resolves with the updated course session
+   */
+  async function toggleCourseActive() {
+    const result = await CourseSessionResource.saveModel({
+      id: courseSession.value.id,
+      data: { active: !courseSession.value.active },
+    });
+    courseSession.value = { ...courseSession.value, active: result.active };
+    if (result.active) {
+      createSnackbar(courseVisible$());
+    } else {
+      createSnackbar(courseNotVisible$());
+    }
+    return result;
   }
 
   return {
@@ -233,6 +289,7 @@ export default function useCourseSession(courseSessionId) {
     activeUnitIndex,
     completedUnits,
     upcomingUnits,
+    isCourseComplete,
 
     // Derived test state
     lastCompletedTest,
@@ -241,5 +298,6 @@ export default function useCourseSession(courseSessionId) {
     // Actions
     activateTest,
     closeTest,
+    toggleCourseActive,
   };
 }

--- a/kolibri/plugins/coach/frontend/constants/courseConstants.js
+++ b/kolibri/plugins/coach/frontend/constants/courseConstants.js
@@ -1,0 +1,13 @@
+/**
+ * Unit phase constants representing the state machine for a unit's test lifecycle.
+ *
+ * State transitions:
+ * PRE_TEST_PENDING → PRE_TEST_ACTIVE → POST_TEST_PENDING → POST_TEST_ACTIVE → COMPLETE
+ */
+export const UnitPhase = Object.freeze({
+  PRE_TEST_PENDING: 'pre_test_pending',
+  PRE_TEST_ACTIVE: 'pre_test_active',
+  POST_TEST_PENDING: 'post_test_pending',
+  POST_TEST_ACTIVE: 'post_test_active',
+  COMPLETE: 'complete',
+});

--- a/kolibri/plugins/coach/frontend/constants/courseConstants.js
+++ b/kolibri/plugins/coach/frontend/constants/courseConstants.js
@@ -1,3 +1,4 @@
+// See courses.models for python-matched definitions for these constants
 /**
  * Unit phase constants representing the state machine for a unit's test lifecycle.
  *
@@ -10,4 +11,15 @@ export const UnitPhase = Object.freeze({
   POST_TEST_PENDING: 'post_test_pending',
   POST_TEST_ACTIVE: 'post_test_active',
   COMPLETE: 'complete',
+});
+
+export const TestType = Object.freeze({
+  PRE: 'pre',
+  POST: 'post',
+});
+
+export const TestStatus = Object.freeze({
+  NOT_STARTED: 'not_started',
+  ACTIVE: 'active',
+  ENDED: 'ended',
 });

--- a/kolibri/plugins/coach/frontend/routes/coursesRoutes.js
+++ b/kolibri/plugins/coach/frontend/routes/coursesRoutes.js
@@ -8,12 +8,12 @@ import SelectRecipientsSubpage from '../views/courses/sidePanels/AssignCourse/su
 import AssignCourseIndexSubpage from '../views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue';
 import { classIdParamRequiredGuard, RouteSegments } from './utils';
 
-const { OPTIONAL_CLASS, ALL_COURSES, CLASS, COURSE } = RouteSegments;
+const { OPTIONAL_CLASS, ALL_COURSES, CLASS, COURSE_SESSION } = RouteSegments;
 
 export default [
   {
     name: PageNames.COURSE_SUMMARY,
-    path: CLASS + COURSE,
+    path: CLASS + COURSE_SESSION,
     component: CourseSummaryPage,
     meta: {
       titleParts: ['COURSE_NAME', 'CLASS_NAME'],

--- a/kolibri/plugins/coach/frontend/routes/utils.js
+++ b/kolibri/plugins/coach/frontend/routes/utils.js
@@ -38,4 +38,5 @@ export const RouteSegments = {
   ALL_QUIZZES: '/quizzes',
   ALL_COURSES: '/courses',
   COURSE: '/courses/:courseId',
+  COURSE_SESSION: '/courses/:courseSessionId',
 };

--- a/kolibri/plugins/coach/frontend/routes/utils.js
+++ b/kolibri/plugins/coach/frontend/routes/utils.js
@@ -37,6 +37,5 @@ export const RouteSegments = {
   QUIZ: '/quizzes/:quizId',
   ALL_QUIZZES: '/quizzes',
   ALL_COURSES: '/courses',
-  COURSE: '/courses/:courseId',
   COURSE_SESSION: '/courses/:courseSessionId',
 };

--- a/kolibri/plugins/coach/frontend/views/common/CoachHeader.vue
+++ b/kolibri/plugins/coach/frontend/views/common/CoachHeader.vue
@@ -7,7 +7,10 @@
         <slot name="actions"></slot>
       </div>
     </div>
-    <div class="class-name-label">
+    <div
+      v-if="!hideClassName"
+      class="class-name-label"
+    >
       <KIcon
         icon="classes"
         class="class-name-icon"
@@ -29,6 +32,10 @@
       title: {
         type: String,
         required: true,
+      },
+      hideClassName: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -241,7 +241,7 @@
             {{ inProgressLabel$() }}
           </div>
           <div class="panel-message">
-            {{ '14 ' + learnersLabel$() }}
+            {{ numLearners$({ num: 100 }) }}
           </div>
         </div>
       </div>
@@ -283,6 +283,7 @@
     setup() {
       const {
         workingOnLessons$,
+        numLearners$,
         startPreTest$,
         startPostTest$,
         dateAssigned$,
@@ -516,6 +517,7 @@
         visibleToLearnersLabel$,
         unitStatusMessages,
         upcomingUnitsAccordionHeaderStyles,
+        numLearners$,
         goBackAction$,
         dateAssigned$,
         optionsLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -319,6 +319,7 @@
         inProgressLabel$,
         goBackAction$,
         optionsLabel$,
+        cancelAction$,
       } = coreStrings;
 
       const route = useRoute();
@@ -447,7 +448,7 @@
               title: startPreTestForUnitConfirmation$({ num: unitNum }),
               text: startTestForUnitDescription$(),
               submitText: startPreTest$(),
-              cancelText: keepRunning$(),
+              cancelText: cancelAction$(),
               submit: () => {
                 activateTest('pre');
                 activeModal.value = null;
@@ -473,7 +474,7 @@
               title: startPostTestForUnitConfirmation$({ num: unitNum }),
               text: startTestForUnitDescription$(),
               submitText: startPostTest$(),
-              cancelText: keepRunning$(),
+              cancelText: cancelAction$(),
               submit: () => {
                 activateTest('post');
                 activeModal.value = null;

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -328,6 +328,8 @@
         return { ...route, name: PageNames.COURSES_ROOT };
       });
 
+      const courseSessionId = computed(() => route.params.courseSessionId);
+
       // Use the composable for all course session state
       const {
         dataLoading,
@@ -343,7 +345,7 @@
         closeTest,
         courseSession,
         toggleCourseActive,
-      } = useCourseSession(route.params.courseSessionId);
+      } = useCourseSession(courseSessionId);
 
       const { getRecipientNamesForCourseSession } = useClassSummary();
 
@@ -555,8 +557,10 @@
         onUnitButtonClick,
       };
     },
-    created() {
-      this.$store.dispatch('notLoading');
+    watch: {
+      courseSession() {
+        this.$store.dispatch('notLoading');
+      },
     },
   };
 

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -31,7 +31,10 @@
           </template>
         </CoachHeader>
       </div>
-      <div class="content">
+      <div
+        v-if="courseSession"
+        class="content"
+      >
         <KCircularLoader v-if="dataLoading" />
         <section
           v-else
@@ -93,6 +96,7 @@
           <KTabsList
             ref="tabList"
             tabsId="courseTabs"
+            :ariaLabel="unitsLabel$()"
             :activeTabId="activeTabId"
             :tabs="tabs"
             @click="id => (activeTabId = id)"
@@ -543,6 +547,7 @@
         activeUnit$,
         numberOfResources$,
         completedUnitsLabel$,
+        unitsLabel$,
         numUnits$,
         upcomingUnitsLabel$,
         lockedLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -1,13 +1,25 @@
 <template>
 
   <CoachAppBarPage>
-    <KPageContainer class='container'>
+    <KPageContainer class="container">
       <KCircularLoader v-if="loading" />
-      <div v-else class='header'>
-        <KButton class='go-back' text='<- Back' appearance="basic-link" />
-        <CoachHeader  hideClassName :title="course?.title || ''">
+      <div
+        v-else
+        class="header"
+      >
+        <KRouterLink
+          class="go-back"
+          icon="back"
+          :text="goBackAction$()"
+          appearance="basic-link"
+          :to="backRoute"
+        />
+        <CoachHeader
+          hideClassName
+          :title="course?.title || ''"
+        >
           <template #actions>
-            <KButton text="Options" >
+            <KButton :text="optionsLabel$()">
               <template #menu>
                 <KDropdownMenu
                   :options="[]"
@@ -19,9 +31,62 @@
           </template>
         </CoachHeader>
       </div>
-      <div v-if="!loading" class="content">
+      <div
+        v-if="!loading"
+        class="content"
+      >
         <section class="course-status">
-          oh snap
+          <div class="course-active">
+            <KLabeledIcon
+              class="status-icon"
+              icon="previewUnavailable"
+              :label="visibleToLearnersLabel$()"
+            />
+            <KSwitch
+              :value="courseSession.active"
+              @change="toggleCourseActive"
+            />
+          </div>
+          <div class="course-class">
+            <KLabeledIcon
+              class="status-icon"
+              icon="classes"
+              :label="classLabel$()"
+            />
+            <div class="icon-aligned-text">{{ courseSession?.classroom?.name }}</div>
+          </div>
+          <div class="course-recipients">
+            <KLabeledIcon
+              class="status-icon"
+              icon="group"
+              :label="recipientsLabel$()"
+            />
+            <Recipients
+              class="icon-aligned-text"
+              :groupNames="getRecipientNamesForExam(courseSession)"
+              :hasAssignments="courseSession.assignments.length > 0"
+            />
+          </div>
+          <div>
+            <KLabeledIcon
+              class="status-icon"
+              icon="data"
+              :label="sizeLabel$()"
+            />
+            <div class="icon-aligned-text">
+              {{ numberOfResources$({ value: course.on_device_resources }) }}
+            </div>
+          </div>
+          <div>
+            <KLabeledIcon
+              class="status-icon"
+              icon="unchecked"
+              :label="dateAssigned$()"
+            />
+            <div class="icon-aligned-text">
+              <ElapsedTime :date="new Date(courseSession.date_created)" />
+            </div>
+          </div>
         </section>
         <section class="course-details">
           <KTabsList
@@ -29,30 +94,41 @@
             tabsId="courseTabs"
             :activeTabId="activeTabId"
             :tabs="tabs"
-            @click="id => activeTabId = id"
+            @click="id => (activeTabId = id)"
           />
           <KTabsPanel
             tabsId="courseTabs"
             :activeTabId="activeTabId"
           >
             <template #[TABS.UNITS]>
-              <div class='active-unit' :style="activeUnitStyles">
-                <div class='active-unit-title'>
-                  <KRouterLink :text="activeUnit.title" :to="{}" />
-                  <div class='unit-status'>
-                    <span class='status-pill' :style="pillStyles">
-                      <KIcon icon='info' :color="$themeTokens.textInverted" /> Active unit
+              <div
+                v-if="activeUnit"
+                class="active-unit"
+                :style="activeUnitStyles"
+              >
+                <div class="active-unit-title">
+                  <KRouterLink
+                    :text="activeUnit.numberedTitle"
+                    :to="{}"
+                  />
+                  <div class="unit-status">
+                    <span
+                      class="pill"
+                      :style="statusPillStyles"
+                    >
+                      <KIcon
+                        icon="info"
+                        :color="$themeTokens.textInverted"
+                      />
+                      {{ activeUnit$() }}
                     </span>
-                    <span v-if="lastCompletedTest && lastCompletedTest.test_type === 'pre'" class='status-message'>
-                      <b> {{ preTestLabel$() }} </b>
-                      <span style='text-transform: lowercase'>{{ completedLabel$() }}</span>
-                    </span>
-                    <span class='status-message'>
+                    <span class="status-message">
                       <b> {{ unitStatusMessages.boldMessage }} </b>
-                      <span style='text-transform: lowercase'>{{ unitStatusMessages.plainMessage }}</span>
+                      <span style="text-transform: lowercase">{{
+                        unitStatusMessages.plainMessage
+                      }}</span>
                     </span>
                   </div>
-
                 </div>
                 <KButton
                   primary
@@ -63,21 +139,79 @@
               </div>
               <AccordionContainer>
                 <AccordionItem
+                  v-if="completedUnits.length"
+                  :title="completedUnitsLabel$()"
+                  :headerAppearanceOverrides="upcomingUnitsAccordionHeaderStyles"
+                  :contentAppearanceOverrides="{
+                    padding: '0',
+                  }"
+                  isOpenByDefault
+                >
+                  <template #trailing-actions>
+                    <div
+                      class="pill"
+                      :style="unitsPillStyles"
+                    >
+                      {{ numUnits$({ num: completedUnits.length || 0 }) }}
+                    </div>
+                  </template>
+                  <template #content>
+                    <div
+                      v-for="unit in completedUnits"
+                      :key="unit.id"
+                      class="upcoming-unit"
+                      :style="{ border: `1px solid ${$themeTokens.fineLine}` }"
+                    >
+                      <KRouterLink
+                        :text="unit.numberedTitle"
+                        :to="{}"
+                      />
+                      <span :style="{ color: $themeTokens.annotation }">
+                        {{ prePercent$({ num: 0.21 }) }}
+                        <KIcon icon="forward" />
+                        {{ postPercent$({ num: 0.74 }) }}
+                        <KIcon
+                          icon="indeterminateCheck"
+                          color="red"
+                        />
+                        <KIcon
+                          icon="indeterminateCheck"
+                          color="yellow"
+                        />
+                        <KIcon
+                          icon="indeterminateCheck"
+                          color="green"
+                        />
+                      </span>
+                    </div>
+                  </template>
+                </AccordionItem>
+                <AccordionItem
+                  v-if="upcomingUnits.length"
                   :title="upcomingUnitsLabel$()"
                   :headerAppearanceOverrides="upcomingUnitsAccordionHeaderStyles"
                   :contentAppearanceOverrides="{
                     padding: '0 0 48px 0',
                   }"
+                  isOpenByDefault
                 >
                   <template #content>
                     <div
                       v-for="unit in upcomingUnits"
-                      class='upcoming-unit'
+                      :key="unit.id"
+                      class="upcoming-unit"
                       :style="{ border: `1px solid ${$themeTokens.fineLine}` }"
                     >
-                      <KRouterLink :text="unit.title" :to="{}" />
+                      <KRouterLink
+                        :text="unit.numberedTitle"
+                        :to="{}"
+                      />
                       <span :style="{ color: $themeTokens.annotation }">
-                        <KIcon icon="permission" :color="$themeTokens.annotation" />  {{ lockedLabel$() }}
+                        <KIcon
+                          icon="permissions"
+                          :color="$themeTokens.annotation"
+                        />
+                        {{ lockedLabel$() }}
                       </span>
                     </div>
                   </template>
@@ -85,10 +219,10 @@
               </AccordionContainer>
             </template>
             <template #[TABS.LEARNERS]>
-              <h1> learners </h1>
+              <h1>{{ learnersLabel$() }}</h1>
             </template>
             <template #[TABS.OBJECTIVES]>
-              <h1> objectives </h1>
+              <h1>{{ learningObjectivesLabel$() }}</h1>
             </template>
           </KTabsPanel>
         </section>
@@ -104,24 +238,24 @@
     >
       <div>{{ activeModal.text }}</div>
       <div
-        v-if="activeTest?.status == 'active'"
-        class='post-modal-panel'
+        v-if="activeTest?.status === 'active'"
+        class="post-modal-panel"
         :style="{ backgroundColor: $themePalette.grey.v_100 }"
       >
-        <div class='panel-item'>
-          <div class='panel-label'>
+        <div class="panel-item">
+          <div class="panel-label">
             {{ completedLabel$() }}
           </div>
-          <div class='panel-message'>
+          <div class="panel-message">
             {{ nOfMLearners$({ n: 0, m: 10 }) }}
           </div>
         </div>
-        <div class='panel-item'>
-          <div class='panel-label'>
+        <div class="panel-item">
+          <div class="panel-label">
             {{ inProgressLabel$() }}
           </div>
-          <div class='panel-message'>
-            {{ "14 " + learnersLabel$() }}
+          <div class="panel-message">
+            {{ '14 ' + learnersLabel$() }}
           </div>
         </div>
       </div>
@@ -134,16 +268,21 @@
 <script>
 
   import { computed, ref } from 'vue';
-  import { useRoute, useRouter } from 'vue-router/composables';
+  import { mapGetters } from 'vuex';
+  import { useRoute } from 'vue-router/composables';
+  import ElapsedTime from 'kolibri-common/components/ElapsedTime';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
   import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
-  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
-  import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
-  import CoachHeader from '../common/CoachHeader.vue';
-  import CoachAppBarPage from '../CoachAppBarPage.vue';
   import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
+  import { PageNames } from '../../constants';
+  import Recipients from '../common/Recipients.vue';
+  import CoachHeader from '../common/CoachHeader.vue';
+  import { coachStrings } from '../../views/common/commonCoachStrings';
+  import CoachAppBarPage from '../CoachAppBarPage.vue';
+  import useCourseSession from '../../composables/useCourseSession';
+  import { UnitPhase } from '../../constants/courseConstants';
 
   export default {
     name: 'CourseSummaryPage',
@@ -152,139 +291,75 @@
       AccordionItem,
       CoachAppBarPage,
       CoachHeader,
+      ElapsedTime,
+      Recipients,
     },
     setup() {
       const {
-        unitNLabel$,
         workingOnLessons$,
         startPreTest$,
         startPostTest$,
-
+        dateAssigned$,
         endPreTest$,
         endPostTest$,
-
         startTestForUnitDescription$,
         endTestForUnitDescription$,
-
         startPreTestForUnitConfirmation$,
         startPostTestForUnitConfirmation$,
         endPreTestForUnitConfirmation$,
         endPostTestForUnitConfirmation$,
         keepRunning$,
         preTestLabel$,
-        postTestLabel$,
         lockedLabel$,
+        numUnits$,
         unitsLabel$,
         learningObjectivesLabel$,
         readyToStartLabel$,
+        completedUnitsLabel$,
         upcomingUnitsLabel$,
         nOfMLearners$,
+        prePercent$,
+        postPercent$,
+        activeUnit$,
+        visibleToLearnersLabel$,
       } = coursesStrings;
 
+      const { recipientsLabel$, sizeLabel$, numberOfResources$ } = coachStrings;
+
       const {
+        classLabel$,
         learnersLabel$,
         cancelAction$,
         completedLabel$,
         inProgressLabel$,
+        goBackAction$,
+        optionsLabel$,
       } = coreStrings;
 
       const route = useRoute();
-      const router = useRouter();
+      const backRoute = computed(() => {
+        // include existing route params/query for classId and such if present
+        return { ...route, name: PageNames.COURSES_ROOT };
+      });
 
-      const courseSession = ref(null);
-      const course = ref(null);
-      const activeTest = ref(null);
-      const testHistory = ref([]);
-      const lastCompletedTest = computed(() => {
-        if(testHistory?.value?.length) {
-          return testHistory.value[testHistory.value.length - 1];
-        } else {
-          return null;
-        }
-      })
+      // Use the composable for all course session state
+      const {
+        loading,
+        course,
+        activeTest,
+        activeUnit,
+        activeUnitIndex,
+        completedUnits,
+        upcomingUnits,
+        unitPhase,
+        activateTest,
+        closeTest,
+        courseSession,
+        toggleCourseActive,
+      } = useCourseSession(route.params.courseSessionId);
 
-      /**
-        When `null` there is no active modal
-        Otherwise, it should be set to an object that has the props
-        that KModal expects:
-          [submitText, submit, cancelText, cancel, title]
-
-        `text` property will be put inside of the modal
-        */
+      // UI-only state
       const activeModal = ref(null);
-
-      const _units = computed(() => course.value?.children?.results || []);
-      const units = computed(() => _units.value.map((u,i) => {
-        u.title = `${unitNLabel$({num: i + 1})} ${u.title}`;
-        return u;
-      }))
-      const activeUnit = computed(() => {
-        const unit = units.value.find(u => u.id === activeTest.value?.unit_contentnode_id);
-        if(unit) {
-          return unit
-        } else {
-          // Return the first unit if there are any units because we're at square one
-          return units.value.length ? units.value[0] : null;
-        }
-      });
-      const activeUnitIndex = computed(() => {
-        return units.value.findIndex(u => u.id === activeUnit?.value?.id);
-      });
-      const completedUnits = computed(() => {
-        if(activeUnitIndex.value > 0) {
-          return units.value.slice(0, activeUnitIndex);
-        } else {
-          return [];
-        }
-      });
-      const upcomingUnits = computed(() => {
-        if(!activeUnit.value) {
-          // If there is no active unit, then we're at square one
-          return [];
-        }
-        return units.value.slice(activeUnitIndex.value + 1);
-      });
-
-      /**
-        @deftype UnitStatusMessage
-        @property boldMessage
-        @property plainMessage
-        */
-
-      const unitStatusMessages = computed(() => {
-        if(!activeTest.value) {
-          if(lastCompletedTest.value) {
-            if(lastCompletedTest.value.test_type === 'pre') {
-              return {
-                boldMessage: nOfMLearners$({ n: 0, m: 5}),
-                plainMessage: workingOnLessons$(),
-                buttonLabel: startPostTest$(),
-              };
-            }
-          }
-          return {
-            boldMessage: preTestLabel$(),
-            plainMessage: readyToStartLabel$(),
-            buttonLabel: startPreTest$(),
-          };
-        }
-        if(lastCompletedTest.value) {
-          if(lastCompletedTest.value.test_type === 'pre') {
-            return {
-              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
-              plainMessage: completedLabel$(),
-              buttonLabel: endPostTest$(),
-            };
-          } else {
-            return {
-              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
-              plainMessage: completedLabel$(),
-              buttonLabel: endPreTest$(),
-            };
-          }
-        }
-      });
-
 
       const TABS = { UNITS: 'units', LEARNERS: 'learners', OBJECTIVES: 'objectives' };
       const activeTabId = ref(TABS.UNITS);
@@ -303,172 +378,187 @@
         },
       ];
 
-
-      const loading = ref(true);
-
-      // Get the course session
-      CourseSessionResource.fetchModel({ id: route.params.courseSessionId })
-        .then(results => {
-          courseSession.value = results;
-          // Now get the course itself now that we have the course's ID
-          return ContentNodeResource.fetchTree({ id: courseSession.value.course })
-        })
-        .then(results => {
-          course.value = results;
-        })
-        .then(() => {
-          Promise.all([
-            CourseSessionResource.activeTest({ id: route.params.courseSessionId }),
-            CourseSessionResource.testHistory({ id: route.params.courseSessionId }),
-          ]).then(([active, history]) => {
-            activeTest.value = active.active_test;
-            testHistory.value = history.data;
-          })
-        })
-        .finally(() => {
-          loading.value = false;
-        });
-
-      function activateTest(unitId, testType) {
-        activeModal.value = null;
-        return CourseSessionResource.activateTest({
-          id: route.params.courseSessionId,
-          data: {
-            unit_contentnode_id: unitId,
-            test_type: testType,
-          },
-        }).then(results => {
-          activeTest.value = results;
-        })
-      }
-
-
-      function closeTest(unitId, testType) {
-        activeModal.value = null;
-        return CourseSessionResource.closeTest({
-          id: route.params.courseSessionId,
-          data: {
-            unit_contentnode_id: unitId,
-            test_type: testType,
-          },
-        }).then(results => {
-          activeTest.value = results;
-        })
-      }
-
-      const activeUnitStyles = computed(() => {
-        if(!activeTest.value) {
-          return {
-            backgroundColor: themePalette().blue.v_100,
-          };
-        }
-        return {
-          backgroundColor: themePalette().yellow.v_100,
-        };
-      })
-
-      const pillStyles = computed(() => {
-        if(!activeTest.value) {
-          return {
-            backgroundColor: themePalette().blue.v_600,
-            color: themeTokens().textInverted,
-          }
-        }
-        return {
-          backgroundColor: themePalette().orange.v_600,
-          color: themeTokens().textInverted,
+      // Phase-based status messages
+      const unitStatusMessages = computed(() => {
+        switch (unitPhase.value) {
+          case UnitPhase.PRE_TEST_PENDING:
+            return {
+              boldMessage: preTestLabel$(),
+              plainMessage: readyToStartLabel$(),
+              buttonLabel: startPreTest$(),
+            };
+          case UnitPhase.PRE_TEST_ACTIVE:
+            return {
+              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
+              plainMessage: completedLabel$(),
+              buttonLabel: endPreTest$(),
+            };
+          case UnitPhase.POST_TEST_PENDING:
+            return {
+              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
+              plainMessage: workingOnLessons$(),
+              buttonLabel: startPostTest$(),
+            };
+          case UnitPhase.POST_TEST_ACTIVE:
+            return {
+              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
+              plainMessage: completedLabel$(),
+              buttonLabel: endPostTest$(),
+            };
+          case UnitPhase.COMPLETE:
+            return {
+              boldMessage: '',
+              plainMessage: completedLabel$(),
+              buttonLabel: '',
+            };
+          default:
+            return {};
         }
       });
+
+      // Phase-based styles
+      const activeUnitStyles = computed(() => {
+        const isTestActive =
+          unitPhase.value === UnitPhase.PRE_TEST_ACTIVE ||
+          unitPhase.value === UnitPhase.POST_TEST_ACTIVE;
+        return {
+          backgroundColor: isTestActive ? themePalette().yellow.v_100 : themePalette().blue.v_100,
+        };
+      });
+
+      const statusPillStyles = computed(() => {
+        const isTestActive =
+          unitPhase.value === UnitPhase.PRE_TEST_ACTIVE ||
+          unitPhase.value === UnitPhase.POST_TEST_ACTIVE;
+        return {
+          backgroundColor: isTestActive ? themePalette().orange.v_600 : themePalette().blue.v_600,
+          color: themeTokens().textInverted,
+        };
+      });
+
+      const unitsPillStyles = {
+        backgroundColor: themeTokens().surface,
+        fontWeight: 'normal',
+      };
 
       const upcomingUnitsAccordionHeaderStyles = computed(() => {
         return {
           backgroundColor: themePalette().grey.v_100,
           padding: '0px 16px',
           fontWeight: 'bold',
-        }
+        };
       });
 
+      // Phase-based button click handler
       function onUnitButtonClick() {
-        if(!activeTest.value) {
-          // We have no activeTest, so we're definitely activating a test
-          if(lastCompletedTest?.value?.test_type === "pre") {
+        const unitNum = activeUnitIndex.value + 1;
+
+        switch (unitPhase.value) {
+          case UnitPhase.PRE_TEST_PENDING:
             activeModal.value = {
-              title: startPostTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
-              text: startTestForUnitDescription$(),
-              submitText: startPostTest$(),
-              cancelText: cancelAction$(),
-              submit: () => activateTest(activeUnit.value.id, 'post'),
-              cancel: () => activeModal.value = null,
-            }
-          } else {
-            activeModal.value = {
-              title: startPreTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              title: startPreTestForUnitConfirmation$({ num: unitNum }),
               text: startTestForUnitDescription$(),
               submitText: startPreTest$(),
               cancelText: cancelAction$(),
-              submit: () => activateTest(activeUnit.value.id, 'pre'),
-              cancel: () => activeModal.value = null,
-            }
-          }
-        } else {
-          if(lastCompletedTest?.value?.test_type === "pre") {
+              submit: () => {
+                activateTest('pre');
+                activeModal.value = null;
+              },
+              cancel: () => (activeModal.value = null),
+            };
+            break;
+          case UnitPhase.PRE_TEST_ACTIVE:
             activeModal.value = {
-              title: endPostTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
-              text: endTestForUnitDescription$(),
-              submitText: endPostTest$(),
-              cancelText: cancelAction$(),
-              submit: () => closeTest(activeUnit.value.id, 'post'),
-              cancel: () => activeModal.value = null,
-            }
-          } else {
-            activeModal.value = {
-              title: endPreTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              title: endPreTestForUnitConfirmation$({ num: unitNum }),
               text: endTestForUnitDescription$(),
               submitText: endPreTest$(),
               cancelText: keepRunning$(),
-              submit: () => closeTest(activeUnit.value.id, 'pre'),
-              cancel: () => activeModal.value = null,
-            }
-          }
+              submit: () => {
+                closeTest();
+                activeModal.value = null;
+              },
+              cancel: () => (activeModal.value = null),
+            };
+            break;
+          case UnitPhase.POST_TEST_PENDING:
+            activeModal.value = {
+              title: startPostTestForUnitConfirmation$({ num: unitNum }),
+              text: startTestForUnitDescription$(),
+              submitText: startPostTest$(),
+              cancelText: cancelAction$(),
+              submit: () => {
+                activateTest('post');
+                activeModal.value = null;
+              },
+              cancel: () => (activeModal.value = null),
+            };
+            break;
+          case UnitPhase.POST_TEST_ACTIVE:
+            activeModal.value = {
+              title: endPostTestForUnitConfirmation$({ num: unitNum }),
+              text: endTestForUnitDescription$(),
+              submitText: endPostTest$(),
+              cancelText: cancelAction$(),
+              submit: () => {
+                closeTest();
+                activeModal.value = null;
+              },
+              cancel: () => (activeModal.value = null),
+            };
+            break;
         }
       }
 
       return {
+        backRoute,
         loading,
         course,
-        units,
+        toggleCourseActive,
 
         tabs,
         TABS,
 
         activeTabId,
-        activateTest,
         activeTest,
         activeUnit,
-        activeUnitIndex,
         activeModal,
 
-        completedUnits,
         courseSession,
+        completedUnits,
         upcomingUnits,
         activeUnitStyles,
+        recipientsLabel$,
+        sizeLabel$,
+        classLabel$,
+        visibleToLearnersLabel$,
         unitStatusMessages,
         upcomingUnitsAccordionHeaderStyles,
+        goBackAction$,
+        dateAssigned$,
+        optionsLabel$,
+        activeUnit$,
+        numberOfResources$,
+        completedUnitsLabel$,
+        numUnits$,
         upcomingUnitsLabel$,
-        preTestLabel$,
         lockedLabel$,
+        prePercent$,
+        postPercent$,
         learnersLabel$,
         completedLabel$,
         inProgressLabel$,
-        unitNLabel$,
         nOfMLearners$,
-        startPreTestForUnitConfirmation$,
-        lastCompletedTest,
-        testHistory,
 
-        pillStyles,
+        unitsPillStyles,
+        statusPillStyles,
         onUnitButtonClick,
       };
+    },
+    computed: {
+      ...mapGetters('classSummary', ['getRecipientNamesForExam']),
+    },
+    created() {
+      this.$store.dispatch('notLoading');
     },
   };
 
@@ -477,86 +567,106 @@
 
 <style scoped>
 
-.container {
-  padding: 0;
+  .container {
+    padding: 0;
 
-  .header {
-    padding: 8px 24px 24px;
+    .header {
+      padding: 8px 24px 24px;
+    }
   }
-}
 
-.go-back {
-  margin-top: 16px;
-}
+  .go-back {
+    margin-top: 16px;
+  }
 
-.content {
-  display: flex;
-  width: 100%;
-}
+  .content {
+    display: flex;
+    width: 100%;
+  }
 
-.course-status {
-  width: 190px;
-  padding: 24px 16px 24px 24px;
-}
-.course-details {
-  width: calc(100% - 190px);
-}
-.active-unit {
-  padding: 16px 24px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0px;
+  .course-status {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 190px;
+    padding: 24px 16px 24px 24px;
+    line-height: 140%;
+  }
 
-  a {
+  .icon-aligned-text {
+    display: block;
+    padding-left: 32px;
+  }
+
+  .course-details {
+    width: calc(100% - 190px);
+  }
+
+  .active-unit {
+    display: flex;
+    gap: 0;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+
+    a {
+      font-weight: bold;
+    }
+  }
+
+  .active-unit-title {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 2;
+    gap: 8px;
+    width: 75%;
+  }
+
+  .pill {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 16px;
+  }
+
+  .unit-status {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+  }
+
+  .upcoming-unit {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+  }
+
+  .post-modal-panel {
+    display: flex;
+    align-items: center;
+    padding: 16px;
+    margin-top: 8px;
+    border-radius: 8px;
+
+    .panel-item {
+      width: 50%;
+    }
+
+    .panel-label {
+      margin-bottom: 8px;
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+  }
+
+  .course-active {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .status-icon {
     font-weight: bold;
   }
-}
-
-.active-unit-title {
-  display: flex;
-  flex-grow: 2;
-  gap: 8px;
-  flex-direction: column;
-  width: 75%;
-}
-
-.status-pill {
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 16px;
-}
-
-.unit-status {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-}
-
-.upcoming-unit {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px;
-}
-
-.post-modal-panel {
-  display: flex;
-  align-items: center;
-  padding: 16px;
-  margin-top: 8px;
-  border-radius: 8px;
-
-  .panel-item {
-    width: 50%;
-  }
-
-  .panel-label {
-    font-size: 12px;
-    text-transform: uppercase;
-    margin-bottom: 8px;
-  }
-
-}
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -2,7 +2,7 @@
 
   <CoachAppBarPage>
     <KPageContainer class="container">
-      <KCircularLoader v-if="loading" />
+      <KCircularLoader v-if="pageLoading" />
       <div
         v-else
         class="header"
@@ -31,11 +31,12 @@
           </template>
         </CoachHeader>
       </div>
-      <div
-        v-if="!loading"
-        class="content"
-      >
-        <section class="course-status">
+      <div class="content">
+        <KCircularLoader v-if="dataLoading" />
+        <section
+          v-else
+          class="course-status"
+        >
           <div class="course-active">
             <KLabeledIcon
               class="status-icon"
@@ -74,7 +75,7 @@
               :label="sizeLabel$()"
             />
             <div class="icon-aligned-text">
-              {{ numberOfResources$({ value: course.on_device_resources }) }}
+              {{ numberOfResources$({ value: course?.on_device_resources }) }}
             </div>
           </div>
           <div>
@@ -133,7 +134,7 @@
                 <KButton
                   primary
                   :text="unitStatusMessages.buttonLabel"
-                  :style="{ backgroundColor: activeTest ? $themeTokens.error + '!important' : '' }"
+                  :class="$computedClass(testButtonStyles)"
                   @click="onUnitButtonClick"
                 />
               </div>
@@ -328,7 +329,8 @@
 
       // Use the composable for all course session state
       const {
-        loading,
+        dataLoading,
+        pageLoading,
         course,
         activeTest,
         activeUnit,
@@ -493,9 +495,20 @@
         }
       }
 
+      const testButtonStyles = computed(() => {
+        const color = activeTest.value ? themeTokens().error : '';
+        return {
+          background: color,
+          ':hover': {
+            background: color,
+          },
+        };
+      });
+
       return {
         backRoute,
-        loading,
+        dataLoading,
+        pageLoading,
         course,
         toggleCourseActive,
 
@@ -510,6 +523,7 @@
         courseSession,
         completedUnits,
         upcomingUnits,
+        testButtonStyles,
         activeUnitStyles,
         recipientsLabel$,
         sizeLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -2,7 +2,8 @@
 
   <CoachAppBarPage>
     <KPageContainer>
-      <!-- To be implemented -->
+      <KCircularLoader v-if="loading" />
+      <h1 v-else>Sup?</h1>
     </KPageContainer>
   </CoachAppBarPage>
 
@@ -11,12 +12,33 @@
 
 <script>
 
+  import { computed, ref } from 'vue';
+  import { useRoute, useRouter } from 'vue-router/composables';
+  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
 
   export default {
     name: 'CourseSummaryPage',
     components: {
       CoachAppBarPage,
+    },
+    setup() {
+      const route = useRoute();
+      const router = useRouter();
+      const course = ref(null);
+      const loading = ref(true);
+      ContentNodeResource.fetchTree({ id: route.params.courseId })
+        .then(results => {
+          course.value = results;
+          loading.value = false;
+        })
+        .catch(() => {
+          loading.value = false;
+        });
+      return {
+        loading,
+        course,
+      };
     },
   };
 

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -64,7 +64,7 @@
             />
             <Recipients
               class="icon-aligned-text"
-              :groupNames="getRecipientNamesForExam(courseSession)"
+              :groupNames="getRecipientNamesForCourseSession(courseSession)"
               :hasAssignments="courseSession.assignments.length > 0"
             />
           </div>
@@ -255,7 +255,6 @@
 <script>
 
   import { computed, ref } from 'vue';
-  import { mapGetters } from 'vuex';
   import { useRoute } from 'vue-router/composables';
   import ElapsedTime from 'kolibri-common/components/ElapsedTime';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
@@ -269,6 +268,7 @@
   import { coachStrings } from '../../views/common/commonCoachStrings';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
   import useCourseSession from '../../composables/useCourseSession';
+  import useClassSummary from '../../composables/useClassSummary.js';
   import { UnitPhase } from '../../constants/courseConstants';
 
   export default {
@@ -343,6 +343,8 @@
         courseSession,
         toggleCourseActive,
       } = useCourseSession(route.params.courseSessionId);
+
+      const { getRecipientNamesForCourseSession } = useClassSummary();
 
       // UI-only state
       const activeModal = ref(null);
@@ -545,14 +547,12 @@
         completedLabel$,
         inProgressLabel$,
         nOfMLearners$,
+        getRecipientNamesForCourseSession,
 
         unitsPillStyles,
         statusPillStyles,
         onUnitButtonClick,
       };
-    },
-    computed: {
-      ...mapGetters('classSummary', ['getRecipientNamesForExam']),
     },
     created() {
       this.$store.dispatch('notLoading');

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -166,22 +166,8 @@
                         :text="unit.numberedTitle"
                         :to="{}"
                       />
-                      <span :style="{ color: $themeTokens.annotation }">
-                        {{ prePercent$({ num: 0.21 }) }}
-                        <KIcon icon="forward" />
-                        {{ postPercent$({ num: 0.74 }) }}
-                        <KIcon
-                          icon="indeterminateCheck"
-                          color="red"
-                        />
-                        <KIcon
-                          icon="indeterminateCheck"
-                          color="yellow"
-                        />
-                        <KIcon
-                          icon="indeterminateCheck"
-                          color="green"
-                        />
+                      <span>
+                        <!-- put end items here -->
                       </span>
                     </div>
                   </template>
@@ -318,8 +304,6 @@
         completedUnitsLabel$,
         upcomingUnitsLabel$,
         nOfMLearners$,
-        prePercent$,
-        postPercent$,
         activeUnit$,
         visibleToLearnersLabel$,
       } = coursesStrings;
@@ -329,7 +313,6 @@
       const {
         classLabel$,
         learnersLabel$,
-        cancelAction$,
         completedLabel$,
         inProgressLabel$,
         goBackAction$,
@@ -459,7 +442,7 @@
               title: startPreTestForUnitConfirmation$({ num: unitNum }),
               text: startTestForUnitDescription$(),
               submitText: startPreTest$(),
-              cancelText: cancelAction$(),
+              cancelText: keepRunning$(),
               submit: () => {
                 activateTest('pre');
                 activeModal.value = null;
@@ -485,7 +468,7 @@
               title: startPostTestForUnitConfirmation$({ num: unitNum }),
               text: startTestForUnitDescription$(),
               submitText: startPostTest$(),
-              cancelText: cancelAction$(),
+              cancelText: keepRunning$(),
               submit: () => {
                 activateTest('post');
                 activeModal.value = null;
@@ -498,7 +481,7 @@
               title: endPostTestForUnitConfirmation$({ num: unitNum }),
               text: endTestForUnitDescription$(),
               submitText: endPostTest$(),
-              cancelText: cancelAction$(),
+              cancelText: keepRunning$(),
               submit: () => {
                 closeTest();
                 activeModal.value = null;
@@ -542,8 +525,6 @@
         numUnits$,
         upcomingUnitsLabel$,
         lockedLabel$,
-        prePercent$,
-        postPercent$,
         learnersLabel$,
         completedLabel$,
         inProgressLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -1,9 +1,52 @@
 <template>
 
   <CoachAppBarPage>
-    <KPageContainer>
+    <KPageContainer class='container'>
       <KCircularLoader v-if="loading" />
-      <h1 v-else>Sup?</h1>
+      <div v-else class='header'>
+        <KButton class='go-back' text='<- Back' appearance="basic-link" />
+        <CoachHeader  hideClassName :title="course?.title">
+          <template #actions>
+            <KButton text="Options" >
+              <template #menu>
+                <KDropdownMenu
+                  :options="[]"
+                  maxWidth="none"
+                  @select="() => null"
+                />
+              </template>
+            </KButton>
+          </template>
+        </CoachHeader>
+      </div>
+      <div class="content">
+        <section class="course-status">
+          oh snap
+        </section>
+        <section class="course-details">
+          <KTabsList
+            ref="tabList"
+            tabsId="courseTabs"
+            :activeTabId="activeTabId"
+            :tabs="tabs"
+            @click="id => activeTabId = id"
+          />
+          <KTabsPanel
+            tabsId="courseTabs"
+            :activeTabId="activeTabId"
+          >
+            <template #[TABS.UNITS]>
+              <h1> unit </h1>
+            </template>
+            <template #[TABS.LEARNERS]>
+              <h1> learners </h1>
+            </template>
+            <template #[TABS.OBJECTIVES]>
+              <h1> objectives </h1>
+            </template>
+          </KTabsPanel>
+        </section>
+      </div>
     </KPageContainer>
   </CoachAppBarPage>
 
@@ -15,18 +58,37 @@
   import { computed, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+  import CoachHeader from '../common/CoachHeader.vue';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
 
   export default {
     name: 'CourseSummaryPage',
     components: {
       CoachAppBarPage,
+      CoachHeader,
     },
     setup() {
       const route = useRoute();
       const router = useRouter();
       const course = ref(null);
+      const units = computed(() => course.value?.children?.results);
       const loading = ref(true);
+      const TABS = { UNITS: 'units', LEARNERS: 'learners', OBJECTIVES: 'objectives' };
+      const tabs = [
+        {
+          id: TABS.UNITS,
+          label: "_UNITS_",
+        },
+        {
+          id: TABS.LEARNERS,
+          label: "_LEARNERS_",
+        },
+        {
+          id: TABS.OBJECTIVES,
+          label: "_OBJECTIVES_",
+        },
+      ];
+      const activeTabId = ref(TABS.UNITS);
       ContentNodeResource.fetchTree({ id: route.params.courseId })
         .then(results => {
           course.value = results;
@@ -38,8 +100,42 @@
       return {
         loading,
         course,
+        units,
+        tabs,
+        TABS,
+        activeTabId,
       };
     },
   };
 
 </script>
+
+
+<style scoped>
+
+.container {
+  padding: 0 0 8px 0;
+
+  .header {
+    padding: 8px 24px 24px;
+  }
+}
+
+.go-back {
+  margin-top: 16px;
+}
+
+.content {
+  display: flex;
+  width: 100%;
+}
+
+.course-status {
+  width: 190px;
+  padding: 24px 16px 24px 24px;
+}
+.course-details {
+  width: calc(100% - 190px);
+}
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -5,7 +5,7 @@
       <KCircularLoader v-if="loading" />
       <div v-else class='header'>
         <KButton class='go-back' text='<- Back' appearance="basic-link" />
-        <CoachHeader  hideClassName :title="course?.title">
+        <CoachHeader  hideClassName :title="course?.title || ''">
           <template #actions>
             <KButton text="Options" >
               <template #menu>
@@ -19,7 +19,7 @@
           </template>
         </CoachHeader>
       </div>
-      <div class="content">
+      <div v-if="!loading" class="content">
         <section class="course-status">
           oh snap
         </section>
@@ -36,7 +36,53 @@
             :activeTabId="activeTabId"
           >
             <template #[TABS.UNITS]>
-              <h1> unit </h1>
+              <div class='active-unit' :style="activeUnitStyles">
+                <div class='active-unit-title'>
+                  <KRouterLink :text="activeUnit.title" :to="{}" />
+                  <div class='unit-status'>
+                    <span class='status-pill' :style="pillStyles">
+                      <KIcon icon='info' :color="$themeTokens.textInverted" /> Active unit
+                    </span>
+                    <span v-if="lastCompletedTest && lastCompletedTest.test_type === 'pre'" class='status-message'>
+                      <b> {{ preTestLabel$() }} </b>
+                      <span style='text-transform: lowercase'>{{ completedLabel$() }}</span>
+                    </span>
+                    <span class='status-message'>
+                      <b> {{ unitStatusMessages.boldMessage }} </b>
+                      <span style='text-transform: lowercase'>{{ unitStatusMessages.plainMessage }}</span>
+                    </span>
+                  </div>
+
+                </div>
+                <KButton
+                  primary
+                  :text="unitStatusMessages.buttonLabel"
+                  :style="{ backgroundColor: activeTest ? $themeTokens.error + '!important' : '' }"
+                  @click="onUnitButtonClick"
+                />
+              </div>
+              <AccordionContainer>
+                <AccordionItem
+                  :title="upcomingUnitsLabel$()"
+                  :headerAppearanceOverrides="upcomingUnitsAccordionHeaderStyles"
+                  :contentAppearanceOverrides="{
+                    padding: '0 0 48px 0',
+                  }"
+                >
+                  <template #content>
+                    <div
+                      v-for="unit in upcomingUnits"
+                      class='upcoming-unit'
+                      :style="{ border: `1px solid ${$themeTokens.fineLine}` }"
+                    >
+                      <KRouterLink :text="unit.title" :to="{}" />
+                      <span :style="{ color: $themeTokens.annotation }">
+                        <KIcon icon="permission" :color="$themeTokens.annotation" />  {{ lockedLabel$() }}
+                      </span>
+                    </div>
+                  </template>
+                </AccordionItem>
+              </AccordionContainer>
             </template>
             <template #[TABS.LEARNERS]>
               <h1> learners </h1>
@@ -48,6 +94,38 @@
         </section>
       </div>
     </KPageContainer>
+    <KModal
+      v-if="activeModal"
+      :title="activeModal.title"
+      :submitText="activeModal.submitText"
+      :cancelText="activeModal.cancelText"
+      @cancel="activeModal.cancel"
+      @submit="activeModal.submit"
+    >
+      <div>{{ activeModal.text }}</div>
+      <div
+        v-if="activeTest?.status == 'active'"
+        class='post-modal-panel'
+        :style="{ backgroundColor: $themePalette.grey.v_100 }"
+      >
+        <div class='panel-item'>
+          <div class='panel-label'>
+            {{ completedLabel$() }}
+          </div>
+          <div class='panel-message'>
+            {{ nOfMLearners$({ n: 0, m: 10 }) }}
+          </div>
+        </div>
+        <div class='panel-item'>
+          <div class='panel-label'>
+            {{ inProgressLabel$() }}
+          </div>
+          <div class='panel-message'>
+            {{ "14 " + learnersLabel$() }}
+          </div>
+        </div>
+      </div>
+    </KModal>
   </CoachAppBarPage>
 
 </template>
@@ -57,53 +135,339 @@
 
   import { computed, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
+  import AccordionItem from 'kolibri-common/components/accordion/AccordionItem';
   import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
+  import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
   import CoachHeader from '../common/CoachHeader.vue';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
+  import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
 
   export default {
     name: 'CourseSummaryPage',
     components: {
+      AccordionContainer,
+      AccordionItem,
       CoachAppBarPage,
       CoachHeader,
     },
     setup() {
+      const {
+        unitNLabel$,
+        workingOnLessons$,
+        startPreTest$,
+        startPostTest$,
+
+        endPreTest$,
+        endPostTest$,
+
+        startTestForUnitDescription$,
+        endTestForUnitDescription$,
+
+        startPreTestForUnitConfirmation$,
+        startPostTestForUnitConfirmation$,
+        endPreTestForUnitConfirmation$,
+        endPostTestForUnitConfirmation$,
+        keepRunning$,
+        preTestLabel$,
+        postTestLabel$,
+        lockedLabel$,
+        unitsLabel$,
+        learningObjectivesLabel$,
+        readyToStartLabel$,
+        upcomingUnitsLabel$,
+        nOfMLearners$,
+      } = coursesStrings;
+
+      const {
+        learnersLabel$,
+        cancelAction$,
+        completedLabel$,
+        inProgressLabel$,
+      } = coreStrings;
+
       const route = useRoute();
       const router = useRouter();
+
+      const courseSession = ref(null);
       const course = ref(null);
-      const units = computed(() => course.value?.children?.results);
-      const loading = ref(true);
+      const activeTest = ref(null);
+      const testHistory = ref([]);
+      const lastCompletedTest = computed(() => {
+        if(testHistory?.value?.length) {
+          return testHistory.value[testHistory.value.length - 1];
+        } else {
+          return null;
+        }
+      })
+
+      /**
+        When `null` there is no active modal
+        Otherwise, it should be set to an object that has the props
+        that KModal expects:
+          [submitText, submit, cancelText, cancel, title]
+
+        `text` property will be put inside of the modal
+        */
+      const activeModal = ref(null);
+
+      const _units = computed(() => course.value?.children?.results || []);
+      const units = computed(() => _units.value.map((u,i) => {
+        u.title = `${unitNLabel$({num: i + 1})} ${u.title}`;
+        return u;
+      }))
+      const activeUnit = computed(() => {
+        const unit = units.value.find(u => u.id === activeTest.value?.unit_contentnode_id);
+        if(unit) {
+          return unit
+        } else {
+          // Return the first unit if there are any units because we're at square one
+          return units.value.length ? units.value[0] : null;
+        }
+      });
+      const activeUnitIndex = computed(() => {
+        return units.value.findIndex(u => u.id === activeUnit?.value?.id);
+      });
+      const completedUnits = computed(() => {
+        if(activeUnitIndex.value > 0) {
+          return units.value.slice(0, activeUnitIndex);
+        } else {
+          return [];
+        }
+      });
+      const upcomingUnits = computed(() => {
+        if(!activeUnit.value) {
+          // If there is no active unit, then we're at square one
+          return [];
+        }
+        return units.value.slice(activeUnitIndex.value + 1);
+      });
+
+      /**
+        @deftype UnitStatusMessage
+        @property boldMessage
+        @property plainMessage
+        */
+
+      const unitStatusMessages = computed(() => {
+        if(!activeTest.value) {
+          if(lastCompletedTest.value) {
+            if(lastCompletedTest.value.test_type === 'pre') {
+              return {
+                boldMessage: nOfMLearners$({ n: 0, m: 5}),
+                plainMessage: workingOnLessons$(),
+                buttonLabel: startPostTest$(),
+              };
+            }
+          }
+          return {
+            boldMessage: preTestLabel$(),
+            plainMessage: readyToStartLabel$(),
+            buttonLabel: startPreTest$(),
+          };
+        }
+        if(lastCompletedTest.value) {
+          if(lastCompletedTest.value.test_type === 'pre') {
+            return {
+              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
+              plainMessage: completedLabel$(),
+              buttonLabel: endPostTest$(),
+            };
+          } else {
+            return {
+              boldMessage: nOfMLearners$({ n: 0, m: 5 }),
+              plainMessage: completedLabel$(),
+              buttonLabel: endPreTest$(),
+            };
+          }
+        }
+      });
+
+
       const TABS = { UNITS: 'units', LEARNERS: 'learners', OBJECTIVES: 'objectives' };
+      const activeTabId = ref(TABS.UNITS);
       const tabs = [
         {
           id: TABS.UNITS,
-          label: "_UNITS_",
+          label: unitsLabel$(),
         },
         {
           id: TABS.LEARNERS,
-          label: "_LEARNERS_",
+          label: learnersLabel$(),
         },
         {
           id: TABS.OBJECTIVES,
-          label: "_OBJECTIVES_",
+          label: learningObjectivesLabel$(),
         },
       ];
-      const activeTabId = ref(TABS.UNITS);
-      ContentNodeResource.fetchTree({ id: route.params.courseId })
+
+
+      const loading = ref(true);
+
+      // Get the course session
+      CourseSessionResource.fetchModel({ id: route.params.courseSessionId })
+        .then(results => {
+          courseSession.value = results;
+          // Now get the course itself now that we have the course's ID
+          return ContentNodeResource.fetchTree({ id: courseSession.value.course })
+        })
         .then(results => {
           course.value = results;
-          loading.value = false;
         })
-        .catch(() => {
+        .then(() => {
+          Promise.all([
+            CourseSessionResource.activeTest({ id: route.params.courseSessionId }),
+            CourseSessionResource.testHistory({ id: route.params.courseSessionId }),
+          ]).then(([active, history]) => {
+            activeTest.value = active.active_test;
+            testHistory.value = history.data;
+          })
+        })
+        .finally(() => {
           loading.value = false;
         });
+
+      function activateTest(unitId, testType) {
+        activeModal.value = null;
+        return CourseSessionResource.activateTest({
+          id: route.params.courseSessionId,
+          data: {
+            unit_contentnode_id: unitId,
+            test_type: testType,
+          },
+        }).then(results => {
+          activeTest.value = results;
+        })
+      }
+
+
+      function closeTest(unitId, testType) {
+        activeModal.value = null;
+        return CourseSessionResource.closeTest({
+          id: route.params.courseSessionId,
+          data: {
+            unit_contentnode_id: unitId,
+            test_type: testType,
+          },
+        }).then(results => {
+          activeTest.value = results;
+        })
+      }
+
+      const activeUnitStyles = computed(() => {
+        if(!activeTest.value) {
+          return {
+            backgroundColor: themePalette().blue.v_100,
+          };
+        }
+        return {
+          backgroundColor: themePalette().yellow.v_100,
+        };
+      })
+
+      const pillStyles = computed(() => {
+        if(!activeTest.value) {
+          return {
+            backgroundColor: themePalette().blue.v_600,
+            color: themeTokens().textInverted,
+          }
+        }
+        return {
+          backgroundColor: themePalette().orange.v_600,
+          color: themeTokens().textInverted,
+        }
+      });
+
+      const upcomingUnitsAccordionHeaderStyles = computed(() => {
+        return {
+          backgroundColor: themePalette().grey.v_100,
+          padding: '0px 16px',
+          fontWeight: 'bold',
+        }
+      });
+
+      function onUnitButtonClick() {
+        if(!activeTest.value) {
+          // We have no activeTest, so we're definitely activating a test
+          if(lastCompletedTest?.value?.test_type === "pre") {
+            activeModal.value = {
+              title: startPostTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              text: startTestForUnitDescription$(),
+              submitText: startPostTest$(),
+              cancelText: cancelAction$(),
+              submit: () => activateTest(activeUnit.value.id, 'post'),
+              cancel: () => activeModal.value = null,
+            }
+          } else {
+            activeModal.value = {
+              title: startPreTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              text: startTestForUnitDescription$(),
+              submitText: startPreTest$(),
+              cancelText: cancelAction$(),
+              submit: () => activateTest(activeUnit.value.id, 'pre'),
+              cancel: () => activeModal.value = null,
+            }
+          }
+        } else {
+          if(lastCompletedTest?.value?.test_type === "pre") {
+            activeModal.value = {
+              title: endPostTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              text: endTestForUnitDescription$(),
+              submitText: endPostTest$(),
+              cancelText: cancelAction$(),
+              submit: () => closeTest(activeUnit.value.id, 'post'),
+              cancel: () => activeModal.value = null,
+            }
+          } else {
+            activeModal.value = {
+              title: endPreTestForUnitConfirmation$({ num: activeUnitIndex.value + 1 }),
+              text: endTestForUnitDescription$(),
+              submitText: endPreTest$(),
+              cancelText: keepRunning$(),
+              submit: () => closeTest(activeUnit.value.id, 'pre'),
+              cancel: () => activeModal.value = null,
+            }
+          }
+        }
+      }
+
       return {
         loading,
         course,
         units,
+
         tabs,
         TABS,
+
         activeTabId,
+        activateTest,
+        activeTest,
+        activeUnit,
+        activeUnitIndex,
+        activeModal,
+
+        completedUnits,
+        courseSession,
+        upcomingUnits,
+        activeUnitStyles,
+        unitStatusMessages,
+        upcomingUnitsAccordionHeaderStyles,
+        upcomingUnitsLabel$,
+        preTestLabel$,
+        lockedLabel$,
+        learnersLabel$,
+        completedLabel$,
+        inProgressLabel$,
+        unitNLabel$,
+        nOfMLearners$,
+        startPreTestForUnitConfirmation$,
+        lastCompletedTest,
+        testHistory,
+
+        pillStyles,
+        onUnitButtonClick,
       };
     },
   };
@@ -114,7 +478,7 @@
 <style scoped>
 
 .container {
-  padding: 0 0 8px 0;
+  padding: 0;
 
   .header {
     padding: 8px 24px 24px;
@@ -136,6 +500,63 @@
 }
 .course-details {
   width: calc(100% - 190px);
+}
+.active-unit {
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0px;
+
+  a {
+    font-weight: bold;
+  }
+}
+
+.active-unit-title {
+  display: flex;
+  flex-grow: 2;
+  gap: 8px;
+  flex-direction: column;
+  width: 75%;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 16px;
+}
+
+.unit-status {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.upcoming-unit {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+}
+
+.post-modal-panel {
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  margin-top: 8px;
+  border-radius: 8px;
+
+  .panel-item {
+    width: 50%;
+  }
+
+  .panel-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
 }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -304,7 +304,7 @@
           name: PageNames.COURSE_SUMMARY,
           params: {
             classId: route.params.classId,
-            courseId: course.id,
+            courseId: course.course,
           },
         };
       };

--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -72,16 +72,9 @@
                 <td>
                   <div class="course-title">
                     <KRouterLink
-                      v-if="course.contentNode"
                       :to="courseSummaryLink(course)"
                       :text="course.title"
                       icon="course"
-                    />
-                    <KTextTruncator
-                      v-else
-                      :text="course.title"
-                      :maxLines="1"
-                      class="course-title-text"
                     />
                   </div>
                   <KTextTruncator
@@ -304,7 +297,7 @@
           name: PageNames.COURSE_SUMMARY,
           params: {
             classId: route.params.classId,
-            courseId: course.course,
+            courseSessionId: course.id,
           },
         };
       };

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -25,7 +25,7 @@ export default new Resource({
   },
   lastUnitTest({ id }) {
     return client({
-      url: this.getUrlFunction('other_last_unit_test')(id),
+      url: this.getUrlFunction('last_unit_test')(id),
       method: 'GET',
     }).then(response => response.data);
   },

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -29,10 +29,4 @@ export default new Resource({
       method: 'GET',
     }).then(response => response.data);
   },
-  testHistory({ id }) {
-    return client({
-      url: this.getUrlFunction('test_history')(id),
-      method: 'GET',
-    });
-  },
 });

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -23,6 +23,12 @@ export default new Resource({
       method: 'GET',
     }).then(response => response.data);
   },
+  lastUnitTest({ id }) {
+    return client({
+      url: this.getUrlFunction('other_last_unit_test')(id),
+      method: 'GET',
+    }).then(response => response.data);
+  },
   testHistory({ id }) {
     return client({
       url: this.getUrlFunction('test_history')(id),

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -27,6 +27,6 @@ export default new Resource({
     return client({
       url: this.getUrlFunction('test_history')(id),
       method: 'GET',
-    })
-  }
+    });
+  },
 });

--- a/packages/kolibri-common/apiResources/CourseSessionResource.js
+++ b/packages/kolibri-common/apiResources/CourseSessionResource.js
@@ -1,5 +1,32 @@
 import { Resource } from 'kolibri/apiResource';
+import client from 'kolibri/client';
 
 export default new Resource({
   name: 'coursesession',
+  activateTest({ id, data }) {
+    return client({
+      url: this.getUrlFunction('activate_test')(id),
+      method: 'POST',
+      data: data,
+    }).then(response => response.data);
+  },
+  closeTest({ id, data }) {
+    return client({
+      url: this.getUrlFunction('close_test')(id),
+      method: 'POST',
+      data: data,
+    }).then(response => response.data);
+  },
+  activeTest({ id }) {
+    return client({
+      url: this.getUrlFunction('active_test')(id),
+      method: 'GET',
+    }).then(response => response.data);
+  },
+  testHistory({ id }) {
+    return client({
+      url: this.getUrlFunction('test_history')(id),
+      method: 'GET',
+    })
+  }
 });

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -238,21 +238,16 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   startTestForUnitDescription: {
     message:
       'All assigned learners can now start the test. You can end the test whenever you want.',
-    context: 'Description text on modal confirming start of pre-test',
+    context: 'Description text on modal confirming start of pre-test or post-test',
   },
   endTestForUnitDescription: {
     message:
       "This action cannot be undone. Learners who haven't completed the test will be marked as incomplete.",
-    context: 'Description text on modal confirming ending of pre-test',
+    context: 'Description text on modal confirming ending of pre-test or post-test',
   },
   endPreTestForUnitConfirmation: {
     message: 'End pre-test for unit {num, number}?',
     context: 'Heading for confirmation modal when user clicks to end a pre-test',
-  },
-  endPreTestForUnitDescription: {
-    message:
-      "This action cannot be undone. Learners who haven't completed the test will be marked as incomplete.",
-    context: 'Description text on modal confirming ending of pre-test',
   },
   keepRunning: {
     message: 'Keep test running',
@@ -284,11 +279,11 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   },
   preTestEndedForUnit: {
     message: 'Pre-test ended for {title}',
-    context: 'Snackbar message upon starting the pre-test',
+    context: 'Snackbar message upon ending the pre-test',
   },
   postTestEndedForUnit: {
     message: 'Post-test ended for {title}',
-    context: 'Snackbar message upon starting the post-test',
+    context: 'Snackbar message upon ending the post-test',
   },
   preTestStartedForUnit: {
     message: 'Pre-test started for {title}',

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -15,7 +15,7 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   },
   unitsLabel: {
     message: 'Units',
-    context: 'Label for tab that shows units on course summary page'
+    context: 'Label for tab that shows units on course summary page',
   },
   assignCourseAction: {
     message: 'Assign course',
@@ -57,6 +57,10 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   masteryLabel: {
     message: 'Mastery',
     context: 'Column header for average mastery percentage',
+  },
+  visibleToLearnersLabel: {
+    message: 'Visible to learners',
+    context: 'Label for toggle switch to make course visible (or not)',
   },
   visibleLabel: {
     message: 'Visible',
@@ -142,6 +146,14 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: '{num, number} {num, plural, one {unit} other {units}}',
     context: 'Part of subtitle shown under the course title',
   },
+  prePercent: {
+    message: 'Pre: {num, number, percent}',
+    context: 'Indicating percentage of passing learners for the pre-test',
+  },
+  postPercent: {
+    message: 'Post: {num, number, percent}',
+    context: 'Indicating percentage of passing learners for the post-test',
+  },
   courseContentLabel: {
     message: 'Course content',
     context: 'Label above list of units in course contents listing',
@@ -203,9 +215,13 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'ready to start',
     context: 'Added to indicate a status of a pre/post test being ready to start',
   },
+  completedUnitsLabel: {
+    message: 'Completed units',
+    context: 'Label for folding accordion title to list/hide units that have been completed',
+  },
   upcomingUnitsLabel: {
     message: 'Upcoming units',
-    context: 'Label for folding accordion title to list/hide units that have not yet been started'
+    context: 'Label for folding accordion title to list/hide units that have not yet been started',
   },
   lockedLabel: {
     message: 'Locked',
@@ -213,7 +229,7 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   },
   unitNLabel: {
     message: 'Unit {num, number}:',
-    context: 'Added to the beginning of the unit title to indicate which unit it is in order'
+    context: 'Added to the beginning of the unit title to indicate which unit it is in order',
   },
   startPreTestForUnitConfirmation: {
     message: 'Start pre-test for unit {num, number}?',
@@ -228,28 +244,32 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     context: 'Heading for confirmation modal when user clicks to end a pre-test',
   },
   startTestForUnitDescription: {
-    message: 'All assigned learners can now start the test. You can end the test whenever you want.',
-    context: 'Description text on modal confirming start of pre-test'
+    message:
+      'All assigned learners can now start the test. You can end the test whenever you want.',
+    context: 'Description text on modal confirming start of pre-test',
   },
   endTestForUnitDescription: {
-    message: 'This action cannot be undone. Learners who haven\'t completed the test will be marked as incomplete.',
-    context: 'Description text on modal confirming ending of pre-test'
+    message:
+      "This action cannot be undone. Learners who haven't completed the test will be marked as incomplete.",
+    context: 'Description text on modal confirming ending of pre-test',
   },
   endPreTestForUnitConfirmation: {
     message: 'End pre-test for unit {num, number}?',
     context: 'Heading for confirmation modal when user clicks to end a pre-test',
   },
   startPreTestForUnitDescription: {
-    message: 'All assigned learners can now start the test. You can end the test whenever you want.',
-    context: 'Description text on modal confirming start of pre-test'
+    message:
+      'All assigned learners can now start the test. You can end the test whenever you want.',
+    context: 'Description text on modal confirming start of pre-test',
   },
   endPreTestForUnitDescription: {
-    message: 'This action cannot be undone. Learners who haven\'t completed the test will be marked as incomplete.',
-    context: 'Description text on modal confirming ending of pre-test'
+    message:
+      "This action cannot be undone. Learners who haven't completed the test will be marked as incomplete.",
+    context: 'Description text on modal confirming ending of pre-test',
   },
   keepRunning: {
     message: 'Keep test running',
-    context: 'Label for button that cancels modal for ending test'
+    context: 'Label for button that cancels modal for ending test',
   },
   nOfMLearners: {
     message: '{n, number} of {m, number} learners',
@@ -257,6 +277,38 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   },
   workingOnLessons: {
     message: 'working on lessons',
-    context: 'Placed after message "n of m learners" - separated like this for styling'
+    context: 'Placed after message "n of m learners" - separated like this for styling',
+  },
+  activeUnit: {
+    message: 'Active unit',
+    context: 'Label for an information flag in the area of the currently active unit',
+  },
+  dateAssigned: {
+    message: 'Date assigned',
+    context: 'Label in course summary showing how long it has been since the course was assigned',
+  },
+  courseVisible: {
+    message: 'Course visible to learners',
+    context: 'Snackbar message after user toggles course to be visible',
+  },
+  courseNotVisible: {
+    message: 'Course not visible to learners',
+    context: 'Snackbar message after user toggles course to be hidden',
+  },
+  preTestEndedForUnit: {
+    message: 'Pre-test ended for {title}',
+    context: 'Snackbar message upon starting the pre-test',
+  },
+  postTestEndedForUnit: {
+    message: 'Post-test ended for {title}',
+    context: 'Snackbar message upon starting the post-test',
+  },
+  preTestStartedForUnit: {
+    message: 'Pre-test started for {title}',
+    context: 'Snackbar message upon starting the pre-test',
+  },
+  postTestStartedForUnit: {
+    message: 'Post-test started for {title}',
+    context: 'Snackbar message upon starting the post-test',
   },
 });

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -9,6 +9,14 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Courses',
     context: 'Label for courses that contain units and lessons.',
   },
+  learningObjectivesLabel: {
+    message: 'Learning objectives',
+    context: 'Label for tab to show learning objectives on course summary page',
+  },
+  unitsLabel: {
+    message: 'Units',
+    context: 'Label for tab that shows units on course summary page'
+  },
   assignCourseAction: {
     message: 'Assign course',
     context: 'Action label for assigning a course to learners.',
@@ -175,5 +183,80 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   markAsCompleteAction: {
     message: 'Mark as complete',
     context: 'Action label for marking a resource as complete',
+  startPreTest: {
+    message: 'Start pre-test',
+    context: 'Button label for starting a pre-test',
+  },
+  endPreTest: {
+    message: 'End pre-test',
+    context: 'Button label for ending a pre-test',
+  },
+  endPostTest: {
+    message: 'End post-test',
+    context: 'Button label for ending a post-test',
+  },
+  startPostTest: {
+    message: 'Start post-test',
+    context: 'Button label for starting a post-test',
+  },
+  readyToStartLabel: {
+    message: 'ready to start',
+    context: 'Added to indicate a status of a pre/post test being ready to start',
+  },
+  upcomingUnitsLabel: {
+    message: 'Upcoming units',
+    context: 'Label for folding accordion title to list/hide units that have not yet been started'
+  },
+  lockedLabel: {
+    message: 'Locked',
+    context: 'Label for a unit that is upcoming and cannot be started',
+  },
+  unitNLabel: {
+    message: 'Unit {num, number}:',
+    context: 'Added to the beginning of the unit title to indicate which unit it is in order'
+  },
+  startPreTestForUnitConfirmation: {
+    message: 'Start pre-test for unit {num, number}?',
+    context: 'Heading for confirmation modal when user clicks to activate a pre-test',
+  },
+  startPostTestForUnitConfirmation: {
+    message: 'Start post-test for unit {num, number}?',
+    context: 'Heading for confirmation modal when user clicks to activate a post-test',
+  },
+  endPostTestForUnitConfirmation: {
+    message: 'End post-test for unit {num, number}?',
+    context: 'Heading for confirmation modal when user clicks to end a pre-test',
+  },
+  startTestForUnitDescription: {
+    message: 'All assigned learners can now start the test. You can end the test whenever you want.',
+    context: 'Description text on modal confirming start of pre-test'
+  },
+  endTestForUnitDescription: {
+    message: 'This action cannot be undone. Learners who haven\'t completed the test will be marked as incomplete.',
+    context: 'Description text on modal confirming ending of pre-test'
+  },
+  endPreTestForUnitConfirmation: {
+    message: 'End pre-test for unit {num, number}?',
+    context: 'Heading for confirmation modal when user clicks to end a pre-test',
+  },
+  startPreTestForUnitDescription: {
+    message: 'All assigned learners can now start the test. You can end the test whenever you want.',
+    context: 'Description text on modal confirming start of pre-test'
+  },
+  endPreTestForUnitDescription: {
+    message: 'This action cannot be undone. Learners who haven\'t completed the test will be marked as incomplete.',
+    context: 'Description text on modal confirming ending of pre-test'
+  },
+  keepRunning: {
+    message: 'Keep test running',
+    context: 'Label for button that cancels modal for ending test'
+  },
+  nOfMLearners: {
+    message: '{n, number} of {m, number} learners',
+    context: 'First part of label to be followed by a label "completed"',
+  },
+  workingOnLessons: {
+    message: 'working on lessons',
+    context: 'Placed after message "n of m learners" - separated like this for styling'
   },
 });

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -298,4 +298,8 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Post-test started for {title}',
     context: 'Snackbar message upon starting the post-test',
   },
+  numLearners: {
+    message: '{num, number} {num, plural, one {learner} other {learners}}',
+    context: 'Label showing a number of learners',
+  },
 });

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -233,7 +233,7 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   },
   endPostTestForUnitConfirmation: {
     message: 'End post-test for unit {num, number}?',
-    context: 'Heading for confirmation modal when user clicks to end a pre-test',
+    context: 'Heading for confirmation modal when user clicks to end a post-test',
   },
   startTestForUnitDescription: {
     message:

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -187,6 +187,7 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   markAsCompleteAction: {
     message: 'Mark as complete',
     context: 'Action label for marking a resource as complete',
+  },
   startPreTest: {
     message: 'Start pre-test',
     context: 'Button label for starting a pre-test',

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -146,14 +146,6 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: '{num, number} {num, plural, one {unit} other {units}}',
     context: 'Part of subtitle shown under the course title',
   },
-  prePercent: {
-    message: 'Pre: {num, number, percent}',
-    context: 'Indicating percentage of passing learners for the pre-test',
-  },
-  postPercent: {
-    message: 'Post: {num, number, percent}',
-    context: 'Indicating percentage of passing learners for the post-test',
-  },
   courseContentLabel: {
     message: 'Course content',
     context: 'Label above list of units in course contents listing',
@@ -256,11 +248,6 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   endPreTestForUnitConfirmation: {
     message: 'End pre-test for unit {num, number}?',
     context: 'Heading for confirmation modal when user clicks to end a pre-test',
-  },
-  startPreTestForUnitDescription: {
-    message:
-      'All assigned learners can now start the test. You can end the test whenever you want.',
-    context: 'Description text on modal confirming start of pre-test',
   },
   endPreTestForUnitDescription: {
     message:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

https://github.com/user-attachments/assets/2225c60b-b6ab-4779-ba35-3a2174a1c594


- Introduces useCourseSession composable for fetching/managing data needed to manage CourseSummaryPage UI
- Handles pre & post test activation workflow - you can activate/close the current unit's pre/post tests from start to finish
- Follows the [Figma](https://www.figma.com/design/MtmNfgSbx8xBlBBJOQmW9g/Pre--post-tests?node-id=3103-130798&t=rfePgsM6Z9k2bxjc-0) (mostly - some icons differ, some data isn't calculated yet)

### Questions and Things that don't work yet
#### Strings that are half-styled don't jive with i18n syntax

For example, I used the percentage strings because that's what ICU syntax provides, but then I can't style half bold the other half red such as the figma requires. There are a few others like `<b>n of m learners</b> completed unit 1` - we force the second half to be lowercase.

Should we just make a `Pre:` string so we can color the %'s?

#### Progress-tracking related stuff (not done yet)

- Color boxes thing is placeholder
- Number of learners who have completed vs not

## References
<!--
 * references to related issues and PRs
-->

Closes #14101 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### General flow

- Assign a course
- Click into the course using the link on the Courses listing page
- You can activate/deactivate the course assignment
- You can proceed through activating & deactivating the pre & post tests for all of the units in the course
- You should see appropriate messaging in all of the parts of the Figma screenshots in #14101 

#### Additional things to test

- The left panel has a part that says who is enrolled, see that it works correctly when you assign the course to a group, individual learners, or a mix of the two; or the entire class.
- Be mindful of the snackbar messaging that it shows appropriate messaging as you proceed through the workflow

### :point_right: In-Scope

Generally, the main things that are in scope here are:
- Can the coach activate all of the tests, end to end, and see the appropriate messaging throughout?
- Does the left panel look and work right? (the one w/ the 'activate' switch)

### :exclamation: Out-of-scope

- Most strings that calculate Course related or progress data (ie, "X of Y learners" or the learner progress information after a test is closed, for example)
- The accordions were not in scope, but they should generally work as expected 

