### PR TITLE
Implement new deseralization logic according to sync_filter 

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -349,11 +349,11 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         # by default, we'll use randomly generated source IDs; this can be overridden as desired
         return None
 
-    def clean_fields(self, *args, **kwargs):
+    def clean_fields(self, exclude=None, sync_filter=None):
         # ensure that we have, or can infer, a dataset for the model instance
         if not self.dataset_id:
             self.ensure_dataset(validating=True)
-        super().clean_fields(*args, **kwargs)
+        super().clean_fields(exclude=exclude, sync_filter=sync_filter)
 
     def full_clean(self, *args, **kwargs):
         kwargs["exclude"] = kwargs.get("exclude", []) + getattr(
@@ -915,13 +915,13 @@ class FacilityUser(AbstractBaseUser, KolibriBaseUserMixin, AbstractFacilityDataM
         return self.full_name.split(" ", 1)[0]
 
     @classmethod
-    def deserialize(cls, dict_model):
+    def deserialize(cls, dict_model, sync_filter=None):
         # be defensive against blank passwords, set to `NOT_SPECIFIED` if blank
         password = dict_model.get("password", "") or ""
         if len(password) == 0:
             dict_model.update(password=NOT_SPECIFIED)
 
-        return super().deserialize(dict_model)
+        return super().deserialize(dict_model, sync_filter=sync_filter)
 
     @classmethod
     def get_is_active_q(cls, relation_prefix=""):
@@ -1209,9 +1209,9 @@ class Collection(AbstractFacilityDataModel):
     def calculate_partition(self):
         return "{dataset_id}:allusers-ro".format(dataset_id=self.dataset_id)
 
-    def clean_fields(self, *args, **kwargs):
+    def clean_fields(self, exclude=None, sync_filter=None):
         self._ensure_kind()
-        super().clean_fields(*args, **kwargs)
+        super().clean_fields(exclude=exclude, sync_filter=sync_filter)
 
     def save(self, *args, **kwargs):
         self._ensure_kind()
@@ -1820,13 +1820,13 @@ class AdHocGroup(Collection):
         proxy = True
 
     @classmethod
-    def deserialize(cls, dict_model):
+    def deserialize(cls, dict_model, sync_filter=None):
         # be defensive against blank names, set to `Ad hoc` if blank
         name = dict_model.get("name", "") or ""
         if len(name) == 0:
             dict_model.update(name="Ad hoc")
 
-        return super().deserialize(dict_model)
+        return super().deserialize(dict_model, sync_filter=sync_filter)
 
     def save(self, *args, **kwargs):
         if not self.parent:

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -10,7 +10,6 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.utils.sync import ClassroomPartitionFactory
-from kolibri.core.device.utils import get_device_setting
 from kolibri.core.fields import DateTimeTzField
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
@@ -99,20 +98,22 @@ class CourseSession(AbstractFacilityDataModel):
         return str(filter_factory.build(classroom_collection.id))
 
     @classmethod
-    def deserialize(cls, dict_model):
-        """
-        Temporary hack to prevent deserialization of created_by_id
+    def deserialize(cls, dict_model, sync_filter=None):
 
-        A proper implementation should leverage the new sync_filter in the enhancement of
-        https://github.com/learningequality/morango/issues/281
-        """
-        # this needs to check both for the setup wizard, and another reason why this is better
-        # handled with logic based off the sync_filter
-        if get_device_setting("subset_of_users_device") or not get_device_setting(
-            "is_provisioned"
-        ):
-            del dict_model["created_by_id"]
-        return super().deserialize(dict_model)
+        if sync_filter is not None and "created_by_id" in dict_model:
+            created_by_id = dict_model["created_by_id"]
+            dataset_id = dict_model.get("dataset_id")
+            if created_by_id and dataset_id:
+                user_partition = f"{dataset_id}:user-ro:{created_by_id}"
+                super_partition = f"{dataset_id}"
+
+                if (
+                    user_partition not in sync_filter
+                    and super_partition not in sync_filter
+                ):
+                    del dict_model["created_by_id"]
+
+        return super().deserialize(dict_model, sync_filter=sync_filter)
 
 
 class CourseSessionAssignment(AbstractFacilityDataModel):
@@ -209,19 +210,21 @@ class CourseSessionAssignment(AbstractFacilityDataModel):
         return str(filter_factory.build(classroom_collection.id))
 
     @classmethod
-    def deserialize(cls, dict_model):
-        """
-        Temporary hack to prevent deserialization of assigned_by_id
+    def deserialize(cls, dict_model, sync_filter=None):
+        if sync_filter is not None and "assigned_by_id" in dict_model:
+            assigned_by_id = dict_model["assigned_by_id"]
+            dataset_id = dict_model.get("dataset_id")
+            if assigned_by_id and dataset_id:
+                user_partition = f"{dataset_id}:user-ro:{assigned_by_id}"
+                super_partition = f"{dataset_id}"
 
-        A proper implementation should leverage the new sync_filter in the enhancement of
-        https://github.com/learningequality/morango/issues/281
-        """
-        if get_device_setting("subset_of_users_device") or not get_device_setting(
-            "is_provisioned"
-        ):
-            del dict_model["assigned_by_id"]
-        return super().deserialize(dict_model)
+            if (
+                    user_partition not in sync_filter
+                    and super_partition not in sync_filter
+                ):
+                    del dict_model["assigned_by_id"]
 
+        return super().deserialize(dict_model, sync_filter=sync_filter)
 
 class UnitTestAssignment(AbstractFacilityDataModel):
     """
@@ -372,15 +375,18 @@ class UnitTestAssignment(AbstractFacilityDataModel):
             self.activated_by = None
 
     @classmethod
-    def deserialize(cls, dict_model):
-        """
-        For now lets implement a temporary hack to prevent deserialization of activated_by_id
+    def deserialize(cls, dict_model, sync_filter=None):
+        if sync_filter is not None and "activated_by_id" in dict_model:
+            activated_by_id = dict_model["activated_by_id"]
+            dataset_id = dict_model.get("dataset_id")
+            if activated_by_id and dataset_id:
+                user_partition = f"{dataset_id}:user-ro:{activated_by_id}"
+                super_partition = f"{dataset_id}"
 
-        A proper implementation should leverage the new sync_filter in the enhancement of
-        https://github.com/learningequality/morango/issues/281
-        """
-        if get_device_setting("subset_of_users_device") or not get_device_setting(
-            "is_provisioned"
-        ):
-            del dict_model["activated_by_id"]
-        return super().deserialize(dict_model)
+                if (
+                    user_partition not in sync_filter
+                    and super_partition not in sync_filter
+                ):
+                    del dict_model["activated_by_id"]
+
+        return super().deserialize(dict_model, sync_filter=sync_filter)

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -104,11 +104,13 @@ class CourseSession(AbstractFacilityDataModel):
             created_by_id = dict_model["created_by_id"]
             dataset_id = dict_model.get("dataset_id")
             if created_by_id and dataset_id:
-                user_partition = f"{dataset_id}:user-ro:{created_by_id}"
+                user_ro_partition = f"{dataset_id}:user-ro:{created_by_id}"
+                user_rw_partition = f"{dataset_id}:user-rw:{created_by_id}"
                 super_partition = f"{dataset_id}"
 
                 if (
-                    user_partition not in sync_filter
+                    user_ro_partition not in sync_filter
+                    and user_rw_partition not in sync_filter
                     and super_partition not in sync_filter
                 ):
                     del dict_model["created_by_id"]
@@ -215,11 +217,13 @@ class CourseSessionAssignment(AbstractFacilityDataModel):
             assigned_by_id = dict_model["assigned_by_id"]
             dataset_id = dict_model.get("dataset_id")
             if assigned_by_id and dataset_id:
-                user_partition = f"{dataset_id}:user-ro:{assigned_by_id}"
+                user_ro_partition = f"{dataset_id}:user-ro:{assigned_by_id}"
+                user_rw_partition = f"{dataset_id}:user-rw:{assigned_by_id}"
                 super_partition = f"{dataset_id}"
 
                 if (
-                    user_partition not in sync_filter
+                    user_ro_partition not in sync_filter
+                    and user_rw_partition not in sync_filter
                     and super_partition not in sync_filter
                 ):
                     del dict_model["assigned_by_id"]
@@ -381,11 +385,13 @@ class UnitTestAssignment(AbstractFacilityDataModel):
             activated_by_id = dict_model["activated_by_id"]
             dataset_id = dict_model.get("dataset_id")
             if activated_by_id and dataset_id:
-                user_partition = f"{dataset_id}:user-ro:{activated_by_id}"
+                user_ro_partition = f"{dataset_id}:user-ro:{activated_by_id}"
+                user_rw_partition = f"{dataset_id}:user-rw:{activated_by_id}"
                 super_partition = f"{dataset_id}"
 
                 if (
-                    user_partition not in sync_filter
+                    user_ro_partition not in sync_filter
+                    and user_rw_partition not in sync_filter
                     and super_partition not in sync_filter
                 ):
                     del dict_model["activated_by_id"]

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -218,13 +218,14 @@ class CourseSessionAssignment(AbstractFacilityDataModel):
                 user_partition = f"{dataset_id}:user-ro:{assigned_by_id}"
                 super_partition = f"{dataset_id}"
 
-            if (
+                if (
                     user_partition not in sync_filter
                     and super_partition not in sync_filter
                 ):
                     del dict_model["assigned_by_id"]
 
         return super().deserialize(dict_model, sync_filter=sync_filter)
+
 
 class UnitTestAssignment(AbstractFacilityDataModel):
     """

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -1,10 +1,11 @@
 import hashlib
 import uuid
-from unittest.mock import patch
 
 from django.db.utils import IntegrityError
 from django.test import SimpleTestCase
 from django.test import TestCase
+from mock import MagicMock
+from mock import patch
 from morango.models import Filter
 
 from .. import models
@@ -21,8 +22,6 @@ DUMMY_PASSWORD = "password"
 
 
 def _patch_base_deserialize_passthrough():
-    from unittest.mock import MagicMock
-
     from morango.models.core import SyncableModel
 
     def _passthrough(*args, **kwargs):
@@ -334,24 +333,23 @@ class BaseDeserializeSyncFilterMixin:
     def test_remove_when_out_of_scope(self):
         sync_filter = Filter(f"{self.dataset_id}:user-ro:{uuid.uuid4().hex}")
         dict_model = self.dict_model.copy()
+        expected_dict = {"dataset_id": self.dataset_id}
         out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
         self.assertNotIn(self.user_field_name, out)
-        self.mock_deserialize.assert_called_once()
-        call = self.mock_deserialize.call_args
-        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
-        passed_dict = call.args[0]
-        self.assertNotIn(self.user_field_name, passed_dict)
+        self.mock_deserialize.assert_called_once_with(
+            expected_dict,
+            sync_filter=sync_filter,
+        )
 
     def test_keep_when_user_ro_partition_in_scope(self):
         sync_filter = Filter(f"{self.dataset_id}:user-ro:{self.user_id}")
         dict_model = self.dict_model.copy()
         out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
         self.assertEqual(out[self.user_field_name], self.user_id)
-        self.mock_deserialize.assert_called_once()
-        call = self.mock_deserialize.call_args
-        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
-        passed_dict = call.args[0]
-        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
+        self.mock_deserialize.assert_called_once_with(
+            dict_model,
+            sync_filter=sync_filter,
+        )
 
     def test_keep_when_user_rw_partition_in_scope(self):
         """user-rw partition in scope (aligns with Morango write_filter) keeps the field."""
@@ -359,32 +357,30 @@ class BaseDeserializeSyncFilterMixin:
         dict_model = self.dict_model.copy()
         out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
         self.assertEqual(out[self.user_field_name], self.user_id)
-        self.mock_deserialize.assert_called_once()
-        call = self.mock_deserialize.call_args
-        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
-        passed_dict = call.args[0]
-        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
+        self.mock_deserialize.assert_called_once_with(
+            dict_model,
+            sync_filter=sync_filter,
+        )
 
     def test_keep_when_super_partition_in_scope(self):
         sync_filter = Filter(f"{self.dataset_id}")
         dict_model = self.dict_model.copy()
         out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
         self.assertEqual(out[self.user_field_name], self.user_id)
-        self.mock_deserialize.assert_called_once()
-        call = self.mock_deserialize.call_args
-        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
-        passed_dict = call.args[0]
-        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
+        self.mock_deserialize.assert_called_once_with(
+            dict_model,
+            sync_filter=sync_filter,
+        )
 
     def test_noop_when_user_field_missing(self):
         dict_model = {"dataset_id": self.dataset_id}
         sync_filter = Filter(f"{self.dataset_id}")
         out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
         self.assertEqual(out, {"dataset_id": self.dataset_id})
-        self.mock_deserialize.assert_called_once()
-        call = self.mock_deserialize.call_args
-        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
-        self.assertEqual(call.args[0], {"dataset_id": self.dataset_id})
+        self.mock_deserialize.assert_called_once_with(
+            {"dataset_id": self.dataset_id},
+            sync_filter=sync_filter,
+        )
 
 
 class CourseSessionDeserializeSyncFilterTestCase(

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -1,7 +1,9 @@
 import hashlib
 import uuid
+from unittest.mock import patch
 
 from django.db.utils import IntegrityError
+from django.test import SimpleTestCase
 from django.test import TestCase
 
 from .. import models
@@ -293,6 +295,183 @@ class UnitTestAssignmentModelTestCase(TestCase):
         self.assertIn(
             "collection must be the same as or a child of", str(context.exception)
         )
+
+
+def _patch_base_deserialize_passthrough():
+    from morango.models.core import SyncableModel
+
+    def _passthrough(cls, dict_model, sync_filter=None):
+        return dict_model
+
+    return patch.object(SyncableModel, "deserialize", classmethod(_passthrough))
+
+
+class CourseSessionDeserializeSyncFilterTestCase(SimpleTestCase):
+    def test_remove_created_by_id_when_out_of_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        created_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
+
+        self.assertNotIn("created_by_id", out)
+
+    def test_keeps_created_by_id_when_user_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        created_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{created_by_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
+
+        self.assertEqual(out["created_by_id"], created_by_id)
+
+    def test_keeps_created_by_id_when_super_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        created_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
+        sync_filter = Filter(f"{dataset_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
+
+        self.assertEqual(out["created_by_id"], created_by_id)
+
+    def test_noop_when_created_by_id_missing(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id}
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSession.deserialize(
+                dict_model, sync_filter=Filter(f"{dataset_id}")
+            )
+        self.assertEqual(out, {"dataset_id": dataset_id})
+
+
+class CourseSessionAssignmentDeserializeSyncFilterTestCase(SimpleTestCase):
+    def test_remove_assigned_by_id_when_out_of_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        assigned_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSessionAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertNotIn("assigned_by_id", out)
+
+    def test_keeps_assigned_by_id_when_user_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        assigned_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{assigned_by_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSessionAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertEqual(out["assigned_by_id"], assigned_by_id)
+
+    def test_keeps_assigned_by_id_when_super_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        assigned_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
+        sync_filter = Filter(f"{dataset_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSessionAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertEqual(out["assigned_by_id"], assigned_by_id)
+
+    def test_noop_when_assigned_by_id_missing(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id}
+        with _patch_base_deserialize_passthrough():
+            out = models.CourseSessionAssignment.deserialize(
+                dict_model, sync_filter=Filter(f"{dataset_id}")
+            )
+        self.assertEqual(out, {"dataset_id": dataset_id})
+
+
+class UnitTestAssignmentDeserializeSyncFilterTestCase(SimpleTestCase):
+    def test_remove_activated_by_id_when_out_of_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        activated_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.UnitTestAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertNotIn("activated_by_id", out)
+
+    def test_keeps_activated_by_id_when_user_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        activated_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
+        sync_filter = Filter(f"{dataset_id}:user-ro:{activated_by_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.UnitTestAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertEqual(out["activated_by_id"], activated_by_id)
+
+    def test_keeps_activated_by_id_when_super_partition_in_scope(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        activated_by_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
+        sync_filter = Filter(f"{dataset_id}")
+
+        with _patch_base_deserialize_passthrough():
+            out = models.UnitTestAssignment.deserialize(
+                dict_model, sync_filter=sync_filter
+            )
+
+        self.assertEqual(out["activated_by_id"], activated_by_id)
+
+    def test_noop_when_activated_by_id_missing(self):
+        from morango.models import Filter
+
+        dataset_id = uuid.uuid4().hex
+        dict_model = {"dataset_id": dataset_id}
+        with _patch_base_deserialize_passthrough():
+            out = models.UnitTestAssignment.deserialize(
+                dict_model, sync_filter=Filter(f"{dataset_id}")
+            )
+        self.assertEqual(out, {"dataset_id": dataset_id})
 
 
 class TestTypeEnumTestCase(TestCase):

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.db.utils import IntegrityError
 from django.test import SimpleTestCase
 from django.test import TestCase
+from morango.models import Filter
 
 from .. import models
 from ..models import TestStatus
@@ -17,6 +18,18 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 
 DUMMY_PASSWORD = "password"
+
+
+def _patch_base_deserialize_passthrough():
+    from unittest.mock import MagicMock
+
+    from morango.models.core import SyncableModel
+
+    def _passthrough(*args, **kwargs):
+        return args[0] if len(args) == 1 else args[1]
+
+    mock = MagicMock(side_effect=_passthrough)
+    return patch.object(SyncableModel, "deserialize", mock)
 
 
 class UnitTestAssignmentModelTestCase(TestCase):
@@ -297,181 +310,102 @@ class UnitTestAssignmentModelTestCase(TestCase):
         )
 
 
-def _patch_base_deserialize_passthrough():
-    from morango.models.core import SyncableModel
+class BaseDeserializeSyncFilterMixin:
+    """
+    Shared tests for model deserialize() sync_filter logic (remove/keep user id field).
+    Subclasses set model_class and user_field_name.
+    """
 
-    def _passthrough(cls, dict_model, sync_filter=None):
-        return dict_model
+    model_class = None
+    user_field_name = None
 
-    return patch.object(SyncableModel, "deserialize", classmethod(_passthrough))
+    def setUp(self):
+        super().setUp()
+        self.dataset_id = uuid.uuid4().hex
+        self.user_id = uuid.uuid4().hex
+        self.dict_model = {
+            "dataset_id": self.dataset_id,
+            self.user_field_name: self.user_id,
+        }
+        deserialize_patcher = _patch_base_deserialize_passthrough()
+        self.mock_deserialize = deserialize_patcher.start()
+        self.addCleanup(deserialize_patcher.stop)
 
+    def test_remove_when_out_of_scope(self):
+        sync_filter = Filter(f"{self.dataset_id}:user-ro:{uuid.uuid4().hex}")
+        dict_model = self.dict_model.copy()
+        out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
+        self.assertNotIn(self.user_field_name, out)
+        self.mock_deserialize.assert_called_once()
+        call = self.mock_deserialize.call_args
+        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
+        passed_dict = call.args[0]
+        self.assertNotIn(self.user_field_name, passed_dict)
 
-class CourseSessionDeserializeSyncFilterTestCase(SimpleTestCase):
-    def test_remove_created_by_id_when_out_of_scope(self):
-        from morango.models import Filter
+    def test_keep_when_user_ro_partition_in_scope(self):
+        sync_filter = Filter(f"{self.dataset_id}:user-ro:{self.user_id}")
+        dict_model = self.dict_model.copy()
+        out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
+        self.assertEqual(out[self.user_field_name], self.user_id)
+        self.mock_deserialize.assert_called_once()
+        call = self.mock_deserialize.call_args
+        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
+        passed_dict = call.args[0]
+        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
 
-        dataset_id = uuid.uuid4().hex
-        created_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
+    def test_keep_when_user_rw_partition_in_scope(self):
+        """user-rw partition in scope (aligns with Morango write_filter) keeps the field."""
+        sync_filter = Filter(f"{self.dataset_id}:user-rw:{self.user_id}")
+        dict_model = self.dict_model.copy()
+        out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
+        self.assertEqual(out[self.user_field_name], self.user_id)
+        self.mock_deserialize.assert_called_once()
+        call = self.mock_deserialize.call_args
+        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
+        passed_dict = call.args[0]
+        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
 
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
+    def test_keep_when_super_partition_in_scope(self):
+        sync_filter = Filter(f"{self.dataset_id}")
+        dict_model = self.dict_model.copy()
+        out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
+        self.assertEqual(out[self.user_field_name], self.user_id)
+        self.mock_deserialize.assert_called_once()
+        call = self.mock_deserialize.call_args
+        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
+        passed_dict = call.args[0]
+        self.assertEqual(passed_dict.get(self.user_field_name), self.user_id)
 
-        self.assertNotIn("created_by_id", out)
-
-    def test_keeps_created_by_id_when_user_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        created_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{created_by_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
-
-        self.assertEqual(out["created_by_id"], created_by_id)
-
-    def test_keeps_created_by_id_when_super_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        created_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "created_by_id": created_by_id}
-        sync_filter = Filter(f"{dataset_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSession.deserialize(dict_model, sync_filter=sync_filter)
-
-        self.assertEqual(out["created_by_id"], created_by_id)
-
-    def test_noop_when_created_by_id_missing(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id}
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSession.deserialize(
-                dict_model, sync_filter=Filter(f"{dataset_id}")
-            )
-        self.assertEqual(out, {"dataset_id": dataset_id})
-
-
-class CourseSessionAssignmentDeserializeSyncFilterTestCase(SimpleTestCase):
-    def test_remove_assigned_by_id_when_out_of_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        assigned_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSessionAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
-
-        self.assertNotIn("assigned_by_id", out)
-
-    def test_keeps_assigned_by_id_when_user_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        assigned_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{assigned_by_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSessionAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
-
-        self.assertEqual(out["assigned_by_id"], assigned_by_id)
-
-    def test_keeps_assigned_by_id_when_super_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        assigned_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "assigned_by_id": assigned_by_id}
-        sync_filter = Filter(f"{dataset_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSessionAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
-
-        self.assertEqual(out["assigned_by_id"], assigned_by_id)
-
-    def test_noop_when_assigned_by_id_missing(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id}
-        with _patch_base_deserialize_passthrough():
-            out = models.CourseSessionAssignment.deserialize(
-                dict_model, sync_filter=Filter(f"{dataset_id}")
-            )
-        self.assertEqual(out, {"dataset_id": dataset_id})
+    def test_noop_when_user_field_missing(self):
+        dict_model = {"dataset_id": self.dataset_id}
+        sync_filter = Filter(f"{self.dataset_id}")
+        out = self.model_class.deserialize(dict_model, sync_filter=sync_filter)
+        self.assertEqual(out, {"dataset_id": self.dataset_id})
+        self.mock_deserialize.assert_called_once()
+        call = self.mock_deserialize.call_args
+        self.assertEqual(call.kwargs.get("sync_filter"), sync_filter)
+        self.assertEqual(call.args[0], {"dataset_id": self.dataset_id})
 
 
-class UnitTestAssignmentDeserializeSyncFilterTestCase(SimpleTestCase):
-    def test_remove_activated_by_id_when_out_of_scope(self):
-        from morango.models import Filter
+class CourseSessionDeserializeSyncFilterTestCase(
+    BaseDeserializeSyncFilterMixin, SimpleTestCase
+):
+    model_class = models.CourseSession
+    user_field_name = "created_by_id"
 
-        dataset_id = uuid.uuid4().hex
-        activated_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{uuid.uuid4().hex}")
 
-        with _patch_base_deserialize_passthrough():
-            out = models.UnitTestAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
+class CourseSessionAssignmentDeserializeSyncFilterTestCase(
+    BaseDeserializeSyncFilterMixin, SimpleTestCase
+):
+    model_class = models.CourseSessionAssignment
+    user_field_name = "assigned_by_id"
 
-        self.assertNotIn("activated_by_id", out)
 
-    def test_keeps_activated_by_id_when_user_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        activated_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
-        sync_filter = Filter(f"{dataset_id}:user-ro:{activated_by_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.UnitTestAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
-
-        self.assertEqual(out["activated_by_id"], activated_by_id)
-
-    def test_keeps_activated_by_id_when_super_partition_in_scope(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        activated_by_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id, "activated_by_id": activated_by_id}
-        sync_filter = Filter(f"{dataset_id}")
-
-        with _patch_base_deserialize_passthrough():
-            out = models.UnitTestAssignment.deserialize(
-                dict_model, sync_filter=sync_filter
-            )
-
-        self.assertEqual(out["activated_by_id"], activated_by_id)
-
-    def test_noop_when_activated_by_id_missing(self):
-        from morango.models import Filter
-
-        dataset_id = uuid.uuid4().hex
-        dict_model = {"dataset_id": dataset_id}
-        with _patch_base_deserialize_passthrough():
-            out = models.UnitTestAssignment.deserialize(
-                dict_model, sync_filter=Filter(f"{dataset_id}")
-            )
-        self.assertEqual(out, {"dataset_id": dataset_id})
+class UnitTestAssignmentDeserializeSyncFilterTestCase(
+    BaseDeserializeSyncFilterMixin, SimpleTestCase
+):
+    model_class = models.UnitTestAssignment
+    user_field_name = "activated_by_id"
 
 
 class TestTypeEnumTestCase(TestCase):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.13
 jsonfield==3.1.0
-morango==0.8.6
+morango==0.8.7
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
- Bump Morango to v0.8.7 so Kolibri can use the new sync filter support during sync.
- Update course models so `created_by / assigned_by` user IDs are only cleared when the current sync filter would not bring those users to the device, instead of relying on generic device flags.
-  Adjust existing `deserialize / clean_fields `overrides to accept and pass through the new sync_filter argument without changing their current logic.

## References
-  closes #14129

## Reviewer guidance
- Confirm that all model deserialize overrides that we changed now accept `sync_filter`.
