### PR TITLE
Add confirmation modal to prevent accidental closure of Course Assignment Side Panel

### DIFF
--- a/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
+++ b/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
@@ -82,6 +82,10 @@ export default function useAssignCourse({ classId }) {
   provide('assignCourseSelectedLearnerIds', selectedLearnerIds);
   provide('assignCourseSelectCourse', selectCourse);
   provide('assignCourseAssignCourse', assignCourse);
+
+  return {
+    selectedCourse,
+  };
 }
 
 /**

--- a/kolibri/plugins/coach/frontend/views/courses/modals/CloseConfirmationModal.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/modals/CloseConfirmationModal.vue
@@ -1,0 +1,116 @@
+<template>
+
+  <div>
+    <KModal
+      v-if="isConfirmationModalOpen"
+      appendToOverlay
+      :submitText="coreString('continueAction')"
+      :cancelText="coreString('cancelAction')"
+      :title="closeConfirmationTitle$()"
+      @cancel="onCancel"
+      @submit="onClose"
+    >
+      <span class="fix-line-height">
+        {{ closeConfirmationMessage$() }}
+      </span>
+    </KModal>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { onMounted, onUnmounted, ref } from 'vue';
+  import { useRouter } from 'vue-router/composables';
+  import { coreString } from 'kolibri/uiText/commonCoreStrings';
+  import { coachStrings } from '../../common/commonCoachStrings';
+
+  /**
+   * This component is used to show a confirmation modal when the user tries to
+   * close the page (by leaving the route) with unsaved changes.
+   */
+  export default {
+    name: 'CloseConfirmationModal',
+    setup(props) {
+      const router = useRouter();
+      const isConfirmationModalOpen = ref(false);
+      const closeConfirmationToRoute = ref(null);
+
+      const onClose = () => {
+        if (closeConfirmationToRoute.value) {
+          return router.push(closeConfirmationToRoute.value);
+        }
+        isConfirmationModalOpen.value = false;
+      };
+
+      const onCancel = () => {
+        isConfirmationModalOpen.value = false;
+        closeConfirmationToRoute.value = null;
+      };
+
+      const { closeConfirmationTitle$, closeConfirmationMessage$ } = coachStrings;
+
+      const beforeUnload = event => {
+        if (props.hasUnsavedChanges) {
+          if (!window.confirm(props.title)) {
+            event.preventDefault();
+          }
+        }
+      };
+
+      onMounted(() => {
+        window.addEventListener('beforeunload', beforeUnload);
+      });
+
+      onUnmounted(() => {
+        window.removeEventListener('beforeunload', beforeUnload);
+      });
+
+      const beforeRouteLeave = (to, from, next) => {
+        if (props.hasUnsavedChanges && !closeConfirmationToRoute.value) {
+          isConfirmationModalOpen.value = true;
+          closeConfirmationToRoute.value = to;
+          next(false);
+        } else {
+          next();
+        }
+      };
+
+      return {
+        isConfirmationModalOpen,
+        onClose,
+        onCancel,
+        closeConfirmationTitle$,
+        closeConfirmationMessage$,
+        coreString,
+
+        /**
+         * BeforeRouteLeave guard to show confirmation modal made public so that
+         * parent components that are route components can use it on their
+         * beforeRouteLeave guard.
+         * @public
+         */
+        beforeRouteLeave,
+      };
+    },
+    props: {
+      hasUnsavedChanges: {
+        type: Boolean,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .fix-line-height {
+    // Override default global line-height of 1.15 which is not enough
+    // space for single lines content modal and makes scrollbar appear.
+    line-height: 1.5;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
@@ -9,6 +9,10 @@
       @closePanel="closeSidePanel"
       @success="onSuccess"
     />
+    <CloseConfirmationModal
+      ref="closeConfirmationGuardRef"
+      :hasUnsavedChanges="hasUnsavedChanges"
+    />
   </SidePanelModal>
 
 </template>
@@ -17,11 +21,13 @@
 <script>
 
   import { useRoute, useRouter } from 'vue-router/composables';
-  import { computed } from 'vue';
+  import { computed, ref, nextTick } from 'vue';
+  import { isNavigationFailure, NavigationFailureType } from 'vue-router';
   import SidePanelModal from 'kolibri-common/components/courses/sidePanel/SidePanelModal';
   import { CoursesModals, PageNames } from '../../../../constants';
   import { overrideRoute } from '../../../../utils';
   import useAssignCourse from '../../composables/useAssignCourse';
+  import CloseConfirmationModal from '../../modals/CloseConfirmationModal.vue';
 
   /**
    * This component will serve as the root component for the
@@ -44,27 +50,48 @@
     name: 'AssignCourseSidePanel',
     components: {
       SidePanelModal,
+      CloseConfirmationModal,
     },
     setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
 
       const classId = computed(() => route.params.classId);
-      useAssignCourse({ classId });
+      const { selectedCourse } = useAssignCourse({ classId });
+
+      const isFinished = ref(false);
+
+      const hasUnsavedChanges = computed(() => {
+        // If course assignment process is finished, don't show confirmation
+        if (isFinished.value) {
+          return false;
+        }
+        return selectedCourse.value != null;
+      });
 
       const closeSidePanel = () => {
-        router.push(overrideRoute(route, { name: PageNames.COURSES_ROOT }));
+        router.push(overrideRoute(route, { name: PageNames.COURSES_ROOT })).catch(e => {
+          if (!isNavigationFailure(e, NavigationFailureType.aborted)) {
+            throw Error(e);
+          }
+        });
       };
 
-      const onSuccess = () => {
+      const onSuccess = async () => {
+        isFinished.value = true;
+        await nextTick();
         closeSidePanel();
         emit('showModal', CoursesModals.ASSIGN_COURSE_SUCCESS);
         emit('refreshData');
       };
       return {
+        hasUnsavedChanges,
         closeSidePanel,
         onSuccess,
       };
+    },
+    beforeRouteLeave(to, from, next) {
+      this.$refs.closeConfirmationGuardRef?.beforeRouteLeave(to, from, next);
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
This pull requests adds a confirmation modal to `AssignCourseSidePanel` so that while selecting and assigning a course, accidentally clicking outside of the panel won't close the side panel.


https://github.com/user-attachments/assets/a8e54a72-344d-40fd-98f0-60b11fe98a28


## References
<!--
 * references to related issues and PRs
-->
Closes #14140 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go to Coach > Courses and attempt to assign a course.
2. Click outside of the side panel to see the confirmation modal.