### PR TITLE
Add browser smoke test to PR build workflow

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -109,6 +109,15 @@ async function generateAssetComment(github, context) {
       text += `\n| ${readableName} | [${artifact.name}](${repoHtmlUrl}/suites/${checkSuiteNumber}/artifacts/${artifact.id.toString()}) |`
     }
   }
+
+  const screenshotArtifact = artifacts.find(
+    (artifact) => artifact.name === 'smoke_test_screenshot' && !artifact.expired
+  )
+  if (screenshotArtifact) {
+    const screenshotUrl = `${repoHtmlUrl}/suites/${checkSuiteNumber}/artifacts/${screenshotArtifact.id.toString()}`
+    text += `\n\n<details>\n<summary>Smoke test screenshot</summary>\n\n[Download screenshot](${screenshotUrl})\n\n</details>`
+  }
+
   return text
 }
 

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -66,6 +66,40 @@ jobs:
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
       ref: v1.0.0
+  browser_smoke_test:
+    name: Browser smoke test
+    needs: whl
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ needs.whl.outputs.whl-file-name }}
+          path: dist
+      - name: Install WHL file
+        run: pip install dist/${{ needs.whl.outputs.whl-file-name }}
+      - name: Install Playwright
+        run: |
+          pip install "playwright<2"
+          playwright install --with-deps chromium
+      - name: Run browser smoke test
+        env:
+          KOLIBRI_HOME: ${{ runner.temp }}/kolibri_home
+          SCREENSHOT_PATH: ${{ runner.temp }}/smoke_test_screenshot.png
+        working-directory: ${{ runner.temp }}
+        run: python ${{ github.workspace }}/integration_testing/smoke_test.py
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: smoke_test_screenshot
+          path: ${{ runner.temp }}/smoke_test_screenshot.png
+          if-no-files-found: ignore
   test_whl_file:
     name: Test WHL file
     needs: whl

--- a/integration_testing/smoke_test.py
+++ b/integration_testing/smoke_test.py
@@ -1,0 +1,136 @@
+"""
+Browser smoke test for Kolibri.
+
+Starts Kolibri, navigates the "On my own" setup wizard using Playwright,
+and takes a screenshot of the post-setup landing page.
+
+Environment variables:
+    KOLIBRI_HOME: Path to Kolibri home directory (optional)
+    KOLIBRI_PORT: Port to run Kolibri on (default: 8080)
+    SCREENSHOT_PATH: Path to save the screenshot (default: screenshot.png)
+"""
+import logging
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import sync_playwright
+
+logger = logging.getLogger(__name__)
+
+KOLIBRI_PORT = os.environ.get("KOLIBRI_PORT", "8080")
+KOLIBRI_URL = f"http://localhost:{KOLIBRI_PORT}"
+STARTUP_TIMEOUT = 120  # seconds to wait for Kolibri to start
+SCREENSHOT_PATH = os.environ.get("SCREENSHOT_PATH", "screenshot.png")
+
+
+def wait_for_kolibri(process, timeout=STARTUP_TIMEOUT):
+    """Wait for Kolibri server to become accessible."""
+    start = time.time()
+    while time.time() - start < timeout:
+        ret = process.poll()
+        if ret is not None:
+            raise RuntimeError(f"Kolibri process exited prematurely with code {ret}")
+        try:
+            urllib.request.urlopen(KOLIBRI_URL, timeout=5)
+            return
+        except (urllib.error.URLError, ConnectionError, OSError):
+            time.sleep(2)
+    raise TimeoutError(f"Kolibri did not start within {timeout} seconds")
+
+
+def run_smoke_test():
+    """Start Kolibri and navigate the setup wizard."""
+    # Start Kolibri as a subprocess, inheriting stdout/stderr so CI captures logs
+    kolibri_process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "kolibri",
+            "start",
+            "--foreground",
+            f"--port={KOLIBRI_PORT}",
+        ],
+    )
+
+    try:
+        logger.info("Waiting for Kolibri to start...")
+        wait_for_kolibri(kolibri_process)
+        logger.info("Kolibri is ready.")
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+
+            try:
+                # Navigate to Kolibri
+                page.goto(KOLIBRI_URL, wait_until="domcontentloaded")
+                logger.info(f"Loaded: {page.url}")
+
+                # Step 1: "How are you using Kolibri?" — "On my own" is pre-selected
+                page.get_by_role("button", name="Continue").click()
+                logger.info("Step 1: Clicked Continue (How are you using Kolibri?)")
+
+                # Wait for the language selection step to appear via URL
+                page.wait_for_url(lambda url: "default-language" in url, timeout=30000)
+                # Step 2: "Please select the default language for Kolibri" — English is default
+                page.get_by_role("button", name="Continue").click()
+                logger.info("Step 2: Clicked Continue (Default language)")
+
+                # Wait for the credentials form to appear
+                page.get_by_label("Full name").wait_for(state="visible")
+                # Step 3: "Create super admin" — fill credentials
+                page.get_by_label("Full name").fill("Smoke Test Admin")
+                page.get_by_label("Username").fill("admin")
+                page.get_by_label("Password", exact=True).fill("test1234")
+                page.get_by_label("Re-enter password").fill("test1234")
+                page.get_by_role("button", name="Continue").click()
+                logger.info("Step 3: Filled credentials and clicked Continue")
+
+                # Step 4: "Setting up Kolibri" — wait for redirect to the learn page
+                page.wait_for_url(
+                    lambda url: "/learn" in url,
+                    timeout=60000,
+                )
+                # Wait for the page to fully load (all resources including CSS/JS)
+                page.wait_for_load_state("load")
+                # Wait for the Library page to finish loading.
+                # The "nothing in library" label only renders after loading
+                # completes on a fresh install with no imported channels.
+                page.locator('[data-test="nothing-in-lib-label"]').wait_for(
+                    state="visible", timeout=30000
+                )
+                logger.info(f"Setup complete, landed on: {page.url}")
+
+                # Take screenshot of the post-setup landing page
+                page.screenshot(path=SCREENSHOT_PATH, full_page=False)
+                logger.info(f"Screenshot saved to {SCREENSHOT_PATH}")
+
+            except PlaywrightError as e:
+                # Take a screenshot of whatever state we're in for debugging
+                try:
+                    page.screenshot(path=SCREENSHOT_PATH, full_page=False)
+                    logger.info(f"Error screenshot saved to {SCREENSHOT_PATH}")
+                except Exception:
+                    pass
+                raise e
+            finally:
+                browser.close()
+
+    finally:
+        kolibri_process.terminate()
+        try:
+            kolibri_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            kolibri_process.kill()
+            kolibri_process.wait()
+        logger.info("Kolibri process stopped.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    run_smoke_test()


### PR DESCRIPTION
## Summary

Adds a Playwright-based browser smoke test that runs as part of the PR build workflow. After the WHL is built, the test:
- Installs the WHL and Playwright (Chromium)
- Starts Kolibri and navigates the "On my own" setup wizard
- Takes a screenshot of the post-setup landing page
- Uploads the screenshot as an artifact, linked in the PR build comment

Verified locally by running the smoke test against a dev build — navigated all wizard steps and produced a screenshot of the Learn page.

| Screenshot |
|------------|
| ![Smoke test screenshot](https://i.imgur.com/bIAEkNq.png) |

## References

N/A — this is new CI infrastructure with no related issues.

## Reviewer guidance

- **`integration_testing/smoke_test.py`** — the core test script. Key areas:
  - `wait_for_kolibri()` checks `process.poll()` each iteration to fail fast if Kolibri crashes on startup rather than waiting the full 120s timeout
  - Wizard step transitions use `wait_for_url()` with step-specific URL paths (e.g. `default-language`) to avoid race conditions between steps that share a "Continue" button
  - Waits for `[data-test="nothing-in-lib-label"]` to confirm the Library page has finished loading before taking the screenshot
- **`.github/workflows/pr_build_kolibri.yml`** — the new `browser_smoke_test` job. Depends on the `whl` job and has a 10-minute timeout
- **`.github/githubUtils.js`** — adds the screenshot artifact link to the PR build comment inside a collapsible `<details>` block

---

🤖 Created with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.6), with repeated rounds of code review, iteration, and local testing.