### PR TITLE
Fix The 'Recipients' drop-down to show groups list

### DIFF
--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -416,7 +416,7 @@
     },
     computed: {
       learnerGroups() {
-        return this.$store.getters.groups || [];
+        return this.$store.getters['classSummary/groups'] || [];
       },
       classId() {
         return this.$store.state.classSummary.id;


### PR DESCRIPTION

## Summary
This PR fixes the Recipient drop-down to show groups list .
Fixes https://github.com/learningequality/kolibri/issues/14141
 ### Before 
https://private-user-images.githubusercontent.com/79847249/547179836-951f38ba-0c43-48bd-a38e-a6645e09b44a.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA4MzY3NzAsIm5iZiI6MTc3MDgzNjQ3MCwicGF0aCI6Ii83OTg0NzI0OS81NDcxNzk4MzYtOTUxZjM4YmEtMGM0My00OGJkLWEzOGUtYTY2NDVlMDliNDRhLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjExVDE5MDExMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWIwNjNkZjUxZDJmZTcyNzkyMmFhNjk0MzcwMjMzY2U5NTkyYmUwMzY1N2EwNjY1NGZmNTVmMGU0ZjkyYjAxYjgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.WjpEWWe0t-zqxEjdVcuk_0BuiWoIo1ir216-WO8JSWk
 ### After 

https://github.com/user-attachments/assets/5cc7576d-428a-431b-b46f-615050c99a9b
## References

https://github.com/learningequality/kolibri/issues/14141

## Reviewer guidance
Go to Coach > Courses and assign a course to a group and try to filter by recipients.