### PR TITLE
Fixes TypeError on clicking 'Select recipients' from the course details page.

### DIFF
--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
@@ -219,6 +219,9 @@
       });
 
       const selectRecipients = () => {
+        if (selectCourse && course.value) {
+          selectCourse(course.value);
+        }
         router.push(
           overrideRoute(route, {
             name: PageNames.COURSES_ASSIGN_SELECT_RECIPIENTS,
@@ -238,9 +241,6 @@
       ContentNodeResource.fetchTree({ id: route.params.courseId })
         .then(results => {
           course.value = results;
-          if (selectCourse) {
-            selectCourse(results);
-          }
           loading.value = false;
         })
         .catch(() => {

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
@@ -147,6 +147,7 @@
         />
         <KButton
           primary
+          :disabled="loading || !course"
           :text="selectRecipientsLabel$()"
           @click="selectRecipients"
         />
@@ -175,6 +176,7 @@
   import { overrideRoute } from '../../../../../utils';
   import { PageNames } from '../../../../../constants';
   import { coachStrings } from '../../../../../views/common/commonCoachStrings';
+  import { injectAssignCourse } from '../../../composables/useAssignCourse';
 
   export default {
     name: 'CourseDetailsSubpage',
@@ -203,6 +205,8 @@
       const { expandAll$, collapseAll$ } = enhancedQuizManagementStrings;
 
       const { numberOfResources$ } = coachStrings;
+
+      const { selectCourse } = injectAssignCourse();
 
       const course = ref(null);
       const units = computed(() => course.value?.children?.results);
@@ -234,6 +238,9 @@
       ContentNodeResource.fetchTree({ id: route.params.courseId })
         .then(results => {
           course.value = results;
+          if (selectCourse) {
+            selectCourse(results);
+          }
           loading.value = false;
         })
         .catch(() => {

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
@@ -3,7 +3,7 @@
   <SidePanelLayout
     :goBack="goBack"
     :title="selectRecipientsLabel$()"
-    :subtitle="courseNameLabel$({ name: selectedCourse.title })"
+    :subtitle="courseNameLabel$({ name: selectedCourseTitle })"
   >
     <template #default>
       <LearnersAndGroupsSelector
@@ -68,6 +68,8 @@
       const { backAction$, defaultErrorMessage$ } = coreStrings;
       const { courseNameLabel$, assignCourseAction$, selectRecipientsLabel$ } = coursesStrings;
 
+      const selectedCourseTitle = computed(() => selectedCourse.value?.title || '');
+
       const goBack = () => {
         router.push(
           overrideRoute(route, {
@@ -104,9 +106,9 @@
       return {
         isSaving,
         classId,
-        selectedCourse,
         selectedGroupIds,
         selectedLearnerIds,
+        selectedCourseTitle,
         isAssignButtonDisabled,
 
         goBack,


### PR DESCRIPTION


## Summary
This PR fixes TypeError on clicking 'Select recipients' from the course details page to assign.
closes https://github.com/learningequality/kolibri/issues/14138


#### Before
<img width="1544" height="1078" alt="image" src="https://github.com/user-attachments/assets/c9f49af7-4dea-4b57-9507-e9fa8f0cf813" />

#### After

https://github.com/user-attachments/assets/add97add-fbaa-415c-b657-780351c51301



## References

#https://github.com/learningequality/kolibri/issues/14138

## Reviewer guidance
Go to Coach > Courses and attempt to assign a course from within the course details page
