### PR TITLE
Migrate plugin tests to Vue Testing Library

### DIFF
--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -171,7 +171,6 @@
     </KPageContainer>
 
     <BottomAppBar
-      data-test="bottom-bar"
       data-testid="bottom-bar"
     >
       <KButton

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -3,6 +3,7 @@
   <FacilityAppBarPage>
     <KPageContainer
       data-test="page-container"
+      data-testid="page-container"
       :style="{ marginBottom: '42px' }"
     >
       <p>
@@ -169,7 +170,10 @@
       />
     </KPageContainer>
 
-    <BottomAppBar data-test="bottom-bar">
+    <BottomAppBar
+      data-test="bottom-bar"
+      data-testid="bottom-bar"
+    >
       <KButton
         v-if="!isAppContext"
         :primary="true"

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -170,9 +170,7 @@
       />
     </KPageContainer>
 
-    <BottomAppBar
-      data-testid="bottom-bar"
-    >
+    <BottomAppBar data-testid="bottom-bar">
       <KButton
         v-if="!isAppContext"
         :primary="true"

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
@@ -1,7 +1,6 @@
-import { mount } from '@vue/test-utils';
-import { Store } from 'vuex';
+import { render, screen } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import FacilityAppBarPage from '../FacilityAppBarPage';
 
@@ -18,55 +17,57 @@ function makeWrapper({ propsData = {}, getters = {} }) {
 }
 jest.mock('kolibri/urls');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
-jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri-common/composables/useFacilities');
+jest.mock('kolibri/components/pages/AppBarPage', () => ({
+  name: 'AppBarPage',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+  render(h) {
+    return h('div', [
+      h('h1', this.title),
+      this.$scopedSlots.default ? this.$scopedSlots.default({ pageContentHeight: 600 }) : null,
+    ]);
+  },
+}));
+
+function renderPage(props = {}) {
+  return render(FacilityAppBarPage, { props });
+}
 
 describe('FacilityAppBarPage', function () {
   beforeEach(() => {
-    useUser.mockImplementation(() => useUserMock());
     useFacilities.mockImplementation(() => useFacilitiesMock());
   });
-  beforeAll(() => {
+  beforeEach(() => {
     useKResponsiveWindow.mockImplementation(() => ({
       windowIsSmall: false,
     }));
   });
-  it('renders the AppBar component', () => {
-    const wrapper = makeWrapper({});
-    expect(wrapper.findComponent({ name: 'AppBar' }).exists()).toBe(true);
+
+  it('shows the page title passed by the parent page', () => {
+    renderPage({ appBarTitle: 'Facility settings' });
+    expect(screen.getByRole('heading', { name: 'Facility settings' })).toBeInTheDocument();
   });
-  describe('the title computed property', () => {
-    it('should return the value of appBarTitle prop when provided', () => {
-      const appBarTitle = 'appBarTitle';
-      const wrapper = makeWrapper({ propsData: { appBarTitle } });
-      expect(wrapper.vm.title).toBe(appBarTitle);
-    });
-    describe('the user is an admin of multiple facilities, and a current facility name is defined', () => {
-      it("should return the string 'Facility – ' with the current facility name", () => {
-        useFacilities.mockImplementation(() =>
-          useFacilitiesMock({
-            userIsMultiFacilityAdmin: true,
-            currentFacilityName: 'currentFacilityName',
-          }),
-        );
-        const wrapper = makeWrapper({
-          propsData: { appBarTitle: null },
-        });
-        const expectedTitle = 'Facility – currentFacilityName';
-        expect(wrapper.vm.title).toBe(expectedTitle);
-      });
-    });
+
+  it('shows the current facility name for multi-facility admins', () => {
+    useFacilities.mockImplementation(() =>
+      useFacilitiesMock({
+        userIsMultiFacilityAdmin: true,
+        currentFacilityName: 'Sunrise School',
+      }),
+    );
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Facility – Sunrise School' })).toBeInTheDocument();
   });
-  describe('the user is not an admin of multiple facilities', () => {
-    it('should return the value of appBarTitle prop when provided', () => {
-      useUser.mockImplementation(() =>
-        useUserMock({
-          userIsMultiFacilityAdmin: false,
-          currentFacilityName: 'currentFacilityName',
-        }),
-      );
-      const wrapper = makeWrapper({});
-      expect(wrapper.vm.title).toBe('Facility');
-    });
+
+  it('shows the default facility title for single-facility admins', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Facility' })).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
@@ -4,17 +4,6 @@ import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResp
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import FacilityAppBarPage from '../FacilityAppBarPage';
 
-function makeWrapper({ propsData = {}, getters = {} }) {
-  const store = new Store(getters);
-  store.getters = {
-    isPageLoading: false,
-    ...getters,
-  };
-  return mount(FacilityAppBarPage, {
-    propsData,
-    store,
-  });
-}
 jest.mock('kolibri/urls');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
 jest.mock('kolibri-common/composables/useFacilities');

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -73,9 +73,9 @@ describe('facility config page view', () => {
 
   describe(`in the browser mode`, () => {
     it(`shows Save changes in the bottom app bar`, () => {
-      const { container } = renderPage({ isAppContext: false });
-      const bottomBar = container.querySelector('[data-test="bottom-bar"]');
-      const pageContainer = container.querySelector('[data-test="page-container"]');
+      renderPage({ isAppContext: false });
+      const bottomBar = screen.getByTestId('bottom-bar');
+      const pageContainer = screen.getByTestId('page-container');
       expect(within(bottomBar).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
       expect(within(pageContainer).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
     });
@@ -83,9 +83,9 @@ describe('facility config page view', () => {
 
   describe(`in the Android app mode`, () => {
     it(`shows Save changes in the page content instead of the bottom app bar`, () => {
-      const { container } = renderPage({ isAppContext: true });
-      const bottomBar = container.querySelector('[data-test="bottom-bar"]');
-      const pageContainer = container.querySelector('[data-test="page-container"]');
+      renderPage({ isAppContext: true });
+      const bottomBar = screen.getByTestId('bottom-bar');
+      const pageContainer = screen.getByTestId('page-container');
       expect(within(bottomBar).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
       expect(within(pageContainer).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
     });

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent, within } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line
 import ConfigPage from '../FacilityConfigPage';
@@ -9,37 +10,41 @@ jest.mock('../../../../device/frontend/views/DeviceSettingsPage/api.js', () => (
   getDeviceSettings: jest.fn(),
 }));
 jest.mock('kolibri/composables/useSnackbar');
+jest.mock('../FacilityAppBarPage', () => ({
+  name: 'FacilityAppBarPage',
+  render(h) {
+    return h('div', this.$slots.default);
+  },
+}));
 
-function makeWrapper(propsData = {}) {
+function renderPage({ props = {}, isAppContext = false } = {}) {
+  useUser.mockImplementation(() => useUserMock({ isAppContext }));
   const store = makeStore();
   store.commit('facilityConfig/SET_STATE', {
     settings: {
       learner_can_edit_username: false,
+      learner_can_edit_password: false,
+      learner_can_edit_name: false,
+      learner_can_sign_up: false,
+      learner_can_login_with_no_password: false,
+      show_download_button_in_learn: false,
     },
   });
-  return mount(ConfigPage, { propsData, store, stubs: ['FacilityAppBarPage'] });
-}
-
-function getElements(wrapper) {
-  return {
-    checkbox: () => wrapper.find('input[class="k-checkbox-input"]'),
-    saveButton: () => wrapper.find('button[name="save-settings"]'),
-    form: () => wrapper.find('form'),
-    bottomBar: () => wrapper.find('[data-test="bottom-bar"]'),
-    pageContainer: () => wrapper.find('[data-test="page-container"]'),
-  };
+  const dispatch = jest.spyOn(store, 'dispatch');
+  const utils = render(ConfigPage, { props, store });
+  return { ...utils, store, dispatch };
 }
 
 describe('facility config page view', () => {
   const createSnackbar = jest.fn();
-  beforeAll(() => {
+  beforeEach(() => {
     useSnackbar.mockImplementation(() => useSnackbarMock({ createSnackbar }));
+    useUser.mockImplementation(() => useUserMock({ isAppContext: false }));
+    createSnackbar.mockReset();
   });
 
-  it('has all of the settings', () => {
-    const wrapper = makeWrapper();
-    const checkboxes = wrapper.findAllComponents({ name: 'KCheckbox' });
-    expect(checkboxes.length).toEqual(6);
+  it('shows all facility setting checkboxes to the admin', () => {
+    renderPage();
     const labels = [
       'Allow learners to edit their username',
       'Allow learners to edit their full name',
@@ -48,65 +53,41 @@ describe('facility config page view', () => {
       'Allow learners to edit their password when signed in',
       "Show 'download' button with resources",
     ];
-    labels.forEach((label, idx) => {
-      expect(checkboxes.at(idx).props().label).toEqual(label);
+    labels.forEach(label => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
   });
 
-  it('clicking checkboxes dispatches a modify action', () => {
-    const wrapper = makeWrapper();
-    const { checkbox } = getElements(wrapper);
-    checkbox().trigger('click');
-    expect(wrapper.vm.$store.state.facilityConfig.settings.learner_can_edit_username).toEqual(true);
+  it('updates a facility setting when the admin toggles a checkbox', async () => {
+    const { store } = renderPage();
+    await fireEvent.click(screen.getByLabelText('Allow learners to edit their username'));
+    expect(store.state.facilityConfig.settings.learner_can_edit_username).toBe(true);
   });
 
-  it('clicking save button dispatches a save action', async () => {
-    const wrapper = makeWrapper();
-    const mock = (wrapper.vm.$store.dispatch = jest.fn().mockResolvedValue());
-    const { saveButton } = getElements(wrapper);
-    saveButton().trigger('click');
-    expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenCalledWith('facilityConfig/saveFacilityConfig');
+  it('saves changes when the admin clicks Save changes', async () => {
+    const { dispatch } = renderPage();
+    dispatch.mockResolvedValue();
+    await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    expect(dispatch).toHaveBeenCalledWith('facilityConfig/saveFacilityConfig');
   });
 
   describe(`in the browser mode`, () => {
-    let wrapper;
-    beforeAll(() => {
-      useUser.mockImplementation(() => useUserMock({ isAppContext: false }));
-      wrapper = makeWrapper();
-    });
-
-    it(`save button is in the bottom bar`, () => {
-      const { bottomBar } = getElements(wrapper);
-      const { saveButton } = getElements(bottomBar());
-      expect(saveButton().exists()).toBeTruthy();
-    });
-
-    it(`save button isn't in the page container`, () => {
-      const { pageContainer } = getElements(wrapper);
-      const { saveButton } = getElements(pageContainer());
-      expect(saveButton().exists()).toBeFalsy();
+    it(`shows Save changes in the bottom app bar`, () => {
+      const { container } = renderPage({ isAppContext: false });
+      const bottomBar = container.querySelector('[data-test="bottom-bar"]');
+      const pageContainer = container.querySelector('[data-test="page-container"]');
+      expect(within(bottomBar).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+      expect(within(pageContainer).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
     });
   });
 
   describe(`in the Android app mode`, () => {
-    let wrapper;
-    beforeAll(() => {
-      useUser.mockImplementation(() => useUserMock({ isAppContext: true }));
-      wrapper = makeWrapper();
-    });
-
-    it(`save button is not in the bottom bar`, () => {
-      const { bottomBar } = getElements(wrapper);
-      const { saveButton } = getElements(bottomBar());
-      expect(saveButton().exists()).toBeFalsy();
-    });
-
-    it(`save button is in the page container`, () => {
-      const { pageContainer } = getElements(wrapper);
-      const { saveButton } = getElements(pageContainer());
-      expect(saveButton().exists()).toBeTruthy();
+    it(`shows Save changes in the page content instead of the bottom app bar`, () => {
+      const { container } = renderPage({ isAppContext: true });
+      const bottomBar = container.querySelector('[data-test="bottom-bar"]');
+      const pageContainer = container.querySelector('[data-test="page-container"]');
+      expect(within(bottomBar).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+      expect(within(pageContainer).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
     });
   });
-  // not tested: notifications
 });

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -77,7 +77,9 @@ describe('facility config page view', () => {
       const bottomBar = screen.getByTestId('bottom-bar');
       const pageContainer = screen.getByTestId('page-container');
       expect(within(bottomBar).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
-      expect(within(pageContainer).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+      expect(
+        within(pageContainer).queryByRole('button', { name: 'Save changes' }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -86,8 +88,12 @@ describe('facility config page view', () => {
       renderPage({ isAppContext: true });
       const bottomBar = screen.getByTestId('bottom-bar');
       const pageContainer = screen.getByTestId('page-container');
-      expect(within(bottomBar).queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
-      expect(within(pageContainer).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+      expect(
+        within(bottomBar).queryByRole('button', { name: 'Save changes' }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(pageContainer).getByRole('button', { name: 'Save changes' }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -23,7 +23,6 @@ const router = new VueRouter({
   ],
 });
 
-UserPage.computed.newUserLink = () => ({});
 async function renderPage({ routeQuery = {}, userManagement = {} } = {}) {
   const store = makeStore();
   store.state.route = { params: {} };
@@ -33,7 +32,16 @@ async function renderPage({ routeQuery = {}, userManagement = {} } = {}) {
     }),
   );
   await router.push({ name: 'UserPage', query: routeQuery });
-  return render(UserPage, {
+  const UserPageWithStubbedNewUserLink = {
+    extends: UserPage,
+    computed: {
+      ...(UserPage.computed || {}),
+      newUserLink() {
+        return {};
+      },
+    },
+  };
+  return render(UserPageWithStubbedNewUserLink, {
     store,
     router,
   });

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -3,9 +3,8 @@ import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-import useUserManagement, {
-  useUserManagementMock,
-} from '../../../../composables/useUserManagement'; // eslint-disable-line
+import useUserManagement from '../../../../composables/useUserManagement';
+import { useUserManagementMock } from '../../../../composables/__mocks__/useUserManagement';
 import makeStore from '../../../../__tests__/utils/makeStore';
 import UserPage from '../index';
 
@@ -19,6 +18,14 @@ const router = new VueRouter({
     {
       path: '/userpage/',
       name: 'UserPage',
+    },
+    {
+      path: '/userpage/new/',
+      name: 'ADD_NEW_USER_SIDE_PANEL__NEW_USERS',
+    },
+    {
+      path: '/userpage/filters/',
+      name: 'FILTER_USERS_SIDE_PANEL',
     },
   ],
 });

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -1,7 +1,11 @@
-import mock from 'xhr-mock';
-import { mount } from '@vue/test-utils';
+import { computed } from 'vue';
+import { render, screen } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import useUserManagement, {
+  useUserManagementMock,
+} from '../../../../composables/useUserManagement'; // eslint-disable-line
 import makeStore from '../../../../__tests__/utils/makeStore';
 import UserPage from '../index';
 
@@ -20,61 +24,70 @@ const router = new VueRouter({
 });
 
 UserPage.computed.newUserLink = () => ({});
-function makeWrapper(options = {}) {
+async function renderPage({ routeQuery = {}, userManagement = {} } = {}) {
   const store = makeStore();
   store.state.route = { params: {} };
-  return mount(UserPage, {
+  useUserManagement.mockImplementation(() =>
+    useUserManagementMock({
+      ...userManagement,
+    }),
+  );
+  await router.push({ name: 'UserPage', query: routeQuery });
+  return render(UserPage, {
     store,
     router,
-    stubs: ['RouterLinkStub'],
-    ...options,
   });
 }
 
-// Intentionally made to not match any 'kind' filter
-const unicornUser = { id: '1', kind: 'UNICORN', username: 'unicorn', full_name: 'unicorn' };
-const coachUser = { id: '1', kind: 'coach', username: 'coach', full_name: 'coach' };
-
 describe('UserPage component', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     useKResponsiveWindow.mockImplementation(() => ({
       windowIsSmall: false,
       windowBreakpoint: 4,
     }));
+    useUserManagement.mockImplementation(() => useUserManagementMock());
   });
-  // replace the real XHR object with the mock XHR object before each test
-  beforeEach(() => mock.setup());
 
-  // put the real XHR object back and clear the mocks after each test
-  afterEach(() => mock.teardown());
+  it('shows the main users management controls', async () => {
+    await renderPage();
 
-  describe('message in empty states', () => {
-    function getUserTableEmptyMessage(wrapper) {
-      return wrapper.findComponent({ name: 'KTable' }).props().emptyMessage;
-    }
+    expect(screen.getByRole('heading', { name: 'Users' })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Search for a user...' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Filter' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Options' })).toBeInTheDocument();
+  });
 
-    it('if a keyword filter is applied, the empty message is "no users match..."', async () => {
-      mock.get(/.*/, {
-        status: 200,
-        body: JSON.stringify({ results: [], page: 1, total_pages: 1, count: 0 }),
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-      setTimeout(async () => {
-        const wrapper = makeWrapper({
-          data() {
-            return {
-              facilityUsers: [{ ...coachUser, ...unicornUser }],
-              roleFilter: { value: 'coach' },
-            };
-          },
-        });
-        wrapper
-          .findComponent({ name: 'PaginatedListContainer' })
-          .setData({ filterInput: 'coachy' });
-        await wrapper.vm.$nextTick();
-        expect(getUserTableEmptyMessage(wrapper)).toEqual("No users match the filter: 'coachy'");
-      }, 1000);
+  it('shows a search-specific empty state when no users match the search term', async () => {
+    await renderPage({
+      routeQuery: { search: 'coachy' },
+      userManagement: {
+        facilityUsers: computed(() => []),
+      },
     });
+
+    expect(screen.getByText('No users match this search')).toBeInTheDocument();
+  });
+
+  it('shows a filter-specific empty state when filters are applied', async () => {
+    await renderPage({
+      userManagement: {
+        facilityUsers: computed(() => []),
+        numAppliedFilters: computed(() => 1),
+      },
+    });
+
+    expect(screen.getByText('No users match this filter')).toBeInTheDocument();
+  });
+
+  it('shows combined empty-state messaging when both search and filters are applied', async () => {
+    await renderPage({
+      routeQuery: { search: 'coachy' },
+      userManagement: {
+        facilityUsers: computed(() => []),
+        numAppliedFilters: computed(() => 2),
+      },
+    });
+
+    expect(screen.getByText('No users match this search and these filters')).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -73,13 +73,36 @@ describe('UserPage component', () => {
   });
 
   it('shows a search-specific empty state when no users match the search term', async () => {
+    const usersInFacility = [
+      {
+        id: 'alice-1',
+        full_name: 'Alice Johnson',
+        username: 'alice',
+      },
+      {
+        id: 'bob-2',
+        full_name: 'Bob Stone',
+        username: 'bstone',
+      },
+    ];
+    const searchQuery = 'coachy';
+    const searchResults = usersInFacility.filter(user => {
+      const normalizedSearch = searchQuery.toLowerCase();
+      return (
+        user.full_name.toLowerCase().includes(normalizedSearch) ||
+        user.username.toLowerCase().includes(normalizedSearch)
+      );
+    });
+
     await renderPage({
-      routeQuery: { search: 'coachy' },
+      routeQuery: { search: searchQuery },
       userManagement: {
-        facilityUsers: computed(() => []),
+        facilityUsers: computed(() => searchResults),
       },
     });
 
+    expect(usersInFacility).toHaveLength(2);
+    expect(searchResults).toHaveLength(0);
     expect(screen.getByText('No users match this search')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
This PR migrates the facility management view tests from `@vue/test-utils` to Vue Testing Library so tests better reflect user-visible behavior and are less coupled to component internals.

Updated files:
- `kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js`
- `kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js`
- `kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js`

What changed:
- Replaced `mount`/wrapper internals assertions with `render` + `screen` queries.
- Removed `@vue/test-utils` imports from all three migrated files.
- Updated test descriptions to user-centered wording.
- Kept coverage focused on major workflows:
  - App bar title behavior in facility contexts.
  - Facility settings visibility, toggling, save action, and save button placement in browser vs app mode.
  - Users page key controls and empty-state messaging for search/filter cases.

Manual verification performed:
- `pnpm run test-jest -- --testPathPattern 'facility-app-bar-page.spec.js|facility-config-page.spec.js|UsersRootPage.spec.js'`
- `pnpm run test-jest -- --testPathPattern facility`

Both commands passed.

## References
- Closes #14195 

## Reviewer guidance
Please review with focus on Testing Library principles (query priority and user-facing assertions), not implementation details.

To test locally:
1. Run `pnpm run test-jest -- --testPathPattern 'facility-app-bar-page.spec.js|facility-config-page.spec.js|UsersRootPage.spec.js'`
2. Optionally run broader coverage: `pnpm run test-jest -- --testPathPattern facility`

Risk areas to sanity-check:
- Accessibility query choices (role/label text) in the migrated specs.
- Users page empty-state assertions tied to search/filter state behavior.