### PR TITLE
Fix/remove pickle protocol cache defaults v0.19.x

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -7,8 +7,6 @@ from kolibri.utils.options import CACHE_SHARDS
 
 cache_options = OPTIONS["Cache"]
 
-pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
-
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
 
 # Default to LocMemCache, as it has the simplest configuration
@@ -30,8 +28,6 @@ process_cache = {
     "SHARDS": CACHE_SHARDS,
     "OPTIONS": {
         "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
-        # Pin pickle protocol for Python 2 compatibility
-        "disk_pickle_protocol": pickle_protocol,
     },
 }
 
@@ -45,8 +41,6 @@ if cache_options["CACHE_BACKEND"] == "redis":
         "OPTIONS": {
             "PASSWORD": cache_options["CACHE_PASSWORD"],
             "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
-            # Pin pickle protocol for Python 2 compatibility
-            "PICKLE_VERSION": pickle_protocol,
             "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
             "CONNECTION_POOL_CLASS_KWARGS": {
                 "max_connections": cache_options["CACHE_REDIS_MAX_POOL_SIZE"],

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -1,3 +1,4 @@
+import pickle
 import sqlite3
 
 from diskcache import DjangoCache
@@ -13,7 +14,11 @@ class CustomDjangoCache(DjangoCache):
     https://github.com/grantjenks/python-diskcache/blob/v4.1.0/diskcache/djangocache.py
     """
 
-    ERRORS_TO_HANDLE = (sqlite3.OperationalError, AssertionError)
+    ERRORS_TO_HANDLE = (
+        sqlite3.OperationalError,
+        AssertionError,
+        pickle.UnpicklingError,
+    )
 
     def try_execute(self, method_name, error_return_value, *args, **kwargs):
         """

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -783,16 +783,6 @@ base_option_spec = {
             """,
         },
     },
-    "Python": {
-        "PICKLE_PROTOCOL": {
-            "type": "integer",
-            "default": 2,
-            "description": """
-                Which Python pickle protocol to use. Pinned to 2 for now to provide maximal cross-Python version compatibility.
-                Can safely be set to a higher value for deployments that will never change Python versions.
-            """,
-        }
-    },
     "Tasks": {
         "USE_WORKER_MULTIPROCESSING": {
             "type": "multiprocess_bool",


### PR DESCRIPTION
## Summary
This PR removes the legacy `PICKLE_PROTOCOL` setting and allows Python to use its default pickle protocol for cache serialization.

## Changes
- Removed `Python.PICKLE_PROTOCOL` from the options spec.
- Removed cache config wiring that forced:
  - `disk_pickle_protocol` for disk cache
  - `PICKLE_VERSION` for Redis cache
- Added `pickle.UnpicklingError` to handled exceptions in `CustomDjangoCache` so stale/incompatible cache entries are treated as cache misses instead of raising.

## Verification
- Confirmed runtime cache configuration and options definitions no longer reference `PICKLE_PROTOCOL`.
- Confirmed unpickling failures now follow the existing safe error path in `CustomDjangoCache` (fallback return value).
- No UI impact.

## References
Fixes #14183

## Reviewer Guidance
Please focus review on cache behavior and compatibility:
1. Verify startup works with default cache setup (memory + process disk cache) and cache read/write paths are unaffected.
2. Verify startup works with Redis cache backend without explicit pickle version configuration.
3. Confirm disk-cache unpickling failures are safely handled (fallback return value, no exception bubble-up).
4. Check behavior when `Python.PICKLE_PROTOCOL` still exists in existing `options.ini` (expected: unknown/ignored with warning behavior).