### PR TITLE
Unprovisioned URL Redirect (+ remove dead code)

### DIFF
--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -94,26 +94,31 @@ class ProvisioningErrorHandler:
         self._provision_app_name = None
 
     def __call__(self, request):
+        # Resolve the URL first — this is cheap in-memory pattern matching.
+        # If it's not a translated endpoint (i.e. not a plugin page view),
+        # return early without hitting the database for provisioning checks.
+        try:
+            match = resolve(request.path_info)
+        except Resolver404:
+            return self.get_response(request)
+
+        # Only redirect plugin page views, not API endpoints or core views.
+        # Page views served through i18n_patterns have 'translated' set on their callback.
+        # API endpoints and core views (like set_language) are left alone so the
+        # setup wizard can function properly.
+        if not getattr(match.func, "translated", False):
+            return self.get_response(request)
+
         if not device_provisioned():
             try:
                 provision_url = SetupHook.provision_url()
             except StopIteration:
                 return self.get_response(request)
 
-            try:
-                match = resolve(request.path_info)
-            except Resolver404:
-                return self.get_response(request)
-
-            # Only redirect plugin page views, not API endpoints or core views.
-            # Page views served through i18n_patterns have 'translated' set on their callback.
-            # API endpoints and core views (like set_language) are left alone so the
-            # setup wizard can function properly.
-            if getattr(match.func, "translated", False):
-                if self._provision_app_name is None:
-                    self._provision_app_name = resolve(provision_url).app_name
-                if match.app_name != self._provision_app_name:
-                    return redirect(provision_url)
+            if self._provision_app_name is None:
+                self._provision_app_name = resolve(provision_url).app_name
+            if match.app_name != self._provision_app_name:
+                return redirect(provision_url)
 
         return self.get_response(request)
 

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -121,7 +121,7 @@ class ProvisioningErrorHandler:
         # so the setup wizard can function (e.g. changing language during setup).
         if (
             match.app_name != self._provision_app_name
-            and "kolibri.plugins." in match.app_name
+            and "kolibri:core" not in match.app_name
         ):
             return redirect(provision_url)
 

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -101,10 +101,9 @@ class ProvisioningErrorHandler:
         except Resolver404:
             return self.get_response(request)
 
-        # Only redirect plugin page views, not API endpoints or core views.
+        # Only redirect plugin page views, not API endpoints.
         # Page views served through i18n_patterns have 'translated' set on their callback.
-        # API endpoints and core views (like set_language) are left alone so the
-        # setup wizard can function properly.
+        # API endpoints are not translated and are always filtered out here.
         if not getattr(match.func, "translated", False) or device_provisioned():
             return self.get_response(request)
 
@@ -115,7 +114,15 @@ class ProvisioningErrorHandler:
 
         if self._provision_app_name is None:
             self._provision_app_name = resolve(provision_url).app_name
-        if match.app_name != self._provision_app_name:
+
+        # Redirect only other plugins' page views to the provisioning URL.
+        # Core views like set_language are also translated (they're inside
+        # i18n_patterns for language prefix routing) but must remain accessible
+        # so the setup wizard can function (e.g. changing language during setup).
+        if (
+            match.app_name != self._provision_app_name
+            and "kolibri.plugins." in match.app_name
+        ):
             return redirect(provision_url)
 
         return self.get_response(request)

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -11,7 +11,6 @@ from django.utils import translation
 from .translation import get_language_from_request_and_is_from_path
 from kolibri.core.device.hooks import SetupHook
 from kolibri.core.device.utils import device_provisioned
-from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.utils.conf import OPTIONS
 
 
@@ -93,15 +92,6 @@ class ProvisioningErrorHandler:
     def __init__(self, get_response):
         self.get_response = get_response
         self._provision_app_name = None
-
-    def process_exception(self, request, exception):
-        if (
-            isinstance(exception, DeviceNotProvisioned)
-            and SetupHook.provision_url()
-            and not request.path.startswith(SetupHook.provision_url())
-        ):
-            return redirect(SetupHook.provision_url())
-        return None
 
     def __call__(self, request):
         if not device_provisioned():

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -48,7 +48,6 @@ class KolibriLocaleMiddleware:
         response = self.get_response(request)
 
         if language is not None:
-
             language = translation.get_language()
 
             if response.status_code == 404 and not language_from_path:
@@ -106,19 +105,18 @@ class ProvisioningErrorHandler:
         # Page views served through i18n_patterns have 'translated' set on their callback.
         # API endpoints and core views (like set_language) are left alone so the
         # setup wizard can function properly.
-        if not getattr(match.func, "translated", False):
+        if not getattr(match.func, "translated", False) or device_provisioned():
             return self.get_response(request)
 
-        if not device_provisioned():
-            try:
-                provision_url = SetupHook.provision_url()
-            except StopIteration:
-                return self.get_response(request)
+        try:
+            provision_url = SetupHook.provision_url()
+        except StopIteration:
+            return self.get_response(request)
 
-            if self._provision_app_name is None:
-                self._provision_app_name = resolve(provision_url).app_name
-            if match.app_name != self._provision_app_name:
-                return redirect(provision_url)
+        if self._provision_app_name is None:
+            self._provision_app_name = resolve(provision_url).app_name
+        if match.app_name != self._provision_app_name:
+            return redirect(provision_url)
 
         return self.get_response(request)
 

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -4,10 +4,13 @@ from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import is_valid_path
+from django.urls import resolve
+from django.urls import Resolver404
 from django.utils import translation
 
 from .translation import get_language_from_request_and_is_from_path
 from kolibri.core.device.hooks import SetupHook
+from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.utils.conf import OPTIONS
 
@@ -89,6 +92,7 @@ class KolibriLocaleMiddleware:
 class ProvisioningErrorHandler:
     def __init__(self, get_response):
         self.get_response = get_response
+        self._provision_app_name = None
 
     def process_exception(self, request, exception):
         if (
@@ -100,6 +104,27 @@ class ProvisioningErrorHandler:
         return None
 
     def __call__(self, request):
+        if not device_provisioned():
+            try:
+                provision_url = SetupHook.provision_url()
+            except StopIteration:
+                return self.get_response(request)
+
+            try:
+                match = resolve(request.path_info)
+            except Resolver404:
+                return self.get_response(request)
+
+            # Only redirect plugin page views, not API endpoints or core views.
+            # Page views served through i18n_patterns have 'translated' set on their callback.
+            # API endpoints and core views (like set_language) are left alone so the
+            # setup wizard can function properly.
+            if getattr(match.func, "translated", False):
+                if self._provision_app_name is None:
+                    self._provision_app_name = resolve(provision_url).app_name
+                if match.app_name != self._provision_app_name:
+                    return redirect(provision_url)
+
         return self.get_response(request)
 
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -33,10 +33,6 @@ DEVICE_UNUSABLE_NO_SUPERUSERS = "NO_SUPERUSERS"
 DEVICE_UNUSABLE_SUPERUSERS_SOFT_DELETED = "SUPERUSERS_SOFT_DELETED"
 
 
-class DeviceNotProvisioned(Exception):
-    pass
-
-
 class DeviceAlreadyProvisioned(Exception):
     pass
 

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -28,6 +28,44 @@ class BeforeDeviceProvisionTests(APITestCase):
             reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
         )
 
+    def test_learn_plugin_redirects_to_setup_wizard(self):
+        response = self.client.get(reverse("kolibri:kolibri.plugins.learn:learn"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"),
+            reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
+        )
+
+    def test_coach_plugin_redirects_to_setup_wizard(self):
+        response = self.client.get(reverse("kolibri:kolibri.plugins.coach:coach"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"),
+            reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
+        )
+
+    def test_facility_plugin_redirects_to_setup_wizard(self):
+        response = self.client.get(
+            reverse("kolibri:kolibri.plugins.facility:facility_management")
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"),
+            reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
+        )
+
+    @patch("kolibri.core.webpack.hooks.WebpackBundleHook.get_by_unique_id")
+    @patch("kolibri.core.webpack.hooks.WebpackBundleHook.bundle", return_value=[])
+    def test_setup_wizard_not_redirected(self, *mocks):
+        response = self.client.get(
+            reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard")
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_endpoint_not_redirected(self):
+        response = self.client.get("/api/device/deviceinfo/")
+        self.assertEqual(response.status_code, 403)
+
 
 class KolibriTagNavigationTestCase(APITestCase):
     databases = "__all__"

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -66,6 +66,29 @@ class BeforeDeviceProvisionTests(APITestCase):
         response = self.client.get("/api/device/deviceinfo/")
         self.assertEqual(response.status_code, 403)
 
+    def test_set_language_not_redirected(self):
+        response = self.client.post(
+            reverse("kolibri:core:set_language"),
+            {"language": "es"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_logout_not_redirected_by_middleware(self):
+        response = self.client.get(reverse("kolibri:core:logout"))
+        # logout_view redirects to redirect_user, not directly to setup wizard.
+        # If the middleware intercepted this, it would redirect straight to
+        # the setup wizard URL instead.
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("redirectuser", response.get("location"))
+
+    def test_unsupported_browser_not_redirected(self):
+        response = self.client.get(reverse("kolibri:core:unsupported"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_unknown_url_not_redirected(self):
+        response = self.client.get("/nonexistent/path/that/does/not/resolve/")
+        self.assertEqual(response.status_code, 404)
+
 
 class KolibriTagNavigationTestCase(APITestCase):
     databases = "__all__"


### PR DESCRIPTION
> :robot: :exclamation: - PR generated with help of Claude Code throughout

## Overview 

Closes #14067

When a Kolibri device is unprovisioned, navigating to any plugin page (Learn, Coach, Facility, etc.) now redirects to the setup wizard. Previously, redirects only happened reactively when views raised `DeviceNotProvisioned` — but nothing in the codebase has raised that exception since 2023, so users could land on broken plugin pages instead of being guided to complete setup.

The `ProvisioningErrorHandler` middleware now proactively checks `device_provisioned()` and redirects translated plugin page views to the setup wizard URL. API endpoints and core views (like `set_language`) are left alone so the setup wizard itself can function properly.

## Changes

- **Proactive redirect in middleware** — `ProvisioningErrorHandler.__call__` checks provisioning status and uses the `translated` attribute (set by `i18n_patterns`) to distinguish plugin page views from API endpoints. Compares `app_name` to avoid redirect loops with the setup wizard.
- **Cached provision app_name** — The resolved `app_name` for the provision URL is cached per process since it's fixed for the lifetime of the server (until it's restarted) *(JP note: this ensures our middleware is basically just a cache check rather than a DB query. DeviceSettings.save() updates the cache so when the device is provisioned (or not) the value will always be right unless someone is poking around in the database recklessly)*
- **Removed dead code** — `DeviceNotProvisioned` exception class and the `process_exception` handler that caught it were dead code (nothing has raised the exception since 2023). Removed both. _(JP Note: I confirmed that this is the case but please give it some care to consider if removing it was better or if it should be used/revised differently)_
- **Tests** — Added positive tests (learn, coach, facility pages redirect) and negative tests (setup wizard and API endpoints are not redirected).

## Manual testing

### Prerequisites
- An unprovisioned Kolibri instance (fresh `KOLIBRI_HOME` with no device setup)
- A provisioned Kolibri instance (normal setup with facility, users, etc.)

### On an unprovisioned device

- [ ] Navigate to `/en/learn/` — should 302 redirect to the setup wizard
- [ ] Navigate to `/en/coach/` — should 302 redirect to the setup wizard
- [ ] Navigate to `/en/facility/` — should 302 redirect to the setup wizard
- [ ] Navigate to `/` (root) — should 302 redirect to the setup wizard
- [ ] Navigate directly to the setup wizard URL — should load normally (no redirect loop)
- [ ] Hit `/api/device/deviceinfo/` — should return a normal API response (e.g. 403), not a 302
- [ ] Complete the full provisioning flow through the setup wizard, including language switching during setup

### On a provisioned device

- [ ] Log in as learner, coach, admin, superuser — each should reach their default landing page
- [ ] Navigate between plugins (learn, coach, facility) without unexpected redirects
