### PR TITLE
Remove no longer needed overflow: unset

### DIFF
--- a/kolibri/plugins/learn/frontend/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/ExamPage/index.vue
@@ -34,7 +34,6 @@
         <KGridItem
           :layout12="{ span: 8 }"
           class="column-pane"
-          :style="!showQuestionsList ? { overflow: 'unset' } : {}"
         >
           <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
             <KPageContainer


### PR DESCRIPTION
## Summary

* Removes `overflow: unset` style on the ExamPage.
  * This was initially introduced in https://github.com/learningequality/kolibri/pull/12484. By then, the ImmersivePage was the one in charge of handling the overflow, but it doesn't seem to be the case now. This is no longer needed anyway, since now KSelect renders its dropdown on the overlay layer, and it doesn't interfere with scroll restrictions on the ExamPage.

https://github.com/user-attachments/assets/727fd74a-72c8-4b50-82c6-d5e3e3502af2


## References
Closes #13819.

## Reviewer guidance
* Create a quiz and assign it to learners
* Sign in as a learner using a small phone in landscape mode
* Attempt to answer the questions in a quiz using a small screen and submit it.