### PR TITLE
Update courses dropdown options to open course preview and assign recipients side panels

### DIFF
--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -4,11 +4,11 @@
     <KPageContainer>
       <CoachHeader :title="coursesLabel$()">
         <template #actions>
-          <KRouterLink
+          <KButton
             primary
             appearance="raised-button"
             :text="assignCourseAction$()"
-            :to="assignCourseRoute"
+            @click="openAssignCourseLink"
           />
         </template>
       </CoachHeader>
@@ -187,9 +187,10 @@
   import useKShow from 'kolibri-design-system/lib/composables/useKShow';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useSnackbar from 'kolibri/composables/useSnackbar';
-  import { useRoute } from 'vue-router/composables';
-  import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue';
+  import { useRoute, useRouter } from 'vue-router/composables';
+  import { computed, getCurrentInstance, onMounted, ref, watch, nextTick } from 'vue';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
   import { CoursesModals, PageNames } from '../../constants';
   import CoachAppBarPage from '../CoachAppBarPage.vue';
   import CoachHeader from '../common/CoachHeader.vue';
@@ -199,6 +200,7 @@
   import emptyPlusCloudSvg from '../../images/empty_plus_cloud.svg';
   import AssignCourseSuccessModal from './modals/AssignCourseSuccess.vue';
   import DeleteCourseConfirmationModal from './modals/DeleteCourseConfirmation.vue';
+  import useAssignCourse from './composables/useAssignCourse';
 
   export default {
     name: 'CoursesRootPage',
@@ -212,6 +214,7 @@
     },
     setup() {
       const route = useRoute();
+      const router = useRouter();
       const instance = getCurrentInstance();
       const store = instance.proxy.$store;
       const modelOpen = ref(null);
@@ -232,8 +235,10 @@
         clearAllFilters$,
         courseDeleted$,
         courseDeleteError$,
+        courseDetailsAction$,
+        editRecipientsAction$,
       } = coursesStrings;
-      const { entireClassLabel$, previewAction$ } = coachStrings;
+      const { entireClassLabel$ } = coachStrings;
       const { show } = useKShow();
       const { windowIsSmall } = useKResponsiveWindow();
       const {
@@ -255,6 +260,12 @@
         updated.delete(courseId);
         updatingCourseIds.value = updated;
       };
+
+      const assignCourseComposable = useAssignCourse({
+        classId: computed(() => route.params.classId),
+      });
+
+      const { selectCourse } = assignCourseComposable;
 
       const assignCourseRoute = computed(() =>
         overrideRoute(route, {
@@ -329,17 +340,63 @@
         courseToDelete.value = null;
       };
 
-      const handleCourseMenuSelect = (selection, course) => {
-        const previewLabel = previewAction$();
-        const editLabel = translateCoreString('editAction');
-        const deleteLabel = translateCoreString('deleteAction');
+      const openAssignCourseLink = () => {
+        assignCourseComposable.resetAssignment();
+        router.push(
+          overrideRoute(route, {
+            name: PageNames.COURSES_ASSIGN,
+          }),
+        );
+      };
 
-        if (selection === previewLabel) {
-          instance.proxy.$router.push(courseSummaryLink(course));
-        } else if (selection === editLabel) {
-          instance.proxy.$router.push(assignCourseRoute.value);
-        } else if (selection === deleteLabel) {
+      const openCourseAssignRecipientsLink = () => {
+        router.push(
+          overrideRoute(route, {
+            name: PageNames.COURSES_ASSIGN_SELECT_RECIPIENTS,
+          }),
+        );
+      };
+
+      const openCourseDetailsLink = course => {
+        router.push(
+          overrideRoute(route, {
+            name: PageNames.COURSES_ASSIGN_COURSE_DETAILS,
+            params: { courseId: course.course },
+          }),
+        );
+      };
+
+      const handleCourseMenuSelect = async (selection, course) => {
+        const actions = {
+          viewDetails: courseDetailsAction$(),
+          edit: editRecipientsAction$(),
+          delete: translateCoreString('deleteAction'),
+        };
+
+        if (selection === actions.delete) {
           deleteCourse(course);
+          return;
+        }
+
+        if (selection === actions.viewDetails) {
+          assignCourseComposable.resetAssignment();
+          assignCourseComposable.setExistingAssignment(course);
+          await nextTick();
+          openCourseDetailsLink(course);
+          return;
+        }
+
+        if (selection === actions.edit) {
+          try {
+            const courseContent = await ContentNodeResource.fetchModel({ id: course.course });
+            selectCourse(courseContent);
+            assignCourseComposable.setCourseVisibility(course.active);
+            assignCourseComposable.setExistingAssignment(course);
+            await nextTick();
+            openCourseAssignRecipientsLink();
+          } catch (e) {
+            store.dispatch('handleApiError', e);
+          }
         }
       };
 
@@ -373,6 +430,7 @@
         modelOpen,
         courseToDelete,
         assignCourseRoute,
+        openAssignCourseLink,
         courseSummaryLink,
         coursesLabel$,
         assignCourseAction$,
@@ -395,7 +453,8 @@
         confirmDeleteCourse,
         cancelDeleteCourse,
         handleCourseMenuSelect,
-        previewAction$,
+        editRecipientsAction$,
+        courseDetailsAction$,
         coreString,
         coachString,
       };
@@ -439,8 +498,8 @@
       },
       courseMenuOptions() {
         return [
-          this.previewAction$(),
-          this.coreString('editAction'),
+          this.courseDetailsAction$(),
+          this.editRecipientsAction$(),
           this.coreString('deleteAction'),
         ];
       },

--- a/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
+++ b/kolibri/plugins/coach/frontend/views/courses/composables/useAssignCourse.js
@@ -20,6 +20,8 @@ import { useCourses } from '../../../composables/useCourses';
 export default function useAssignCourse({ classId }) {
   const searchKeywords = ref('');
   const selectedCourse = ref(null);
+  const courseSessionId = ref(null);
+  const courseSessionVisible = ref(false);
 
   const selectedGroupIds = ref([]);
   const selectedLearnerIds = ref([]);
@@ -50,20 +52,52 @@ export default function useAssignCourse({ classId }) {
     selectedCourse.value = course;
   };
 
+  /**
+   * Set existing course assignment data for editing
+   * @param {Object} courseSession - The course session object from CoursesRootPage
+   */
+  const setExistingAssignment = courseSession => {
+    courseSessionId.value = courseSession.id;
+    selectedGroupIds.value = [...(courseSession.assignments || [])];
+    selectedLearnerIds.value = [...(courseSession.learner_ids || [])];
+  };
+
+  /**
+   * Set existing course visibility data for editing
+   * @param {boolean} isActive - The active status of the course session
+   */
+  const setCourseVisibility = isActive => {
+    courseSessionVisible.value = isActive;
+  };
+
   const assignCourse = () => {
+    const isEditing = courseSessionId.value != null;
     return CourseSessionResource.saveModel({
+      id: isEditing ? courseSessionId.value : undefined,
       data: {
-        active: false,
+        active: isEditing ? courseSessionVisible.value : false,
         collection: classId.value,
         course: selectedCourse.value.id,
         assignments: selectedGroupIds.value,
         learner_ids: selectedLearnerIds.value,
       },
+      exists: isEditing,
     }).then(response => {
-      // Refresh local course list so the new course shows immediately
+      // Refresh local course list so the changes show immediately
       refreshClassCourses();
       return response;
     });
+  };
+
+  /**
+   * Reset the assignment state
+   */
+  const resetAssignment = () => {
+    selectedCourse.value = null;
+    courseSessionId.value = null;
+    selectedGroupIds.value = [];
+    selectedLearnerIds.value = [];
+    courseSessionVisible.value = false;
   };
 
   // Initial fetch of courses
@@ -73,6 +107,22 @@ export default function useAssignCourse({ classId }) {
     coursesFetch.fetchData();
   });
 
+  const composableApi = {
+    classId,
+    isLoading,
+    searchKeywords,
+    coursesFetch,
+    selectedCourse,
+    selectedGroupIds,
+    selectedLearnerIds,
+    selectCourse,
+    courseSessionId,
+    setCourseVisibility,
+    setExistingAssignment,
+    resetAssignment,
+    assignCourse,
+  };
+
   provide('assignCourseClassId', classId);
   provide('assignCourseIsLoading', isLoading);
   provide('assignCourseSearchKeywords', searchKeywords);
@@ -80,12 +130,13 @@ export default function useAssignCourse({ classId }) {
   provide('assignCourseSelectedCourse', selectedCourse);
   provide('assignCourseSelectedGroupIds', selectedGroupIds);
   provide('assignCourseSelectedLearnerIds', selectedLearnerIds);
+  provide('assignCourseCourseSessionId', courseSessionId);
   provide('assignCourseSelectCourse', selectCourse);
+  provide('assignCourseSetExistingAssignment', setExistingAssignment);
+  provide('assignCourseResetAssignment', resetAssignment);
   provide('assignCourseAssignCourse', assignCourse);
 
-  return {
-    selectedCourse,
-  };
+  return composableApi;
 }
 
 /**
@@ -117,6 +168,9 @@ export function injectAssignCourse() {
     selectedGroupIds: inject('assignCourseSelectedGroupIds'),
     selectedLearnerIds: inject('assignCourseSelectedLearnerIds'),
     selectCourse: inject('assignCourseSelectCourse'),
+    courseSessionId: inject('assignCourseCourseSessionId'),
+    setExistingAssignment: inject('assignCourseSetExistingAssignment'),
+    resetAssignment: inject('assignCourseResetAssignment'),
     assignCourse: inject('assignCourseAssignCourse'),
   };
 }

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/index.vue
@@ -26,7 +26,7 @@
   import SidePanelModal from 'kolibri-common/components/courses/sidePanel/SidePanelModal';
   import { CoursesModals, PageNames } from '../../../../constants';
   import { overrideRoute } from '../../../../utils';
-  import useAssignCourse from '../../composables/useAssignCourse';
+  import { injectAssignCourse } from '../../composables/useAssignCourse';
   import CloseConfirmationModal from '../../modals/CloseConfirmationModal.vue';
 
   /**
@@ -56,8 +56,7 @@
       const route = useRoute();
       const router = useRouter();
 
-      const classId = computed(() => route.params.classId);
-      const { selectedCourse } = useAssignCourse({ classId });
+      const { selectedCourse, resetAssignment } = injectAssignCourse();
 
       const isFinished = ref(false);
 
@@ -70,15 +69,28 @@
       });
 
       const closeSidePanel = () => {
-        router.push(overrideRoute(route, { name: PageNames.COURSES_ROOT })).catch(e => {
-          if (!isNavigationFailure(e, NavigationFailureType.aborted)) {
-            throw Error(e);
-          }
-        });
+        router
+          .push(
+            overrideRoute(route, {
+              name: PageNames.COURSES_ROOT,
+              query: null,
+            }),
+          )
+          .catch(e => {
+            if (
+              !isNavigationFailure(
+                e,
+                NavigationFailureType.aborted || NavigationFailureType.duplicated,
+              )
+            ) {
+              throw Error(e);
+            }
+          });
       };
 
       const onSuccess = async () => {
         isFinished.value = true;
+        resetAssignment();
         await nextTick();
         closeSidePanel();
         emit('showModal', CoursesModals.ASSIGN_COURSE_SUCCESS);

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/CourseDetails.vue
@@ -1,7 +1,8 @@
 <template>
 
   <SidePanelLayout
-    :goBack="goBack"
+    :goBack="isPreviewMode ? undefined : goBack"
+    :closePanel="isPreviewMode ? closePanel : undefined"
     :title="course ? courseNameLabel$({ name: course.title }) : ''"
     :subtitle="courseSubtitle"
   >
@@ -142,10 +143,11 @@
     <template #bottomNavigation>
       <div class="bottom-actions">
         <KButton
-          :text="backAction$()"
-          @click="goBack"
+          :text="isPreviewMode ? cancelAction$() : backAction$()"
+          @click="isPreviewMode ? closePanel() : goBack()"
         />
         <KButton
+          v-if="!isPreviewMode"
           primary
           :disabled="loading || !course"
           :text="selectRecipientsLabel$()"
@@ -186,11 +188,11 @@
       ContentIcon,
       SidePanelLayout,
     },
-    setup() {
+    setup(props, { emit }) {
       const route = useRoute();
       const router = useRouter();
 
-      const { backAction$, viewMoreAction$, viewLessAction$ } = coreStrings;
+      const { cancelAction$, backAction$, viewMoreAction$, viewLessAction$ } = coreStrings;
       const {
         courseContentLabel$,
         courseNameLabel$,
@@ -206,7 +208,10 @@
 
       const { numberOfResources$ } = coachStrings;
 
-      const { selectCourse } = injectAssignCourse();
+      const { selectCourse, courseSessionId } = injectAssignCourse();
+
+      // Check if side panel is in preview mode based on query parameter
+      const isPreviewMode = computed(() => courseSessionId?.value != null);
 
       const course = ref(null);
       const units = computed(() => course.value?.children?.results);
@@ -235,6 +240,10 @@
             name: PageNames.COURSES_ASSIGN_INDEX,
           }),
         );
+      };
+
+      const closePanel = () => {
+        emit('closePanel');
       };
 
       const loading = ref(true);
@@ -269,11 +278,14 @@
         descOverflowing,
         loading,
         goBack,
+        closePanel,
         selectRecipients,
         numTestQuestions,
+        isPreviewMode,
 
         courseSubtitle,
         backAction$,
+        cancelAction$,
         preTestLabel$,
         postTestLabel$,
         courseContentLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/SelectRecipients.vue
@@ -1,7 +1,8 @@
 <template>
 
   <SidePanelLayout
-    :goBack="goBack"
+    :goBack="isEditMode ? undefined : goBack"
+    :closePanel="isEditMode ? closePanel : undefined"
     :title="selectRecipientsLabel$()"
     :subtitle="courseNameLabel$({ name: selectedCourseTitle })"
   >
@@ -28,9 +29,9 @@
       </div>
       <div class="bottom-actions">
         <KButton
-          :text="backAction$()"
+          :text="isEditMode ? cancelAction$() : backAction$()"
           :disabled="isSaving"
-          @click="goBack"
+          @click="isEditMode ? closePanel() : goBack()"
         />
         <KButton
           primary
@@ -71,10 +72,16 @@
       const isSaving = ref(false);
       const errorMessage = ref(null);
 
-      const { classId, selectedCourse, assignCourse, selectedGroupIds, selectedLearnerIds } =
-        injectAssignCourse();
+      const {
+        classId,
+        selectedCourse,
+        assignCourse,
+        selectedGroupIds,
+        selectedLearnerIds,
+        courseSessionId,
+      } = injectAssignCourse();
 
-      const { backAction$, defaultErrorMessage$ } = coreStrings;
+      const { cancelAction$, backAction$, defaultErrorMessage$ } = coreStrings;
       const {
         courseNameLabel$,
         assignCourseAction$,
@@ -84,12 +91,18 @@
 
       const selectedCourseTitle = computed(() => selectedCourse.value?.title || '');
 
+      const isEditMode = computed(() => courseSessionId?.value != null);
+
       const goBack = () => {
         router.push(
           overrideRoute(route, {
             name: PageNames.COURSES_ASSIGN_INDEX,
           }),
         );
+      };
+
+      const closePanel = () => {
+        emit('closePanel');
       };
 
       const isAssignButtonDisabled = computed(() => {
@@ -125,15 +138,18 @@
         isSaving,
         errorMessage,
         classId,
+        isEditMode,
         selectedGroupIds,
         selectedLearnerIds,
         selectedCourseTitle,
         isAssignButtonDisabled,
 
         goBack,
+        closePanel,
         handleAssignCourse,
 
         backAction$,
+        cancelAction$,
         courseNameLabel$,
         assignCourseAction$,
         selectRecipientsLabel$,

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -334,4 +334,12 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Previous resource',
     context: 'Action label for navigating to the previous resource in a course unit',
   },
+  courseDetailsAction: {
+    message: 'Course details',
+    context: 'Action label to view course details',
+  },
+  editRecipientsAction: {
+    message: 'Edit Recipients',
+    context: 'Action label for editing which learners are assigned to a course.',
+  },
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

This pull request edits the course list dropdown menu options to include the options "Course Details" and "Edit Recipients", opening the corresponding side panels. Previously the "preview" option lead to a new page, but did not load, and the "edit" option lead to the course selection, instead of to editing the recipients.

Before:

https://github.com/user-attachments/assets/a95934ce-0a1f-4557-a964-0a587d48b0b6


After:


https://github.com/user-attachments/assets/abe829eb-6070-49a2-80b2-d7ecbd1a4e7c



## References
<!--
 * references to related issues and PRs
-->
Fixes #14135 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Coach > Courses page and select the three dots to open the dropdown menu.
2. Select the options "Course Details" or "Edit Recipients" to see the side panel.
4. Ensure there are no regressions when selecting and assigning a new course.
