### PR TITLE
Add better error message for deleted learners in assignments

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/AssignmentDetailsModal.vue
@@ -186,6 +186,8 @@
         titleLabel$,
         saveLessonError$,
         saveQuizError$,
+        saveLessonErrorDeletedUsers$,
+        saveQuizErrorDeletedUsers$,
         quizDuplicateTitleError$,
         lessonDuplicateTitleError$,
         reportVisibilityLabel$,
@@ -202,6 +204,8 @@
         titleLabel$,
         saveLessonError$,
         saveQuizError$,
+        saveLessonErrorDeletedUsers$,
+        saveQuizErrorDeletedUsers$,
         quizDuplicateTitleError$,
         lessonDuplicateTitleError$,
         reportVisibilityLabel$,
@@ -262,6 +266,7 @@
         adHocLearners: this.assignment.learner_ids || [],
         formIsSubmitted: false,
         showServerError: false,
+        showDeletedUsersError: false,
         showTitleError: false,
         instantReportVisibility: this.assignment.instant_report_visibility,
       };
@@ -319,6 +324,11 @@
         return 50;
       },
       submitErrorMessage() {
+        if (this.showDeletedUsersError) {
+          return this.assignmentIsQuiz
+            ? this.saveQuizErrorDeletedUsers$()
+            : this.saveLessonErrorDeletedUsers$();
+        }
         return this.assignmentIsQuiz ? this.saveQuizError$() : this.saveLessonError$();
       },
       iconName() {
@@ -404,6 +414,16 @@
        */
       handleSubmitFailure() {
         this.formIsSubmitted = false;
+        this.showDeletedUsersError = false;
+        this.showServerError = true;
+      },
+      /**
+       * Called when the save fails because one or more selected learners no longer exist.
+       * @public
+       */
+      handleSubmitDeletedUsersFailure() {
+        this.formIsSubmitted = false;
+        this.showDeletedUsersError = true;
         this.showServerError = true;
       },
       /**
@@ -422,6 +442,7 @@
       handleSubmitSuccess() {
         this.showTitleError = false;
         this.showServerError = false;
+        this.showDeletedUsersError = false;
       },
       /**
        * @public

--- a/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
@@ -443,7 +443,6 @@ const coachStrings = createTranslator('CommonCoachStrings', {
       'Error message shown when saving a quiz fails because one or more selected individual learners have been deleted from the facility.',
   },
 
-
   // empty states
   activityListEmptyState: {
     message: 'There is no activity',

--- a/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/frontend/views/common/commonCoachStrings.js
@@ -430,6 +430,19 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     message: 'There was a problem saving this quiz',
     context: 'Error message.',
   },
+  saveLessonErrorDeletedUsers: {
+    message:
+      'There was a problem saving this lesson. One or more selected users no longer exist in this class. Please refresh the page and try again.',
+    context:
+      'Error message shown when saving a lesson fails because one or more selected individual learners have been deleted from the facility.',
+  },
+  saveQuizErrorDeletedUsers: {
+    message:
+      'There was a problem saving this quiz. One or more selected users no longer exist in this class. Please refresh the page and try again.',
+    context:
+      'Error message shown when saving a quiz fails because one or more selected individual learners have been deleted from the facility.',
+  },
+
 
   // empty states
   activityListEmptyState: {

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonCreationPage.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonCreationPage.vue
@@ -74,6 +74,8 @@
             const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
             if (errors) {
               this.$refs.detailsModal.handleSubmitTitleFailure();
+            } else if (error.response && error.response.data && error.response.data.learner_ids) {
+              this.$refs.detailsModal.handleSubmitDeletedUsersFailure();
             } else {
               this.$refs.detailsModal.handleSubmitFailure();
             }

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonsRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonsRootPage.vue
@@ -324,6 +324,8 @@
             const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
             if (errors) {
               this.$refs.detailsModal.handleSubmitTitleFailure();
+            } else if (error.response && error.response.data && error.response.data.learner_ids) {
+              this.$refs.detailsModal.handleSubmitDeletedUsersFailure();
             } else {
               this.$refs.detailsModal.handleSubmitFailure();
             }

--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/index.vue
@@ -356,9 +356,12 @@
           })
           .catch(error => {
             const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE, 'BLANK']);
-            this.$refs.detailsModal.handleSubmitFailure();
-            if (errors.length) {
+            if (errors && errors.length) {
               this.$refs.detailsModal.handleSubmitTitleFailure();
+            } else if (error.response && error.response.data && error.response.data.learner_ids) {
+              this.$refs.detailsModal.handleSubmitDeletedUsersFailure();
+            } else {
+              this.$refs.detailsModal.handleSubmitFailure();
             }
           });
       },


### PR DESCRIPTION

## Summary
This PR fixes the general error message, which doesn't give an indication to the user how to proceed if the user was suddenly deleted.
closes https://github.com/learningequality/kolibri/issues/14155

###  Before 

https://private-user-images.githubusercontent.com/79847249/548326235-498c66d9-8211-47e2-a1a2-ad6ebc617f67.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzE1MDk4MjEsIm5iZiI6MTc3MTUwOTUyMSwicGF0aCI6Ii83OTg0NzI0OS81NDgzMjYyMzUtNDk4YzY2ZDktODIxMS00N2UyLWExYTItYWQ2ZWJjNjE3ZjY3Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjE5VDEzNTg0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJhMjU0NTRkNjNlMmJiMmVkMDUzMDU0YmU0ZDM2NDYxZjY5MDE0Mzg2MDNmNjZmMjk3MTJjNGI5ZWZjMjJjZTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.XYAiHdUJ8qIp9GviOdL5_i8bIkC4IkZNBV7LcvQynG4
### After 

https://github.com/user-attachments/assets/368ffd2b-4eed-45a6-bbc5-34f9b73d47be



## References
https://github.com/learningequality/kolibri/issues/14155
## Reviewer guidance
Go to Coach > quiz/ lesson/ course  and attempt to assign a course
Delete a class/group/learner and attempt to proceed