### PR TITLE
prevent double scrollbar by hiding overflow

### DIFF
--- a/packages/kolibri-common/components/courses/sidePanel/SidePanelModal.vue
+++ b/packages/kolibri-common/components/courses/sidePanel/SidePanelModal.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onMounted, onUnmounted, ref } from 'vue';
   import Backdrop from 'kolibri/components/Backdrop';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
@@ -109,6 +109,13 @@
 
       onMounted(() => {
         sidePanel.value?.focus();
+        // Prevent the background page from scrolling while the side panel is open,
+        // which would otherwise cause a double scrollbar effect.
+        document.documentElement.style['overflow-y'] = 'hidden';
+      });
+
+      onUnmounted(() => {
+        document.documentElement.style['overflow-y'] = 'auto';
       });
 
       return {


### PR DESCRIPTION

## Summary
This PR fixes  a bit distracting issue with the double scrollbar appearing when there are more courses to select from 
closes https://github.com/learningequality/kolibri/issues/14154
## References
https://github.com/learningequality/kolibri/issues/14154

## Reviewer guidance

1. Go to Coach > Courses and assign multiple courses
2. Click the 'Assign course' button and start scrolling while the 'Select course to assign' panel is open