### PR TITLE
Remove explicit object base class from Python classes

### DIFF
--- a/kolibri/core/analytics/middleware.py
+++ b/kolibri/core/analytics/middleware.py
@@ -91,7 +91,7 @@ def cherrypy_access_log_middleware(get_response):
     return middleware
 
 
-class Metrics(object):
+class Metrics:
     def __init__(self):
         """
         Save the initial values when the request comes in

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -48,7 +48,7 @@ def mean(data):
     return None
 
 
-class BaseDeviceSetupMixin(object):
+class BaseDeviceSetupMixin:
     n_facilities = 1
     n_superusers = 1
     n_users = 20  # 20 users x 1 facility = 20 users

--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -297,7 +297,7 @@ def _generate_request(request, query_params, method="GET"):
     return ret
 
 
-class ListModelMixin(object):
+class ListModelMixin:
     def _get_list_queryset(self):
         queryset = self.filter_queryset(self.get_queryset())
 
@@ -326,7 +326,7 @@ class ListModelMixin(object):
         return response.data
 
 
-class RetrieveModelMixin(object):
+class RetrieveModelMixin:
     def retrieve(self, request, *args, **kwargs):
         return Response(self.serialize_object())
 

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -501,7 +501,7 @@ class PublicFacilityUserViewSet(ReadOnlyValuesViewset):
         return output
 
 
-class FacilityUserConsolidateMixin(object):
+class FacilityUserConsolidateMixin:
     """
     Mixin for FacilityUser ViewSets to handle consolidate logic
     """

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -12,7 +12,7 @@ from kolibri.core.auth.models import Session
 FACILITY_CREDENTIAL_KEY = "facility"
 
 
-class FacilityUserBackend(object):
+class FacilityUserBackend:
     """
     A class that implements authentication for FacilityUsers.
     """

--- a/kolibri/core/auth/constants/demographics.py
+++ b/kolibri/core/auth/constants/demographics.py
@@ -85,7 +85,7 @@ unique_translations_validator = NoRepeatedValueJSONArrayValidator(
 
 
 @deconstructible
-class DescriptionTranslationValidator(object):
+class DescriptionTranslationValidator:
     def __init__(self, custom_demographics_key):
         self.custom_demographics_key = custom_demographics_key
 
@@ -109,7 +109,7 @@ unique_value_validator = NoRepeatedValueJSONArrayValidator(
 
 
 @deconstructible
-class EnumValuesValidator(object):
+class EnumValuesValidator:
     def __init__(self, custom_demographics_key):
         self.custom_demographics_key = custom_demographics_key
 
@@ -129,7 +129,7 @@ class EnumValuesValidator(object):
 
 
 @deconstructible
-class LabelTranslationValidator(object):
+class LabelTranslationValidator:
     def __init__(self, custom_demographics_key):
         self.custom_demographics_key = custom_demographics_key
 

--- a/kolibri/core/auth/constants/morango_sync.py
+++ b/kolibri/core/auth/constants/morango_sync.py
@@ -12,7 +12,7 @@ PARTITION_SUFFIX_LEARNER_RW = ":learner-rw"
 PARTITION_SUFFIX_COACH_RW = ":coach-rw"
 
 
-class ScopeDefinitions(object):
+class ScopeDefinitions:
     """
     Class contains morango scope definition constants for certificates.
     """
@@ -21,7 +21,7 @@ class ScopeDefinitions(object):
     SINGLE_USER = "single-user"
 
 
-class State(object):
+class State:
     """
     Class containing constants for reporting current sync state
     """

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -245,7 +245,7 @@ def reverse_dict(original):
     return final
 
 
-class Validator(object):
+class Validator:
     """
     Class to apply different validation checks on a CSV data reader.
     """

--- a/kolibri/core/auth/middleware.py
+++ b/kolibri/core/auth/middleware.py
@@ -95,7 +95,7 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
         request.user = SimpleLazyObject(lambda: _get_user(request))
 
 
-class XhrPreventLoginPromptMiddleware(object):
+class XhrPreventLoginPromptMiddleware:
     """
     By default, HTTP 401 responses are sent with a ``WWW-Authenticate``
     header. Web browsers react to this header by displaying a login prompt

--- a/kolibri/core/auth/permissions/base.py
+++ b/kolibri/core/auth/permissions/base.py
@@ -12,7 +12,7 @@ from kolibri.core.auth.constants import role_kinds
 q_none = Q(pk__in=[])
 
 
-class BasePermissions(object):
+class BasePermissions:
     """
     Base Permission class from which all other Permission classes should inherit.
 

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -30,7 +30,7 @@ def get_free_tcp_port():
     return port
 
 
-class KolibriServer(object):
+class KolibriServer:
     def __init__(
         self,
         autostart=True,
@@ -185,7 +185,7 @@ class KolibriServer(object):
         return facility, learner, staff
 
 
-class multiple_kolibri_servers(object):
+class multiple_kolibri_servers:
     def __init__(self, count=2, **server_kwargs):
         self.server_count = count
         self.server_kwargs = [

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1774,7 +1774,7 @@ class LoginLogoutTestCase(APITestCase):
         self.assertEqual(response.data[0]["id"], error_constants.MISSING_PASSWORD)
 
 
-class SignUpBase(object):
+class SignUpBase:
     @classmethod
     def setUpTestData(cls):
         cls.facility = FacilityFactory.create()

--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -63,7 +63,7 @@ def fake_job(**kwargs):
     return Mock(spec=Job, **fake_data)
 
 
-class dummy_orm_job_data(object):
+class dummy_orm_job_data:
     scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=None)
     repeat = 5
     interval = 8600

--- a/kolibri/core/auth/test/test_middleware.py
+++ b/kolibri/core/auth/test/test_middleware.py
@@ -8,7 +8,7 @@ from ..middleware import get_anonymous_user_model
 from ..models import KolibriAnonymousUser
 
 
-class DummyRequestObject(object):
+class DummyRequestObject:
     def __init__(self):
         self.session = {}
 

--- a/kolibri/core/auth/test/test_sync_event_hook_utils.py
+++ b/kolibri/core/auth/test/test_sync_event_hook_utils.py
@@ -15,7 +15,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
     def setUp(self):
         super().setUp()
 
-        class TestHook(object):
+        class TestHook:
             pre_transfer = mock.Mock()
             post_transfer = mock.Mock()
 

--- a/kolibri/core/auth/utils/delete.py
+++ b/kolibri/core/auth/utils/delete.py
@@ -52,7 +52,7 @@ from kolibri.core.logger.models import UserSessionLog
 logger = logging.getLogger(__name__)
 
 
-class DisablePostDeleteSignal(object):
+class DisablePostDeleteSignal:
     """
     Helper that disables the post_delete signal temporarily when deleting, so Morango doesn't
     create DeletedModels objects for what we're deleting
@@ -67,7 +67,7 @@ class DisablePostDeleteSignal(object):
         self.receivers = None
 
 
-class GroupDeletion(object):
+class GroupDeletion:
     """
     Helper to manage deleting many models, or groups of models
     """

--- a/kolibri/core/auth/utils/sync.py
+++ b/kolibri/core/auth/utils/sync.py
@@ -168,7 +168,7 @@ def learner_canonicalized_assignments(resource_name, assignments):
     )
 
 
-class ClassroomPartitionFactory(object):
+class ClassroomPartitionFactory:
     """
     A factory class to create partitions for syncable models related to the classroom partition
     structure.

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -174,7 +174,7 @@ def no_cache_on_method(view_func):
     return method_decorator(never_cache, name="dispatch")(view_func)
 
 
-class RemoteMixin(object):
+class RemoteMixin:
     def _should_proxy_request(self, request):
         return REMOTE_URL_PARAM in request.GET
 
@@ -317,7 +317,7 @@ def _split_text_field(text):
     return text.split(",") if text else []
 
 
-class BaseChannelMetadataMixin(object):
+class BaseChannelMetadataMixin:
     filter_backends = (DjangoFilterBackend,)
     filterset_class = ChannelMetadataFilter
 
@@ -647,7 +647,7 @@ contentnode_previously_omitted_fields = {
 }
 
 
-class BaseContentNodeMixin(object):
+class BaseContentNodeMixin:
     """
     A base mixin for viewsets that need to return the same format of data
     serialization for ContentNodes.
@@ -1004,7 +1004,7 @@ NUM_CHILDREN = 12
 NUM_GRANDCHILDREN_PER_CHILD = 12
 
 
-class TreeQueryMixin(object):
+class TreeQueryMixin:
     def validate_and_return_params(self, request):
         depth = request.query_params.get("depth", 2)
         next__gt = request.query_params.get("next__gt")

--- a/kolibri/core/content/legacy_models.py
+++ b/kolibri/core/content/legacy_models.py
@@ -20,7 +20,7 @@ class License(models.Model):
         abstract = True
 
 
-class File(object):
+class File:
     """
     A mixin for previously deleted fields of the File Model
     """
@@ -33,7 +33,7 @@ class File(object):
     available = models.BooleanField(default=False)
 
 
-class ContentNode(object):
+class ContentNode:
     """
     A mixin for previously deleted field of the File Model
     """

--- a/kolibri/core/content/test/helpers.py
+++ b/kolibri/core/content/test/helpers.py
@@ -41,7 +41,7 @@ def choices(sequence, k):
     return [random.choice(sequence) for _ in range(0, k)]
 
 
-class ChannelBuilder(object):
+class ChannelBuilder:
     """
     This class is purely to generate all the relevant data for a single
     channel for use during testing.

--- a/kolibri/core/content/test/test_channel_order.py
+++ b/kolibri/core/content/test/test_channel_order.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from kolibri.core.content import models as content
 
 
-class ChannelOrderMixin(object):
+class ChannelOrderMixin:
     def _refresh_data(self, *args):
         for obj in args:
             obj.refresh_from_db()

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -41,7 +41,7 @@ from kolibri.utils.tests.helpers import override_option
 DUMMY_PASSWORD = "password"
 
 
-class ContentNodeTestBase(object):
+class ContentNodeTestBase:
     """
     Basecase for content metadata methods
     """
@@ -228,7 +228,7 @@ def infer_learning_activity(kind):
     return []
 
 
-class ContentNodeAPIBase(object):
+class ContentNodeAPIBase:
 
     fixtures = ["content_test.json"]
     the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -54,7 +54,7 @@ def Any(cls):
     return Any()
 
 
-class FalseThenTrue(object):
+class FalseThenTrue:
     def __init__(self, times=1):
         self.times = times
         self.count = 0

--- a/kolibri/core/content/test/test_tasks.py
+++ b/kolibri/core/content/test/test_tasks.py
@@ -245,7 +245,7 @@ class ValidateLocalImportTaskTestCase(TestCase):
             }
         )
 
-        class drive(object):
+        class drive:
             datafolder = "kolibri"
 
         mock_get_mounted_drive_by_id.return_value = drive

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -19,7 +19,7 @@ DeletedAssignment = namedtuple("ContentAssignment", ["source_model", "source_id"
 CONTENT_ASSIGNMENT_MANAGER_REGISTRY = {}
 
 
-class ContentAssignmentManager(object):
+class ContentAssignmentManager:
     """
     The ContentAssignmentManager is attached to a model, similar to a Django manager, but it's
     purpose is to allow introspection of changes to the model that occur during a sync, and to

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -197,7 +197,7 @@ def get_attribute(obj, key, default):
     return obj.get(key, default)
 
 
-class ChannelImport(object):
+class ChannelImport:
     """
     The ChannelImport class has two functions:
 

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -22,7 +22,7 @@ class ContentManifestParseError(ValueError):
     pass
 
 
-class ContentManifest(object):
+class ContentManifest:
     """
     A content manifest describes a selection of Kolibri content across
     multiple channels. It is usually stored as a JSON file along with exported

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -190,7 +190,7 @@ def synchronize_content_requests(dataset_id, transfer_session=None):
     )
 
 
-class PreferredDevices(object):
+class PreferredDevices:
     """
     A class that produces a generator returning preferred network locations (devices), given a list
     of instance IDs, and a filter for the version of Kolibri running on the server.

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -191,7 +191,7 @@ def load_metadata(name):
     return module.Base.metadata
 
 
-class LazyBases(object):
+class LazyBases:
     _valid_bases = set(CONTENT_DB_SCHEMA_VERSIONS + [CURRENT_SCHEMA_VERSION])
     _loaded_bases = {}
 
@@ -274,7 +274,7 @@ class SchemaNotFoundError(Exception):
     pass
 
 
-class Bridge(object):
+class Bridge:
     def __init__(self, sqlite_file_path=None, schema_version=None, app_name=None):
         if sqlite_file_path is None:
             # If sqlite_file_path is None, we are referencing the Django default database

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -36,7 +36,7 @@ TUPLE_TYPES = tuple, set, frozenset, list
 VALID_TYPES = int, float, str, bool
 
 
-class ParamValidator(object):
+class ParamValidator:
     # the name of the param in the request, e.g. 'user_id' (even if we pass 'user' to the Fn)
     param_name = None
 

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -12,7 +12,7 @@ from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.utils.conf import OPTIONS
 
 
-class KolibriLocaleMiddleware(object):
+class KolibriLocaleMiddleware:
     """
     Copied and then modified into a new style middleware from:
     https://github.com/django/django/blob/stable/3.2.x/django/middleware/locale.py#L10
@@ -86,7 +86,7 @@ class KolibriLocaleMiddleware(object):
         return response
 
 
-class ProvisioningErrorHandler(object):
+class ProvisioningErrorHandler:
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -103,7 +103,7 @@ class ProvisioningErrorHandler(object):
         return self.get_response(request)
 
 
-class DatabaseBusyErrorHandler(object):
+class DatabaseBusyErrorHandler:
     """
     A middleware class to raise a 503 when the database is under heavy load
     For SQLite this will trigger for database locked errors.

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -26,7 +26,7 @@ class NoFacilityFacilityUserSerializer(serializers.ModelSerializer):
         fields = ("username", "full_name", "password")
 
 
-class DeviceSerializerMixin(object):
+class DeviceSerializerMixin:
     def validate_language_id(self, language_id):
         """
         Check that the language_id is supported by Kolibri

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -38,7 +38,7 @@ WINDOW_SEC = 3
 MAX_ATTEMPTS = 5
 
 
-class Context(object):
+class Context:
     """
     A helper class to hold the context of a SoUD sync request, providing access to the necessary
     models and data.

--- a/kolibri/core/device/test/test_locale_middleware.py
+++ b/kolibri/core/device/test/test_locale_middleware.py
@@ -59,7 +59,7 @@ class URLTestCaseBase(TestCase):
         clear_process_cache()
 
 
-class URLPrefixTestsBase(object):
+class URLPrefixTestsBase:
     """
     Tests if the `i18n_patterns` is adding the prefix correctly.
     """
@@ -100,7 +100,7 @@ class PrefixedURLPrefixTests(URLPrefixTestsBase, URLTestCaseBase):
     pass
 
 
-class URLRedirectTestsBase(object):
+class URLRedirectTestsBase:
     """
     Tests if the user gets redirected to the right URL when there is no
     language-prefix in the request URL.
@@ -148,7 +148,7 @@ class PrefixedURLRedirectTests(URLRedirectTestsBase, URLTestCaseBase):
     pass
 
 
-class URLRedirectWithoutTrailingSlashTestsBase(object):
+class URLRedirectWithoutTrailingSlashTestsBase:
     """
     Tests the redirect when the requested URL doesn't end with a slash
     """
@@ -197,7 +197,7 @@ class PrefixedURLRedirectWithoutTrailingSlashTests(
     pass
 
 
-class URLResponseTestsBase(object):
+class URLResponseTestsBase:
     """
     Tests if the response has the right language-code.
     """

--- a/kolibri/core/discovery/test/test_filesystem_utils.py
+++ b/kolibri/core/discovery/test/test_filesystem_utils.py
@@ -14,7 +14,7 @@ from .dummydata import windows_data
 
 
 def _get_mocked_popen(cmd_resp):
-    class MockedPopen(object):
+    class MockedPopen:
         def __init__(self, cmd, *args, **kwargs):
             if cmd not in cmd_resp:
                 raise Exception(
@@ -39,7 +39,7 @@ def _get_mocked_disk_usage(disk_sizes):
 
         sizes = disk_sizes[path]
 
-        class MockDiskSizes(object):
+        class MockDiskSizes:
             f_frsize = 2
             f_blocks = sizes["total"] / 2
             f_bavail = sizes["free"] / 2
@@ -52,7 +52,7 @@ def _get_mocked_disk_usage(disk_sizes):
     return mock_disk_usage
 
 
-class patch_popen(object):
+class patch_popen:
     def __init__(self, cmd_resp):
         self.mocked_popen = _get_mocked_popen(cmd_resp)
 
@@ -61,7 +61,7 @@ class patch_popen(object):
         return f
 
 
-class patch_disk_usage(object):
+class patch_disk_usage:
     def __init__(self, disk_sizes):
         self.mocked_disk_usage = _get_mocked_disk_usage(disk_sizes)
 

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -64,7 +64,7 @@ NETWORK_EVENTS = {
 logger = logging.getLogger(__name__)
 
 
-class KolibriInstance(object):
+class KolibriInstance:
     """
     Class representing network Kolibri instances, including this instance, on Zeroconf network
     """
@@ -336,7 +336,7 @@ class KolibriInstanceListener(SimplePlugin):
         self.broadcast = broadcast
 
 
-class KolibriBroadcast(object):
+class KolibriBroadcast:
     """
     Responsible for handling Zeroconf service broadcast and listeners
     """

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -194,7 +194,7 @@ attemptlog_fields = [
 ]
 
 
-class LogContext(object):
+class LogContext:
     """
     Object used to provide a limited dict like interface for encoding the
     context that can be stored in the sessionlog, and which is then

--- a/kolibri/core/logger/test/helpers.py
+++ b/kolibri/core/logger/test/helpers.py
@@ -19,7 +19,7 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import MasteryLog
 
 
-class EvaluationMixin(object):
+class EvaluationMixin:
     """
     try0: most recent try
     try1: previous try

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -1224,7 +1224,7 @@ class ProgressTrackingViewSetStartSessionCoachQuizResumeTestCase(APITestCase):
         self.client.logout()
 
 
-class UpdateSessionBase(object):
+class UpdateSessionBase:
     def _make_request(self, data):
         data["context"] = {"node_id": self.node.id}
         return self.client.put(
@@ -1527,7 +1527,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionTestCase(
         self.client.logout()
 
 
-class ProgressTrackingViewSetUpdateSessionAssessmentBase(object):
+class ProgressTrackingViewSetUpdateSessionAssessmentBase:
     def _make_request(self, data):
         return self.client.put(
             reverse(

--- a/kolibri/core/mixins.py
+++ b/kolibri/core/mixins.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 logger = logging.getLogger(__name__)
 
 
-class BulkCreateMixin(object):
+class BulkCreateMixin:
     def get_serializer(self, *args, **kwargs):
         """ if an array is passed, set serializer to many """
         if isinstance(kwargs.get("data", {}), list):
@@ -26,7 +26,7 @@ class BulkCreateMixin(object):
         return super().get_serializer(*args, **kwargs)
 
 
-class BulkDeleteMixin(object):
+class BulkDeleteMixin:
 
     # Taken from https://github.com/miki725/django-rest-framework-bulk
 
@@ -155,7 +155,7 @@ def validate_uuids(ids):
     return ids
 
 
-class FilterByUUIDQuerysetMixin(object):
+class FilterByUUIDQuerysetMixin:
     """
     As a workaround to the SQLITE_MAX_VARIABLE_NUMBER, so we can avoid having to chunk our queries,
     we pass in the list of ids (after being validated) as an inline query statement.

--- a/kolibri/core/tasks/constants.py
+++ b/kolibri/core/tasks/constants.py
@@ -1,7 +1,7 @@
 DEFAULT_QUEUE = "kolibri"
 
 
-class Priority(object):
+class Priority:
     """
     This class defines the priority levels and their corresponding integer values.
 

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -23,7 +23,7 @@ from kolibri.utils.translation import gettext as _
 logger = logging.getLogger(__name__)
 
 
-class State(object):
+class State:
     """
     The State object enumerates a Job's possible valid states.
 
@@ -102,7 +102,7 @@ def default_status_text(job):
 ALLOWED_RETRY_IN_KWARGS = {"priority", "repeat", "interval", "retry_interval"}
 
 
-class Job(object):
+class Job:
     """
     Job represents a function whose execution has been deferred through the Client's schedule function.
 

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -129,7 +129,7 @@ class _registry(dict):
 TaskRegistry = _registry()
 
 
-class RegisteredTask(object):
+class RegisteredTask:
     """
     This class acts as a transparent wrapper around the `func` argument.
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -94,7 +94,7 @@ class ORMJob(Base):
 NO_VALUE = object()
 
 
-class Storage(object):
+class Storage:
     def __init__(self, connection, Base=Base):
         self.engine = connection
         if self.engine.name == "sqlite":

--- a/kolibri/core/tasks/test/taskrunner/conftest.py
+++ b/kolibri/core/tasks/test/taskrunner/conftest.py
@@ -11,7 +11,7 @@ def mock_compat(request, monkeypatch):
         from multiprocessing import Event  # noqa
         from concurrent.futures import ProcessPoolExecutor as PoolExecutor  # noqa
 
-        class local(object):
+        class local:
             """
             Dummy class to use for a local object for multiprocessing
             """

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -73,7 +73,7 @@ def _underlying_event(f):
     return func
 
 
-class EventProxy(object):
+class EventProxy:
     """
     The tests in this file were originally written when we didn't need
     to pickle objects in storage. That way, we could use threading.Event
@@ -162,7 +162,7 @@ def update_progress_cancelable_job():
             return
 
 
-class TestJobStorage(object):
+class TestJobStorage:
     def test_does_not_enqueue_a_function(self, storage_fixture):
         try:
             storage_fixture.enqueue_job(id)

--- a/kolibri/core/tasks/test/taskrunner/test_scheduler.py
+++ b/kolibri/core/tasks/test/taskrunner/test_scheduler.py
@@ -19,7 +19,7 @@ def job_storage():
         s.clear(force=True)
 
 
-class TestScheduler(object):
+class TestScheduler:
     @pytest.fixture
     def job(self):
         return Job(id)

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -52,7 +52,7 @@ def fake_job(**kwargs):
     return Mock(spec=Job, **fake_data)
 
 
-class dummy_orm_job_data(object):
+class dummy_orm_job_data:
     scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=None)
     repeat = 5
     interval = 8600

--- a/kolibri/core/tasks/test/test_utils.py
+++ b/kolibri/core/tasks/test/test_utils.py
@@ -6,7 +6,7 @@ from mock import patch
 from kolibri.core.tasks.utils import InfiniteLoopThread
 
 
-class TestBaseCloseableThread(object):
+class TestBaseCloseableThread:
     def test_handles_interpreter_shutting_down(self):
         """
         For python interpreters older than 3.4, we know that it sets

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -269,7 +269,7 @@ class ProgressTracker:
                 self.progressbar.label = message
 
 
-class JobProgressMixin(object):
+class JobProgressMixin:
     """A mixin with convenience functions for displaying
     progress to the user, and updating progress on a job.
 

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -59,7 +59,7 @@ def execute_job_with_python_worker(job_id, log_queue=None):
     )
 
 
-class Worker(object):
+class Worker:
     def __init__(self, connection, regular_workers=2, high_workers=1, log_queue=None):
         # Internally, we use concurrent.future.Future to run and track
         # job executions. We need to keep track of which future maps to which

--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -12,7 +12,7 @@ from kolibri.utils.version import version_matches_range
 CURRENT_VERSION = VersionInfo.parse(normalize_version_to_semver(kolibri.__version__))
 
 
-class VersionUpgrade(object):
+class VersionUpgrade:
     """
     Class for version upgrade operations
     """

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -18,7 +18,7 @@ def __get_process_cache():
 process_cache = SimpleLazyObject(__get_process_cache)
 
 
-class RedisSettingsHelper(object):
+class RedisSettingsHelper:
     """
     Small wrapper for the Redis client to explicitly get/set values from the client
     """

--- a/kolibri/core/utils/lock.py
+++ b/kolibri/core/utils/lock.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.utils.functional import wraps
 
 
-class DummyOperation(object):
+class DummyOperation:
     def __init__(self):
         self.obj = None
 
@@ -20,7 +20,7 @@ class DummyOperation(object):
             self.obj.delete()
 
 
-class PostgresLock(object):
+class PostgresLock:
     def __init__(self, key=None):
         self.key = key
 

--- a/kolibri/core/utils/validators.py
+++ b/kolibri/core/utils/validators.py
@@ -6,7 +6,7 @@ from json_schema_validator.validator import Validator
 
 
 @deconstructible
-class JSON_Schema_Validator(object):
+class JSON_Schema_Validator:
     def __init__(self, schema):
         self.schema = Schema(schema)
 
@@ -24,7 +24,7 @@ class JSON_Schema_Validator(object):
 
 
 @deconstructible
-class NoRepeatedValueJSONArrayValidator(object):
+class NoRepeatedValueJSONArrayValidator:
     def __init__(self, array_key=None, object_key=None):
         """
         A validator that checks that the values of the array are unique.

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -309,7 +309,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         return mark_safe("\n".join(tags))
 
 
-class WebpackInclusionMixin(object):
+class WebpackInclusionMixin:
     @abstractproperty
     def bundle_html(self):
         pass

--- a/kolibri/core/webpack/test/base.py
+++ b/kolibri/core/webpack/test/base.py
@@ -18,7 +18,7 @@ TEST_STATS_FILE_DATA = {
 }
 
 
-class HookMixin(object):
+class HookMixin:
     """
     This hook will mock stats file JSON (normally created by npm)
     and populate it with test data according to the unique_id of the hook

--- a/kolibri/plugins/app/utils.py
+++ b/kolibri/plugins/app/utils.py
@@ -19,7 +19,7 @@ CAPABILITES = (
 )
 
 
-class AppInterface(object):
+class AppInterface:
     __slot__ = "_capabilities"
 
     def __init__(self):

--- a/kolibri/plugins/registry.py
+++ b/kolibri/plugins/registry.py
@@ -84,7 +84,7 @@ def parse_installed_app_entry(app):
     return app
 
 
-class Registry(object):
+class Registry:
     __slots__ = ("_apps",)
 
     def __init__(self):

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -301,7 +301,7 @@ class PluginUpdateException(Exception):
     pass
 
 
-class PluginUpdateManager(object):
+class PluginUpdateManager:
     def __init__(self, updated_plugins):
         # Import here as triggers django app loading
         from django.db.migrations.loader import MigrationLoader

--- a/kolibri/utils/data.py
+++ b/kolibri/utils/data.py
@@ -47,7 +47,7 @@ def bytes_from_humans(size, suffix="B"):
     raise ValueError("Could not parse bytes value from {}".format(size))
 
 
-class ChoicesEnum(object):
+class ChoicesEnum:
     @classmethod
     def choices(cls):
         choices_list = [

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -134,7 +134,7 @@ class TransferFileBase(BufferedIOBase, ABC):
         pass
 
 
-class ChunkedFileDirectoryManager(object):
+class ChunkedFileDirectoryManager:
     """
     A class to manage all chunked files in a directory and all its descendant directories.
     Its main purpose is to allow for the deletion of chunked files based on a least recently used

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -28,7 +28,7 @@ from kolibri.utils.urls import validator
 compressed_file_extensions = ("gz",)
 
 
-class NotFoundStaticFile(object):
+class NotFoundStaticFile:
     """
     A special static file class to give a not found response,
     rather than letting it be further handled by the wrapped WSGI server.

--- a/kolibri/utils/multiprocessing_compat.py
+++ b/kolibri/utils/multiprocessing_compat.py
@@ -36,7 +36,7 @@ def Queue(*args, **kwargs):
     return ThreadingQueue(*args, **kwargs)
 
 
-class _Local(object):
+class _Local:
     """
     Dummy class to use for a local object for multiprocessing
     """

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -313,7 +313,7 @@ def cache_option(value):
         raise VdtValueError(value)
 
 
-class LazyImportFunction(object):
+class LazyImportFunction:
     """
     A function wrapper that will import a module when called.
     We may be able to drop this when Python 2.7 support is dropped

--- a/kolibri/utils/pskolibri/__init__.py
+++ b/kolibri/utils/pskolibri/__init__.py
@@ -205,7 +205,7 @@ def pids():
     return _psplatform.pids()
 
 
-class Process(object):
+class Process:
     """Represents an OS process with the given PID.
     If PID is omitted current process PID (os.getpid()) is used.
     Raise NoSuchProcess if PID does not exist.

--- a/kolibri/utils/pskolibri/_pslinux.py
+++ b/kolibri/utils/pskolibri/_pslinux.py
@@ -194,7 +194,7 @@ def boot_time():
         raise RuntimeError("line 'btime' not found in %s" % path)
 
 
-class Process(object):
+class Process:
     """Linux process implementation."""
 
     __slots__ = ["pid", "_name", "_ppid", "_procfs_path"]

--- a/kolibri/utils/pskolibri/_pswindows.py
+++ b/kolibri/utils/pskolibri/_pswindows.py
@@ -201,7 +201,7 @@ def handle_from_pid(pid):
     return kernel32.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, pid)
 
 
-class Process(object):
+class Process:
     """Wrapper class around underlying C implementation."""
 
     __slots__ = ["pid", "_name", "_ppid"]

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -14,7 +14,7 @@ from kolibri.utils import server
 from kolibri.utils.constants import installation_types
 
 
-class TestServerInstallation(object):
+class TestServerInstallation:
     @mock.patch("sys.argv", ["kolibri-0.9.3.pex", "start"])
     def test_pex(self):
         install_type = server.installation_type()
@@ -88,7 +88,7 @@ def job_storage():
         s.clear()
 
 
-class TestServerServices(object):
+class TestServerServices:
     @mock.patch("kolibri.core.deviceadmin.tasks.schedule_vacuum")
     @mock.patch("kolibri.core.analytics.tasks.schedule_ping")
     @mock.patch("kolibri.core.tasks.main.initialize_workers")
@@ -128,7 +128,7 @@ class TestServerServices(object):
         ]
 
 
-class TestServerDefaultScheduledTasks(object):
+class TestServerDefaultScheduledTasks:
     @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
     def test_scheduled_jobs_persist_on_restart(
         self,
@@ -176,7 +176,7 @@ class TestServerDefaultScheduledTasks(object):
             assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
 
 
-class TestZeroConfPlugin(object):
+class TestZeroConfPlugin:
     @mock.patch("kolibri.core.discovery.utils.network.search.NetworkLocationListener")
     @mock.patch(
         "kolibri.core.discovery.utils.network.broadcast.build_broadcast_instance"


### PR DESCRIPTION
## Summary

Removed explicit inheritance from the `object` base class, since it's not needed in Python 3.

In brief: `class Foo(object):` → `class Foo:`

At the time of commit, there were exactly 100 occurrences across 69 files, exactly matching the issue description.

## References

Fixes #14179 

## Reviewer guidance

To test these changes, after this PR, the following command should return zero matches:

```
grep -rn 'class \w\+(object):' kolibri/
```