### PR TITLE
Convert epub viewer bar unit tests to Vue Testing Library

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/BottomBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/BottomBar.spec.js
@@ -1,59 +1,51 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import BottomBar from '../BottomBar';
 
-function createWrapper({
-  heading,
-  sliderValue = 0,
-  sliderStep = 1,
-  locationsAreReady = true,
-} = {}) {
-  return mount(BottomBar, {
-    propsData: {
-      heading,
-      sliderValue,
-      sliderStep,
-      locationsAreReady,
+function renderBottomBar(props = {}) {
+  return render(BottomBar, {
+    props: {
+      sliderValue: 0,
+      sliderStep: 1,
+      locationsAreReady: true,
+      ...props,
     },
   });
 }
 
 describe('Bottom bar', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
-  });
   it('should not display a heading if none is provided', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.find('h3').element).toBeFalsy();
+    renderBottomBar();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
   });
   it('should display a heading if one is provided', () => {
     const heading = 'Chapter 1';
-    const wrapper = createWrapper({ heading });
-    expect(wrapper.find('h3').element).toBeTruthy();
+    renderBottomBar({ heading });
+    expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument();
   });
   it('should not display slider if locations are not ready', () => {
-    const wrapper = createWrapper({ locationsAreReady: false });
-    expect(wrapper.find('input').element).toBeFalsy();
+    renderBottomBar({ locationsAreReady: false });
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
   });
   it('should display slider if locations are ready', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.find('input').element).toBeTruthy();
+    renderBottomBar();
+    expect(screen.getByRole('slider')).toBeInTheDocument();
   });
   it('should set the correct value on the slider', () => {
     const sliderValue = 100;
-    const wrapper = createWrapper({ sliderValue });
-    expect(wrapper.find('input').element.value).toBe(String(sliderValue));
+    renderBottomBar({ sliderValue});
+    expect(screen.getByRole('slider')).toHaveValue('100');
   });
   it('should set the correct step on the slider', () => {
     const sliderStep = 10;
-    const wrapper = createWrapper({ sliderStep });
-    expect(wrapper.find('input').element.step).toBe(String(sliderStep));
+    renderBottomBar({ sliderStep });
+    expect(screen.getByRole('slider')).toHaveAttribute('step', String(sliderStep));
   });
-  it("should emit an event when the slider's value is changed", () => {
-    const newValue = 50;
-    const wrapper = createWrapper();
-    wrapper.find('input').element.value = newValue;
-    wrapper.find('input').trigger('change');
-    expect(wrapper.emitted().sliderChanged[0][0]).toBe(newValue);
+  it("should emit an event when the slider's value is changed", async () => {
+    const newValue = '50';
+    const { emitted } = renderBottomBar();
+    const slider = screen.getByRole('slider');
+    slider.value = newValue;
+    await fireEvent.change(slider);
+    expect(emitted().sliderChanged[0][0]).toBe(Number(newValue));
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/BottomBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/BottomBar.spec.js
@@ -32,7 +32,7 @@ describe('Bottom bar', () => {
   });
   it('should set the correct value on the slider', () => {
     const sliderValue = 100;
-    renderBottomBar({ sliderValue});
+    renderBottomBar({ sliderValue });
     expect(screen.getByRole('slider')).toHaveValue('100');
   });
   it('should set the correct step on the slider', () => {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -21,16 +21,14 @@ describe('Top bar', () => {
     const title = 'Book title';
     renderTopBar({ title });
 
-    expect(
-      screen.getByRole('heading', { name: title })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
   });
 
   it('allows parent to focus on table of contents button', () => {
     renderTopBar();
     const tocButton = screen.getByRole('button', { name: /toggle table of contents/i });
     tocButton.focus();
-    expect(document.activeElement).toBe(tocButton);
+    expect(tocButton).toHaveFocus();
   });
 
   it('allows parent to focus on settings button', () => {
@@ -39,7 +37,7 @@ describe('Top bar', () => {
     const settingsButton = screen.getByRole('button', { name: /toggle settings/i });
     settingsButton.focus();
 
-    expect(document.activeElement).toBe(settingsButton);
+    expect(settingsButton).toHaveFocus();
   });
 
   it('allows parent to focus on search button', () => {
@@ -48,7 +46,7 @@ describe('Top bar', () => {
     const searchButton = screen.getByRole('button', { name: /toggle search/i });
     searchButton.focus();
 
-    expect(document.activeElement).toBe(searchButton);
+    expect(searchButton).toHaveFocus();
   });
 
   it('emits event when table of contents button is clicked', async () => {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -1,69 +1,85 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import TopBar from '../TopBar';
 
-function createWrapper({ title, isInFullscreen = false } = {}) {
-  const node = document.createElement('app');
-  document.body.appendChild(node);
-  return mount(TopBar, {
-    propsData: {
-      title,
-      isInFullscreen,
+function renderTopBar(props = {}) {
+  return render(TopBar, {
+    props: {
+      isInFullscreen: false,
+      ...props,
     },
-    attachTo: node,
   });
 }
 
 describe('Top bar', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
-  });
-  it('should not have a heading if a title is not passed in', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.find('h2').element).toBeFalsy();
-  });
-  it('should have a heading if a title is passed in', () => {
-    const title = 'Book title';
-    const wrapper = createWrapper({ title });
-    expect(wrapper.find('h2').element).toBeTruthy();
-  });
-  it('should allow parent to focus on table of contents button', () => {
-    const wrapper = createWrapper();
-    wrapper.vm.focusOnTocButton();
-    const elementThatIsFocused = document.activeElement;
-    expect(elementThatIsFocused).toHaveAttribute('data-test', 'toc button');
-  });
-  it('should allow parent to focus on settings button', () => {
-    const wrapper = createWrapper();
-    wrapper.vm.focusOnSettingsButton();
-    const elementThatIsFocused = document.activeElement;
-    expect(elementThatIsFocused).toHaveAttribute('data-test', 'settings button');
-  });
-  it('should allow parent to focus on search button', () => {
-    const wrapper = createWrapper();
-    wrapper.vm.focusOnSearchButton();
-    const elementThatIsFocused = document.activeElement;
-    expect(elementThatIsFocused).toHaveAttribute('data-test', 'search button');
+  it('does not show heading when title is not provided', () => {
+    renderTopBar();
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
   });
 
-  it('should emit and event when the table of contents button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ name: 'TocButton' }).trigger('click');
-    expect(wrapper.emitted().tableOfContentsButtonClicked).toBeTruthy();
+  it('shows heading when title is provided', () => {
+    const title = 'Book title';
+    renderTopBar({ title });
+
+    expect(
+      screen.getByRole('heading', { name: title })
+    ).toBeInTheDocument();
   });
-  it('should emit and event when the settings button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ name: 'SettingsButton' }).trigger('click');
-    expect(wrapper.emitted().settingsButtonClicked).toBeTruthy();
+
+  it('allows parent to focus on table of contents button', () => {
+    renderTopBar();
+    const tocButton = screen.getByRole('button', { name: /toggle table of contents/i });
+    tocButton.focus();
+    expect(document.activeElement).toBe(tocButton);
   });
-  it('should emit and event when the search button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ name: 'SearchButton' }).trigger('click');
-    expect(wrapper.emitted().searchButtonClicked).toBeTruthy();
+
+  it('allows parent to focus on settings button', () => {
+    renderTopBar();
+
+    const settingsButton = screen.getByRole('button', { name: /toggle settings/i });
+    settingsButton.focus();
+
+    expect(document.activeElement).toBe(settingsButton);
   });
-  it('should emit and event when the fullscreen button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ ref: 'fullscreenButton' }).trigger('click');
-    expect(wrapper.emitted().fullscreenButtonClicked).toBeTruthy();
+
+  it('allows parent to focus on search button', () => {
+    renderTopBar();
+
+    const searchButton = screen.getByRole('button', { name: /toggle search/i });
+    searchButton.focus();
+
+    expect(document.activeElement).toBe(searchButton);
+  });
+
+  it('emits event when table of contents button is clicked', async () => {
+    const { emitted } = renderTopBar();
+
+    await fireEvent.click(screen.getAllByRole('button')[0]);
+
+    expect(emitted().tableOfContentsButtonClicked).toBeTruthy();
+  });
+
+  it('emits event when settings button is clicked', async () => {
+    const { emitted } = renderTopBar();
+
+    await fireEvent.click(screen.getAllByRole('button')[1]);
+
+    expect(emitted().settingsButtonClicked).toBeTruthy();
+  });
+
+  it('emits event when search button is clicked', async () => {
+    const { emitted } = renderTopBar();
+
+    await fireEvent.click(screen.getAllByRole('button')[2]);
+
+    expect(emitted().searchButtonClicked).toBeTruthy();
+  });
+
+  it('emits event when fullscreen button is clicked', async () => {
+    const { emitted } = renderTopBar();
+
+    await fireEvent.click(screen.getAllByRole('button')[3]);
+
+    expect(emitted().fullscreenButtonClicked).toBeTruthy();
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -46,7 +46,7 @@ describe('Top bar', () => {
     const searchButton = screen.getByRole('button', { name: /toggle search/i });
     searchButton.focus();
 
-    expect(searchButton).toHaveFocus();
+    expect(document.activeElement).toBe(searchButton);
   });
 
   it('emits event when table of contents button is clicked', async () => {
@@ -60,7 +60,7 @@ describe('Top bar', () => {
   it('emits event when settings button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getAllByRole('button')[1]);
+    await fireEvent.click(screen.getByRole('button', { name: /toggle settings/i }));
 
     expect(emitted().settingsButtonClicked).toBeTruthy();
   });
@@ -68,7 +68,7 @@ describe('Top bar', () => {
   it('emits event when search button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getAllByRole('button')[2]);
+    await fireEvent.click(screen.getByRole('button', { name: /toggle search/i }));
 
     expect(emitted().searchButtonClicked).toBeTruthy();
   });
@@ -76,7 +76,7 @@ describe('Top bar', () => {
   it('emits event when fullscreen button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getAllByRole('button')[3]);
+    await fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
 
     expect(emitted().fullscreenButtonClicked).toBeTruthy();
   });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -46,7 +46,7 @@ describe('Top bar', () => {
     const searchButton = screen.getByRole('button', { name: /toggle search/i });
     searchButton.focus();
 
-    expect(document.activeElement).toBe(searchButton);
+    expect(searchButton).toHaveFocus();
   });
 
   it('emits event when table of contents button is clicked', async () => {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -52,7 +52,7 @@ describe('Top bar', () => {
   it('emits event when table of contents button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getAllByRole('button')[0]);
+    await fireEvent.click(screen.getByRole('button', { name: /toggle table of contents/i }));
 
     expect(emitted().tableOfContentsButtonClicked).toBeTruthy();
   });


### PR DESCRIPTION

## Summary
Refactored `BottomBar.spec.js` and `TopBar.spec.js` test files to use Vue Testing Library (VTL) instead of Vue Test Utils.

## Manual Verification
1. Run tests: `pnpm run test-jest -- --testPathPattern epub_viewer`
2. Verify all BottomBar and TopBar tests pass

<img width="807" height="414" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/3ebf1a44-78c7-4969-be0a-35c85d2e8536" />





3. Manually test EPUB viewer controls in the UI:
   - Verify slider adjusts page position (BottomBar)
   - Verify all top bar buttons (TOC, Settings, Search, Fullscreen) respond to clicks


## References
Closes #14185 

