### PR TITLE
Remove Python 2 compatibility shims

### DIFF
--- a/kolibri/core/discovery/tasks.py
+++ b/kolibri/core/discovery/tasks.py
@@ -166,10 +166,6 @@ def hydrate_instance(func):
         new_args[1] = KolibriInstance.from_dict(args[1])
         return func(*new_args)
 
-    # for py2.7
-    if not hasattr(wrapped, "__wrapped__"):
-        setattr(wrapped, "__wrapped__", func)
-
     return wrapped
 
 

--- a/kolibri/core/test/test_nothing.py
+++ b/kolibri/core/test/test_nothing.py
@@ -25,11 +25,7 @@ class TestNothing(TestCase):
         try:
             x = Nothing()
             pickled_nothingness = pickle.dumps(x)
-            pickled_nothingness_py2_7 = pickle.dumps(x, protocol=2)
             y = pickle.loads(pickled_nothingness)
-            z = pickle.loads(pickled_nothingness_py2_7)
             assert x == y
-            assert x == z
-            assert y == z
         except Exception:
             self.fail("we couldn't get `Nothing()` back after pickling it")

--- a/kolibri/plugins/utils/test/helpers.py
+++ b/kolibri/plugins/utils/test/helpers.py
@@ -1,12 +1,5 @@
 from contextlib import contextmanager
-
-try:
-    from importlib import reload
-except ImportError:
-    # This will happen on Python 2.7
-    # use built in reload.
-    reload = reload
-
+from importlib import reload
 import sys
 
 from django.conf import settings

--- a/kolibri/plugins/utils/test/helpers.py
+++ b/kolibri/plugins/utils/test/helpers.py
@@ -1,6 +1,6 @@
+import sys
 from contextlib import contextmanager
 from importlib import reload
-import sys
 
 from django.conf import settings
 from django.urls import clear_url_caches

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -1,12 +1,5 @@
 import os
-
-try:
-    from importlib import reload
-except ImportError:
-    # This will happen on Python 2.7
-    # use built in reload.
-    reload = reload
-
+from importlib import reload
 import sys
 
 from django.conf import settings

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -1,10 +1,10 @@
 import os
-from importlib import reload
 import sys
+from importlib import reload
 
 from django.conf import settings
-from django.urls import clear_url_caches
 from django.test.utils import TestContextDecorator
+from django.urls import clear_url_caches
 
 from kolibri.utils import conf
 from kolibri.utils.options import option_spec


### PR DESCRIPTION

## Summary

Removes Python 2.7 dead code paths : 

- Replace `try/except` reload fallbacks with `from importlib import reload`
- Remove manual `__wrapped__` shim 
- Remove `protocol=2` pickle test

No functional changes, cleanup only.


## References

Closes #14180 