### PR TITLE
Update Node.js version in getting_started docs from 18.x to 20.x

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -176,7 +176,7 @@ The Python project-specific dependencies installed above will install ``nodeenv`
 .. code-block:: bash
 
   # node.js, npm, and pnpm
-  nodeenv -p --node=18.20.7
+  nodeenv -p --node=20.19.0
   npm install -g pnpm
 
   # other required project dependencies


### PR DESCRIPTION
## Summary

The Getting Started documentation recommends installing Node.js 18.x via `nodeenv -p --node=18.20.7`, but [package.json](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/package.json:0:0-0:0) on the `develop` branch specifies `"node": "^20.19.0"` in the `engines` field.

Following the current docs and using Node 18.20.7 results in warnings during `pnpm install`:

```
WARN Unsupported engine: wanted: {"node":"^20.19.0"} (current: {"node":"v18.20.7"})
```

This PR updates the `nodeenv` command in [docs/getting_started.rst](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/docs/getting_started.rst:0:0-0:0) from `18.20.7` to `20.19.0` to match the minimum version required by [package.json](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/package.json:0:0-0:0).

The [docs/howtos/nodeenv.md](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/docs/howtos/nodeenv.md:0:0-0:0) guide already references Node 20.x, so this was the only place that needed updating.

## References

- Related to the `engines.node` field in [package.json](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/package.json:0:0-0:0): `"node": "^20.19.0"`
- [docs/howtos/nodeenv.md](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/docs/howtos/nodeenv.md:0:0-0:0) already uses Node 20.19.3

## Reviewer guidance

- Check that `nodeenv -p --node=20.19.0` installs successfully and `pnpm install` runs without engine warnings.
- This is a docs-only change — no code or tests are affected.
