### PR TITLE
Use update_dirty_bit_to in pre_save to allow null user fields during deserialization

### DIFF
--- a/kolibri/core/attendance/models.py
+++ b/kolibri/core/attendance/models.py
@@ -48,8 +48,8 @@ class AttendanceSession(AbstractFacilityDataModel):
     def __str__(self):
         return "AttendanceSession for {}".format(self.collection)
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
         if self._state.adding and self.created_by is None:
             raise IntegrityError("AttendanceSession must be saved with a creator")
         if self.created_by and self.created_by.dataset_id != self.dataset_id:

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -361,7 +361,7 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
         )
         super().full_clean(*args, **kwargs)
 
-    def pre_save(self):
+    def pre_save(self, **kwargs):
         # before saving, ensure we have a dataset, and convert any validation errors into integrity
         # errors, since by this point the `clean_fields` method should already have prevented
         # this situation from arising
@@ -371,7 +371,7 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
             raise IntegrityError(str(e))
 
     def save(self, *args, **kwargs):
-        self.pre_save()
+        self.pre_save(**kwargs)
         super().save(*args, **kwargs)
 
     def ensure_dataset(self, *args, **kwargs):

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -74,10 +74,16 @@ class CourseSession(AbstractFacilityDataModel):
             self.title, self.collection.name
         )
 
-    def pre_save(self):
-        super().pre_save()
-        # if the created_by user is in a different dataset than the dataset we've determined, then
-        # we'll unset it to prevent deserialization errors when syncing
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
+
+        is_deserialization = kwargs.get("update_dirty_bit_to") is False
+
+        if not is_deserialization and self.created_by is None:
+            raise IntegrityError(
+                "CourseSession must be saved with a non None created_by field"
+            )
+
         if self.created_by and self.created_by.dataset_id != self.dataset_id:
             if not self.created_by.is_superuser:
                 raise IntegrityError(
@@ -163,8 +169,8 @@ class CourseSessionAssignment(AbstractFacilityDataModel):
     # Morango fields
     morango_model_name = "coursesessionassignment"
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # this shouldn't happen
         if (
@@ -176,11 +182,11 @@ class CourseSessionAssignment(AbstractFacilityDataModel):
                 "CourseSession assignment foreign models must be in same dataset"
             )
 
-        # maintain stricter enforcement on when assigned_by is allowed to be null
-        # assignments aren't usually updated, but ensure only during creation
-        if self._state.adding and self.assigned_by is None:
+        is_deserialization = kwargs.get("update_dirty_bit_to") is False
+
+        if not is_deserialization and self.assigned_by is None:
             raise IntegrityError(
-                "CourseSession assignment must be saved with an assigner"
+                "CourseSession assignment must be saved with a non None assigned_by field"
             )
 
         # validate that datasets match so this would be syncable
@@ -340,8 +346,8 @@ class UnitTestAssignment(AbstractFacilityDataModel):
         )
         return str(filter_factory.build(classroom_collection.id))
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # Ensure course_session and collection are in the same dataset
         if (
@@ -363,7 +369,13 @@ class UnitTestAssignment(AbstractFacilityDataModel):
                     "UnitTestAssignment collection must be the same as or a child of the CourseSession's collection"
                 )
 
-        # If activated_by is set, validate it's in the same dataset
+        is_deserialization = kwargs.get("update_dirty_bit_to") is False
+
+        if not is_deserialization and self.activated_by is None:
+            raise IntegrityError(
+                "UnitTestAssignment must be saved with an non None activated_by field"
+            )
+
         if self.activated_by and self.activated_by.dataset_id != self.dataset_id:
             # Only allow null for superusers
             if not self.activated_by.is_superuser:

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -401,6 +401,89 @@ class UnitTestAssignmentDeserializeSyncFilterTestCase(
 ):
     model_class = models.UnitTestAssignment
     user_field_name = "activated_by_id"
+class PreSaveKwargsTestMixin:
+    """
+    Shared tests for pre_save update_dirty_bit_to logic.
+    Subclasses set model_class, user_field_name, and build_instance().
+    """
+
+    databases = "__all__"
+    model_class = None
+    user_field_name = None
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = Facility.objects.create(name="TestFacility")
+        cls.classroom = Classroom.objects.create(
+            name="TestClassroom", parent=cls.facility
+        )
+        cls.coach = FacilityUser.objects.create(username="coach", facility=cls.facility)
+        cls.course_session = models.CourseSession.objects.create(
+            course=uuid.uuid4().hex,
+            title="Test",
+            collection=cls.classroom,
+            created_by=cls.coach,
+        )
+
+    def build_instance(self, with_user=True):
+        raise NotImplementedError
+
+    def test_normal_save_raises_when_user_field_is_null(self):
+        instance = self.build_instance(with_user=False)
+        with self.assertRaises(IntegrityError):
+            instance.save()
+
+    def test_deserialization_save_allows_null_user_field(self):
+        instance = self.build_instance(with_user=False)
+        instance.save(update_dirty_bit_to=False)
+        instance.refresh_from_db()
+        self.assertIsNone(getattr(instance, self.user_field_name))
+
+    def test_normal_save_passes_with_user_field_set(self):
+        instance = self.build_instance(with_user=True)
+        instance.save()
+        instance.refresh_from_db()
+        self.assertIsNotNone(getattr(instance, self.user_field_name))
+
+
+class CourseSessionPreSaveTestCase(PreSaveKwargsTestMixin, TestCase):
+    model_class = models.CourseSession
+    user_field_name = "created_by"
+
+    def build_instance(self, with_user=True):
+        return models.CourseSession(
+            course=uuid.uuid4().hex,
+            title="Test",
+            collection=self.classroom,
+            created_by=self.coach if with_user else None,
+        )
+
+
+class CourseSessionAssignmentPreSaveTestCase(PreSaveKwargsTestMixin, TestCase):
+    model_class = models.CourseSessionAssignment
+    user_field_name = "assigned_by"
+
+    def build_instance(self, with_user=True):
+        return models.CourseSessionAssignment(
+            course_session=self.course_session,
+            collection=self.classroom,
+            assigned_by=self.coach if with_user else None,
+        )
+
+
+class UnitTestAssignmentPreSaveTestCase(PreSaveKwargsTestMixin, TestCase):
+    model_class = models.UnitTestAssignment
+    user_field_name = "activated_by"
+
+    def build_instance(self, with_user=True):
+        return models.UnitTestAssignment(
+            course_session=self.course_session,
+            unit_contentnode_id=uuid.uuid4().hex,
+            collection=self.classroom,
+            test_type="pre",
+            activated_by=self.coach if with_user else None,
+        )
 
 
 class TestTypeEnumTestCase(TestCase):

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -401,6 +401,8 @@ class UnitTestAssignmentDeserializeSyncFilterTestCase(
 ):
     model_class = models.UnitTestAssignment
     user_field_name = "activated_by_id"
+
+
 class PreSaveKwargsTestMixin:
     """
     Shared tests for pre_save update_dirty_bit_to logic.

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -102,6 +102,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="pre",
             closed=False,
+            activated_by=self.coach,
         )
 
         # Try to create duplicate - should fail
@@ -112,6 +113,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
                 collection=self.classroom,
                 test_type="pre",  # Same combination
                 closed=False,
+                activated_by=self.coach,
             )
 
     def test_unique_together_allows_different_test_types(self):
@@ -123,6 +125,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="pre",
             closed=True,
+            activated_by=self.coach,
         )
 
         # Create post-test - should succeed
@@ -132,6 +135,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="post",  # Different test type
             closed=False,
+            activated_by=self.coach,
         )
 
         self.assertIsNotNone(pre_test.id)
@@ -154,6 +158,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
                 collection=other_classroom,  # From facility 2 - different dataset
                 test_type="pre",
                 closed=False,
+                activated_by=self.coach,
             )
 
         self.assertIn("same dataset", str(context.exception))
@@ -166,6 +171,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="pre",
             closed=False,
+            activated_by=self.coach,
         )
 
         key = "{}:{}:{}:{}".format(
@@ -191,6 +197,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="pre",
             closed=True,
+            activated_by=self.coach,
         )
 
         unit_id_2 = uuid.uuid4().hex
@@ -200,6 +207,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="pre",
             closed=False,
+            activated_by=self.coach,
         )
 
         self.assertNotEqual(
@@ -211,6 +219,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,
             test_type="post",  # Different test type
             closed=False,
+            activated_by=self.coach,
         )
 
         # Different test types should generate different source_ids
@@ -227,6 +236,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.classroom,  # Same as course_session.collection
             test_type="pre",
             closed=False,
+            activated_by=self.coach,
         )
 
         self.assertIsNotNone(assignment.id)
@@ -241,6 +251,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
             collection=self.learner_group,  # Child of course_session.collection
             test_type="pre",
             closed=False,
+            activated_by=self.coach,
         )
 
         self.assertIsNotNone(assignment.id)
@@ -263,6 +274,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
                 collection=other_classroom,  # Different classroom, not a child
                 test_type="pre",
                 closed=False,
+                activated_by=self.coach,
             )
 
         self.assertIn(
@@ -288,6 +300,7 @@ class UnitTestAssignmentModelTestCase(TestCase):
                 collection=other_learner_group,  # Child of other_classroom, not self.classroom
                 test_type="pre",
                 closed=False,
+                activated_by=self.coach,
             )
 
         self.assertIn(

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -474,6 +474,7 @@ class CourseSessionViewset(ValuesViewset):
                 unit_contentnode_id=unit_contentnode_id,
                 test_type=test_type,
                 collection=course_session.collection,
+                defaults={"activated_by": request.user},
             )
 
             unit_test_assignment.closed = False

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -265,8 +265,8 @@ class Exam(AbstractExam, AbstractFacilityDataModel):
         LearnerProgressNotification.objects.filter(quiz_id=self.id).delete()
         super().delete(using, keep_parents)
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # maintain stricter enforcement on when creator is allowed to be null
         if self._state.adding and self.creator is None:
@@ -347,8 +347,8 @@ class ExamAssignment(AbstractFacilityDataModel):
         on_delete=models.CASCADE,
     )
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # this shouldn't happen
         if (

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -94,8 +94,8 @@ class Lesson(AbstractFacilityDataModel):
     def __str__(self):
         return "Lesson {} for Classroom {}".format(self.title, self.collection.name)
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # maintain stricter enforcement on when assigned_by is allowed to be null
         if self._state.adding and self.created_by is None:
@@ -165,8 +165,8 @@ class LessonAssignment(AbstractFacilityDataModel):
     # Morango fields
     morango_model_name = "lessonassignment"
 
-    def pre_save(self):
-        super().pre_save()
+    def pre_save(self, **kwargs):
+        super().pre_save(**kwargs)
 
         # this shouldn't happen
         if (

--- a/kolibri/plugins/learn/test/test_learner_course.py
+++ b/kolibri/plugins/learn/test/test_learner_course.py
@@ -443,6 +443,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Pre,
                 closed=True,
+                activated_by=self.coach,
             )
 
             UnitTestAssignment.objects.create(
@@ -451,6 +452,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Post,
                 closed=True,
+                activated_by=self.coach,
             )
 
         unit, lessons = units[2]
@@ -460,6 +462,7 @@ class LearnerCourseTestCase(APITestCase):
             collection=self.classroom,
             test_type=TestType.Pre,
             closed=False,
+            activated_by=self.coach,
         )
 
         self.client.login(username="learner", password=DUMMY_PASSWORD)
@@ -488,6 +491,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Pre,
                 closed=True,
+                activated_by=self.coach,
             )
 
             UnitTestAssignment.objects.create(
@@ -496,6 +500,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Post,
                 closed=True,
+                activated_by=self.coach,
             )
 
         unit, lessons = units[3]
@@ -505,6 +510,7 @@ class LearnerCourseTestCase(APITestCase):
             collection=self.classroom,
             test_type=TestType.Pre,
             closed=True,
+            activated_by=self.coach,
         )
 
         UnitTestAssignment.objects.create(
@@ -513,6 +519,7 @@ class LearnerCourseTestCase(APITestCase):
             collection=self.classroom,
             test_type=TestType.Post,
             closed=False,
+            activated_by=self.coach,
         )
 
         self.client.login(username="learner", password=DUMMY_PASSWORD)
@@ -541,6 +548,7 @@ class LearnerCourseTestCase(APITestCase):
             collection=self.classroom,
             test_type=TestType.Pre,
             closed=True,
+            activated_by=self.coach,
         )
 
         resume_lesson, lesson_resources = lessons[0]
@@ -575,6 +583,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Pre,
                 closed=True,
+                activated_by=self.coach,
             )
             UnitTestAssignment.objects.create(
                 course_session=course_session,
@@ -582,6 +591,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Post,
                 closed=True,
+                activated_by=self.coach,
             )
 
             for lesson, lesson_resources in lessons:
@@ -602,6 +612,7 @@ class LearnerCourseTestCase(APITestCase):
             collection=self.classroom,
             test_type=TestType.Pre,
             closed=True,
+            activated_by=self.coach,
         )
         resume_lesson, lesson_resources = lessons[0]
         resource_1 = lesson_resources[0]
@@ -648,6 +659,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Pre,
                 closed=True,
+                activated_by=self.coach,
             )
             UnitTestAssignment.objects.create(
                 course_session=course_session,
@@ -655,6 +667,7 @@ class LearnerCourseTestCase(APITestCase):
                 collection=self.classroom,
                 test_type=TestType.Post,
                 closed=True,
+                activated_by=self.coach,
             )
 
             for lesson, lesson_resources in lessons:


### PR DESCRIPTION
## Summary
- Pass save kwargs to pre_save and use update_dirty_bit_to for user field null enforcement.
- Update tests to incorporate new changes. 

## References
- closes #14130

## Reviewer guidance
- Check all instances of classes that inherit AbstractFacilityDataMode have the pre_save method updated.
- Defensive logic for  user ID fields to be null is appropriate as mentioned in the issue #14130 .