### PR TITLE
Refactor epub navigation button tests to use Vue Testing Library

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/NextButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/NextButton.spec.js
@@ -1,18 +1,21 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import NextButton from '../NextButton';
 
-function createWrapper() {
-  return mount(NextButton);
-}
+const renderComponent = () => {
+  return render(NextButton, {
+    props: { color: 'black' },
+  });
+};
 
 describe('Next button', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('renders a button accessible as go to next page', () => {
+    renderComponent();
+    expect(screen.getByRole('button', { name: 'Go to next page' })).toBeInTheDocument();
   });
-  it('should emit an event when the button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.find('.next-button').trigger('click');
-    expect(wrapper.emitted().goToNextPage).toBeTruthy();
+  it('emits goToNextPage when clicked', async () => {
+    const { emitted } = renderComponent();
+    await fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+    expect(emitted()).toHaveProperty('goToNextPage');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js
@@ -1,18 +1,21 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import PreviousButton from '../PreviousButton';
 
-function createWrapper() {
-  return mount(PreviousButton);
-}
+const renderComponent = () => {
+  return render(PreviousButton, {
+    props: { color: 'black' },
+  });
+};
 
 describe('Previous button', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('renders a button accessible as go to previous page', () => {
+    renderComponent();
+    expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeInTheDocument();
   });
-  it('should emit an event when the button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().goToPreviousPage).toBeTruthy();
+  it('emits goToPreviousPage when clicked', async () => {
+    const { emitted } = renderComponent();
+    await fireEvent.click(screen.getByRole('button', { name: 'Go to previous page' }));
+    expect(emitted()).toHaveProperty('goToPreviousPage');
   });
 });


### PR DESCRIPTION
## Summary

Refactored [NextButton.spec.js](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/kolibri/plugins/epub_viewer/frontend/views/__tests__/NextButton.spec.js:0:0-0:0) and [PreviousButton.spec.js](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js:0:0-0:0) in the epub viewer plugin from `@vue/test-utils` to `@testing-library/vue`.

Changes made:
- Replaced `mount()` with [render()](cci:1://file:///Users/nityajain/Desktop/open-source/kolibri-1/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js:4:0-8:2) from `@testing-library/vue`
- Replaced `wrapper.find('.next-button').trigger('click')` and `wrapper.find('button').trigger('click')` with `fireEvent.click(screen.getByRole('button', { name }))` following the Testing Library query priority recommendation (`getByRole` is the most preferred query)
- Replaced `wrapper.exists()` checks with `toBeInTheDocument()` assertions on accessible button queries
- Replaced `wrapper.emitted()` with VTL's `emitted()` return value from [render()](cci:1://file:///Users/nityajain/Desktop/open-source/kolibri-1/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js:4:0-8:2)
- Added the required `color` prop that was missing in the original tests
- Updated test descriptions to reflect user-facing behavior

Verification:
- Ran `pnpm run test-jest -- --testPathPattern epub_viewer` before and after changes
- All 12 test suites and 51 tests pass in both cases

## References

- Closes #14186
- Reference VTL test pattern: [packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js](cci:7://file:///Users/nityajain/Desktop/open-source/kolibri-1/packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js:0:0-0:0)
- [Testing Library query priority](https://testing-library.com/docs/queries/about#priority)

## Reviewer guidance

- Run `pnpm run test-jest -- --testPathPattern epub_viewer` to verify all epub viewer tests pass
- Only two test files were modified, no other files were changed
- The tests cover the same behaviors as before (rendering and click-to-emit), rewritten to use accessible queries (`getByRole`) instead of CSS selectors and component internals
