### PR TITLE
Converted user auth page unit tests to Vue Testing Library

### DIFF
--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/NewPasswordPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/NewPasswordPage.spec.js
@@ -1,85 +1,73 @@
-import { mount, createLocalVue } from '@vue/test-utils';
-import VueRouter from 'vue-router';
+import { render, screen, waitFor, configure } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 import useUser from 'kolibri/composables/useUser';
 import { coreStoreFactory } from 'kolibri/store';
 import NewPasswordPage from '../NewPasswordPage.vue';
 
+configure({ testIdAttribute: 'data-test' });
 jest.mock('kolibri/composables/useUser');
+const mockLogin = jest.fn();
+const mockSetUnspecifiedPassword = jest.fn();
+const mockRouterPush = jest.fn();
 
-const localVue = createLocalVue();
-localVue.use(VueRouter);
+function renderComponent() {
+  const store = coreStoreFactory({
+    actions: {
+      kolibriSetUnspecifiedPassword: mockSetUnspecifiedPassword,
+    },
+  });
+  useUser.mockImplementation(() => ({
+    login: mockLogin,
+  }));
+
+  return render(
+    NewPasswordPage,
+    {
+      store,
+      props: {
+        username: 'testuser',
+        facilityId: 'facility_1',
+      },
+      routes: [{ name: 'SignInPage', path: '/signin' }],
+      stubs: {
+        // inorder to bypass the loading wrapper
+        AuthBase: { template: '<div><slot></slot></div>' },
+      },
+    },
+    (_vue, _store, router) => {
+      router.push = mockRouterPush;
+    },
+  );
+}
 
 describe('NewPasswordPage', () => {
-  let wrapper;
-  let router;
-  const mockLogin = jest.fn();
-  const mockSetUnspecifiedPassword = jest.fn();
-  const mockFocus = jest.fn();
-
   beforeEach(() => {
     // Reset mocks
     mockLogin.mockReset();
     mockSetUnspecifiedPassword.mockReset();
-    mockFocus.mockReset();
-
-    // Create a fresh router instance for each test
-    router = new VueRouter({
-      routes: [
-        { path: '/', name: 'SignInPage' },
-        { path: '/back', name: 'Back' },
-      ],
-    });
-
-    // Mock router methods to avoid actual navigation
-    router.push = jest.fn();
-    router.go = jest.fn();
-
-    // Mock useUser composable
-    useUser.mockImplementation(() => ({
-      login: mockLogin,
-    }));
-
-    wrapper = mount(NewPasswordPage, {
-      localVue,
-      router,
-      store: coreStoreFactory({
-        actions: {
-          kolibriSetUnspecifiedPassword: mockSetUnspecifiedPassword,
-        },
-      }),
-      propsData: {
-        username: 'testuser',
-        facilityId: 'facility_1',
-      },
-      stubs: {
-        // Stub the PasswordTextbox component to avoid DOM manipulation
-        PasswordTextbox: true,
-      },
-    });
-
-    // Properly spy on the goBack method after mounting
-    jest.spyOn(wrapper.vm, 'goBack').mockImplementation(jest.fn());
-
-    // Mock the $refs.createPassword element
-    wrapper.vm.$refs.createPassword = { focus: mockFocus };
+    mockRouterPush.mockReset();
   });
 
   it('calls setUnspecifiedPassword and login when form is submitted with valid password', async () => {
+    renderComponent();
+    const user = userEvent.setup();
     const password = 'validpassword';
-    wrapper.vm.password = password;
-
-    // Mock valid password
-    wrapper.setData({ passwordIsValid: true });
-
-    // Submit the form
-    await wrapper.vm.updatePassword();
-
-    expect(mockSetUnspecifiedPassword.mock.calls[0][1]).toEqual({
-      username: 'testuser',
-      facility: 'facility_1',
-      password: 'validpassword',
+    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const submitButton = screen.getByTestId('submit');
+    await user.type(passwordInputs[0], password);
+    await user.type(passwordInputs[1], password);
+    await user.click(submitButton);
+    await waitFor(() => {
+      expect(mockSetUnspecifiedPassword).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          username: 'testuser',
+          facility: 'facility_1',
+          password: 'validpassword',
+        }),
+      );
     });
-
     expect(mockLogin).toHaveBeenCalledWith({
       username: 'testuser',
       facility: 'facility_1',
@@ -88,35 +76,42 @@ describe('NewPasswordPage', () => {
   });
 
   it('does not call setUnspecifiedPassword when password is invalid', async () => {
-    // Mock invalid password
-    wrapper.setData({ passwordIsValid: false });
-
-    // Submit the form
-    await wrapper.vm.updatePassword();
-
-    // Should focus on the password field
-    expect(mockFocus).toHaveBeenCalled();
-
-    // Should not call the APIs
+    renderComponent();
+    const user = userEvent.setup();
+    const submitButton = screen.getByTestId('submit');
+    await user.click(submitButton);
     expect(mockSetUnspecifiedPassword).not.toHaveBeenCalled();
     expect(mockLogin).not.toHaveBeenCalled();
   });
 
   it('calls goBack when setUnspecifiedPassword fails', async () => {
     mockSetUnspecifiedPassword.mockRejectedValue(new Error('Failed'));
+    renderComponent();
+    const user = userEvent.setup();
+    const password = 'password';
+    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const submitButton = screen.getByTestId('submit');
+    await user.type(passwordInputs[0], password);
+    await user.type(passwordInputs[1], password);
+    await user.click(submitButton);
 
-    wrapper.setData({ passwordIsValid: true });
-    await wrapper.vm.updatePassword();
-
-    expect(wrapper.vm.goBack).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith({ name: 'SignInPage' });
+    });
   });
 
   it('calls goBack when login fails', async () => {
     mockLogin.mockRejectedValue(new Error('Failed'));
-
-    wrapper.setData({ passwordIsValid: true });
-    await wrapper.vm.updatePassword();
-
-    expect(wrapper.vm.goBack).toHaveBeenCalled();
+    renderComponent();
+    const user = userEvent.setup();
+    const password = 'validpassword';
+    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const submitButton = screen.getByTestId('submit');
+    await user.type(passwordInputs[0], password);
+    await user.type(passwordInputs[1], password);
+    await user.click(submitButton);
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith({ name: 'SignInPage' });
+    });
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
@@ -1,4 +1,6 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import SignInPage from '../SignInPage';
 import makeStore from '../../__tests__/utils/makeStore';
@@ -6,7 +8,7 @@ import makeStore from '../../__tests__/utils/makeStore';
 jest.mock('kolibri/urls');
 jest.mock('kolibri-common/composables/useFacilities');
 
-function makeWrapper() {
+function renderComponent() {
   const store = makeStore();
   store.state.facilityId = '123';
   const selectedFacility = {
@@ -28,33 +30,67 @@ function makeWrapper() {
         ],
       },
       facilityId: '123',
-      selectedFacility: selectedFacility,
+      selectedFacility,
     }),
   );
-  return mount(SignInPage, {
-    store,
-  });
+
+  return render(
+    SignInPage,
+    {
+      store,
+      routes: [{ name: 'SIGN_IN', path: '/signin' }],
+      stubs: {
+        // inorder to bypass the loading wrapper
+        AuthBase: { template: '<div><slot></slot></div>' },
+      },
+    },
+    (_vue, _store, router) => {
+      router.getRoute = () => {
+        return { name: 'SIGN_IN', path: '/signin' };
+      };
+    },
+  );
 }
 
-//
 describe('signInPage component', () => {
-  it('smoke test', () => {
-    const wrapper = makeWrapper();
-    expect(wrapper.exists()).toEqual(true);
+  it('smoke test', async () => {
+    renderComponent();
+    expect(await screen.findByRole('textbox', { name: /username/i })).toBeInTheDocument();
   });
-  it('will set the username as invalid if it contains punctuation and is blurred', () => {
-    const wrapper = makeWrapper();
-    wrapper.setData({ username: '?', usernameBlurred: true });
-    expect(wrapper.vm.usernameIsInvalid).toEqual(true);
+
+  it('will set the username as invalid if it contains punctuation and is blurred', async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+
+    await user.type(usernameInput, '?');
+    await user.tab();
+
+    await waitFor(() => {
+      const wrapper = usernameInput.closest('.ui-textbox');
+      expect(wrapper).toHaveClass('is-touched');
+    });
   });
-  it('will set the validation text to required if the username is empty and blurred', () => {
-    const wrapper = makeWrapper();
-    wrapper.setData({ username: '', usernameBlurred: true });
-    expect(wrapper.vm.usernameIsInvalidText).toEqual(wrapper.vm.coreString('requiredFieldError'));
+
+  it('will set the validation text to required if the username is empty and blurred', async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+
+    await user.click(usernameInput);
+    await user.tab();
+
+    await waitFor(() => {
+      const wrapper = usernameInput.closest('.ui-textbox');
+      expect(wrapper).toHaveClass('is-touched');
+    });
   });
-  it('will set the validation text to empty if the username is empty and not blurred', () => {
-    const wrapper = makeWrapper();
-    wrapper.setData({ username: '', usernameBlurred: false });
-    expect(wrapper.vm.usernameIsInvalidText).toEqual('');
+
+  it('will not show validation text if username is empty and not blurred', async () => {
+    renderComponent();
+    expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/alpha/i)).not.toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
@@ -58,33 +58,31 @@ describe('signInPage component', () => {
     expect(await screen.findByRole('textbox', { name: /username/i })).toBeInTheDocument();
   });
 
-  it('will set the username as invalid if it contains punctuation and is blurred', async () => {
+  it('will set the username as invalid if it contains punctuation', async () => {
     renderComponent();
     const user = userEvent.setup();
 
     const usernameInput = await screen.findByRole('textbox', { name: /username/i });
 
     await user.type(usernameInput, '?');
-    await user.tab();
 
     await waitFor(() => {
-      const wrapper = usernameInput.closest('.ui-textbox');
-      expect(wrapper).toHaveClass('is-touched');
+      expect(screen.getByText(/Username can only contain/i)).toBeInTheDocument();
     });
   });
 
-  it('will set the validation text to required if the username is empty and blurred', async () => {
+  it('will set the validation text to required if the username is empty', async () => {
     renderComponent();
     const user = userEvent.setup();
 
     const usernameInput = await screen.findByRole('textbox', { name: /username/i });
 
     await user.click(usernameInput);
-    await user.tab();
+    await user.type(usernameInput, 'a');
+    await user.clear(usernameInput);
 
     await waitFor(() => {
-      const wrapper = usernameInput.closest('.ui-textbox');
-      expect(wrapper).toHaveClass('is-touched');
+      expect(screen.getByText(/required/i)).toBeInTheDocument();
     });
   });
 

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
@@ -1,26 +1,19 @@
-import VueRouter from 'vue-router';
-import { mount, createLocalVue } from '@vue/test-utils';
+import { render, screen, configure } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
-import { ref, nextTick } from 'vue';
+import { ref } from 'vue';
 import SignUpPage from '../SignUpPage';
 import makeStore from '../../__tests__/utils/makeStore';
 
+configure({ testIdAttribute: 'data-test' });
+
 jest.mock('kolibri-common/composables/useFacilities');
-
-const localVue = createLocalVue();
-localVue.use(VueRouter);
-
-const router = new VueRouter({
-  routes: [{ name: 'SIGN_IN', path: '/signin' }],
-});
-router.getRoute = () => {
-  return { name: 'SIGN_IN', path: '/signin' };
-};
 
 const selectedFacility = ref({ id: 1, name: 'Facility 1' });
 
-function makeWrapper() {
+function renderComponent() {
   const store = makeStore();
+
   useFacilities.mockImplementation(() =>
     useFacilitiesMock({
       facilities: {
@@ -32,26 +25,33 @@ function makeWrapper() {
       selectedFacility: selectedFacility,
     }),
   );
-  return mount(SignUpPage, {
-    store,
-    router,
-  });
+
+  return render(
+    SignUpPage,
+    {
+      store,
+      routes: [{ name: 'SIGN_IN', path: '/signin' }],
+    },
+    (_vue, _store, router) => {
+      router.getRoute = () => {
+        return { name: 'SIGN_IN', path: '/signin' };
+      };
+    },
+  );
 }
 
 describe('signUpPage component', () => {
   it('smoke test', () => {
-    const wrapper = makeWrapper();
-    expect(wrapper.exists()).toBeTruthy();
+    renderComponent();
+    expect(screen.getByTestId('facilityLabel')).toBeInTheDocument();
   });
 });
 
 describe('multiFacility signUpPage component', () => {
   it('right facility', async () => {
-    const wrapper = makeWrapper();
-    const facilityLabel = wrapper.find('[data-test="facilityLabel"]').element;
-    expect(facilityLabel).toHaveTextContent(/Facility 1/);
+    renderComponent();
+    expect(screen.getByTestId('facilityLabel')).toHaveTextContent('Facility 1');
     selectedFacility.value = { id: 2, name: 'Facility 2' };
-    await nextTick();
-    expect(facilityLabel).toHaveTextContent(/Facility 2/);
+    expect(await screen.findByText(/Facility 2/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Converted the test suites for the user authentication page components to Vue Testing Library. The existing test suites and the testcases were rewritten. The changes apply to the following files in the codebase:
- `kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js`
- `kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js`
- `kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/NewPasswordPage.spec.js`

<img width="824" height="220" alt="image" src="https://github.com/user-attachments/assets/bbb95c7d-ad06-4142-af7c-2254d17d3c66" />


## References
Closes #14191

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
The tests for these corresponsing files can be verified altogether using the command:
- `pnpm run test-jest -- --testPathPattern user_auth`