### PR TITLE
Integrate assesment wrapper to CourseUnitView

### DIFF
--- a/kolibri/plugins/learn/frontend/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/AssessmentWrapper/index.vue
@@ -1,4 +1,4 @@
-<template v-if="ready">
+<template>
 
   <div>
     <LessonMasteryBar :requiredCorrectAnswers="totalCorrectRequiredM">

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
@@ -5,26 +5,55 @@
       v-if="!sessionReady"
       disableDefaultTransition
     />
-    <ContentViewer
-      v-else
-      class="content-viewer"
-      :lang="contentNode.lang"
-      :files="contentNode.files"
-      :options="contentNode.options"
-      :duration="contentNode.duration"
-      :extraFields="extra_fields"
-      :progress="progress"
-      :userId="currentUserId"
-      :userFullName="fullName"
-      :timeSpent="time_spent"
-      @startTracking="startTrackingProgress"
-      @stopTracking="stopTrackingProgress"
-      @updateProgress="handleUpdateProgress"
-      @addProgress="handleAddProgress"
-      @updateContentState="handleUpdateContentState"
-      @error="onError"
-      @finished="$emit('finished')"
-    />
+    <template v-else>
+      <ContentViewer
+        v-if="!contentNode.assessmentmetadata"
+        class="content-viewer"
+        :lang="contentNode.lang"
+        :files="contentNode.files"
+        :options="contentNode.options"
+        :duration="contentNode.duration"
+        :extraFields="extra_fields"
+        :progress="progress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="time_spent"
+        @startTracking="startTrackingProgress"
+        @stopTracking="stopTrackingProgress"
+        @updateProgress="handleUpdateProgress"
+        @addProgress="handleAddProgress"
+        @updateContentState="handleUpdateContentState"
+        @error="onError"
+        @finished="$emit('finished')"
+      />
+      <div v-else-if="isPracticeQuiz || isSurvey"></div>
+      <AssessmentWrapper
+        v-else
+        class="content-viewer"
+        :files="contentNode.files"
+        :lang="contentNode.lang"
+        :randomize="contentNode.assessmentmetadata.randomize"
+        :masteryModel="contentNode.assessmentmetadata.mastery_model"
+        :assessmentIds="contentNode.assessmentmetadata.assessment_item_ids"
+        :extraFields="extra_fields"
+        :progress="progress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="time_spent"
+        :pastattempts="pastattempts"
+        :mastered="complete"
+        :totalattempts="totalattempts"
+        :hasNextResource="hasNext"
+        @startTracking="startTrackingProgress"
+        @stopTracking="stopTrackingProgress"
+        @updateInteraction="handleUpdateInteraction"
+        @updateProgress="handleUpdateProgress"
+        @updateContentState="handleUpdateContentState"
+        @nextResource="$emit('next')"
+        @error="onError"
+        @finished="$emit('finished')"
+      />
+    </template>
   </div>
 
 </template>
@@ -33,6 +62,9 @@
 <script>
 
   import useUser from 'kolibri/composables/useUser';
+  import Modalities from 'kolibri-constants/Modalities';
+  import { computed } from 'vue';
+  import AssessmentWrapper from '../courses/AssessmentWrapper/index.vue';
   import { injectCourseContentProgress } from './useCourseContentProgressTracking';
 
   /**
@@ -52,12 +84,19 @@
   export default {
     name: 'CourseContentViewer',
     emits: ['finished'],
-    setup() {
+    components: {
+      AssessmentWrapper,
+    },
+    setup(props) {
       const {
         sessionReady,
         progress,
         time_spent,
         extra_fields,
+        pastattempts,
+        complete,
+        totalattempts,
+        handleUpdateInteraction,
         startTrackingProgress,
         stopTrackingProgress,
         handleUpdateProgress,
@@ -68,6 +107,14 @@
 
       const { currentUserId, full_name: fullName } = useUser();
 
+      const isPracticeQuiz = computed(() => {
+        return props.contentNode.modality === Modalities.QUIZ;
+      });
+
+      const isSurvey = computed(() => {
+        return props.contentNode.modality === Modalities.SURVEY;
+      });
+
       return {
         // State
         sessionReady,
@@ -76,12 +123,20 @@
         extra_fields,
         currentUserId,
         fullName,
+        pastattempts,
+        complete,
+        totalattempts,
+
+        // computed
+        isPracticeQuiz,
+        isSurvey,
 
         // Methods
         startTrackingProgress,
         stopTrackingProgress,
         handleUpdateProgress,
         handleAddProgress,
+        handleUpdateInteraction,
         handleUpdateContentState,
         onError,
       };
@@ -90,6 +145,10 @@
       contentNode: {
         type: Object,
         required: true,
+      },
+      hasNext: {
+        type: Boolean,
+        default: false,
       },
     },
   };

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
@@ -83,7 +83,7 @@
    */
   export default {
     name: 'CourseContentViewer',
-    emits: ['finished'],
+    emits: ['finished', 'next'],
     components: {
       AssessmentWrapper,
     },

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
@@ -19,8 +19,10 @@
         disableDefaultTransition
       />
       <CourseContentViewer
-        v-else-if="currentResource && !currentResource.assessmentmetadata"
+        v-else-if="currentResource"
         :contentNode="currentResource"
+        :hasNext="nextEnabled"
+        @next="handleNext"
         @finished="onResourceFinished"
       />
     </template>
@@ -34,7 +36,7 @@
         :prevEnabled="prevEnabled"
         :nextEnabled="nextEnabled"
         :style="{
-          backgroundColor: $themeTokens.background,
+          backgroundColor: $themeTokens.surface,
           borderTop: `1px solid ${$themeTokens.fineLine}`,
         }"
         @prev="handlePrev"

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/useCourseContentProgressTracking.js
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/useCourseContentProgressTracking.js
@@ -8,11 +8,15 @@ const SessionReadyKey = Symbol('SessionReady');
 const ProgressKey = Symbol('Progress');
 const TimeSpentKey = Symbol('TimeSpent');
 const ExtraFieldsKey = Symbol('ExtraFields');
+const PastAttemptsKey = Symbol('PastAttempts');
+const CompleteKey = Symbol('Complete');
+const TotalAttemptsKey = Symbol('TotalAttempts');
 const StartTrackingProgressKey = Symbol('StartTrackingProgress');
 const StopTrackingProgressKey = Symbol('StopTrackingProgress');
 const HandleUpdateProgressKey = Symbol('HandleUpdateProgress');
 const HandleAddProgressKey = Symbol('HandleAddProgress');
 const HandleUpdateContentStateKey = Symbol('HandleUpdateContentState');
+const HandleUpdateInteractionKey = Symbol('HandleUpdateInteraction');
 const OnErrorKey = Symbol('OnError');
 
 /**
@@ -31,6 +35,9 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
     progress,
     time_spent,
     extra_fields,
+    pastattempts,
+    complete,
+    totalattempts,
     initContentSession,
     updateContentSession,
     startTrackingProgress,
@@ -75,6 +82,10 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
 
   const handleUpdateContentState = contentState => {
     return wrappedUpdateContentSession({ contentState });
+  };
+
+  const handleUpdateInteraction = ({ progress, interaction }) => {
+    return wrappedUpdateContentSession({ progress, interaction });
   };
 
   const onError = error => {
@@ -128,11 +139,15 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
   provide(ProgressKey, progress);
   provide(TimeSpentKey, time_spent);
   provide(ExtraFieldsKey, extra_fields);
+  provide(PastAttemptsKey, pastattempts);
+  provide(CompleteKey, complete);
+  provide(TotalAttemptsKey, totalattempts);
   provide(StartTrackingProgressKey, startTrackingProgress);
   provide(StopTrackingProgressKey, stopTrackingProgress);
   provide(HandleUpdateProgressKey, handleUpdateProgress);
   provide(HandleAddProgressKey, handleAddProgress);
   provide(HandleUpdateContentStateKey, handleUpdateContentState);
+  provide(HandleUpdateInteractionKey, handleUpdateInteraction);
   provide(OnErrorKey, onError);
 }
 
@@ -148,6 +163,11 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
  * @property {import('vue').Ref<number|null>} progress The current progress value (0 to 1).
  * @property {import('vue').Ref<number|null>} time_spent The time spent on the content in seconds.
  * @property {Object} extra_fields Reactive object containing extra fields from the session.
+ * @property {import('vue').Ref<Array>} pastattempts An array of past attempts for the content.
+ * @property {import('vue').Ref<boolean|null>} complete Whether the content is marked as
+ *                                                      complete.
+ * @property {import('vue').Ref<number|null>} totalattempts The total number of attempts for the
+ *                                                          content.
  * @property {() => void} startTrackingProgress Starts the interval timer for progress tracking.
  * @property {() => Promise<void>} stopTrackingProgress Stops the interval timer and saves
  *                                                      final progress.
@@ -157,6 +177,8 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
  *                                                                        current progress.
  * @property {(contentState: Object) => Promise<void>} handleUpdateContentState Updates the
  *                                                                              content state.
+ * @property {(interaction: Object) => Promise<void>} handleUpdateInteraction Updates the
+ *                                                                          interaction state.
  * @property {(error: Error) => void} onError Handles errors by flagging the session as errored
  *                                            and dispatching to the store.
  *
@@ -169,11 +191,15 @@ export function injectCourseContentProgress() {
     progress: inject(ProgressKey),
     time_spent: inject(TimeSpentKey),
     extra_fields: inject(ExtraFieldsKey),
+    pastattempts: inject(PastAttemptsKey),
+    complete: inject(CompleteKey),
+    totalattempts: inject(TotalAttemptsKey),
     startTrackingProgress: inject(StartTrackingProgressKey),
     stopTrackingProgress: inject(StopTrackingProgressKey),
     handleUpdateProgress: inject(HandleUpdateProgressKey),
     handleAddProgress: inject(HandleAddProgressKey),
     handleUpdateContentState: inject(HandleUpdateContentStateKey),
+    handleUpdateInteraction: inject(HandleUpdateInteractionKey),
     onError: inject(OnErrorKey),
   };
 }

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/ExerciseAttempts/AnswerIcon.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/ExerciseAttempts/AnswerIcon.vue
@@ -1,0 +1,110 @@
+<template>
+
+  <div>
+    <div ref="icon">
+      <KIcon
+        v-if="answer === 'right'"
+        icon="correct"
+        class="correct"
+        :color="$themeTokens.correct"
+        style="top: 0; width: 24px; height: 24px"
+      />
+      <KIcon
+        v-else-if="answer === 'wrong'"
+        icon="incorrect"
+        style="top: 0; width: 24px; height: 24px"
+        :color="$themeTokens.annotation"
+      />
+      <KIcon
+        v-else-if="answer === 'hint'"
+        icon="hint"
+        style="top: 0; width: 24px; height: 24px"
+        :color="$themeTokens.annotation"
+      />
+      <KIcon
+        v-else-if="answer === 'rectified'"
+        icon="rectified"
+        class="rectified"
+        :color="$themeTokens.annotation"
+      />
+    </div>
+    <KTooltip
+      reference="icon"
+      :refs="$refs"
+      placement="right"
+    >
+      {{ tooltipText }}
+    </KTooltip>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'AnswerIcon',
+    props: {
+      answer: {
+        type: String,
+        required: true,
+        validator(val) {
+          return ['right', 'wrong', 'hint', 'rectified'].includes(val);
+        },
+      },
+    },
+    computed: {
+      tooltipText() {
+        switch (this.answer) {
+          case 'right':
+            return this.$tr('correct');
+          case 'wrong':
+            return this.$tr('incorrect');
+          case 'hint':
+            return this.$tr('hintUsed');
+          case 'rectified':
+            return this.$tr('incorrectFirstTry');
+          default:
+            return '';
+        }
+      },
+    },
+    $trs: {
+      correct: {
+        message: 'Correct',
+        context: 'Indicates if the learner answered the question correctly.',
+      },
+      incorrect: {
+        message: 'Incorrect',
+        context: 'Indicates if the learner answered the question incorrectly.',
+      },
+      hintUsed: {
+        message: 'Hint used',
+        context:
+          "Some exercises can offer hints. These can be suggestions to help learners solve a problem.\n\nIf the learner uses a hint, the text 'Hint used' appears in the exercise.",
+      },
+      incorrectFirstTry: {
+        message: 'Incorrect first try',
+        context:
+          'Indicates if the learner answered a question incorrectly on the first attempt at answering it.\n',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  svg {
+    height: 30px;
+    transition: transform $core-time ease-in;
+  }
+
+  .rectified {
+    width: 12px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/ExerciseAttempts/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/ExerciseAttempts/index.vue
@@ -1,0 +1,134 @@
+<template>
+
+  <div class="exercise-attempts">
+    <div
+      v-for="(item, index) in itemsToRender"
+      :key="`attempt-${item.originalIndex}`"
+      class="attempt"
+      :style="styleForIndex(index, item.originalIndex)"
+    >
+      <transition name="fade">
+        <AnswerIcon :answer="item.answer" />
+      </transition>
+    </div>
+    <div
+      v-for="i in numSpaces"
+      :key="`placeholder-${i}`"
+      class="placeholder"
+      :style="{ borderBottom: `2px solid ${$themeTokens.annotation}` }"
+    ></div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import AnswerIcon from './AnswerIcon';
+
+  export default {
+    name: 'ExerciseAttempts',
+    components: { AnswerIcon },
+    props: {
+      // Creates an empty space awaiting a new attempt
+      waitingForAttempt: {
+        type: Boolean,
+        required: true,
+      },
+      // Total number of answer spaces to show
+      numSpaces: {
+        type: Number,
+        required: true,
+      },
+      // Array of answers - strings that are 'right', 'wrong', or 'hint'
+      // ordered from first to last
+      log: {
+        type: Array,
+        default: () => [],
+        validator(arr) {
+          return arr.every(val => ['right', 'wrong', 'hint', 'rectified'].includes(val));
+        },
+      },
+    },
+    computed: {
+      numItemsToRender() {
+        if (this.waitingForAttempt) {
+          return this.numSpaces;
+        }
+        return this.numSpaces + 1;
+      },
+      // returns a list of items the items to be rendered in the DOM
+      itemsToRender() {
+        // save the original index of the item in the log and slice of the end
+        return this.log
+          .map((answer, originalIndex) => ({
+            answer,
+            originalIndex,
+          }))
+          .slice(-1 * this.numItemsToRender)
+          .reverse();
+      },
+    },
+    methods: {
+      styleForIndex(visualIndex, originalIndex) {
+        const ANSWER_WIDTH = 4 + 30 + 4;
+        let xPos = ANSWER_WIDTH * (this.log.length - 1 - originalIndex);
+        if (this.waitingForAttempt) {
+          xPos += ANSWER_WIDTH;
+        }
+        const style = {};
+        const side = this.isRtl ? 'right' : 'left';
+        style[side] = `${xPos}px`;
+        // hidden "slide-off" item
+        if (visualIndex === this.numItemsToRender - 1) {
+          style.opacity = 0;
+        }
+        return style;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  $size: 30px;
+  $margin: 4px;
+
+  .exercise-attempts {
+    position: relative;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+  }
+
+  .attempt,
+  .placeholder {
+    display: inline-block;
+    width: $size;
+    height: $size;
+    margin: $margin;
+  }
+
+  .attempt {
+    position: absolute;
+    text-align: center;
+    transition: all 0.5s ease-in-out;
+  }
+
+  .placeholder {
+    transition: border-bottom 0.1s linear;
+  }
+
+  .fade-enter,
+  .fade-leave-to {
+    opacity: 0;
+  }
+
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 0.5s;
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/LessonMasteryBar.vue
@@ -1,0 +1,66 @@
+<template>
+
+  <!-- z-index 7 - one beneath top menu bar for nested elevations -->
+  <BaseToolbar style="z-index: 7">
+    <div
+      class="container"
+      :style="{ flexWrap: windowBreakpoint > 0 ? 'nowrap' : 'wrap' }"
+    >
+      <KTextTruncator
+        class="requirements"
+        :text="coreString('shortExerciseGoalDescription', { count: requiredCorrectAnswers })"
+      />
+      <span>
+        <slot name="hint"></slot>
+      </span>
+    </div>
+  </BaseToolbar>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import BaseToolbar from 'kolibri-common/components/BaseToolbar';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+
+  export default {
+    name: 'LessonMasteryBar',
+    components: {
+      BaseToolbar,
+    },
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
+    props: {
+      // typically this would be "m" from "m of n" mastery model
+      requiredCorrectAnswers: {
+        type: Number,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .container {
+    display: flex;
+    justify-content: space-between;
+    padding-top: 16px;
+    padding-bottom: 8px;
+  }
+
+  .requirements {
+    min-width: 0; // allow text to be shrinked and truncated
+    margin-right: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/LessonMasteryBar.vue
@@ -1,20 +1,21 @@
 <template>
 
-  <!-- z-index 7 - one beneath top menu bar for nested elevations -->
-  <BaseToolbar style="z-index: 7">
+  <div>
     <div
       class="container"
       :style="{ flexWrap: windowBreakpoint > 0 ? 'nowrap' : 'wrap' }"
     >
-      <KTextTruncator
-        class="requirements"
-        :text="coreString('shortExerciseGoalDescription', { count: requiredCorrectAnswers })"
-      />
+      <strong>
+        <KTextTruncator
+          class="requirements"
+          :text="coreString('shortExerciseGoalDescription', { count: requiredCorrectAnswers })"
+        />
+      </strong>
       <span>
         <slot name="hint"></slot>
       </span>
     </div>
-  </BaseToolbar>
+  </div>
 
 </template>
 
@@ -22,14 +23,10 @@
 <script>
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import BaseToolbar from 'kolibri-common/components/BaseToolbar';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   export default {
     name: 'LessonMasteryBar',
-    components: {
-      BaseToolbar,
-    },
     mixins: [commonCoreStrings],
     setup() {
       const { windowBreakpoint } = useKResponsiveWindow();
@@ -53,9 +50,15 @@
 
   .container {
     display: flex;
+    gap: 8px;
+    align-items: center;
     justify-content: space-between;
-    padding-top: 16px;
-    padding-bottom: 8px;
+    min-height: 2.5rem;
+    padding: 8px 24px;
+
+    strong {
+      font-weight: 600;
+    }
   }
 
   .requirements {

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
@@ -1,0 +1,708 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+
+import AssessmentWrapper from '../index.vue';
+
+jest.mock('kolibri/composables/useUser');
+
+const ASSESSMENT_IDS = ['item-1', 'item-2', 'item-3', 'item-4', 'item-5'];
+const DEFAULT_MASTERY_MODEL = { type: 'm_of_n', m: 3, n: 5 };
+
+function buildProps(overrides = {}) {
+  return {
+    files: [],
+    assessmentIds: ASSESSMENT_IDS,
+    randomize: false,
+    masteryModel: DEFAULT_MASTERY_MODEL,
+    pastattempts: [],
+    mastered: false,
+    totalattempts: 0,
+    hasNextResource: false,
+    ...overrides,
+  };
+}
+
+/**
+ * ContentViewer stub that exposes events through test-trigger buttons.
+ * This avoids needing to access __vue__ or the component vm.
+ *
+ * By default `checkAnswer` returns null (no answer given).
+ * Override by providing a different stub via the `stubs` option.
+ */
+function makeContentViewerStub({ checkAnswerFn, availableHints = 0, totalHints = 0 } = {}) {
+  return {
+    name: 'ContentViewer',
+    props: [
+      'lang',
+      'files',
+      'extraFields',
+      'assessment',
+      'itemId',
+      'progress',
+      'userId',
+      'userFullName',
+      'timeSpent',
+    ],
+    data() {
+      return {
+        availableHints,
+        totalHints,
+      };
+    },
+    methods: {
+      checkAnswer() {
+        return checkAnswerFn ? checkAnswerFn() : null;
+      },
+      takeHint() {
+        this.$emit('hintTaken', { answerState: {} });
+      },
+    },
+    template: `
+      <div data-testid="content-viewer">
+        <span data-testid="content-viewer-item-id">{{ itemId }}</span>
+        <button data-testid="trigger-start-tracking" @click="$emit('startTracking')">start-tracking</button>
+        <button data-testid="trigger-stop-tracking" @click="$emit('stopTracking')">stop-tracking</button>
+        <button data-testid="trigger-update-progress" @click="$emit('updateProgress', 0.5)">update-progress</button>
+        <button data-testid="trigger-update-content-state" @click="$emit('updateContentState', { someState: true })">update-content-state</button>
+        <button data-testid="trigger-error" @click="$emit('error', 'test error')">trigger-error</button>
+        <button data-testid="trigger-item-error" @click="$emit('itemError')">trigger-item-error</button>
+        <button data-testid="trigger-hint-taken" @click="$emit('hintTaken', { answerState: {} })">trigger-hint-taken</button>
+        <button data-testid="trigger-answer-given-correct" @click="$emit('answerGiven', { correct: true, answerState: { answer: 42 }, simpleAnswer: '42' })">trigger-answer-correct</button>
+        <button data-testid="trigger-answer-given-incorrect" @click="$emit('answerGiven', { correct: false, answerState: { answer: 0 }, simpleAnswer: '0' })">trigger-answer-incorrect</button>
+      </div>
+    `,
+  };
+}
+
+const DefaultStub = makeContentViewerStub();
+
+function renderComponent(props = {}, { stubs, ...restOptions } = {}) {
+  const mergedProps = buildProps(props);
+  return render(AssessmentWrapper, {
+    props: mergedProps,
+    stubs: {
+      ContentViewer: DefaultStub,
+      ...stubs,
+    },
+    ...restOptions,
+  });
+}
+
+/** Helper to read the current-status text content. */
+function getStatusText() {
+  return screen.getByTestId('current-status').textContent.trim();
+}
+
+/** Helper to get the displayed item id from the content viewer stub. */
+function getDisplayedItemId() {
+  return screen.getByTestId('content-viewer-item-id').textContent.trim();
+}
+
+describe('AssessmentWrapper', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+  describe('rendering', () => {
+    it('renders the mastery goal text', () => {
+      renderComponent();
+      // "Get 3 correct" appears in both the mastery bar and the bottom status bar
+      const elements = screen.getAllByText(/Get 3 correct/);
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the Check button initially', () => {
+      renderComponent();
+      expect(screen.getByText('Check')).toBeInTheDocument();
+    });
+
+    it('does not render the Next button initially', () => {
+      renderComponent();
+      expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    });
+
+    it('renders the content viewer with the first item id', () => {
+      renderComponent();
+      // totalattempts=0, not randomized → index=0 → 'item-1'
+      expect(getDisplayedItemId()).toBe('item-1');
+    });
+
+    it('renders the completed label when mastered', () => {
+      renderComponent({ mastered: true });
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+    });
+
+    it('does not render the completed label when not mastered', () => {
+      renderComponent({ mastered: false });
+      expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    });
+
+    it('shows additional button when hasNextResource is true', () => {
+      renderComponent({ hasNextResource: true });
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('renders exercise attempt placeholder slots equal to attemptsWindowN', () => {
+      const { container } = renderComponent();
+      // With m_of_n m=3, n=5 there should be 5 placeholder slots
+      const placeholders = container.querySelectorAll('.placeholder');
+      expect(placeholders).toHaveLength(5);
+    });
+  });
+
+  describe('item selection', () => {
+    it('selects item based on totalattempts modulo assessmentIds length', () => {
+      renderComponent({ totalattempts: 7 });
+      // 7 % 5 = 2 → 'item-3'
+      expect(getDisplayedItemId()).toBe('item-3');
+    });
+
+    it('selects the first item when totalattempts is 0', () => {
+      renderComponent({ totalattempts: 0 });
+      expect(getDisplayedItemId()).toBe('item-1');
+    });
+
+    it('uses shuffled order when randomize is true', () => {
+      renderComponent({ randomize: true, totalattempts: 0 });
+      expect(ASSESSMENT_IDS).toContain(getDisplayedItemId());
+    });
+  });
+
+  describe('checkAnswer with no answer', () => {
+    it('shows "Please enter an answer above" when check is clicked but content viewer returns null', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByText('Check'));
+      expect(getStatusText()).toBe('Please enter an answer above');
+    });
+
+    it('keeps the Check button visible when no answer is returned', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByText('Check'));
+      expect(screen.getByText('Check')).toBeInTheDocument();
+    });
+  });
+
+  describe('correct answer on first attempt', () => {
+    function renderWithCorrectViewer(props = {}) {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({
+          correct: true,
+          answerState: { answer: 42 },
+          simpleAnswer: '42',
+        }),
+      });
+      return renderComponent(props, { stubs: { ContentViewer: stub } });
+    }
+
+    it('shows the Next button after a correct answer', async () => {
+      renderWithCorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      expect(screen.getByText('Next')).toBeInTheDocument();
+      expect(screen.queryByText('Check')).not.toBeInTheDocument();
+    });
+
+    it('shows "Correct!" status when pastattempts contain a correct attempt', async () => {
+      // currentStatus shows "Correct!" only when correct===1 AND
+      // recentAttempts[last] === 'right'. The parent updates pastattempts.
+      renderWithCorrectViewer({ pastattempts: [{ correct: 1 }] });
+      await fireEvent.click(screen.getByText('Check'));
+      expect(getStatusText()).toBe('Correct!');
+    });
+
+    it('emits updateInteraction with progress > 0 and correct=1 on the first attempt', async () => {
+      const { emitted } = renderWithCorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      const interactions = emitted().updateInteraction;
+      expect(interactions).toHaveLength(1);
+      const [{ progress, interaction }] = interactions[0];
+      expect(interaction.correct).toBe(1);
+      expect(interaction.complete).toBe(true);
+      expect(progress).toBeGreaterThan(0);
+    });
+
+    it('includes answerState and simpleAnswer in the emitted interaction', async () => {
+      const { emitted } = renderWithCorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ interaction }] = emitted().updateInteraction[0];
+      expect(interaction.answer).toEqual({ answer: 42 });
+      expect(interaction.simple_answer).toBe('42');
+    });
+
+    it('includes item id and time_spent in the emitted interaction', async () => {
+      const { emitted } = renderWithCorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ interaction }] = emitted().updateInteraction[0];
+      expect(interaction.item).toBe('item-1');
+      expect(typeof interaction.time_spent).toBe('number');
+    });
+  });
+
+  describe('incorrect answer', () => {
+    function renderWithIncorrectViewer(props = {}) {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({
+          correct: false,
+          answerState: { answer: 0 },
+          simpleAnswer: '0',
+        }),
+      });
+      return renderComponent(props, { stubs: { ContentViewer: stub } });
+    }
+
+    it('shows "Try again" after an incorrect answer', async () => {
+      renderWithIncorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      expect(getStatusText()).toBe('Try again');
+    });
+
+    it('keeps the Check button after an incorrect answer', async () => {
+      renderWithIncorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      expect(screen.getByText('Check')).toBeInTheDocument();
+    });
+
+    it('adds the shaking class on the Check button', async () => {
+      renderWithIncorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      const checkButton = screen.getByText('Check').closest('button');
+      expect(checkButton.className).toContain('shaking');
+    });
+
+    it('emits updateInteraction with correct=0 on first attempt', async () => {
+      const { emitted } = renderWithIncorrectViewer();
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ interaction, progress }] = emitted().updateInteraction[0];
+      expect(interaction.correct).toBe(0);
+      expect(interaction.complete).toBe(false);
+      // Progress is set because it's the first attempt
+      expect(progress).toBeDefined();
+    });
+  });
+
+  describe('rectified answer', () => {
+    it('shows "Great! Keep going" when answer is corrected on second attempt', async () => {
+      let callCount = 0;
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => {
+          callCount++;
+          if (callCount === 1) {
+            return { correct: false, answerState: { answer: 0 }, simpleAnswer: '0' };
+          }
+          return { correct: true, answerState: { answer: 42 }, simpleAnswer: '42' };
+        },
+      });
+
+      renderComponent(
+        // Must provide a past attempt with an id so second attempt doesn't error
+        // when it tries to read currentattempt.id
+        { pastattempts: [{ correct: 0, id: 'att-1' }] },
+        { stubs: { ContentViewer: stub } },
+      );
+
+      // First click: incorrect
+      await fireEvent.click(screen.getByText('Check'));
+      expect(getStatusText()).toBe('Try again');
+
+      // Second click: correct (rectified)
+      await fireEvent.click(screen.getByText('Check'));
+      expect(getStatusText()).toBe('Great! Keep going');
+    });
+
+    it('does not send progress on the second attempt', async () => {
+      let callCount = 0;
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => {
+          callCount++;
+          if (callCount === 1) {
+            return { correct: false, answerState: {}, simpleAnswer: '' };
+          }
+          return { correct: true, answerState: {}, simpleAnswer: '' };
+        },
+      });
+
+      const { emitted } = renderComponent(
+        { pastattempts: [{ correct: 0, id: 'att-1' }] },
+        { stubs: { ContentViewer: stub } },
+      );
+
+      await fireEvent.click(screen.getByText('Check')); // first attempt
+      await fireEvent.click(screen.getByText('Check')); // second attempt
+
+      const secondInteraction = emitted().updateInteraction[1][0];
+      expect(secondInteraction.progress).toBeUndefined();
+      expect(secondInteraction.interaction.id).toBe('att-1');
+    });
+  });
+
+  describe('nextQuestion', () => {
+    it('resets state and shows Check button after clicking Next', async () => {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({ correct: true, answerState: {}, simpleAnswer: '' }),
+      });
+      renderComponent({}, { stubs: { ContentViewer: stub } });
+
+      await fireEvent.click(screen.getByText('Check'));
+      expect(screen.getByText('Next')).toBeInTheDocument();
+
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText('Check')).toBeInTheDocument();
+      expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('item error handling', () => {
+    it('shows error alert with "Try a different question" button', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-item-error'));
+
+      await waitFor(() => {
+        expect(screen.getByText('There was an error showing this question')).toBeInTheDocument();
+        expect(screen.getByText('Try a different question')).toBeInTheDocument();
+      });
+    });
+
+    it('shows "Try next question" in the status area on item error', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-item-error'));
+
+      await waitFor(() => {
+        expect(getStatusText()).toBe('Try next question');
+      });
+    });
+
+    it('switches to Next button on item error', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-item-error'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Next')).toBeInTheDocument();
+      });
+    });
+
+    it('emits updateInteraction with error=true on item error', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-item-error'));
+
+      await waitFor(() => {
+        const [{ interaction }] = emitted().updateInteraction[0];
+        expect(interaction.error).toBe(true);
+      });
+    });
+
+    it('clicking "Try a different question" resets to a new question', async () => {
+      renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-item-error'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Try a different question')).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByText('Try a different question'));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('There was an error showing this question'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Check')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('hintTaken', () => {
+    it('shows "Hint used" in the status area after a hint is taken on a non-first attempt', async () => {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({ correct: false, answerState: {}, simpleAnswer: '' }),
+      });
+
+      renderComponent(
+        { pastattempts: [{ correct: 0, id: 'past-1' }] },
+        { stubs: { ContentViewer: stub } },
+      );
+
+      // First click: wrong → consumes first attempt at question
+      await fireEvent.click(screen.getByText('Check'));
+
+      // Now trigger hint taken via the stub button
+      await fireEvent.click(screen.getByTestId('trigger-hint-taken'));
+
+      await waitFor(() => {
+        expect(getStatusText()).toBe('Hint used');
+      });
+    });
+  });
+
+  describe('success watcher', () => {
+    it('emits "finished" when mastered changes from false to true', async () => {
+      const { emitted, updateProps } = renderComponent({ mastered: false });
+      expect(emitted().finished).toBeUndefined();
+
+      await updateProps({ mastered: true });
+      expect(emitted().finished).toBeTruthy();
+    });
+
+    it('does not emit "finished" if mastered starts as true', () => {
+      const { emitted } = renderComponent({ mastered: true });
+      expect(emitted().finished).toBeUndefined();
+    });
+  });
+
+  describe('event pass-through from ContentViewer', () => {
+    it('emits startTracking when content viewer fires startTracking', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
+      expect(emitted().startTracking).toBeTruthy();
+    });
+
+    it('emits stopTracking when content viewer fires stopTracking', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-stop-tracking'));
+      expect(emitted().stopTracking).toBeTruthy();
+    });
+
+    it('emits updateProgress when content viewer fires updateProgress', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-update-progress'));
+      expect(emitted().updateProgress).toBeTruthy();
+      expect(emitted().updateProgress[0]).toEqual([0.5]);
+    });
+
+    it('emits updateContentState when content viewer fires updateContentState', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-update-content-state'));
+      expect(emitted().updateContentState).toBeTruthy();
+      expect(emitted().updateContentState[0]).toEqual([{ someState: true }]);
+    });
+
+    it('emits error when content viewer fires error', async () => {
+      const { emitted } = renderComponent();
+      await fireEvent.click(screen.getByTestId('trigger-error'));
+      expect(emitted().error).toBeTruthy();
+    });
+
+    it('emits nextResource when the next resource button is clicked', async () => {
+      const { emitted } = renderComponent({ hasNextResource: true });
+      // The next resource button is rendered separately from the Check/Next button
+      const buttons = screen.getAllByRole('button');
+      const nextResourceButton = buttons[buttons.length - 1];
+      await fireEvent.click(nextResourceButton);
+      expect(emitted().nextResource).toBeTruthy();
+    });
+  });
+
+  describe('hints UI', () => {
+    it('does not show hint buttons when totalHints is 0', () => {
+      renderComponent();
+      expect(screen.queryByText(/Use a hint/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/No more hints/i)).not.toBeInTheDocument();
+    });
+
+    it('shows hint button with count after startTracking', async () => {
+      const stub = makeContentViewerStub({ availableHints: 3, totalHints: 5 });
+      renderComponent({}, { stubs: { ContentViewer: stub } });
+
+      await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/3 left/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows "No more hints" when available hints is 0 but total hints > 0', async () => {
+      const stub = makeContentViewerStub({ availableHints: 0, totalHints: 5 });
+      renderComponent({}, { stubs: { ContentViewer: stub } });
+
+      await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
+
+      await waitFor(() => {
+        expect(screen.getByText('No more hints')).toBeInTheDocument();
+      });
+    });
+
+    it('calls takeHint on the content viewer when the hint button is clicked', async () => {
+      const stub = makeContentViewerStub({ availableHints: 3, totalHints: 5 });
+      const { emitted } = renderComponent({}, { stubs: { ContentViewer: stub } });
+
+      await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/3 left/)).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByText(/3 left/));
+
+      await waitFor(() => {
+        expect(emitted().updateInteraction).toBeTruthy();
+        const [{ interaction }] = emitted().updateInteraction[0];
+        expect(interaction.hinted).toBe(true);
+      });
+    });
+  });
+
+  describe('mastery model variations in UI', () => {
+    it('shows correct goal for do_all model', () => {
+      renderComponent({
+        assessmentIds: ['a', 'b'],
+        masteryModel: { type: 'do_all' },
+      });
+      const elements = screen.getAllByText(/Get 2 correct/);
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows correct goal for num_correct_in_a_row_2', () => {
+      renderComponent({ masteryModel: { type: 'num_correct_in_a_row_2' } });
+      const elements = screen.getAllByText(/Get 2 correct/);
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows correct goal for num_correct_in_a_row_3', () => {
+      renderComponent({ masteryModel: { type: 'num_correct_in_a_row_3' } });
+      const elements = screen.getAllByText(/Get 3 correct/);
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows correct goal for num_correct_in_a_row_10', () => {
+      renderComponent({ masteryModel: { type: 'num_correct_in_a_row_10' } });
+      const elements = screen.getAllByText(/Get 10 correct/);
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the correct number of attempt placeholder slots for do_all', () => {
+      const { container } = renderComponent({
+        assessmentIds: ['a', 'b', 'c'],
+        masteryModel: { type: 'do_all' },
+      });
+      // do_all with 3 items → n=3
+      const placeholders = container.querySelectorAll('.placeholder');
+      expect(placeholders).toHaveLength(3);
+    });
+
+    it('renders the correct number of attempt placeholder slots for num_correct_in_a_row_5', () => {
+      const { container } = renderComponent({
+        masteryModel: { type: 'num_correct_in_a_row_5' },
+      });
+      const placeholders = container.querySelectorAll('.placeholder');
+      expect(placeholders).toHaveLength(5);
+    });
+  });
+
+  describe('exerciseProgress through emitted progress', () => {
+    function renderAndCheck(props) {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({ correct: true, answerState: {}, simpleAnswer: '' }),
+      });
+      const result = renderComponent(props, { stubs: { ContentViewer: stub } });
+      return result;
+    }
+
+    function renderAndCheckIncorrect(props) {
+      const stub = makeContentViewerStub({
+        checkAnswerFn: () => ({ correct: false, answerState: {}, simpleAnswer: '' }),
+      });
+      return renderComponent(props, { stubs: { ContentViewer: stub } });
+    }
+
+    it('emits progress > 0 with no past attempts and a correct answer', async () => {
+      const { emitted } = renderAndCheck({});
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      expect(progress).toBeGreaterThan(0);
+    });
+
+    it('emits progress=1 when already mastered', async () => {
+      const { emitted } = renderAndCheck({ mastered: true });
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      expect(progress).toBe(1);
+    });
+
+    it('calculates partial progress with m_of_n model', async () => {
+      // 2 correct past + 1 correct submitting = 3/3 = 1
+      const { emitted } = renderAndCheck({
+        pastattempts: [{ correct: 1 }, { correct: 1 }],
+        masteryModel: { type: 'm_of_n', m: 3, n: 5 },
+      });
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      expect(progress).toBe(1);
+    });
+
+    it('caps progress at 1 when all attempts in window are correct', async () => {
+      const { emitted } = renderAndCheck({
+        pastattempts: [{ correct: 1 }, { correct: 1 }, { correct: 1 }, { correct: 1 }],
+        masteryModel: { type: 'm_of_n', m: 3, n: 5 },
+      });
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      expect(progress).toBe(1);
+    });
+
+    it('returns at least 0.001 when there are attempts but none correct', async () => {
+      const { emitted } = renderAndCheckIncorrect({
+        masteryModel: { type: 'm_of_n', m: 3, n: 5 },
+      });
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      // exerciseProgress([{correct:0}]) → 0/3=0 → max(0, 0.001)=0.001
+      expect(progress).toBe(0.001);
+    });
+
+    it('uses window of n when past attempts exceed n', async () => {
+      // 6 past attempts, window n=5, submitting 1 correct → total 7.
+      // Window = first 5 of [submitting, ...past] = [1, 1, 1, 1, 0] → 4/3 capped at 1
+      const { emitted } = renderAndCheck({
+        pastattempts: [
+          { correct: 1 },
+          { correct: 1 },
+          { correct: 1 },
+          { correct: 0 },
+          { correct: 0 },
+          { correct: 0 },
+        ],
+        masteryModel: { type: 'm_of_n', m: 3, n: 5 },
+      });
+      await fireEvent.click(screen.getByText('Check'));
+      const [{ progress }] = emitted().updateInteraction[0];
+      expect(progress).toBe(1);
+    });
+  });
+
+  describe('recentAttempts rendering through ExerciseAttempts', () => {
+    it('renders correct icons for past correct attempts', () => {
+      const { container } = renderComponent({
+        pastattempts: [{ correct: 1 }, { correct: 1 }],
+      });
+      // Each correct attempt renders an SVG with class="correct" inside the AnswerIcon
+      const correctIcons = container.querySelectorAll('.attempt svg.correct');
+      expect(correctIcons).toHaveLength(2);
+    });
+
+    it('renders rectified icon for past incorrect attempt (else branch)', () => {
+      const { container } = renderComponent({
+        pastattempts: [{ correct: 0 }],
+      });
+      // When firstAttemptAtQuestion=true, incorrect attempt → 'rectified' →
+      // SVG with class="rectified"
+      const rectifiedIcons = container.querySelectorAll('.attempt svg.rectified');
+      expect(rectifiedIcons).toHaveLength(1);
+    });
+
+    it('renders correct number of attempt icons for mixed results', () => {
+      const { container } = renderComponent({
+        pastattempts: [{ correct: 1 }, { correct: 0 }, { correct: 1 }],
+      });
+      // 1→'right'(correct), 0→'rectified', 1→'right'(correct)
+      const correctIcons = container.querySelectorAll('.attempt svg.correct');
+      const rectifiedIcons = container.querySelectorAll('.attempt svg.rectified');
+      expect(correctIcons).toHaveLength(2);
+      expect(rectifiedIcons).toHaveLength(1);
+    });
+  });
+});

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -1,0 +1,636 @@
+<template v-if="ready">
+
+  <div>
+    <LessonMasteryBar :requiredCorrectAnswers="totalCorrectRequiredM">
+      <template #hint>
+        <div
+          v-if="totalHints > 0"
+          class="hint-btn-container"
+          :class="{ rtl: isRtl }"
+        >
+          <KButton
+            v-if="availableHints > 0"
+            class="hint-btn"
+            appearance="basic-link"
+            :text="hint$tr('hint', { hintsLeft: availableHints })"
+            :primary="false"
+            @click="takeHint"
+          />
+          <KButton
+            v-else
+            class="hint-btn"
+            appearance="basic-link"
+            :text="hint$tr('noMoreHint')"
+            :primary="false"
+            :disabled="true"
+          />
+          <CoreInfoIcon
+            class="info-icon"
+            tooltipPlacement="bottom left"
+            :iconAriaLabel="hint$tr('hintExplanation')"
+            :tooltipText="hint$tr('hintExplanation')"
+          />
+        </div>
+      </template>
+    </LessonMasteryBar>
+    <div class="content-attempts-wrapper">
+      <UiAlert
+        v-if="itemError"
+        :dismissible="false"
+        type="error"
+      >
+        {{ $tr('itemError') }}
+        <KButton
+          appearance="basic-link"
+          :text="$tr('tryDifferentQuestion')"
+          @click="nextQuestion"
+        />
+      </UiAlert>
+      <div
+        class="content-wrapper"
+        :style="{ backgroundColor: $themePalette.grey.v_100 }"
+      >
+        <ContentViewer
+          ref="contentViewer"
+          :lang="lang"
+          :files="files"
+          :extraFields="extraFields"
+          :assessment="true"
+          :itemId="currentItemId"
+          :progress="progress"
+          :userId="userId"
+          :userFullName="userFullName"
+          :timeSpent="timeSpent"
+          @answerGiven="answerGiven"
+          @hintTaken="hintTaken"
+          @itemError="handleItemError"
+          @startTracking="startTracking"
+          @stopTracking="stopTracking"
+          @updateProgress="updateProgress"
+          @updateContentState="updateContentState"
+          @error="err => $emit('error', err)"
+        />
+      </div>
+
+      <BottomAppBar
+        class="attempts-container"
+        :class="{ mobile: windowIsSmall }"
+      >
+        <div
+          class="overall-status"
+          :style="{ color: $themeTokens.text }"
+        >
+          <KIcon
+            icon="mastered"
+            :color="success ? $themeTokens.mastered : $themePalette.grey.v_300"
+          />
+          <div class="overall-status-text">
+            <span
+              v-if="success"
+              class="completed"
+              :style="{ color: $themeTokens.annotation }"
+            >
+              {{ coreString('completedLabel') }}
+            </span>
+            <span>
+              {{ $tr('goal', { count: totalCorrectRequiredM }) }}
+            </span>
+          </div>
+        </div>
+        <div class="table">
+          <div class="row">
+            <div class="left">
+              <transition mode="out-in">
+                <KButton
+                  v-if="!complete"
+                  appearance="raised-button"
+                  :text="$tr('check')"
+                  :primary="true"
+                  :class="{ shaking: shake }"
+                  :disabled="checkingAnswer"
+                  @click="checkAnswer"
+                />
+                <KButton
+                  v-else
+                  ref="nextButton"
+                  appearance="raised-button"
+                  :text="$tr('next')"
+                  :primary="true"
+                  @click="nextQuestion"
+                />
+              </transition>
+            </div>
+
+            <div class="right">
+              <ExerciseAttempts
+                :waitingForAttempt="firstAttemptAtQuestion || itemError"
+                :numSpaces="attemptsWindowN"
+                :log="recentAttempts"
+              />
+              <p class="current-status">
+                {{ currentStatus }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </BottomAppBar>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import { MasteryModelGenerators } from 'kolibri/constants';
+  import { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import shuffled from 'kolibri-common/utils/shuffled';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import BottomAppBar from 'kolibri/components/BottomAppBar';
+  import CoreInfoIcon from 'kolibri-common/components/labels/CoreInfoIcon';
+  import { createTranslator } from 'kolibri/utils/i18n';
+  import useUser from 'kolibri/composables/useUser';
+  import LessonMasteryBar from './LessonMasteryBar';
+  import ExerciseAttempts from './ExerciseAttempts';
+
+  const hintTranslator = createTranslator('PerseusRendererIndex', {
+    hint: {
+      message: 'Use a hint ({hintsLeft, number} left)',
+      context:
+        'A hint is a suggestion to help learners solve a problem. This phrase tells the learner how many hints they have left to use.',
+    },
+    hintExplanation: {
+      message: 'If you use a hint, this question will not be added to your progress',
+      context: 'A hint is a suggestion to help learners solve a problem.',
+    },
+    noMoreHint: {
+      message: 'No more hints',
+      context: 'A hint is a suggestion to help learners solve a problem.',
+    },
+  });
+
+  export default {
+    name: 'AssessmentWrapper',
+    components: {
+      ExerciseAttempts,
+      UiAlert,
+      BottomAppBar,
+      LessonMasteryBar,
+      CoreInfoIcon,
+    },
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
+      const { currentUserId } = useUser();
+      return {
+        windowIsSmall,
+        currentUserId,
+      };
+    },
+    props: {
+      ...contentViewerProps,
+      assessmentIds: {
+        type: Array,
+        required: true,
+      },
+      randomize: {
+        type: Boolean,
+        required: true,
+      },
+      masteryModel: {
+        type: Object,
+        required: true,
+      },
+      pastattempts: {
+        type: Array,
+        default: () => [],
+      },
+      mastered: {
+        type: Boolean,
+        default: false,
+      },
+      totalattempts: {
+        type: Number,
+        default: 0,
+      },
+    },
+    data() {
+      return {
+        mounted: false,
+        currentItemId: '',
+        shake: false,
+        firstAttemptAtQuestion: true,
+        complete: false,
+        correct: 0,
+        itemError: false,
+        hintWasTaken: false,
+        // Attempted fix for #1725
+        checkingAnswer: false,
+        checkWasAttempted: false,
+        startTime: null,
+      };
+    },
+    computed: {
+      currentattempt() {
+        return !this.firstAttemptAtQuestion ? this.pastattempts[0] : null;
+      },
+      recentAttempts() {
+        return this.pastattempts
+          .map((attempt, index) => {
+            // if first item and not a current attempt
+            if (index === 0 && !this.firstAttemptAtQuestion) {
+              if (attempt.correct === 1) {
+                // first attempt was correct
+                return 'right';
+              } else if (this.correct === 1 && this.complete === true) {
+                // correct but not in first attempt
+                return 'rectified';
+              } else if (this.correct === 0 && this.hintWasTaken) {
+                // not correct and hint
+                return 'hint';
+              } else {
+                // not correct and no hint
+                return 'wrong';
+              }
+            } else {
+              return attempt.correct === 1 ? 'right' : 'rectified';
+            }
+          })
+          .reverse();
+      },
+      mOfNMasteryModel() {
+        return MasteryModelGenerators[this.masteryModel.type](
+          this.assessmentIds,
+          this.masteryModel,
+        );
+      },
+      totalCorrectRequiredM() {
+        return this.mOfNMasteryModel.m;
+      },
+      attemptsWindowN() {
+        return this.mOfNMasteryModel.n;
+      },
+      success() {
+        return this.mastered;
+      },
+      currentStatus() {
+        if (this.itemError) {
+          return this.$tr('tryNextQuestion');
+        } else if (this.firstAttemptAtQuestion && this.checkWasAttempted) {
+          return this.$tr('inputAnswer');
+        } else if (
+          this.correct === 1 &&
+          this.recentAttempts[this.recentAttempts.length - 1] === 'right'
+        ) {
+          return this.$tr('correct');
+        } else if (this.correct === 1 && this.complete === true) {
+          // rectified
+          return this.$tr('greatKeepGoing');
+        } else if (this.correct === 0 && this.hintWasTaken) {
+          return this.$tr('hintUsed');
+        } else if (this.checkWasAttempted) {
+          return this.$tr('tryAgain');
+        }
+        return null;
+      },
+      viewer() {
+        return this.mounted && this.$refs.contentViewer;
+      },
+      availableHints() {
+        return (this.viewer && this.viewer.availableHints) || 0;
+      },
+      totalHints() {
+        return (this.viewer && this.viewer.totalHints) || 0;
+      },
+    },
+    watch: {
+      success(newValue, oldValue) {
+        if (newValue && !oldValue) {
+          this.$emit('finished');
+        }
+      },
+    },
+    created() {
+      this.nextQuestion();
+    },
+    methods: {
+      takeHint() {
+        this.viewer && this.viewer.takeHint();
+      },
+      exerciseProgress(submittingAttempt) {
+        if (this.mastered) {
+          return 1;
+        }
+        const pastAttempts = submittingAttempt
+          ? [submittingAttempt].concat(this.pastattempts)
+          : this.pastattempts;
+        if (pastAttempts.length) {
+          let calculatedMastery;
+          if (pastAttempts.length > this.attemptsWindowN) {
+            calculatedMastery = Math.min(
+              pastAttempts.slice(0, this.attemptsWindowN).reduce((a, b) => a + b.correct, 0) /
+                this.totalCorrectRequiredM,
+              1,
+            );
+          } else {
+            calculatedMastery = Math.min(
+              pastAttempts.reduce((a, b) => a + b.correct, 0) / this.totalCorrectRequiredM,
+              1,
+            );
+          }
+          // If there are any attempts at all, set some progress on the exercise
+          // because they have now started the exercise.
+          return Math.max(calculatedMastery, 0.001);
+        }
+        return 0;
+      },
+      checkAnswer() {
+        this.checkWasAttempted = true;
+        if (!this.checkingAnswer) {
+          this.checkingAnswer = true;
+          const answer = this.$refs.contentViewer.checkAnswer();
+          if (answer) {
+            this.answerGiven(answer);
+          }
+          this.checkingAnswer = false;
+        }
+      },
+      answerGiven({ correct, answerState, simpleAnswer }) {
+        this.hintWasTaken = false;
+        correct = Number(correct);
+        this.correct = correct;
+        if (correct < 1) {
+          if (!this.shake) {
+            setTimeout(() => {
+              this.shake = false;
+            }, 1000);
+            this.shake = true;
+          }
+        }
+        this.complete = correct === 1;
+        this.updateAttempt({ answerState, simpleAnswer });
+        if (this.complete) {
+          this.$nextTick(() => {
+            this.$refs.nextButton.$el.focus();
+          });
+        }
+      },
+      hintTaken({ answerState }) {
+        this.hintWasTaken = true;
+        this.updateAttempt({ answerState });
+      },
+      updateAttempt({ answerState, simpleAnswer } = {}) {
+        const interaction = {
+          complete: this.complete,
+          time_spent: (new Date() - this.startTime) / 1000,
+          correct: this.correct,
+          hinted: this.hintWasTaken,
+          error: this.itemError,
+          item: this.currentItemId,
+        };
+        if (answerState) {
+          interaction.answer = answerState;
+        }
+        if (simpleAnswer) {
+          interaction.simple_answer = simpleAnswer;
+        }
+        let progress;
+        if (this.firstAttemptAtQuestion) {
+          // Only update progress on first attempt at question
+          // as cannot change progress on subsequent attempts.
+          progress = this.exerciseProgress(interaction);
+          this.firstAttemptAtQuestion = false;
+        } else {
+          interaction.id = this.currentattempt.id;
+        }
+        this.updateInteraction({ progress, interaction });
+      },
+      setItemId() {
+        const index = this.totalattempts % this.assessmentIds.length;
+        if (this.randomize) {
+          const seed = this.currentUserId ? this.currentUserId : Date.now();
+          this.currentItemId = shuffled(this.assessmentIds, seed)[index];
+        } else {
+          this.currentItemId = this.assessmentIds[index];
+        }
+      },
+      nextQuestion() {
+        this.complete = false;
+        this.shake = false;
+        this.firstAttemptAtQuestion = true;
+        this.correct = 0;
+        this.itemError = false;
+        this.checkWasAttempted = false;
+        this.startTime = new Date();
+        this.hintWasTaken = false;
+        this.setItemId();
+      },
+      handleItemError() {
+        this.itemError = true;
+        this.complete = true;
+        this.updateAttempt();
+      },
+      updateInteraction(...args) {
+        this.$emit('updateInteraction', ...args);
+      },
+      updateProgress(...args) {
+        this.$emit('updateProgress', ...args);
+      },
+      updateContentState(...args) {
+        this.$emit('updateContentState', ...args);
+      },
+      startTracking(...args) {
+        this.mounted = true;
+        this.$emit('startTracking', ...args);
+      },
+      stopTracking(...args) {
+        this.$emit('stopTracking', ...args);
+      },
+      hint$tr(msgId, options) {
+        return hintTranslator.$tr(msgId, options);
+      },
+    },
+    $trs: {
+      goal: {
+        message: 'Get {count, number, integer} {count, plural, other {correct}}',
+        context:
+          'Message that indicates to the learner how many correct answers they need to give in order to master the given topic, and for the exercise to be considered completed.',
+      },
+      tryAgain: {
+        message: 'Try again',
+        context:
+          "If a learner answers a question incorrectly, the message 'Try again' displays. They can then attempt to answer again.",
+      },
+      correct: {
+        message: 'Correct!',
+        context: "An answer that the learner got right will be marked as 'Correct!'.",
+      },
+      check: {
+        message: 'Check',
+        context:
+          "Learners use the 'CHECK' button when doing an exercise to check if they have answered a question correctly or not.",
+      },
+      next: {
+        message: 'Next',
+        context: 'Button that takes user to next question.',
+      },
+      itemError: {
+        message: 'There was an error showing this question',
+        context:
+          'Error message a user sees if there was a problem accessing a learning resource. This may be because the resource has been removed, for example.',
+      },
+      inputAnswer: {
+        message: 'Please enter an answer above',
+        context:
+          'Message that a learner sees if they try to check their answer without answering the question.',
+      },
+      hintUsed: {
+        message: 'Hint used',
+        context:
+          "Some exercises can offer hints. These can be suggestions to help learners solve a problem.\n\nIf the learner uses a hint, the text 'Hint used' appears in the exercise.",
+      },
+      greatKeepGoing: {
+        message: 'Great! Keep going',
+        context:
+          'Message of encouragement that learner is shown when they answer a question incorrectly but then on a further attempt they get it correct.',
+      },
+      tryDifferentQuestion: {
+        message: 'Try a different question',
+        context:
+          'Message that displays if learner answers a question incorrectly multiple times. It allows them to try a new question.',
+      },
+      tryNextQuestion: {
+        message: 'Try next question',
+        context:
+          'Message that displays if learner answers a question incorrectly multiple times. It allows them to move on to the next question.\n',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .content-attempts-wrapper {
+    // Make the wrapper for the content and attempts the full height of the parent
+    // minus the height of the mastery bar above: 56px.
+    height: calc(100% - 56px);
+  }
+
+  .content-wrapper {
+    // Make the content wrapper the full height of the parent content attempts wrapper
+    // minus the height of the attempts container below: 111px.
+    height: calc(100% - 111px);
+  }
+
+  .attempts-container {
+    height: 111px;
+    text-align: left;
+  }
+
+  .overall-status {
+    margin-bottom: 8px;
+    margin-left: 12px;
+  }
+
+  .overall-status-text {
+    display: inline-block;
+    margin-left: 4px;
+  }
+
+  .completed {
+    font-size: 12px;
+  }
+
+  .table {
+    display: table;
+    padding-left: 12px;
+  }
+
+  .row {
+    display: table-row;
+  }
+
+  .left,
+  .right {
+    display: table-cell;
+    vertical-align: top;
+  }
+
+  .right {
+    width: 99%;
+    padding-left: 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  // checkAnswer btn animation
+  .shaking {
+    @extend %enable-gpu-acceleration;
+
+    animation: shake 0.8s ease-in-out both;
+  }
+
+  @keyframes shake {
+    10%,
+    90% {
+      transform: translate3d(-1px, 0, 0);
+    }
+
+    20%,
+    80% {
+      transform: translate3d(2px, 0, 0);
+    }
+
+    30%,
+    50%,
+    70% {
+      transform: translate3d(-4px, 0, 0);
+    }
+
+    40%,
+    60% {
+      transform: translate3d(4px, 0, 0);
+    }
+  }
+
+  .current-status {
+    height: 18px;
+    margin: 0;
+  }
+
+  .hint-btn-container {
+    display: flex;
+    align-items: center;
+    font-size: medium;
+
+    // Ensures the tooltip is visible on the screen in RTL and LTR
+    /deep/ &.rtl {
+      /deep/ .k-tooltip {
+        right: auto !important;
+        left: 0 !important;
+      }
+    }
+
+    /deep/ .k-tooltip {
+      right: 0 !important;
+      left: auto !important;
+      transform: translate3d(0, 23px, 0) !important;
+    }
+  }
+
+  .hint-btn {
+    padding: 0 4px; // Space from btn in RTL and LTR
+    vertical-align: text-bottom;
+
+    /deep/ .link-text {
+      text-align: right;
+    }
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -110,7 +110,10 @@
                 :numSpaces="attemptsWindowN"
                 :log="recentAttempts"
               />
-              <p class="current-status">
+              <p
+                class="current-status"
+                data-testid="current-status"
+              >
                 {{ currentStatus }}
               </p>
             </div>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -1,4 +1,4 @@
-<template v-if="ready">
+<template>
 
   <ResourceLayout>
     <template #default>

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -1,127 +1,110 @@
 <template v-if="ready">
 
-  <div>
-    <LessonMasteryBar :requiredCorrectAnswers="totalCorrectRequiredM">
-      <template #hint>
-        <div
-          v-if="totalHints > 0"
-          class="hint-btn-container"
-          :class="{ rtl: isRtl }"
-        >
-          <KButton
-            v-if="availableHints > 0"
-            class="hint-btn"
-            appearance="basic-link"
-            :text="hint$tr('hint', { hintsLeft: availableHints })"
-            :primary="false"
-            @click="takeHint"
-          />
-          <KButton
-            v-else
-            class="hint-btn"
-            appearance="basic-link"
-            :text="hint$tr('noMoreHint')"
-            :primary="false"
-            :disabled="true"
-          />
-          <CoreInfoIcon
-            class="info-icon"
-            tooltipPlacement="bottom left"
-            :iconAriaLabel="hint$tr('hintExplanation')"
-            :tooltipText="hint$tr('hintExplanation')"
-          />
-        </div>
-      </template>
-    </LessonMasteryBar>
-    <div class="content-attempts-wrapper">
-      <UiAlert
-        v-if="itemError"
-        :dismissible="false"
-        type="error"
-      >
-        {{ $tr('itemError') }}
-        <KButton
-          appearance="basic-link"
-          :text="$tr('tryDifferentQuestion')"
-          @click="nextQuestion"
-        />
-      </UiAlert>
-      <div
-        class="content-wrapper"
-        :style="{ backgroundColor: $themePalette.grey.v_100 }"
-      >
-        <ContentViewer
-          ref="contentViewer"
-          :lang="lang"
-          :files="files"
-          :extraFields="extraFields"
-          :assessment="true"
-          :itemId="currentItemId"
-          :progress="progress"
-          :userId="userId"
-          :userFullName="userFullName"
-          :timeSpent="timeSpent"
-          @answerGiven="answerGiven"
-          @hintTaken="hintTaken"
-          @itemError="handleItemError"
-          @startTracking="startTracking"
-          @stopTracking="stopTracking"
-          @updateProgress="updateProgress"
-          @updateContentState="updateContentState"
-          @error="err => $emit('error', err)"
-        />
-      </div>
-
-      <BottomAppBar
-        class="attempts-container"
-        :class="{ mobile: windowIsSmall }"
-      >
-        <div
-          class="overall-status"
-          :style="{ color: $themeTokens.text }"
-        >
-          <KIcon
-            icon="mastered"
-            :color="success ? $themeTokens.mastered : $themePalette.grey.v_300"
-          />
-          <div class="overall-status-text">
-            <span
-              v-if="success"
-              class="completed"
-              :style="{ color: $themeTokens.annotation }"
+  <ResourceLayout>
+    <template #default>
+      <div class="assesment-wrapper-content">
+        <LessonMasteryBar :requiredCorrectAnswers="totalCorrectRequiredM">
+          <template #hint>
+            <div
+              v-if="totalHints > 0"
+              class="hint-btn-container"
+              :class="{ rtl: isRtl }"
             >
-              {{ coreString('completedLabel') }}
-            </span>
-            <span>
-              {{ $tr('goal', { count: totalCorrectRequiredM }) }}
-            </span>
+              <KButton
+                v-if="availableHints > 0"
+                class="hint-btn"
+                appearance="basic-link"
+                :text="hint$tr('hint', { hintsLeft: availableHints })"
+                :primary="false"
+                @click="takeHint"
+              />
+              <KButton
+                v-else
+                class="hint-btn"
+                appearance="basic-link"
+                :text="hint$tr('noMoreHint')"
+                :primary="false"
+                :disabled="true"
+              />
+              <CoreInfoIcon
+                class="info-icon"
+                tooltipPlacement="bottom left"
+                :iconAriaLabel="hint$tr('hintExplanation')"
+                :tooltipText="hint$tr('hintExplanation')"
+              />
+            </div>
+          </template>
+        </LessonMasteryBar>
+        <div class="content-attempts-wrapper">
+          <UiAlert
+            v-if="itemError"
+            :dismissible="false"
+            type="error"
+          >
+            {{ $tr('itemError') }}
+            <KButton
+              appearance="basic-link"
+              :text="$tr('tryDifferentQuestion')"
+              @click="nextQuestion"
+            />
+          </UiAlert>
+          <div
+            class="content-wrapper"
+            :style="{ backgroundColor: $themePalette.grey.v_100 }"
+          >
+            <ContentViewer
+              ref="contentViewer"
+              :lang="lang"
+              :files="files"
+              :extraFields="extraFields"
+              :assessment="true"
+              :itemId="currentItemId"
+              :progress="progress"
+              :userId="userId"
+              :userFullName="userFullName"
+              :timeSpent="timeSpent"
+              @answerGiven="answerGiven"
+              @hintTaken="hintTaken"
+              @itemError="handleItemError"
+              @startTracking="startTracking"
+              @stopTracking="stopTracking"
+              @updateProgress="updateProgress"
+              @updateContentState="updateContentState"
+              @error="err => $emit('error', err)"
+            />
           </div>
         </div>
-        <div class="table">
-          <div class="row">
-            <div class="left">
-              <transition mode="out-in">
-                <KButton
-                  v-if="!complete"
-                  appearance="raised-button"
-                  :text="$tr('check')"
-                  :primary="true"
-                  :class="{ shaking: shake }"
-                  :disabled="checkingAnswer"
-                  @click="checkAnswer"
-                />
-                <KButton
-                  v-else
-                  ref="nextButton"
-                  appearance="raised-button"
-                  :text="$tr('next')"
-                  :primary="true"
-                  @click="nextQuestion"
-                />
-              </transition>
+      </div>
+    </template>
+    <template #bottomBar>
+      <div
+        class="bottom-bar"
+        :style="{
+          backgroundColor: $themeTokens.surface,
+          borderTop: `1px solid ${$themeTokens.fineLine}`,
+        }"
+      >
+        <div class="attempts-container">
+          <div>
+            <KIcon
+              icon="mastered"
+              :color="success ? $themeTokens.mastered : $themePalette.grey.v_300"
+            />
+            <div class="overall-status-text">
+              <span
+                v-if="success"
+                class="completed"
+                :style="{ color: $themeTokens.annotation }"
+              >
+                {{ coreString('completedLabel') }}
+              </span>
+              <span>
+                {{ $tr('goal', { count: totalCorrectRequiredM }) }}
+              </span>
             </div>
-
-            <div class="right">
+          </div>
+          <div class="attempts-details">
+            <div class="flex-grow">
               <ExerciseAttempts
                 :waitingForAttempt="firstAttemptAtQuestion || itemError"
                 :numSpaces="attemptsWindowN"
@@ -133,9 +116,36 @@
             </div>
           </div>
         </div>
-      </BottomAppBar>
-    </div>
-  </div>
+        <div class="bottom-bar-actions">
+          <div>
+            <transition mode="out-in">
+              <KButton
+                v-if="!complete"
+                :text="$tr('check')"
+                :primary="!hasNextResource"
+                :class="{ shaking: shake }"
+                :disabled="checkingAnswer"
+                @click="checkAnswer"
+              />
+              <KButton
+                v-else
+                ref="nextButton"
+                :text="hasNextResource ? practiceAction$() : $tr('next')"
+                :primary="!hasNextResource"
+                @click="nextQuestion"
+              />
+            </transition>
+          </div>
+          <KButton
+            v-if="hasNextResource"
+            primary
+            :text="nextLabel$()"
+            @click="$emit('nextResource')"
+          />
+        </div>
+      </div>
+    </template>
+  </ResourceLayout>
 
 </template>
 
@@ -147,11 +157,11 @@
   import { contentViewerProps } from 'kolibri/composables/useContentViewer';
   import shuffled from 'kolibri-common/utils/shuffled';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import BottomAppBar from 'kolibri/components/BottomAppBar';
   import CoreInfoIcon from 'kolibri-common/components/labels/CoreInfoIcon';
   import { createTranslator } from 'kolibri/utils/i18n';
   import useUser from 'kolibri/composables/useUser';
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings.js';
+  import ResourceLayout from '../../ResourceLayout/index.vue';
   import LessonMasteryBar from './LessonMasteryBar';
   import ExerciseAttempts from './ExerciseAttempts';
 
@@ -176,17 +186,18 @@
     components: {
       ExerciseAttempts,
       UiAlert,
-      BottomAppBar,
       LessonMasteryBar,
       CoreInfoIcon,
+      ResourceLayout,
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { windowIsSmall } = useKResponsiveWindow();
       const { currentUserId } = useUser();
+      const { practiceAction$, nextLabel$ } = coursesStrings;
       return {
-        windowIsSmall,
         currentUserId,
+        practiceAction$,
+        nextLabel$,
       };
     },
     props: {
@@ -214,6 +225,10 @@
       totalattempts: {
         type: Number,
         default: 0,
+      },
+      hasNextResource: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {
@@ -516,26 +531,40 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .content-attempts-wrapper {
-    // Make the wrapper for the content and attempts the full height of the parent
-    // minus the height of the mastery bar above: 56px.
-    height: calc(100% - 56px);
+  .assesment-wrapper-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .content-attempts-wrapper {
+      flex: 1;
+      overflow: hidden;
+    }
   }
 
   .content-wrapper {
-    // Make the content wrapper the full height of the parent content attempts wrapper
-    // minus the height of the attempts container below: 111px.
-    height: calc(100% - 111px);
+    height: 100%;
+  }
+
+  .bottom-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 16px 8px;
+  }
+
+  .bottom-bar-actions {
+    display: flex;
+    gap: 16px;
+    align-items: center;
   }
 
   .attempts-container {
-    height: 111px;
-    text-align: left;
-  }
-
-  .overall-status {
-    margin-bottom: 8px;
-    margin-left: 12px;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 8px;
   }
 
   .overall-status-text {
@@ -547,26 +576,15 @@
     font-size: 12px;
   }
 
-  .table {
-    display: table;
-    padding-left: 12px;
+  .flex-grow {
+    flex-grow: 1;
   }
 
-  .row {
-    display: table-row;
-  }
-
-  .left,
-  .right {
-    display: table-cell;
-    vertical-align: top;
-  }
-
-  .right {
-    width: 99%;
-    padding-left: 8px;
-    overflow-x: auto;
-    overflow-y: hidden;
+  .attempts-details {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    justify-content: flex-start;
   }
 
   // checkAnswer btn animation
@@ -631,6 +649,10 @@
     /deep/ .link-text {
       text-align: right;
     }
+  }
+
+  /deep/ .framework-perseus {
+    margin: 0 !important;
   }
 
 </style>

--- a/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
@@ -808,14 +808,10 @@
   /deep/ .perseus > div {
     box-sizing: border-box;
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    // Use min(400px, 100%) to ensure that columns are at most 400px wide,
+    // but can shrink to fit smaller screens
+    grid-template-columns: repeat(auto-fit, minmax(#{'min(400px, 100%)'}, 1fr));
     gap: 10px; /* Optional: space between the grid items */
-  }
-
-  @media (max-width: 600px) {
-    /deep/ .perseus > div {
-      grid-template-columns: 1fr;
-    }
   }
 
   /deep/ .perseus {

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -312,4 +312,8 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: '{num, number} {num, plural, one {learner} other {learners}}',
     context: 'Label showing a number of learners',
   },
+  practiceAction: {
+    message: 'Practice',
+    context: 'Action label for practicing an assessment that has already been completed',
+  },
 });


### PR DESCRIPTION
## Summary

* Copies the current AssessmentWrapper to courses.
* Adapts AssessmentWrapper to use ResourceLayout, and claims the parent's bottom bar with its bottom bar.
* Adds `bottomBarActions` slot to AssessmentWrapper to render the CourseUnitView's next button on its bottom bar.

https://github.com/user-attachments/assets/facc6e7d-964f-4868-8a28-fd5fb5122256


## References
Closes #14106.

## Reviewer guidance

* Assign a course to a learner.
* Open learner course.
* Complete/check resources until you get to an assessment node.
* Check assessment wrapper integration into the CourseUnitView

## Note
I have intentionally isolated the copy of the AssessmentWrapper in the first commit, so that subsequent commits would actually show the changes made to these components.