### PR TITLE
Fix selected value handling in  select components

### DIFF
--- a/packages/kolibri-common/components/ExtraDemographics/ExtraDemographicField.vue
+++ b/packages/kolibri-common/components/ExtraDemographics/ExtraDemographicField.vue
@@ -46,9 +46,6 @@
         }));
       },
       optionValue() {
-        if (!this.value || !this.value.trim()) {
-          return { value: '', label: '' };
-        }
         return this.options.find(option => option.value === this.value) || { value: '', label: '' };
       },
       description() {

--- a/packages/kolibri-common/components/ExtraDemographics/ExtraDemographicField.vue
+++ b/packages/kolibri-common/components/ExtraDemographics/ExtraDemographicField.vue
@@ -46,7 +46,10 @@
         }));
       },
       optionValue() {
-        return this.options.find(option => option.value === this.value) || {};
+        if (!this.value || !this.value.trim()) {
+          return { value: '', label: '' };
+        }
+        return this.options.find(option => option.value === this.value) || { value: '', label: '' };
       },
       description() {
         if (!this.field) {

--- a/packages/kolibri-common/components/userAccounts/BirthYearSelect.vue
+++ b/packages/kolibri-common/components/userAccounts/BirthYearSelect.vue
@@ -75,7 +75,10 @@
     },
     computed: {
       selected() {
-        return this.options.find(o => o.value === this.value) || {};
+        if (!this.value || !this.value.trim()) {
+          return { value: '', label: '' };
+        }
+        return this.options.find(o => o.value === this.value) || { value: '', label: '' };
       },
       options() {
         // The backend validation actually lets you pick years up to 3000, so we'll

--- a/packages/kolibri-common/components/userAccounts/BirthYearSelect.vue
+++ b/packages/kolibri-common/components/userAccounts/BirthYearSelect.vue
@@ -75,9 +75,6 @@
     },
     computed: {
       selected() {
-        if (!this.value || !this.value.trim()) {
-          return { value: '', label: '' };
-        }
         return this.options.find(o => o.value === this.value) || { value: '', label: '' };
       },
       options() {

--- a/packages/kolibri-common/components/userAccounts/GenderSelect.vue
+++ b/packages/kolibri-common/components/userAccounts/GenderSelect.vue
@@ -30,7 +30,10 @@
     },
     computed: {
       selected() {
-        return this.options.find(o => o.value === this.value) || {};
+        if (!this.value || !this.value.trim()) {
+          return { value: '', label: '' };
+        }
+        return this.options.find(o => o.value === this.value) || { value: '', label: '' };
       },
       options() {
         return [

--- a/packages/kolibri-common/components/userAccounts/GenderSelect.vue
+++ b/packages/kolibri-common/components/userAccounts/GenderSelect.vue
@@ -30,9 +30,6 @@
     },
     computed: {
       selected() {
-        if (!this.value || !this.value.trim()) {
-          return { value: '', label: '' };
-        }
         return this.options.find(o => o.value === this.value) || { value: '', label: '' };
       },
       options() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

- Fix default return value in select components to include empty label and value, since when the value is empty or null, it would return an empty object, which would raise a Vue Prop warning
- I found a similar bug in `ExtraDemographicField.vue`, and when I added a demo demographic field in my local facility, I noticed the same Vue prop warning 
- 
<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/59d12a4b-54dc-4785-b426-805da074b446" />

## References
<!--
 * references to related issues and PRs
-->
Fixes : #14137 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Open the Create Account page (User Auth -> Create account)
- Inspect the browser console and see if there are any Vue-prop-related warnings.
- Migrate to the facility section and open the create-new-user form, make sure the facility has some demographic fields.
-  Inspect the browser console and see if there are any Vue-prop-related warnings.
