### PR TITLE
Add autoapproval of identical translations from translation memory as part of upload

### DIFF
--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -46,4 +46,6 @@ jobs:
       - name: Extract and upload strings to Crowdin
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_API_KEY }}
-        run: make i18n-upload
+        run: |
+          make i18n-upload
+          make i18n-pretranslate-approve-all


### PR DESCRIPTION
## Summary
To make it simpler to move strings around as we need, we can use auto approval of exact match strings.
Currently, we don't do this automaticaly on string upload.
This PR changes that.