### PR TITLE
Convert epub viewer settings unit tests to Vue Testing Library for SettingsButton.spec.js and SettingsSideBar.spec.js

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsButton.spec.js
@@ -1,18 +1,18 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import SettingsButton from '../SettingsButton';
 
-function createWrapper() {
-  return mount(SettingsButton);
-}
-
 describe('Settings button', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('renders a button', () => {
+    render(SettingsButton);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
-  it('should emit an event when the button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeTruthy();
+
+  it('emits a click event when the user clicks the button', async () => {
+    const { emitted } = render(SettingsButton);
+
+    await fireEvent.click(screen.getByRole('button'));
+
+    expect(emitted().click).toBeTruthy();
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
@@ -43,16 +43,9 @@ describe('Settings side bar', () => {
   it('renders expected theme options', () => {
     renderSettingsSideBar();
 
-    const themeLabels = [
-      'Set white theme',
-      'Set beige theme',
-      'Set grey theme',
-      'Set black theme',
-    ];
+    const themeLabels = ['Set white theme', 'Set beige theme', 'Set grey theme', 'Set black theme'];
 
-    const renderedThemes = themeLabels.filter(label =>
-      screen.queryByLabelText(label)
-    );
+    const renderedThemes = themeLabels.filter(label => screen.queryByLabelText(label));
 
     expect([2, 3, 4, 6]).toContain(renderedThemes.length);
   });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
@@ -1,38 +1,68 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import SettingsSideBar from '../SettingsSideBar';
 import { THEMES } from '../EpubConstants';
 
-function createWrapper({ theme = THEMES.BEIGE } = {}) {
-  return mount(SettingsSideBar, {
-    propsData: {
-      theme,
+function renderSettingsSideBar(props = {}) {
+  return render(SettingsSideBar, {
+    props: {
+      theme: THEMES.BEIGE,
+      ...props,
     },
   });
 }
 
 describe('Settings side bar', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('renders font size controls and theme options', () => {
+    renderSettingsSideBar();
+
+    // Font buttons
+    expect(screen.getByText('Decrease')).toBeInTheDocument();
+    expect(screen.getByText('Increase')).toBeInTheDocument();
+
+    // Theme buttons (check a few representative ones)
+    expect(screen.getByLabelText('Set white theme')).toBeInTheDocument();
+    expect(screen.getByLabelText('Set beige theme')).toBeInTheDocument();
   });
 
-  it('should emit an event if the decrease font size button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ ref: 'decreaseFontSizeButton' }).trigger('click');
-    expect(wrapper.emitted().decreaseFontSize).toBeTruthy();
+  it('emits event when decrease font size button is clicked', async () => {
+    const { emitted } = renderSettingsSideBar();
+
+    await fireEvent.click(screen.getByText('Decrease'));
+
+    expect(emitted().decreaseFontSize).toBeTruthy();
   });
-  it('should emit an event if the increase font size button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.findComponent({ ref: 'increaseFontSizeButton' }).trigger('click');
-    expect(wrapper.emitted().increaseFontSize).toBeTruthy();
+
+  it('emits event when increase font size button is clicked', async () => {
+    const { emitted } = renderSettingsSideBar();
+
+    await fireEvent.click(screen.getByText('Increase'));
+
+    expect(emitted().increaseFontSize).toBeTruthy();
   });
-  it('should have 2, 3, 4, or 6 themes', () => {
-    const wrapper = createWrapper();
-    expect([2, 3, 4, 6]).toContain(Object.keys(wrapper.vm.themes).length);
+
+  it('renders expected theme options', () => {
+    renderSettingsSideBar();
+
+    const themeLabels = [
+      'Set white theme',
+      'Set beige theme',
+      'Set grey theme',
+      'Set black theme',
+    ];
+
+    const renderedThemes = themeLabels.filter(label =>
+      screen.queryByLabelText(label)
+    );
+
+    expect([2, 3, 4, 6]).toContain(renderedThemes.length);
   });
-  it('should emit an event when a theme is selected', () => {
-    const wrapper = createWrapper();
-    wrapper.find('.theme-button').trigger('click');
-    expect(wrapper.emitted().setTheme[0][0]).toBe(THEMES.WHITE);
+
+  it('emits event when a theme is selected', async () => {
+    const { emitted } = renderSettingsSideBar();
+
+    await fireEvent.click(screen.getByLabelText('Set white theme'));
+
+    expect(emitted().setTheme).toBeTruthy();
+    expect(emitted().setTheme[0][0]).toBe(THEMES.WHITE);
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors the EPUB viewer settings-related test suites to use 'Vue Testing Library (VTL)' instead of `@vue/test-utils`.

The following test files were updated:
-SettingsButton.spec.js
-SettingsSideBar.spec.js


## References

closes #14188 



## Verification
Ran pnpm run test-jest -- --testPathPattern epub_viewer

<img width="965" height="504" alt="image" src="https://github.com/user-attachments/assets/765ee391-0b68-4556-8e86-0a8c29df3f75" />