### PR TITLE
Fixes notification for no resources on the device being shown when no exercises exist

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/frontend/views/common/QuizLessonDetailsHeader.vue
@@ -14,7 +14,7 @@
         <h1 class="exam-title">
           <!-- KLabeledIcon does not have an 'exam' token, but rather 'quiz' -->
           <KLabeledIcon
-            :icon="examOrLesson === 'exam' ? 'quiz' : 'lesson'"
+            :icon="icon"
             :label="resource.title"
           />
         </h1>
@@ -103,7 +103,7 @@
         return this.lessonMap[this.$route.params.lessonId] || {};
       },
       resource() {
-        return this.examOrLesson === 'lesson' ? this.lesson : this.exam;
+        return this.isExam ? this.exam : this.lesson;
       },
       isActive() {
         return this.exam.active;
@@ -120,6 +120,12 @@
       hasChannels() {
         return this.channels.length > 0;
       },
+      isExam() {
+        return this.examOrLesson === 'exam';
+      },
+      icon() {
+        return this.isExam ? 'quiz' : 'lesson';
+      },
     },
     async mounted() {
       await this.loadChannels();
@@ -128,7 +134,8 @@
       async loadChannels() {
         this.loading = true;
         try {
-          this.channels = await this.fetchChannels({ contains_exercise: true });
+          const params = this.isExam ? { contains_exercise: true } : {};
+          this.channels = await this.fetchChannels(params);
         } finally {
           this.loading = false;
         }


### PR DESCRIPTION


<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
This pr fixes the "No resources on the device" notification being shown when no exercises exist on the lessons page. It also makes minor code tweaks to improve code readability.

## References
<!--
 * references to related issues and PRs
-->
Fixes #14251

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Delete some quiz/exercise resources from your channel.
2. Navigate to the the Lessons page.
3. There should be no notification displayed.
4. Delete all channels or resources the channels on your device.
5. Navigate back to the the Lessons page.
6. A "No resources on the device" should be displayed.


Also, see the replication video in #14251

<!--
AI USAGE - DEEP guidelines

If AI was used in preparing this PR, please fill in the section below.
Our DEEP guidelines ask that when using AI you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

If AI was not used, delete the section below.
-->
