### PR TITLE
"Resume" card display and progress fixes

### DIFF
--- a/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
@@ -24,7 +24,7 @@ import useContentNodeProgress, { setContentNodeProgress } from './useContentNode
 const _resumableContentNodes = ref([]);
 const moreResumableContentNodes = ref(null);
 const classes = ref([]);
-const { fetchContentNodeProgress } = useContentNodeProgress();
+const { fetchContentNodeProgress, contentNodeProgressMap } = useContentNodeProgress();
 const courses = ref([]);
 const courseContent = ref({});
 const courseProgress = ref({});
@@ -144,7 +144,13 @@ export default function useLearnerResources() {
    */
   const resumableClassesResources = computed(() => {
     return get(_classesResources).filter(resource => {
-      return resource.progress && resource.progress < 1 && resource.contentNode;
+      if (!resource.contentNode) return false;
+      const contentId = resource.contentNode.content_id;
+      const progress = Math.max(
+        resource.progress || 0,
+        (contentId && contentNodeProgressMap[contentId]) || 0,
+      );
+      return progress > 0 && progress < 1;
     });
   });
 

--- a/kolibri/plugins/learn/frontend/views/cards/AssignmentCard/__tests__/AssignmentCard.spec.js
+++ b/kolibri/plugins/learn/frontend/views/cards/AssignmentCard/__tests__/AssignmentCard.spec.js
@@ -1,5 +1,12 @@
 import { mount, RouterLinkStub } from '@vue/test-utils';
+/* eslint-disable import/named */
+import useContentNodeProgress, {
+  useContentNodeProgressMock,
+} from '../../../../composables/useContentNodeProgress';
+/* eslint-enable import/named */
 import AssignmentCard from '../index.vue';
+
+jest.mock('../../../../composables/useContentNodeProgress');
 
 // --- Course test data ---
 const baseCourse = {
@@ -7,14 +14,17 @@ const baseCourse = {
   title: 'Test Course 1',
 };
 
+const makeResource = (contentId, progress = 0) => ({
+  contentnode_id: contentId,
+  progress,
+  contentnode: { content_id: contentId },
+});
+
 // --- Lesson test data ---
 const baseLesson = {
   id: '395b68e7be06485cbe65ce159dac6859',
   title: 'Test Lesson 1',
-  progress: {
-    resource_progress: 0,
-    total_resources: 10,
-  },
+  resources: [],
 };
 
 // --- Quiz test data ---
@@ -54,10 +64,6 @@ function makeLessonWrapper(lessonOverrides = {}) {
       lesson: {
         ...baseLesson,
         ...lessonOverrides,
-        progress: {
-          ...baseLesson.progress,
-          ...(lessonOverrides.progress || {}),
-        },
       },
       collectionTitle: 'Test Classroom 1',
       to: { path: '/lesson' },
@@ -86,6 +92,10 @@ function makeQuizWrapper(quizOverrides = {}) {
 }
 
 describe('AssignmentCard', () => {
+  beforeEach(() => {
+    useContentNodeProgress.mockImplementation(() => useContentNodeProgressMock());
+  });
+
   describe('when rendering a course', () => {
     let wrapper;
 
@@ -180,27 +190,68 @@ describe('AssignmentCard', () => {
       };
 
       it('shows no label if there are no resources', () => {
-        wrapper = makeLessonWrapper({ progress: { resource_progress: 10, total_resources: 0 } });
+        wrapper = makeLessonWrapper({ resources: [] });
         expect(wrapper.findComponent({ name: 'KLabeledIcon' }).exists()).toBe(false);
         assertProgressEquals(wrapper, '');
       });
 
       it('shows no label when the lesson has not been started', () => {
-        wrapper = makeLessonWrapper({ progress: { resource_progress: 0 } });
+        // resources exist but none have progress in the map (all default to 0)
+        wrapper = makeLessonWrapper({
+          resources: [makeResource('content1'), makeResource('content2')],
+        });
         expect(wrapper.findComponent({ name: 'KLabeledIcon' }).exists()).toBe(false);
         assertProgressEquals(wrapper, '');
       });
 
       it('shows a "In progress" label if still in progress', () => {
-        wrapper = makeLessonWrapper({ progress: { resource_progress: 1 } });
+        useContentNodeProgress.mockImplementation(() =>
+          useContentNodeProgressMock({
+            contentNodeProgressMap: { content1: 0.5, content2: 0 },
+          }),
+        );
+        wrapper = makeLessonWrapper({
+          resources: [makeResource('content1'), makeResource('content2')],
+        });
         assertProgressEquals(wrapper, 'In progress');
         assertKIconIs(wrapper, 'inProgress');
       });
 
       it('shows a "Completed" label if all resources are complete', () => {
-        wrapper = makeLessonWrapper({ progress: { resource_progress: 10 } });
+        useContentNodeProgress.mockImplementation(() =>
+          useContentNodeProgressMock({
+            contentNodeProgressMap: { content1: 1, content2: 1 },
+          }),
+        );
+        wrapper = makeLessonWrapper({
+          resources: [makeResource('content1'), makeResource('content2')],
+        });
         assertProgressEquals(wrapper, 'Completed');
         assertKIconIs(wrapper, 'mastered');
+      });
+
+      it('uses API-provided resource progress as fallback when not in the map', () => {
+        // resource.progress from API is used when contentNodeProgressMap has no entry
+        wrapper = makeLessonWrapper({
+          resources: [makeResource('content1', 0.5), makeResource('content2', 0)],
+        });
+        assertProgressEquals(wrapper, 'In progress');
+        assertKIconIs(wrapper, 'inProgress');
+      });
+
+      it('uses the higher of API progress and map progress', () => {
+        // contentNodeProgressMap has a higher value than the stale API data
+        useContentNodeProgress.mockImplementation(() =>
+          useContentNodeProgressMock({
+            contentNodeProgressMap: { content1: 1 },
+          }),
+        );
+        wrapper = makeLessonWrapper({
+          resources: [makeResource('content1', 0.5), makeResource('content2', 0)],
+        });
+        // content1: max(1, 0.5)=1, content2: max(0, 0)=0 → sum=1, total=2 → 1-2=-1 → in progress
+        assertProgressEquals(wrapper, 'In progress');
+        assertKIconIs(wrapper, 'inProgress');
       });
     });
   });

--- a/kolibri/plugins/learn/frontend/views/cards/AssignmentCard/index.vue
+++ b/kolibri/plugins/learn/frontend/views/cards/AssignmentCard/index.vue
@@ -114,6 +114,7 @@
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import useContentNodeProgress from '../../../composables/useContentNodeProgress';
   import { learnStrings } from '../../commonLearnStrings';
 
   export default {
@@ -123,6 +124,7 @@
       const { quizLabel$, inProgressLabel$, completedLabel$ } = coreStrings;
       const { courseLabel$, numUnits$, numLessons$ } = coursesStrings;
       const { questionsLeft$, completedPercentLabel$ } = learnStrings;
+      const { contentNodeProgressMap } = useContentNodeProgress();
 
       // All computed properties
       const assignment = computed(() => props.course || props.lesson || props.quiz);
@@ -146,15 +148,22 @@
         return parts.join(' · ');
       });
 
-      // Lesson-specific
+      // Lesson-specific: use contentNodeProgressMap for real-time progress,
+      // falling back to API-provided progress for each resource
       const lessonProgress = computed(() => {
-        if (!props.lesson || !props.lesson.progress) return NaN;
-        const { resource_progress, total_resources } = props.lesson.progress;
-        if (resource_progress * total_resources === 0) {
-          return NaN;
-        } else {
-          return resource_progress - total_resources;
-        }
+        if (!props.lesson) return NaN;
+        const resources = props.lesson.resources || [];
+        const total_resources = resources.length;
+        if (total_resources === 0) return NaN;
+        const resource_progress = resources.reduce((sum, resource) => {
+          const contentId = resource.contentnode && resource.contentnode.content_id;
+          const progress = contentId
+            ? Math.max(contentNodeProgressMap[contentId] || 0, resource.progress || 0)
+            : resource.progress || 0;
+          return sum + progress;
+        }, 0);
+        if (resource_progress * total_resources === 0) return NaN;
+        return resource_progress - total_resources;
       });
 
       // Quiz-specific


### PR DESCRIPTION
## Summary
This PR fixes some related bugs around the display of in-progress and completed cards on the learner home page. The underlying bugs had to do with stale data, and using the `contentNodeProgressMap` gives a more accurate state.

## References
Fixes https://github.com/learningequality/kolibri/issues/14217

Screencasts for items 1 and 2 in the issue as Peter reports.



https://github.com/user-attachments/assets/e369c8cc-73ed-409e-a0f7-05022215f277



https://github.com/user-attachments/assets/ef4f4d3b-fc6a-4389-a1da-0f182840fe4a


## Reviewer guidance
- Manual QA: I think that reviewing Peter's video, the ones I've captured here, and cross checking to ensure that you are able to see the same problems (in the release beta) and fixes (in the PR) is probably the best thing. I feel fairly confident that items 1 and 2 are resolved, and I believe that item 3 (around the completion) is connected to the same root cause, but it felt harder to definitively demonstrate to myself in manual QA. 
- Code review: my main concern here is that making changes to progress tracking in general makes me a bit nervous, as I think there's potential to side effects I wouldn't be able to anticipate. Is this setting us up for progress bugs whackamole? The test changes make sense to me, I've reviewed them several times and while they are more verbose (and could potentially be cut down), I think for the most part it's useful test coverage. Again -- same concern though, am I missing anything? 

## AI usage

I used Claude as a resource to help understand the problem first, then had Claude write the code and update the tests for the fixes. I did a first code review and extensive manual verification. So far it seems to resolve all 3 problems @pcenov describes and I have not been able to find any further regressions it causes.
