### PR TITLE
Integrate course quiz renderer to CourseUnitView

### DIFF
--- a/kolibri/plugins/learn/frontend/views/ContentPage.vue
+++ b/kolibri/plugins/learn/frontend/views/ContentPage.vue
@@ -141,6 +141,7 @@
         extra_fields,
         pastattempts,
         complete,
+        context,
         totalattempts,
         initContentSession,
         updateContentSession,
@@ -165,6 +166,7 @@
         extra_fields,
         pastattempts,
         complete,
+        context,
         totalattempts,
         initContentSession,
         updateContentSession: wrappedUpdateContentSession,
@@ -262,7 +264,7 @@
         return get(this, ['content', 'options', 'modality']) === Modalities.SURVEY;
       },
       masteryLevel() {
-        return get(this, ['context', 'mastery_level']);
+        return this.context?.mastery_level;
       },
     },
     watch: {

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
@@ -24,9 +24,43 @@
         @addProgress="handleAddProgress"
         @updateContentState="handleUpdateContentState"
         @error="onError"
-        @finished="$emit('finished')"
+        @finished="onFinished"
       />
-      <div v-else-if="isPracticeQuiz || isSurvey"></div>
+      <QuizRenderer
+        v-else-if="isPracticeQuiz || isSurvey"
+        class="content-viewer"
+        :content="contentNode"
+        :extraFields="extra_fields"
+        :progress="progress"
+        :userId="currentUserId"
+        :userFullName="fullName"
+        :timeSpent="time_spent"
+        :pastattempts="pastattempts"
+        :mastered="complete"
+        :masteryLevel="masteryLevel"
+        :updateContentSession="updateContentSession"
+        :isSurvey="isSurvey"
+        @startTracking="startTrackingProgress"
+        @stopTracking="stopTrackingProgress"
+        @updateInteraction="handleUpdateInteraction"
+        @updateProgress="handleUpdateProgress"
+        @updateContentState="handleUpdateContentState"
+        @repeat="restartContentSession"
+        @error="onError"
+        @finished="onFinished"
+      >
+        <template
+          v-if="nextResource || previousResource"
+          #sidePanelFooter
+        >
+          <UpNextNavigationFooter
+            nextEnabled
+            :label="nextResource ? nextResourceLabel$() : previousResourceLabel$()"
+            :nextNode="nextResource || previousResource"
+            @next="nextResource ? $emit('next') : $emit('prev')"
+          />
+        </template>
+      </QuizRenderer>
       <AssessmentWrapper
         v-else
         class="content-viewer"
@@ -43,7 +77,7 @@
         :pastattempts="pastattempts"
         :mastered="complete"
         :totalattempts="totalattempts"
-        :hasNextResource="hasNext"
+        :hasNextResource="Boolean(nextResource)"
         @startTracking="startTrackingProgress"
         @stopTracking="stopTrackingProgress"
         @updateInteraction="handleUpdateInteraction"
@@ -51,7 +85,7 @@
         @updateContentState="handleUpdateContentState"
         @nextResource="$emit('next')"
         @error="onError"
-        @finished="$emit('finished')"
+        @finished="onFinished"
       />
     </template>
   </div>
@@ -64,8 +98,11 @@
   import useUser from 'kolibri/composables/useUser';
   import Modalities from 'kolibri-constants/Modalities';
   import { computed } from 'vue';
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings.js';
   import AssessmentWrapper from '../courses/AssessmentWrapper/index.vue';
+  import QuizRenderer from '../courses/QuizRenderer/index.vue';
   import { injectCourseContentProgress } from './useCourseContentProgressTracking';
+  import UpNextNavigationFooter from './UpNextNavigationFooter.vue';
 
   /**
    * CourseContentView renders non-assessment content (videos, PDFs, articles, HTML5)
@@ -85,9 +122,11 @@
     name: 'CourseContentViewer',
     emits: ['finished', 'next'],
     components: {
+      QuizRenderer,
       AssessmentWrapper,
+      UpNextNavigationFooter,
     },
-    setup(props) {
+    setup(props, { emit }) {
       const {
         sessionReady,
         progress,
@@ -95,13 +134,16 @@
         extra_fields,
         pastattempts,
         complete,
+        context,
         totalattempts,
         handleUpdateInteraction,
         startTrackingProgress,
         stopTrackingProgress,
+        restartContentSession,
         handleUpdateProgress,
         handleAddProgress,
         handleUpdateContentState,
+        updateContentSession,
         onError,
       } = injectCourseContentProgress();
 
@@ -114,6 +156,16 @@
       const isSurvey = computed(() => {
         return props.contentNode.modality === Modalities.SURVEY;
       });
+
+      const masteryLevel = computed(() => {
+        return context.value?.mastery_level;
+      });
+
+      const onFinished = () => {
+        emit('finished');
+      };
+
+      const { nextResourceLabel$, previousResourceLabel$ } = coursesStrings;
 
       return {
         // State
@@ -128,17 +180,25 @@
         totalattempts,
 
         // computed
-        isPracticeQuiz,
         isSurvey,
+        masteryLevel,
+        isPracticeQuiz,
 
         // Methods
         startTrackingProgress,
         stopTrackingProgress,
+        restartContentSession,
         handleUpdateProgress,
         handleAddProgress,
         handleUpdateInteraction,
         handleUpdateContentState,
+        updateContentSession,
         onError,
+        onFinished,
+
+        // strings
+        nextResourceLabel$,
+        previousResourceLabel$,
       };
     },
     props: {
@@ -146,9 +206,23 @@
         type: Object,
         required: true,
       },
-      hasNext: {
-        type: Boolean,
-        default: false,
+      /**
+       * Next available resource in the course unit. If provided, it means
+       * that the resource is available to be navigated, which may enable a "next" button
+       * on the content viewers.
+       */
+      nextResource: {
+        type: Object,
+        default: null,
+      },
+      /**
+       * Previous resource in the course unit. Used mainly as navigation fallback in case there
+       * isn't any other way to get out of the current viewer (e.g. no next resource available,but
+       * no other way to get out of the current resource except going back to the previous one).
+       */
+      previousResource: {
+        type: Object,
+        default: null,
       },
     },
   };

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/UpNextNavigationFooter.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/UpNextNavigationFooter.vue
@@ -1,0 +1,81 @@
+<template>
+
+  <div class="course-side-panel-footer">
+    <div class="up-next-wrapper">
+      <span class="up-next-label">
+        {{ label }}
+      </span>
+      <span class="up-next-title">
+        <KTextTruncator
+          :text="nextNode.title"
+          :maxLines="1"
+        />
+      </span>
+    </div>
+    <div>
+      <KIconButton
+        v-if="nextEnabled"
+        icon="forward"
+        @click="$emit('next')"
+      />
+      <KIconButton
+        v-else
+        icon="permissions"
+        disabled
+      />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'UpNextNavigationFooter',
+    props: {
+      label: {
+        type: String,
+        default: '',
+      },
+      nextNode: {
+        type: Object,
+        required: true,
+      },
+      nextEnabled: {
+        type: Boolean,
+        default: false,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .course-side-panel-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 8px 8px 16px;
+
+    .up-next-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+
+      .up-next-label {
+        font-size: 12px;
+      }
+
+      .up-next-title {
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 1.2;
+      }
+    }
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
@@ -21,8 +21,10 @@
       <CourseContentViewer
         v-else-if="currentResource"
         :contentNode="currentResource"
-        :hasNext="nextEnabled"
+        :nextResource="nextAvailableResource"
+        :previousResource="previousAvailableResource"
         @next="handleNext"
+        @prev="handlePrev"
         @finished="onResourceFinished"
       />
     </template>
@@ -70,31 +72,12 @@
       v-if="nextUnit"
       #sidePanelFooter
     >
-      <div class="course-side-panel-footer">
-        <div class="up-next-wrapper">
-          <span class="up-next-label">
-            {{ upNextLabel$() }}
-          </span>
-          <span class="up-next-title">
-            <KTextTruncator
-              :text="nextUnit.title"
-              :maxLines="1"
-            />
-          </span>
-        </div>
-        <div>
-          <KIconButton
-            v-if="canGoToNextUnit"
-            icon="forward"
-            @click="goToNextUnit"
-          />
-          <KIconButton
-            v-else
-            icon="permissions"
-            disabled
-          />
-        </div>
-      </div>
+      <UpNextNavigationFooter
+        :label="upNextLabel$()"
+        :nextNode="nextUnit"
+        :nextEnabled="canGoToNextUnit"
+        @next="goToNextUnit"
+      />
     </template>
   </ResourceLayout>
 
@@ -119,6 +102,7 @@
   import CourseContentViewer from './CourseContentViewer.vue';
   import UnitTreeAccordion from './UnitTreeAccordion/index.vue';
   import useCourseContentProgress from './useCourseContentProgressTracking';
+  import UpNextNavigationFooter from './UpNextNavigationFooter.vue';
 
   export default {
     name: 'CourseUnitView',
@@ -127,6 +111,7 @@
       PrevNextBar,
       CourseContentViewer,
       UnitTreeAccordion,
+      UpNextNavigationFooter,
     },
     setup(props) {
       const router = useRouter();
@@ -293,6 +278,20 @@
         }
         const currentResource = unitResources.value[currentResourceIndexInUnit.value];
         return currentResource.lft < maxResourceLft.value;
+      });
+
+      const nextAvailableResource = computed(() => {
+        if (!nextEnabled.value) {
+          return null;
+        }
+        return unitResources.value[currentResourceIndexInUnit.value + 1];
+      });
+
+      const previousAvailableResource = computed(() => {
+        if (!prevEnabled.value) {
+          return null;
+        }
+        return unitResources.value[currentResourceIndexInUnit.value - 1];
       });
 
       const currentLessonResources = computed(() => {
@@ -746,6 +745,8 @@
         unitNumberLabel,
         prevEnabled,
         nextEnabled,
+        nextAvailableResource,
+        previousAvailableResource,
         maxResourceLft,
         handlePrev,
         handleNext,
@@ -791,30 +792,6 @@
     align-items: center;
     min-width: 0;
     line-height: 1.2;
-  }
-
-  .course-side-panel-footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 8px 8px 8px 16px;
-
-    .up-next-wrapper {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      min-width: 0;
-
-      .up-next-label {
-        font-size: 12px;
-      }
-
-      .up-next-title {
-        font-size: 14px;
-        font-weight: 600;
-        line-height: 1.2;
-      }
-    }
   }
 
   .side-panel-top-bar {

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/useCourseContentProgressTracking.js
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/useCourseContentProgressTracking.js
@@ -11,12 +11,15 @@ const ExtraFieldsKey = Symbol('ExtraFields');
 const PastAttemptsKey = Symbol('PastAttempts');
 const CompleteKey = Symbol('Complete');
 const TotalAttemptsKey = Symbol('TotalAttempts');
+const ContextKey = Symbol('Context');
 const StartTrackingProgressKey = Symbol('StartTrackingProgress');
 const StopTrackingProgressKey = Symbol('StopTrackingProgress');
+const RestartContentSessionKey = Symbol('RestartContentSession');
 const HandleUpdateProgressKey = Symbol('HandleUpdateProgress');
 const HandleAddProgressKey = Symbol('HandleAddProgress');
 const HandleUpdateContentStateKey = Symbol('HandleUpdateContentState');
 const HandleUpdateInteractionKey = Symbol('HandleUpdateInteraction');
+const UpdateContentSessionKey = Symbol('UpdateContentSession');
 const OnErrorKey = Symbol('OnError');
 
 /**
@@ -37,6 +40,7 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
     extra_fields,
     pastattempts,
     complete,
+    context,
     totalattempts,
     initContentSession,
     updateContentSession,
@@ -96,7 +100,7 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
   /**
    * Initialize the content session for progress tracking
    */
-  const initSession = async () => {
+  const initSession = async (repeat = false) => {
     const node = contentNode.value;
     if (!node) {
       return;
@@ -109,6 +113,7 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
       await initContentSession({
         node,
         courseSessionId: courseSessionId.value,
+        repeat,
       });
       sessionReady.value = true;
       // Set progress into the content node progress store
@@ -116,6 +121,11 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
     } catch (error) {
       store.dispatch('handleApiError', { error });
     }
+  };
+
+  const restartContentSession = async () => {
+    await stopTrackingProgress();
+    await initSession(true);
   };
 
   // Watch for progress changes to keep cache up to date
@@ -142,12 +152,15 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
   provide(PastAttemptsKey, pastattempts);
   provide(CompleteKey, complete);
   provide(TotalAttemptsKey, totalattempts);
+  provide(ContextKey, context);
   provide(StartTrackingProgressKey, startTrackingProgress);
   provide(StopTrackingProgressKey, stopTrackingProgress);
+  provide(RestartContentSessionKey, restartContentSession);
   provide(HandleUpdateProgressKey, handleUpdateProgress);
   provide(HandleAddProgressKey, handleAddProgress);
   provide(HandleUpdateContentStateKey, handleUpdateContentState);
   provide(HandleUpdateInteractionKey, handleUpdateInteraction);
+  provide(UpdateContentSessionKey, wrappedUpdateContentSession);
   provide(OnErrorKey, onError);
 }
 
@@ -168,9 +181,13 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
  *                                                      complete.
  * @property {import('vue').Ref<number|null>} totalattempts The total number of attempts for the
  *                                                          content.
+ * @property {import('vue').Ref<Object>} context The context object containing additional
+ *                                              information about the content session.
  * @property {() => void} startTrackingProgress Starts the interval timer for progress tracking.
  * @property {() => Promise<void>} stopTrackingProgress Stops the interval timer and saves
  *                                                      final progress.
+ * @property {() => Promise<void>} restartContentSession Restarts the content session, resetting
+ *                                                       progress and time spent.
  * @property {(progressValue: number) => Promise<void>} handleUpdateProgress Updates progress
  *                                                                           to an absolute value.
  * @property {(progressDelta: number) => Promise<void>} handleAddProgress Adds a delta to the
@@ -179,6 +196,7 @@ export default function useCourseContentProgress({ contentNode, courseSessionId 
  *                                                                              content state.
  * @property {(interaction: Object) => Promise<void>} handleUpdateInteraction Updates the
  *                                                                          interaction state.
+ * @property {(data: any) => Promise<void>} updateContentSession Updates the content session.
  * @property {(error: Error) => void} onError Handles errors by flagging the session as errored
  *                                            and dispatching to the store.
  *
@@ -194,12 +212,15 @@ export function injectCourseContentProgress() {
     pastattempts: inject(PastAttemptsKey),
     complete: inject(CompleteKey),
     totalattempts: inject(TotalAttemptsKey),
+    context: inject(ContextKey),
     startTrackingProgress: inject(StartTrackingProgressKey),
     stopTrackingProgress: inject(StopTrackingProgressKey),
+    restartContentSession: inject(RestartContentSessionKey),
     handleUpdateProgress: inject(HandleUpdateProgressKey),
     handleAddProgress: inject(HandleAddProgressKey),
     handleUpdateContentState: inject(HandleUpdateContentStateKey),
     handleUpdateInteraction: inject(HandleUpdateInteractionKey),
+    updateContentSession: inject(UpdateContentSessionKey),
     onError: inject(OnErrorKey),
   };
 }

--- a/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
+++ b/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
@@ -9,10 +9,13 @@
       :aria-label="previousLabel$()"
       @click="handlePrev"
     >
-      <template #icon>
-        <KIcon icon="back" />
-      </template>
-      <span v-if="showButtonLabels">{{ previousLabel$() }}</span>
+      <div class="btn-flex">
+        <KIcon
+          class="icon"
+          icon="back"
+        />
+        <span v-if="showButtonLabels">{{ previousLabel$() }}</span>
+      </div>
     </KButton>
 
     <!-- Progress/status in the center -->
@@ -40,10 +43,13 @@
         :aria-label="nextLabel$()"
         @click="handleNext"
       >
-        <span v-if="showButtonLabels">{{ nextLabel$() }}</span>
-        <template #iconAfter>
-          <KIcon icon="forward" />
-        </template>
+        <div class="btn-flex">
+          <span v-if="showButtonLabels">{{ nextLabel$() }}</span>
+          <KIcon
+            class="icon"
+            icon="forward"
+          />
+        </div>
       </KButton>
     </div>
   </div>
@@ -158,6 +164,17 @@
   .actions-area {
     display: flex;
     align-items: center;
+  }
+
+  .btn-flex {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: center;
+
+    .icon {
+      top: 0;
+    }
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/AnswerHistory.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/AnswerHistory.vue
@@ -1,0 +1,156 @@
+<template>
+
+  <ul class="history-list">
+    <li
+      v-for="(question, index) in questions"
+      :key="index"
+      :ref="`item-${index}`"
+      class="list-item"
+    >
+      <button
+        :class="buttonClass(index)"
+        :disabled="questionNumber === index"
+        class="clickable"
+        @click="$emit('goToQuestion', index)"
+      >
+        <KIcon
+          class="dot"
+          icon="notStarted"
+          :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
+        />
+        <div class="text">
+          {{ questionText(index + 1) }}
+        </div>
+      </button>
+    </li>
+  </ul>
+
+</template>
+
+
+<script>
+
+  function isAboveContainer(element, container) {
+    return element.offsetTop < container.scrollTop;
+  }
+
+  function isBelowContainer(element, container) {
+    return element.offsetTop + element.offsetHeight > container.offsetHeight + container.scrollTop;
+  }
+
+  export default {
+    name: 'AnswerHistory',
+    props: {
+      pastattempts: {
+        type: Array,
+        default: () => [],
+      },
+      questions: {
+        type: Array,
+        default: () => [],
+      },
+      questionNumber: {
+        type: Number,
+        required: true,
+      },
+      currentQuestionAnswered: {
+        type: Boolean,
+        required: true,
+      },
+      // hack to get access to the scrolling pane
+      wrapperComponentRefs: {
+        type: Object,
+        required: true,
+      },
+    },
+    watch: {
+      questionNumber(index) {
+        // If possible, scroll it into view
+        const element = this.$refs[`item-${index}`][0];
+        if (element && element.scrollIntoView && this.wrapperComponentRefs.questionListWrapper) {
+          const container = this.wrapperComponentRefs.questionListWrapper.$el;
+          if (isAboveContainer(element, container)) {
+            element.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
+          } else if (isBelowContainer(element, container)) {
+            element.scrollIntoView({ block: 'end', inline: 'nearest', behavior: 'smooth' });
+          }
+        }
+      },
+    },
+    methods: {
+      questionText(num) {
+        return this.$tr('question', { num });
+      },
+      isAnswered(question) {
+        if (question === this.questions[this.questionNumber] && this.currentQuestionAnswered) {
+          return this.currentQuestionAnswered;
+        }
+        const attempt = this.pastattempts.find(attempt => attempt.item === question);
+        return attempt && attempt.answer;
+      },
+      buttonClass(index) {
+        if (this.questionNumber === index) {
+          return this.$computedClass({ backgroundColor: this.$themePalette.grey.v_200 });
+        }
+        return this.$computedClass({
+          backgroundColor: this.$themeTokens.surface,
+          ':hover': {
+            backgroundColor: this.$themePalette.grey.v_200,
+          },
+        });
+      },
+    },
+    $trs: {
+      question: {
+        message: 'Question { num, number, integer}',
+        context:
+          "In the report section, the 'Answer history' shows the learner if they have answered questions correctly or incorrectly.\n\nOnly translate 'Question'.",
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .history-list {
+    max-height: inherit;
+    padding-left: 0;
+    margin: 0;
+    margin-top: 16px;
+    list-style-type: none;
+  }
+
+  .list-item {
+    margin-bottom: 4px;
+  }
+
+  .clickable {
+    @extend %md-decelerate-func;
+
+    position: relative;
+    display: block;
+    width: 100%;
+    text-align: left;
+    user-select: none;
+    border: 0;
+    border-radius: 4px;
+    outline-offset: -2px;
+    transition: background-color $core-time;
+  }
+
+  .dot {
+    position: absolute;
+    top: 18px;
+    left: 16px;
+  }
+
+  .text {
+    margin: 16px;
+    margin-left: 48px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/AnswerHistory.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/AnswerHistory.vue
@@ -30,12 +30,22 @@
 
 <script>
 
-  function isAboveContainer(element, container) {
-    return element.offsetTop < container.scrollTop;
+  function isAboveContainer(child, parent) {
+    const childRect = child.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+
+    // If the top of the child is less than the top of the parent,
+    // it is partially hidden above the scroll view.
+    return childRect.top < parentRect.top;
   }
 
-  function isBelowContainer(element, container) {
-    return element.offsetTop + element.offsetHeight > container.offsetHeight + container.scrollTop;
+  function isBelowContainer(child, parent) {
+    const childRect = child.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+
+    // If the bottom of the child is greater than the bottom of the parent,
+    // it is partially hidden below the scroll view.
+    return childRect.bottom > parentRect.bottom;
   }
 
   export default {
@@ -57,9 +67,13 @@
         type: Boolean,
         required: true,
       },
-      // hack to get access to the scrolling pane
-      wrapperComponentRefs: {
-        type: Object,
+      /**
+       * Id of the scrollable parent element that contains the question list. This is needed to
+       * compute if we need to use `scrollIntoView` to scroll a question into view when navigating
+       * through the question history.
+       */
+      overflowableParentId: {
+        type: String,
         required: true,
       },
     },
@@ -67,8 +81,9 @@
       questionNumber(index) {
         // If possible, scroll it into view
         const element = this.$refs[`item-${index}`][0];
-        if (element && element.scrollIntoView && this.wrapperComponentRefs.questionListWrapper) {
-          const container = this.wrapperComponentRefs.questionListWrapper.$el;
+        const overflowableParent = document.getElementById(this.overflowableParentId);
+        if (element && element.scrollIntoView && overflowableParent) {
+          const container = overflowableParent;
           if (isAboveContainer(element, container)) {
             element.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
           } else if (isBelowContainer(element, container)) {

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/QuizReport.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/QuizReport.vue
@@ -1,0 +1,121 @@
+<template>
+
+  <ExamReport
+    v-if="content"
+    class="report"
+    :contentId="content.content_id"
+    :title="content.title"
+    :duration="content.duration"
+    :userName="userName"
+    :userId="userId"
+    :selectedInteractionIndex="selectedInteractionIndex"
+    :questionNumber="questionNumber"
+    :tryIndex="tryIndex"
+    :exercise="content"
+    :exerciseContentNodes="[content]"
+    :navigateTo="navigateTo"
+    :questions="questions"
+    :isSurvey="isSurvey"
+    :isQuiz="!isSurvey"
+  >
+    <template #actions>
+      <KButton @click="$emit('repeat')">
+        {{ isSurvey ? $tr('submitAgainButton') : $tr('tryAgainButton') }}
+      </KButton>
+    </template>
+  </ExamReport>
+
+</template>
+
+
+<script>
+
+  import get from 'lodash/get';
+  import Modalities from 'kolibri-constants/Modalities';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import ExamReport from 'kolibri-common/components/quizzes/QuizReport';
+  import commonLearnStrings from '../../commonLearnStrings';
+
+  export default {
+    name: 'QuizReport',
+    components: {
+      ExamReport,
+    },
+    mixins: [commonCoreStrings, commonLearnStrings],
+    props: {
+      content: {
+        type: Object,
+        required: true,
+      },
+      userId: {
+        type: String,
+        default: null,
+      },
+      userName: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        questionNumber: 0,
+        selectedInteractionIndex: 0,
+        tryIndex: 0,
+      };
+    },
+    computed: {
+      questions() {
+        return this.content
+          ? this.content.assessmentmetadata.assessment_item_ids.map((id, index) => ({
+            item: id,
+            question_id: id,
+            exercise_id: this.content.id,
+            counter_in_exercise: index,
+            title: this.content.title,
+          }))
+          : [];
+      },
+      isSurvey() {
+        return get(this, ['content', 'options', 'modality']) === Modalities.SURVEY;
+      },
+    },
+    methods: {
+      navigateTo(tryIndex, question, interaction) {
+        this.tryIndex = tryIndex;
+        this.questionNumber = question;
+        this.selectedInteractionIndex = interaction;
+      },
+    },
+    $trs: {
+      tryAgainButton: {
+        message: 'Try again',
+        context: 'Label for a button used to retake the quiz',
+      },
+      submitAgainButton: {
+        message: 'Submit again',
+        context: 'Label for a button used to resubmit the survey',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .no-exercise {
+    text-align: center;
+  }
+
+  .container {
+    top: 24px;
+    max-width: 1000px;
+    margin: 0 auto;
+    background-color: white;
+  }
+
+  .report {
+    margin: auto;
+  }
+
+</style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -81,14 +81,14 @@
             :appearanceOverrides="navigationButtonStyle"
             @click="goToQuestion(questionNumber + 1)"
           >
-            <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
-            <template #iconAfter>
+            <div class="btn-flex">
+              <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
               <KIcon
                 icon="forward"
                 color="white"
-                :style="navigationIconStyleNext"
+                class="icon"
               />
-            </template>
+            </div>
           </KButton>
           <KButton
             :disabled="questionNumber === 0"
@@ -97,14 +97,15 @@
             :aria-label="$tr('previousQuestion')"
             @click="goToQuestion(questionNumber - 1)"
           >
-            <template #icon>
+            <div class="btn-flex">
               <KIcon
                 icon="back"
                 color="white"
+                class="icon"
                 :style="navigationIconStylePrevious"
               />
-            </template>
-            <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+              <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+            </div>
           </KButton>
         </div>
 
@@ -302,16 +303,6 @@
         return this.displayNavigationButtonLabel
           ? {}
           : { minWidth: '36px', width: '36px', padding: 0 };
-      },
-      navigationIconStyleNext() {
-        return this.displayNavigationButtonLabel
-          ? { position: 'relative', top: '3px', left: '4px' }
-          : {};
-      },
-      navigationIconStylePrevious() {
-        return this.displayNavigationButtonLabel
-          ? { position: 'relative', top: '0px', left: '-4px' }
-          : {};
       },
     },
     watch: {
@@ -555,6 +546,17 @@
 
   .bottom-block.window-is-small {
     text-align: center;
+  }
+
+  .btn-flex {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: center;
+
+    .icon {
+      top: 0;
+    }
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -1,173 +1,154 @@
 <template>
 
-  <div>
-    <KCircularLoader v-if="submitting" />
-    <QuizReport
-      v-else-if="mastered"
-      :userId="userId"
-      :userName="userFullName"
-      :content="content"
-      @repeat="repeat"
-    />
-    <KGrid
-      v-else
-      :gridStyle="gridStyle"
-    >
-      <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
-      <KGridItem
-        v-if="windowIsLarge"
-        ref="questionListWrapper"
-        :layout12="{ span: 4 }"
-        class="column-pane"
+  <ResourceLayout>
+    <template #default>
+      <div
+        class="content-wrapper"
+        :style="{
+          backgroundColor: $themeTokens.surface,
+        }"
       >
-        <div class="column-contents-wrapper">
-          <KPageContainer>
-            <AnswerHistory
-              :pastattempts="pastattempts"
-              :questionNumber="questionNumber"
-              :wrapperComponentRefs="$refs"
-              :questions="itemIdArray"
-              :currentQuestionAnswered="currentQuestionAnswered"
-              @goToQuestion="goToQuestion"
-            />
-          </KPageContainer>
-        </div>
-      </KGridItem>
-      <KGridItem
-        :layout12="{ span: 8 }"
-        class="column-pane"
-      >
-        <div :class="{ 'column-contents-wrapper': !windowIsSmall }">
-          <KPageContainer>
-            <h1>
-              {{ $tr('question', { num: questionNumber + 1, total: questionsTotal }) }}
-            </h1>
-            <ContentViewer
-              v-if="itemId"
-              ref="contentViewer"
-              :lang="content.lang"
-              :files="content.files"
-              :extraFields="extraFields"
-              :itemId="itemId"
-              :assessment="true"
-              :allowHints="false"
-              :answerState="currentAttempt.answer"
-              :progress="progress"
-              :userId="userId"
-              :userFullName="userFullName"
-              :timeSpent="timeSpent"
-              @interaction="interactionHandler"
-              @updateProgress="updateProgress"
-              @updateContentState="updateContentState"
-              @error="err => $emit('error', err)"
-            />
-            <UiAlert
-              v-else
-              :dismissible="false"
-              type="error"
-            >
-              {{ $tr('noItemId') }}
-            </UiAlert>
-          </KPageContainer>
-
-          <BottomAppBar
-            :dir="bottomBarLayoutDirection"
-            :maxWidth="null"
+        <KCircularLoader v-if="submitting" />
+        <QuizReport
+          v-else-if="mastered"
+          :userId="userId"
+          :userName="userFullName"
+          :content="content"
+          @repeat="repeat"
+        />
+        <div v-else>
+          <h1>
+            {{ $tr('question', { num: questionNumber + 1, total: questionsTotal }) }}
+          </h1>
+          <ContentViewer
+            v-if="itemId"
+            ref="contentViewer"
+            :lang="content.lang"
+            :files="content.files"
+            :extraFields="extraFields"
+            :itemId="itemId"
+            :assessment="true"
+            :allowHints="false"
+            :answerState="currentAttempt.answer"
+            :progress="progress"
+            :userId="userId"
+            :userFullName="userFullName"
+            :timeSpent="timeSpent"
+            @interaction="interactionHandler"
+            @updateProgress="updateProgress"
+            @updateContentState="updateContentState"
+            @error="err => $emit('error', err)"
+          />
+          <UiAlert
+            v-else
+            :dismissible="false"
+            type="error"
           >
-            <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
-              <KButton
-                :disabled="questionNumber === questionsTotal - 1"
-                :primary="true"
-                :dir="layoutDirReset"
-                :aria-label="$tr('nextQuestion')"
-                :appearanceOverrides="navigationButtonStyle"
-                @click="goToQuestion(questionNumber + 1)"
-              >
-                <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
-                <template #iconAfter>
-                  <KIcon
-                    icon="forward"
-                    color="white"
-                    :style="navigationIconStyleNext"
-                  />
-                </template>
-              </KButton>
-              <KButton
-                :disabled="questionNumber === 0"
-                :primary="true"
-                :dir="layoutDirReset"
-                :appearanceOverrides="navigationButtonStyle"
-                :aria-label="$tr('previousQuestion')"
-                :class="{ 'left-align': windowIsSmall }"
-                @click="goToQuestion(questionNumber - 1)"
-              >
-                <template #icon>
-                  <KIcon
-                    icon="back"
-                    color="white"
-                    :style="navigationIconStylePrevious"
-                  />
-                </template>
-                <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
-              </KButton>
-            </component>
-
-            <!-- below prev/next buttons in tab and DOM order, in footer -->
-            <div
-              v-if="windowIsLarge"
-              :dir="layoutDirReset"
-              class="left-align"
-            >
-              <div class="answered">
-                {{ answeredText }}
-              </div>
-              <KButton
-                :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
-                :primary="false"
-                appearance="flat-button"
-                @click="toggleModal"
-              />
-            </div>
-          </BottomAppBar>
-
-          <!-- below prev/next buttons in tab and DOM order, in page -->
-          <KPageContainer
-            v-if="!windowIsLarge"
-            style="margin-bottom: 45px"
+            {{ $tr('noItemId') }}
+          </UiAlert>
+          <KModal
+            v-if="submitModalOpen"
+            :title="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+            :submitText="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+            :cancelText="coreString('goBackAction')"
+            @submit="finishExam"
+            @cancel="toggleModal"
           >
-            <div
-              class="bottom-block"
-              :class="{ 'window-is-small': windowIsSmall }"
-            >
-              <div class="answered">
-                {{ answeredText }}
-              </div>
-              <KButton
-                :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
-                :primary="false"
-                appearance="flat-button"
-                @click="toggleModal"
-              />
-            </div>
-          </KPageContainer>
+            <p>{{ $tr('areYouSure') }}</p>
+            <p v-if="questionsUnanswered">
+              {{ $tr('unanswered', { numLeft: questionsUnanswered }) }}
+            </p>
+          </KModal>
         </div>
-      </KGridItem>
-    </KGrid>
-
-    <KModal
-      v-if="submitModalOpen"
-      :title="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
-      :submitText="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
-      :cancelText="coreString('goBackAction')"
-      @submit="finishExam"
-      @cancel="toggleModal"
+      </div>
+    </template>
+    <template
+      v-if="!mastered"
+      #bottomBar
     >
-      <p>{{ $tr('areYouSure') }}</p>
-      <p v-if="questionsUnanswered">
-        {{ $tr('unanswered', { numLeft: questionsUnanswered }) }}
-      </p>
-    </KModal>
-  </div>
+      <div
+        class="bottom-bar"
+        :style="{
+          background: $themeTokens.surface,
+          borderTop: `1px solid ${$themeTokens.fineLine}`,
+        }"
+      >
+        <div class="navigation-buttons-wrapper">
+          <KButton
+            :disabled="questionNumber === questionsTotal - 1"
+            :primary="true"
+            :aria-label="$tr('nextQuestion')"
+            :appearanceOverrides="navigationButtonStyle"
+            @click="goToQuestion(questionNumber + 1)"
+          >
+            <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
+            <template #iconAfter>
+              <KIcon
+                icon="forward"
+                color="white"
+                :style="navigationIconStyleNext"
+              />
+            </template>
+          </KButton>
+          <KButton
+            :disabled="questionNumber === 0"
+            :primary="true"
+            :appearanceOverrides="navigationButtonStyle"
+            :aria-label="$tr('previousQuestion')"
+            @click="goToQuestion(questionNumber - 1)"
+          >
+            <template #icon>
+              <KIcon
+                icon="back"
+                color="white"
+                :style="navigationIconStylePrevious"
+              />
+            </template>
+            <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+          </KButton>
+        </div>
+
+        <!-- below prev/next buttons in tab and DOM order, in footer -->
+        <div class="submit-info-wrapper">
+          <div class="answered">
+            {{ answeredText }}
+          </div>
+          <KButton
+            :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+            :primary="false"
+            appearance="flat-button"
+            class="submit-button"
+            @click="toggleModal"
+          />
+        </div>
+      </div>
+    </template>
+    <template
+      v-if="!mastered"
+      #sidePanel
+    >
+      <nav
+        :id="answerHistoryWrapperId"
+        class="answer-history-wrapper"
+      >
+        <AnswerHistory
+          :style="{ margin: 0 }"
+          :pastattempts="pastattempts"
+          :questionNumber="questionNumber"
+          :overflowableParentId="answerHistoryWrapperId"
+          :questions="itemIdArray"
+          :currentQuestionAnswered="currentQuestionAnswered"
+          @goToQuestion="goToQuestion"
+        />
+      </nav>
+    </template>
+    <template
+      v-if="$slots.sidePanelFooter && !mastered"
+      #sidePanelFooter
+    >
+      <slot name="sidePanelFooter"></slot>
+    </template>
+  </ResourceLayout>
 
 </template>
 
@@ -175,32 +156,33 @@
 <script>
 
   import isEqual from 'lodash/isEqual';
-  import BottomAppBar from 'kolibri/components/BottomAppBar';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import shuffled from 'kolibri-common/utils/shuffled';
   import { LearnerClassroomResource } from '../../../apiResources';
+  import ResourceLayout from '../../ResourceLayout/index.vue';
   import AnswerHistory from './AnswerHistory';
   import QuizReport from './QuizReport';
+
+  let _uid = 0;
 
   export default {
     name: 'QuizRenderer',
     components: {
       AnswerHistory,
       UiAlert,
-      UiIconButton,
-      BottomAppBar,
       QuizReport,
+      ResourceLayout,
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
+      const { windowBreakpoint } = useKResponsiveWindow();
+      const answerHistoryWrapperId = `answer-history-wrapper-${_uid++}`;
+
       return {
+        answerHistoryWrapperId,
         windowBreakpoint,
-        windowIsLarge,
-        windowIsSmall,
       };
     },
     props: {
@@ -265,18 +247,6 @@
       };
     },
     computed: {
-      gridStyle() {
-        if (!this.windowIsSmall) {
-          return {
-            position: 'fixed',
-            top: '64px',
-            right: '16px',
-            bottom: '72px',
-            left: '16px',
-          };
-        }
-        return {};
-      },
       answeredText() {
         return this.$tr('questionsAnswered', {
           numAnswered: this.questionsAnswered,
@@ -325,15 +295,6 @@
       questionsTotal() {
         return this.content.assessmentmetadata.assessment_item_ids.length;
       },
-      bottomBarLayoutDirection() {
-        // Allows contents to be displayed visually in reverse-order,
-        // but semantically in correct order.
-        return this.isRtl ? 'ltr' : 'rtl';
-      },
-      layoutDirReset() {
-        // Overrides bottomBarLayoutDirection reversal
-        return this.isRtl ? 'rtl' : 'ltr';
-      },
       displayNavigationButtonLabel() {
         return this.windowBreakpoint > 0;
       },
@@ -349,7 +310,7 @@
       },
       navigationIconStylePrevious() {
         return this.displayNavigationButtonLabel
-          ? { position: 'relative', top: '3px', left: '-4px' }
+          ? { position: 'relative', top: '0px', left: '-4px' }
           : {};
       },
     },
@@ -534,22 +495,58 @@
 
 <style lang="scss" scoped>
 
-  .answered {
-    display: inline-block;
-    margin-right: 8px;
-    margin-left: 8px;
-    white-space: nowrap;
+  .bottom-bar {
+    display: flex;
+    // Using row-reverse to make the navigation buttons come first in the DOM order for better
+    // accessibility, but still have it appear on the right side visually.
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+  }
+
+  .navigation-buttons-wrapper {
+    display: flex;
+    // Using row-reverse to make the "next" button come first in the DOM order for better
+    // accessibility, but still have it appear on the right side visually.
+    flex-direction: row-reverse;
+    flex-grow: 1;
+    gap: 16px;
+    justify-content: space-between;
+  }
+
+  .submit-info-wrapper {
+    display: flex;
+    // Adding a very big flex-grow here to push the navigation buttons to the right, and
+    // avoid the navigation-buttons-wrapper to grow if they are on the same row. This is needed
+    // because that node has a `justify-content: space-between` but we just want this style to
+    // apply when the navigation buttons are on a different row (wrapped into a new line).
+    flex-grow: 999;
+    gap: 16px;
+    align-items: center;
+
+    .submit-button {
+      flex-shrink: 0;
+    }
+  }
+
+  .content-wrapper {
+    height: 100%;
+    padding: 24px;
+    overflow: auto;
   }
 
   .column-pane {
     height: 100%;
-    padding-bottom: 32px;
     overflow-y: auto;
   }
 
-  .column-contents-wrapper {
-    padding-top: 16px;
-    padding-bottom: 16px;
+  .answer-history-wrapper {
+    height: 100%;
+    padding: 8px;
+    overflow-y: auto;
   }
 
   .bottom-block {
@@ -558,12 +555,6 @@
 
   .bottom-block.window-is-small {
     text-align: center;
-  }
-
-  .left-align {
-    position: absolute;
-    left: 16px;
-    display: inline-block;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -1,0 +1,569 @@
+<template>
+
+  <div>
+    <KCircularLoader v-if="submitting" />
+    <QuizReport
+      v-else-if="mastered"
+      :userId="userId"
+      :userName="userFullName"
+      :content="content"
+      @repeat="repeat"
+    />
+    <KGrid
+      v-else
+      :gridStyle="gridStyle"
+    >
+      <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
+      <KGridItem
+        v-if="windowIsLarge"
+        ref="questionListWrapper"
+        :layout12="{ span: 4 }"
+        class="column-pane"
+      >
+        <div class="column-contents-wrapper">
+          <KPageContainer>
+            <AnswerHistory
+              :pastattempts="pastattempts"
+              :questionNumber="questionNumber"
+              :wrapperComponentRefs="$refs"
+              :questions="itemIdArray"
+              :currentQuestionAnswered="currentQuestionAnswered"
+              @goToQuestion="goToQuestion"
+            />
+          </KPageContainer>
+        </div>
+      </KGridItem>
+      <KGridItem
+        :layout12="{ span: 8 }"
+        class="column-pane"
+      >
+        <div :class="{ 'column-contents-wrapper': !windowIsSmall }">
+          <KPageContainer>
+            <h1>
+              {{ $tr('question', { num: questionNumber + 1, total: questionsTotal }) }}
+            </h1>
+            <ContentViewer
+              v-if="itemId"
+              ref="contentViewer"
+              :lang="content.lang"
+              :files="content.files"
+              :extraFields="extraFields"
+              :itemId="itemId"
+              :assessment="true"
+              :allowHints="false"
+              :answerState="currentAttempt.answer"
+              :progress="progress"
+              :userId="userId"
+              :userFullName="userFullName"
+              :timeSpent="timeSpent"
+              @interaction="interactionHandler"
+              @updateProgress="updateProgress"
+              @updateContentState="updateContentState"
+              @error="err => $emit('error', err)"
+            />
+            <UiAlert
+              v-else
+              :dismissible="false"
+              type="error"
+            >
+              {{ $tr('noItemId') }}
+            </UiAlert>
+          </KPageContainer>
+
+          <BottomAppBar
+            :dir="bottomBarLayoutDirection"
+            :maxWidth="null"
+          >
+            <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
+              <KButton
+                :disabled="questionNumber === questionsTotal - 1"
+                :primary="true"
+                :dir="layoutDirReset"
+                :aria-label="$tr('nextQuestion')"
+                :appearanceOverrides="navigationButtonStyle"
+                @click="goToQuestion(questionNumber + 1)"
+              >
+                <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
+                <template #iconAfter>
+                  <KIcon
+                    icon="forward"
+                    color="white"
+                    :style="navigationIconStyleNext"
+                  />
+                </template>
+              </KButton>
+              <KButton
+                :disabled="questionNumber === 0"
+                :primary="true"
+                :dir="layoutDirReset"
+                :appearanceOverrides="navigationButtonStyle"
+                :aria-label="$tr('previousQuestion')"
+                :class="{ 'left-align': windowIsSmall }"
+                @click="goToQuestion(questionNumber - 1)"
+              >
+                <template #icon>
+                  <KIcon
+                    icon="back"
+                    color="white"
+                    :style="navigationIconStylePrevious"
+                  />
+                </template>
+                <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+              </KButton>
+            </component>
+
+            <!-- below prev/next buttons in tab and DOM order, in footer -->
+            <div
+              v-if="windowIsLarge"
+              :dir="layoutDirReset"
+              class="left-align"
+            >
+              <div class="answered">
+                {{ answeredText }}
+              </div>
+              <KButton
+                :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+                :primary="false"
+                appearance="flat-button"
+                @click="toggleModal"
+              />
+            </div>
+          </BottomAppBar>
+
+          <!-- below prev/next buttons in tab and DOM order, in page -->
+          <KPageContainer
+            v-if="!windowIsLarge"
+            style="margin-bottom: 45px"
+          >
+            <div
+              class="bottom-block"
+              :class="{ 'window-is-small': windowIsSmall }"
+            >
+              <div class="answered">
+                {{ answeredText }}
+              </div>
+              <KButton
+                :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+                :primary="false"
+                appearance="flat-button"
+                @click="toggleModal"
+              />
+            </div>
+          </KPageContainer>
+        </div>
+      </KGridItem>
+    </KGrid>
+
+    <KModal
+      v-if="submitModalOpen"
+      :title="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+      :submitText="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
+      :cancelText="coreString('goBackAction')"
+      @submit="finishExam"
+      @cancel="toggleModal"
+    >
+      <p>{{ $tr('areYouSure') }}</p>
+      <p v-if="questionsUnanswered">
+        {{ $tr('unanswered', { numLeft: questionsUnanswered }) }}
+      </p>
+    </KModal>
+  </div>
+
+</template>
+
+
+<script>
+
+  import isEqual from 'lodash/isEqual';
+  import BottomAppBar from 'kolibri/components/BottomAppBar';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+  import shuffled from 'kolibri-common/utils/shuffled';
+  import { LearnerClassroomResource } from '../../../apiResources';
+  import AnswerHistory from './AnswerHistory';
+  import QuizReport from './QuizReport';
+
+  export default {
+    name: 'QuizRenderer',
+    components: {
+      AnswerHistory,
+      UiAlert,
+      UiIconButton,
+      BottomAppBar,
+      QuizReport,
+    },
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsSmall,
+      };
+    },
+    props: {
+      content: {
+        type: Object,
+        required: true,
+      },
+      extraFields: {
+        type: Object,
+        default: () => ({}),
+      },
+      // An explicit record of the current progress through this
+      // piece of content.
+      progress: {
+        type: Number,
+        default: 0,
+      },
+      // An identifier for the user interacting with this content
+      userId: {
+        type: String,
+        default: null,
+      },
+      userFullName: {
+        type: String,
+        default: null,
+      },
+      timeSpent: {
+        type: Number,
+        default: null,
+      },
+      pastattempts: {
+        type: Array,
+        default: () => [],
+      },
+      mastered: {
+        type: Boolean,
+        default: false,
+      },
+      masteryLevel: {
+        type: Number,
+        default: 0,
+      },
+      // TODO: is this a sustainable way to pass this?
+      updateContentSession: {
+        type: Function,
+        default: () => {},
+      },
+      isSurvey: {
+        type: Boolean,
+        default: () => {},
+      },
+    },
+    data() {
+      return {
+        submitModalOpen: false,
+        // Note this time is only used to calculate the time spent on a
+        // question, it is not used to generate any timestamps.
+        startTime: Date.now(),
+        questionNumber: 0,
+        submitting: false,
+        currentQuestionAnswered: false,
+      };
+    },
+    computed: {
+      gridStyle() {
+        if (!this.windowIsSmall) {
+          return {
+            position: 'fixed',
+            top: '64px',
+            right: '16px',
+            bottom: '72px',
+            left: '16px',
+          };
+        }
+        return {};
+      },
+      answeredText() {
+        return this.$tr('questionsAnswered', {
+          numAnswered: this.questionsAnswered,
+          numTotal: this.questionsTotal,
+        });
+      },
+      currentAttempt() {
+        return (
+          this.pastattempts.find(attempt => attempt.item === this.itemId) || {
+            item: this.itemId,
+            complete: false,
+            time_spent: 0,
+            correct: 0,
+            answer: null,
+            simple_answer: '',
+            hinted: false,
+          }
+        );
+      },
+      itemIdArray() {
+        if (this.content.assessmentmetadata.randomize) {
+          // Differentiate the seed for each 'try' indicated by the masteryLevel.
+          const seed = this.userId ? this.userId + this.masteryLevel : Date.now();
+          return shuffled(this.content.assessmentmetadata.assessment_item_ids, seed);
+        }
+        return this.content.assessmentmetadata.assessment_item_ids;
+      },
+      itemId() {
+        return this.itemIdArray[this.questionNumber];
+      },
+      questionsAnswered() {
+        const answeredAttemptItems = this.pastattempts.reduce((map, attempt) => {
+          if (attempt.answer) {
+            map[attempt.item] = true;
+          }
+          return map;
+        }, {});
+        if (!answeredAttemptItems[this.itemId] && this.currentQuestionAnswered) {
+          answeredAttemptItems[this.itemId] = true;
+        }
+        return Object.keys(answeredAttemptItems).length;
+      },
+      questionsUnanswered() {
+        return this.questionsTotal - this.questionsAnswered;
+      },
+      questionsTotal() {
+        return this.content.assessmentmetadata.assessment_item_ids.length;
+      },
+      bottomBarLayoutDirection() {
+        // Allows contents to be displayed visually in reverse-order,
+        // but semantically in correct order.
+        return this.isRtl ? 'ltr' : 'rtl';
+      },
+      layoutDirReset() {
+        // Overrides bottomBarLayoutDirection reversal
+        return this.isRtl ? 'rtl' : 'ltr';
+      },
+      displayNavigationButtonLabel() {
+        return this.windowBreakpoint > 0;
+      },
+      navigationButtonStyle() {
+        return this.displayNavigationButtonLabel
+          ? {}
+          : { minWidth: '36px', width: '36px', padding: 0 };
+      },
+      navigationIconStyleNext() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '4px' }
+          : {};
+      },
+      navigationIconStylePrevious() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '-4px' }
+          : {};
+      },
+    },
+    watch: {
+      itemId(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          this.startTime = Date.now();
+          this.currentQuestionAnswered = false;
+        }
+      },
+      mastered(newVal, oldVal) {
+        if (!newVal && oldVal) {
+          // We were looking at a report before but now we are retaking
+          // the quiz, so start tracking.
+          this.startTracking();
+        }
+      },
+    },
+    created() {
+      // Only start tracking if we're not currently on a completed try
+      if (!this.mastered) {
+        this.startTracking();
+      }
+    },
+    methods: {
+      setAndSaveCurrentExamAttemptLog({ close, interaction } = {}) {
+        // Clear the learner classroom cache here as its progress data is now
+        // stale
+        LearnerClassroomResource.clearCache();
+
+        const data = {};
+
+        if (interaction) {
+          data.interaction = { ...interaction, replace: true };
+        }
+
+        if (close) {
+          data.progress = 1;
+          data.force = true;
+          data.immediate = true;
+          this.submitting = true;
+        } else {
+          // We don't set progress to 1 until the quiz is submitted, so we max out here.
+          // If any interaction has happened, we set a peppercorn progress so that it shows
+          // as interacted with.
+          data.progress = Math.max(
+            0.001,
+            Math.min(
+              this.pastattempts.length / this.content.assessmentmetadata.assessment_item_ids.length,
+              0.99,
+            ),
+          );
+        }
+        return this.updateContentSession(data).then(() => {
+          if (close) {
+            this.stopTracking();
+            this.submitting = false;
+          }
+        });
+      },
+      checkAnswer() {
+        if (this.$refs.contentViewer) {
+          return this.$refs.contentViewer.checkAnswer();
+        }
+        return null;
+      },
+      interactionHandler() {
+        const answer = this.checkAnswer();
+        if (answer) {
+          this.currentQuestionAnswered = true;
+        }
+      },
+      saveAnswer(close = false) {
+        const answer = this.checkAnswer();
+        if (
+          this.currentQuestionAnswered &&
+          answer &&
+          !isEqual(answer.answerState, this.currentAttempt.answer)
+        ) {
+          const interaction = {
+            answer: answer.answerState,
+            simple_answer: answer.simpleAnswer || '',
+            correct: answer.correct,
+            item: this.itemId,
+            id: this.currentAttempt.id,
+            time_spent:
+              ((this.currentAttempt.time_spent || 0) + Date.now() - this.startTime) / 1000,
+          };
+          this.startTime = Date.now();
+          return this.setAndSaveCurrentExamAttemptLog({ close, interaction });
+        } else if (close) {
+          return this.setAndSaveCurrentExamAttemptLog({ close });
+        }
+        return Promise.resolve();
+      },
+      goToQuestion(questionNumber) {
+        this.saveAnswer();
+        this.questionNumber = questionNumber;
+      },
+      toggleModal() {
+        // Flush any existing save event to ensure
+        // that the submit modal contains the latest state
+        if (!this.submitModalOpen) {
+          this.saveAnswer();
+        }
+        this.submitModalOpen = !this.submitModalOpen;
+      },
+      finishExam() {
+        this.saveAnswer(true).then(() => {
+          this.submitModalOpen = false;
+          this.$emit('finished');
+        });
+      },
+      updateProgress(...args) {
+        this.$emit('updateProgress', ...args);
+      },
+      updateContentState(...args) {
+        this.$emit('updateContentState', ...args);
+      },
+      startTracking(...args) {
+        this.mounted = true;
+        this.$emit('startTracking', ...args);
+      },
+      stopTracking(...args) {
+        this.$emit('stopTracking', ...args);
+      },
+      repeat() {
+        this.$emit('repeat');
+      },
+    },
+    $trs: {
+      submitExam: {
+        message: 'Submit quiz',
+        context:
+          'Action that learner takes to submit their quiz answers so that the coach can review them.',
+      },
+      submitSurvey: {
+        message: 'Submit survey',
+        context:
+          'Action that learner takes to submit their exam answers so that they can be reviewed.',
+      },
+      questionsAnswered: {
+        message:
+          '{numAnswered, number} of {numTotal, number} {numTotal, plural, one {question answered} other {questions answered}}',
+        context:
+          'Indicates the number of questions a learner has answered. Only translate "of" and "question/questions answered".',
+      },
+      previousQuestion: {
+        message: 'Previous',
+        context: 'Button indicating the previous question in a quiz.',
+      },
+      nextQuestion: {
+        message: 'Next',
+        context: 'Button indicating the next question in a quiz.',
+      },
+      areYouSure: {
+        message: 'You cannot change your answers after you submit',
+        context:
+          "Message a learner sees when they submit answers in an exercise to their coach. It serves as a way of checking that the user is aware that once they've submitted their answers, they cannot change them afterwards.",
+      },
+      unanswered: {
+        message:
+          'You have {numLeft, number} {numLeft, plural, one {question unanswered} other {questions unanswered}}',
+
+        context: 'Indicates how many questions the learner has not answered.',
+      },
+      noItemId: {
+        message: 'This question has an error, please move on to the next question',
+        context:
+          'Message they may appear to the learner if there is a question missing in a quiz. The question may have been deleted accidentally, for example.',
+      },
+      question: {
+        message: 'Question {num, number, integer} of {total, number, integer}',
+        context:
+          'Indicates which question the user is working on currently and the total number of questions in a quiz.\n\nFor example: "Question 2 of 10".',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .answered {
+    display: inline-block;
+    margin-right: 8px;
+    margin-left: 8px;
+    white-space: nowrap;
+  }
+
+  .column-pane {
+    height: 100%;
+    padding-bottom: 32px;
+    overflow-y: auto;
+  }
+
+  .column-contents-wrapper {
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
+
+  .bottom-block {
+    margin-top: 8px;
+  }
+
+  .bottom-block.window-is-small {
+    text-align: center;
+  }
+
+  .left-align {
+    position: absolute;
+    left: 16px;
+    display: inline-block;
+  }
+
+</style>

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -320,4 +320,12 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Practice',
     context: 'Action label for practicing an assessment that has already been completed',
   },
+  nextResourceLabel: {
+    message: 'Next resource',
+    context: 'Action label for navigating to the next resource in a course unit',
+  },
+  previousResourceLabel: {
+    message: 'Previous resource',
+    context: 'Action label for navigating to the previous resource in a course unit',
+  },
 });


### PR DESCRIPTION

## Summary
* Copies the current QuizRenderer to courses.
* Adapts QuizRenderer to use ResourceLayout, and claims the parent's bottom bar and parent's side panel.
* Adds sidePanelFooter slot to QuizRenderer to render next/previous resource button, to have a way to get out of the quiz resource.
* Note that I have intentionally made the QuizRenderer claim the side panel and bottom bar just if the QuizReport is not being rendered, as it made sense to me.

https://github.com/user-attachments/assets/d79f4030-a84d-4e50-b2c8-66d2416feef2


## References

Closes #14107.

## Reviewer guidance

* Assign a course to a learner.
* Open learner course.
* Complete/check resources until you get to an assessment node.
* Check assessment wrapper integration into the CourseUnitView

## Note
I have intentionally isolated the copy of the AssessmentWrapper in the first commit, so that subsequent commits would actually show the changes made to these components.

<!--
AI USAGE - DEEP guidelines

If AI was used in preparing this PR, please fill in the section below.
Our DEEP guidelines ask that when using AI you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

If AI was not used, delete the section below.
-->

## AI usage

* Asked Gemini about a bug in the `isAboveContainer`/`isBelowContainer` implementation. It taught me that `offsetTop` provides the `top` relative to a relative-positioned parent, and suggested using `getBoundingClientRect` as it is more robust, which made much more sense to me, so used it.