### PR TITLE
Resume pagination fixes

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -50,6 +50,7 @@ from kolibri.core.api import BaseValuesViewset
 from kolibri.core.api import CreateModelMixin
 from kolibri.core.api import ListModelMixin
 from kolibri.core.api import ReadOnlyValuesViewset
+from kolibri.core.api import ValuesViewsetOrderingFilter
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.middleware import session_exempt
@@ -1709,7 +1710,7 @@ class UserContentNodeViewset(
     A content node viewset for filtering on user specific fields.
     """
 
-    filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
+    filter_backends = (DjangoFilterBackend, ValuesViewsetOrderingFilter)
     ordering_fields = ["last_interacted"]
     ordering = ("lft", "id")
     filterset_class = UserContentNodeFilter

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -12,19 +12,33 @@ from jsonfield import JSONField as JSONFieldBase
 date_time_format = "%Y-%m-%d %H:%M:%S.%f"
 tz_format = "({tz})"
 tz_regex = re.compile(r"\(([^\)]+)\)")
+offset_regex = re.compile(r"([+-])(\d{2}):(\d{2})$")
 db_storage_string = "{date_time_string}{tz_string}"
 
 
 def parse_timezonestamp(value):
+    # Track what timezone the naive datetime (after typecast_timestamp
+    # strips tz info) should be interpreted as.
+    naive_tz = pytz.utc
     if tz_regex.search(value):
         tz = pytz.timezone(tz_regex.search(value).groups()[0])
     else:
-        tz = timezone.get_current_timezone()
+        offset_match = offset_regex.search(value)
+        if offset_match:
+            # Handle +HH:MM / -HH:MM offset format (produced by str(datetime))
+            sign = 1 if offset_match.group(1) == "+" else -1
+            hours = int(offset_match.group(2))
+            minutes = int(offset_match.group(3))
+            tz = pytz.FixedOffset(sign * (hours * 60 + minutes))
+            naive_tz = tz
+            value = value[: offset_match.start()]
+        else:
+            tz = timezone.get_current_timezone()
     utc_value = tz_regex.sub("", value)
     value = typecast_timestamp(utc_value)
     if value.tzinfo is None:
         # Naive datetime, make aware
-        value = timezone.make_aware(value, pytz.utc)
+        value = timezone.make_aware(value, naive_tz)
     return value.astimezone(tz)
 
 

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -43,8 +43,8 @@ def parse_timezonestamp(value):
 
 
 def create_timezonestamp(value):
-    if value.tzinfo and hasattr(value.tzinfo, "zone"):
-        # We have a pytz timezone, we can work with this
+    if value.tzinfo and hasattr(value.tzinfo, "zone") and value.tzinfo.zone is not None:
+        # We have a pytz timezone with a named zone, we can work with this
         tz = value.tzinfo.zone
     elif value.tzinfo:
         # Got some timezone data, but it's not a pytz timezone

--- a/kolibri/core/test/test_datetimetzfield.py
+++ b/kolibri/core/test/test_datetimetzfield.py
@@ -3,6 +3,7 @@ from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
 
+from kolibri.core.fields import DateTimeTzField as DateTimeTzModelField
 from kolibri.core.fields import parse_timezonestamp
 from kolibri.core.serializers import DateTimeTzField as DateTimeTzSerializerField
 from kolibri.core.test.test_app.models import aware_datetime
@@ -69,6 +70,51 @@ class AwareDateTimeTzFieldTestCase(TestCase):
             )
         finally:
             timezone.deactivate()
+
+    def test_get_prep_value_roundtrips_str_datetime_format(self):
+        """
+        Regression test for cursor pagination with DateTimeTzField.
+
+        DRF CursorPagination extracts cursor positions by calling str() on
+        datetime values returned by from_db_value. These str(datetime) strings
+        (e.g. "2024-01-15 10:30:00+00:00") are then used in queryset filter
+        expressions, which pass through get_prep_value to produce the varchar
+        storage format for comparison.
+
+        When the server TIME_ZONE differs from the stored timezone, the
+        round-trip through str(datetime) -> get_prep_value must still produce
+        the same storage string, otherwise varchar comparisons in the database
+        will use mismatched timezone suffixes.
+        """
+        field = DateTimeTzModelField()
+
+        # Step 1: Store a UTC timestamp (Kolibri uses timezone.now() which is UTC)
+        timezone.activate(pytz.utc)
+        try:
+            utc_dt = timezone.now()
+            stored_value = field.get_prep_value(utc_dt)
+        finally:
+            timezone.deactivate()
+
+        # Step 2: Read from DB via from_db_value
+        read_back = field.from_db_value(stored_value, None, None)
+
+        # Step 3: CursorPagination calls str() on the datetime
+        position = str(read_back)
+
+        # Step 4: Simulate a production server with non-UTC TIME_ZONE
+        # (Kolibri sets TIME_ZONE = get_localzone_name() in settings)
+        tz = pytz.timezone("Africa/Nairobi")
+        timezone.activate(tz)
+        try:
+            # Step 5: The cursor filter calls get_prep_value on the position
+            roundtripped = field.get_prep_value(position)
+        finally:
+            timezone.deactivate()
+
+        # The round-tripped value must be identical to the original stored
+        # value for correct varchar comparison in the database.
+        self.assertEqual(stored_value, roundtripped)
 
 
 @override_settings(USE_TZ=False)

--- a/kolibri/core/test/test_datetimetzfield.py
+++ b/kolibri/core/test/test_datetimetzfield.py
@@ -3,6 +3,7 @@ from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
 
+from kolibri.core.fields import create_timezonestamp
 from kolibri.core.fields import DateTimeTzField as DateTimeTzModelField
 from kolibri.core.fields import parse_timezonestamp
 from kolibri.core.serializers import DateTimeTzField as DateTimeTzSerializerField
@@ -70,6 +71,29 @@ class AwareDateTimeTzFieldTestCase(TestCase):
             )
         finally:
             timezone.deactivate()
+
+    def test_create_timezonestamp_with_non_utc_fixed_offset(self):
+        """
+        Regression test for pytz.FixedOffset with non-zero offset.
+
+        pytz.FixedOffset(180).zone is None (only FixedOffset(0) returns
+        pytz.UTC with zone='UTC'). If a datetime with a non-UTC FixedOffset
+        tzinfo reaches create_timezonestamp, the stored suffix must not
+        become '(None)'.
+        """
+        # A datetime with a non-UTC FixedOffset (e.g., +03:00)
+        tz = pytz.FixedOffset(180)
+        dt = timezone.now().astimezone(tz)
+
+        # Round-trip through create → parse
+        stored = create_timezonestamp(dt)
+
+        # Should fall back to UTC storage since FixedOffset has no named zone
+        self.assertTrue(stored.endswith("(UTC)"))
+
+        # Must be parseable back to the same instant
+        parsed = parse_timezonestamp(stored)
+        self.assertEqual(dt, parsed)
 
     def test_get_prep_value_roundtrips_str_datetime_format(self):
         """

--- a/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
+++ b/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import { ClassesPageNames } from '../../constants';
 import { LearnerClassroomResource } from '../../apiResources';
-import useLearnerResources from '../useLearnerResources';
+import useLearnerResources, { setResumableContentNodes } from '../useLearnerResources';
 
 const {
   classes,
@@ -21,6 +21,7 @@ const {
   getClassQuizLink,
   fetchClasses,
   fetchResumableContentNodes,
+  fetchMoreResumableContentNodes,
 } = useLearnerResources();
 
 jest.mock('kolibri-common/apiResources/ContentNodeResource');
@@ -624,6 +625,65 @@ describe(`useLearnerResources`, () => {
       await fetchResumableContentNodes();
       expect(resumableContentNodes.value).toEqual(TEST_RESUMABLE_CONTENT_NODES);
       expect(moreResumableContentNodes.value).toEqual(more);
+    });
+
+    it('should not call cacheData', async () => {
+      ContentNodeResource.fetchResume = jest
+        .fn()
+        .mockResolvedValue({ results: TEST_RESUMABLE_CONTENT_NODES, more: null });
+      ContentNodeResource.cacheData.mockClear();
+      await fetchResumableContentNodes();
+      expect(ContentNodeResource.cacheData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchMoreResumableContentNodes', () => {
+    beforeEach(() => {
+      // Set up initial resumable content nodes with a more parameter
+      const initialNodes = TEST_RESUMABLE_CONTENT_NODES.slice(0, 3);
+      const moreParams = { resume: true, max_results: 12, cursor: 'abc' };
+      setResumableContentNodes(initialNodes, moreParams);
+    });
+
+    it('should append results to existing resumable content nodes', async () => {
+      const additionalNodes = TEST_RESUMABLE_CONTENT_NODES.slice(3, 5);
+      const nextMore = { resume: true, max_results: 12, cursor: 'def' };
+      ContentNodeResource.fetchResume = jest
+        .fn()
+        .mockResolvedValue({ results: additionalNodes, more: nextMore });
+      await fetchMoreResumableContentNodes();
+      // Should contain both the initial 3 and the additional 2
+      expect(resumableContentNodes.value).toHaveLength(5);
+      expect(moreResumableContentNodes.value).toEqual(nextMore);
+    });
+
+    it('should not call cacheData', async () => {
+      const additionalNodes = TEST_RESUMABLE_CONTENT_NODES.slice(3, 5);
+      ContentNodeResource.fetchResume = jest
+        .fn()
+        .mockResolvedValue({ results: additionalNodes, more: null });
+      ContentNodeResource.cacheData.mockClear();
+      await fetchMoreResumableContentNodes();
+      expect(ContentNodeResource.cacheData).not.toHaveBeenCalled();
+    });
+
+    it('should clear moreResumableContentNodes when results are empty', async () => {
+      ContentNodeResource.fetchResume = jest.fn().mockResolvedValue({ results: [], more: null });
+      await fetchMoreResumableContentNodes();
+      expect(moreResumableContentNodes.value).toBeNull();
+    });
+
+    it('should clear moreResumableContentNodes when results are missing', async () => {
+      ContentNodeResource.fetchResume = jest.fn().mockResolvedValue({ results: null, more: null });
+      await fetchMoreResumableContentNodes();
+      expect(moreResumableContentNodes.value).toBeNull();
+    });
+
+    it('should not fetch when moreResumableContentNodes is null', async () => {
+      setResumableContentNodes(TEST_RESUMABLE_CONTENT_NODES.slice(0, 3), null);
+      ContentNodeResource.fetchResume = jest.fn();
+      await fetchMoreResumableContentNodes();
+      expect(ContentNodeResource.fetchResume).not.toHaveBeenCalled();
     });
   });
 });

--- a/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
@@ -32,13 +32,11 @@ const courseProgress = ref({});
 export function setResumableContentNodes(nodes, more = null) {
   set(_resumableContentNodes, nodes);
   set(moreResumableContentNodes, more);
-  ContentNodeResource.cacheData(nodes);
 }
 
 function addResumableContentNodes(nodes, more = null) {
   set(_resumableContentNodes, [...get(_resumableContentNodes), ...nodes]);
   set(moreResumableContentNodes, more);
-  ContentNodeResource.cacheData(nodes);
 }
 
 function _cacheLessonResources(lesson) {
@@ -69,7 +67,6 @@ export function setClasses(classData) {
 function setCourseData(courseId, content, progress) {
   set(courseContent, { ...get(courseContent), [courseId]: content });
   set(courseProgress, { ...get(courseProgress), [courseId]: progress });
-  ContentNodeResource.cacheData(content);
 }
 
 export default function useLearnerResources() {
@@ -351,6 +348,8 @@ export default function useLearnerResources() {
     fetchContentNodeProgress(params);
     return ContentNodeResource.fetchResume(params).then(({ results, more }) => {
       if (!results || !results.length) {
+        // Clear the more params so the "View more" button is hidden
+        set(moreResumableContentNodes, null);
         return [];
       }
       addResumableContentNodes(results, more);

--- a/kolibri/plugins/learn/frontend/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/HomePage/index.vue
@@ -88,6 +88,7 @@
   import urls from 'kolibri/urls';
   import useUser from 'kolibri/composables/useUser';
   import useChannels from 'kolibri-common/composables/useChannels';
+  import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
   import { mapState } from 'vuex';
   import ResourceSyncingUiAlert from '../ResourceSyncingUiAlert';
   import useDeviceSettings from '../../composables/useDeviceSettings';
@@ -206,10 +207,12 @@
             // Update our hydrated class membership boolean in case it has changed
             // since the learn page was opened.
             set(inClasses, Boolean(response.data.classrooms.length));
+            const resumableResults = response.data.resumable_resources.results || [];
             setResumableContentNodes(
-              response.data.resumable_resources.results || [],
+              resumableResults,
               response.data.resumable_resources.more || null,
             );
+            ContentNodeResource.cacheData(resumableResults);
             for (const progress of response.data.resumable_resources_progress) {
               setContentNodeProgress(progress);
             }

--- a/packages/kolibri-common/utils/__tests__/contentNode.spec.js
+++ b/packages/kolibri-common/utils/__tests__/contentNode.spec.js
@@ -1,0 +1,53 @@
+import { deduplicateResources } from '../contentNode';
+
+jest.mock('kolibri/utils/i18n', () => ({
+  getContentLangActive: () => 0,
+}));
+
+describe('deduplicateResources', () => {
+  it('returns nodes as-is when there are no duplicates', () => {
+    const nodes = [
+      { id: 'a', content_id: '1', title: 'A' },
+      { id: 'b', content_id: '2', title: 'B' },
+    ];
+    const result = deduplicateResources(nodes);
+    expect(result).toHaveLength(2);
+  });
+
+  it('groups nodes by content_id and sets copies on the result', () => {
+    const nodes = [
+      { id: 'a1', content_id: '1', title: 'Copy A' },
+      { id: 'a2', content_id: '1', title: 'Copy B' },
+    ];
+    const result = deduplicateResources(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].copies).toHaveLength(2);
+  });
+
+  it('does not mutate the original node objects when deduplicating', () => {
+    const nodeA = { id: 'a1', content_id: '1', title: 'Copy A' };
+    const nodeB = { id: 'a2', content_id: '1', title: 'Copy B' };
+    const nodes = [nodeA, nodeB];
+
+    deduplicateResources(nodes);
+
+    // The original objects must not have a 'copies' property added
+    expect(nodeA).not.toHaveProperty('copies');
+    expect(nodeB).not.toHaveProperty('copies');
+  });
+
+  it('does not accumulate copies when called repeatedly with the same nodes', () => {
+    const nodes = [
+      { id: 'a1', content_id: '1', title: 'Copy A' },
+      { id: 'a2', content_id: '1', title: 'Copy B' },
+    ];
+
+    const result1 = deduplicateResources(nodes);
+    expect(result1[0].copies).toHaveLength(2);
+
+    // Simulate what happens when a computed re-runs with the same source nodes:
+    // the original nodes should be unchanged, so we get the same result
+    const result2 = deduplicateResources(nodes);
+    expect(result2[0].copies).toHaveLength(2);
+  });
+});

--- a/packages/kolibri-common/utils/contentNode.js
+++ b/packages/kolibri-common/utils/contentNode.js
@@ -25,10 +25,10 @@ export function deduplicateResources(contentNodes) {
       // Everything else
       return 2;
     });
-    const primaryNode = sortedNodes[0];
-    // Include self in copies
-    primaryNode.copies = sortedNodes;
-    return primaryNode;
+    // Return a shallow copy with copies set, so we don't mutate the original
+    // objects stored in reactive refs. Mutating originals causes copies to
+    // accumulate when the computed re-runs after new nodes are appended.
+    return { ...sortedNodes[0], copies: sortedNodes };
   });
 }
 


### PR DESCRIPTION
## Summary
* Add regression tests for and fix bad data handling in the frontend for resume and other data types that get loaded by learn home page hydration and use the deduplicate content nodes functionality
* Update the UserContentNode viewset to use the ValuesViewsetOrdering filter to make sure it doesn't get tripped up by our unique viewset implementation
* Add regression test and fix for the DateTimeTZField implementation that failed to coerce timestamps using offset notation `+8:00` for e.g. PST into a the right format for doing queries - this caused paginated requests after the first page to return an empty result.

## References
Fixes https://github.com/learningequality/kolibri/issues/14218

## Reviewer guidance
All the changes are covered by tests.

https://github.com/user-attachments/assets/04946d98-7d47-43c8-aa01-d02e6155b106

## AI usage

Claude Code was used to write the regression tests and code modifications - investigation and root cause analysis was conducted collaboratively for the frontend work, but solely by @rtibbles on the backend. All work was reviewed at commit time for correctness.