### PR TITLE
[Pre|Post Tests] Progress tracking 

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -580,7 +580,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
         start_timestamp,
         context,
     ):
-        is_quiz = mastery_model["type"] == exercises.QUIZ
+        is_quiz = mastery_model["type"] in (exercises.QUIZ, exercises.PRE_POST_TEST)
         masterylogs = MasteryLog.objects.filter(
             summarylog=summarylog,
             user=user,
@@ -667,7 +667,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
             attemptlogs = attemptlogs[: mastery_criterion["n"]]
         elif exercise_type in MAPPING:
             attemptlogs = attemptlogs[: MAPPING[exercise_type]]
-        elif exercise_type == exercises.QUIZ:
+        elif exercise_type in (exercises.QUIZ, exercises.PRE_POST_TEST):
             attemptlogs = attemptlogs.order_by()
         else:
             attemptlogs = attemptlogs[:10]

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -89,6 +89,11 @@ class StartSessionSerializer(serializers.Serializer):
     course_session_id = HexStringUUIDField(required=False)
     # Do this as a special way of handling our coach generated quizzes
     quiz_id = HexStringUUIDField(required=False)
+    # Pre/post test fields
+    unit_id = HexStringUUIDField(required=False)
+    test_type = serializers.ChoiceField(
+        choices=[("pre", "Pre"), ("post", "Post")], required=False
+    )
     # A flag to indicate whether to start the session over again
     repeat = serializers.BooleanField(required=False, default=False)
 
@@ -96,11 +101,12 @@ class StartSessionSerializer(serializers.Serializer):
         self._validate_required_fields(data)
         self._validate_context_exclusivity(data)
         self._validate_node_id_fields(data)
+        self._validate_unit_id_fields(data)
         return data
 
     def _validate_required_fields(self, data):
-        if "node_id" not in data and "quiz_id" not in data:
-            raise ValidationError("node_id is required if not a coach assigned quiz")
+        if "node_id" not in data and "quiz_id" not in data and "unit_id" not in data:
+            raise ValidationError("One of node_id, quiz_id, or unit_id is required")
 
     def _validate_context_exclusivity(self, data):
         if "quiz_id" in data and ("lesson_id" in data or "node_id" in data):
@@ -108,6 +114,10 @@ class StartSessionSerializer(serializers.Serializer):
         if "course_session_id" in data and "lesson_id" in data:
             raise ValidationError(
                 "The course_session_id and lesson_id are mutually exclusive identifiers"
+            )
+        if "unit_id" in data and ("node_id" in data or "quiz_id" in data):
+            raise ValidationError(
+                "unit_id must not be combined with node_id or quiz_id"
             )
 
     def _validate_node_id_fields(self, data):
@@ -140,6 +150,21 @@ class StartSessionSerializer(serializers.Serializer):
             errors["mastery_model"] = ValidationError(
                 "mastery model must not be specified for non-exercise kinds"
             )
+
+    def _validate_unit_id_fields(self, data):
+        if "unit_id" not in data:
+            return
+        errors = {}
+        if "test_type" not in data:
+            errors["test_type"] = ValidationError(
+                "test_type is required when unit_id is provided"
+            )
+        if "course_session_id" not in data:
+            errors["course_session_id"] = ValidationError(
+                "course_session_id is required when unit_id is provided"
+            )
+        if errors:
+            raise ValidationError(errors)
 
 
 class InteractionSerializer(serializers.Serializer):

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import uuid as uuid_module
 from datetime import timedelta
 from itertools import groupby
 from math import ceil
@@ -236,13 +238,21 @@ class LogContext:
     indicate a different try at the assessment.
     course_session_id - represents the id of the CourseSession model object that this
     session is regarding (if any).
+    unit_id - represents the id of the unit ContentNode for pre/post test sessions.
     This is used to encode the values that are sent when initializing a session
     (see its use in the _get_context method below)
     and then also used to hold the values from an existing sessionlog when
     updating a session (see _update_session method).
     """
 
-    __slots__ = "node_id", "quiz_id", "lesson_id", "mastery_level", "course_session_id"
+    __slots__ = (
+        "node_id",
+        "quiz_id",
+        "lesson_id",
+        "mastery_level",
+        "course_session_id",
+        "unit_id",
+    )
 
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
@@ -356,6 +366,38 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
             channel_id = None
             kind = content_kinds.QUIZ
             context["quiz_id"] = quiz_id
+        else:
+            # Pre/post test branch — unit_id is guaranteed present by validation
+            unit_id = validated_data["unit_id"]
+            test_type = validated_data["test_type"]
+            self._check_course_session_permissions(user, course_session_id)
+
+            # Deterministic hash for A/B split
+            raw = "{}:{}:{}".format(user.id, course_session_id, unit_id)
+            deterministic_hash = hashlib.md5(raw.encode()).hexdigest()
+
+            # A/B version: last hex digit even -> pre=A/post=B; odd -> reverse
+            last_digit = int(deterministic_hash[-1], 16)
+            if last_digit % 2 == 0:
+                version = "A" if test_type == "pre" else "B"
+            else:
+                version = "B" if test_type == "pre" else "A"
+
+            mastery_model = {
+                "type": exercises.PRE_POST_TEST,
+                "version": version,
+                "test_type": test_type,
+            }
+
+            # Synthetic content_id: UUID5 so pre and post are distinct
+            content_id = uuid_module.uuid5(
+                uuid_module.UUID(deterministic_hash), test_type
+            ).hex
+            channel_id = None
+            kind = content_kinds.QUIZ
+
+            context["unit_id"] = unit_id
+            context["course_session_id"] = course_session_id
         return content_id, channel_id, kind, mastery_model, context
 
     def _get_or_create_summarylog(

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -565,6 +565,77 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_start_session_unit_id_without_test_type_fails(self):
+        course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.post(
+            reverse("kolibri:core:trackprogress-list"),
+            data={
+                "unit_id": uuid.uuid4().hex,
+                "course_session_id": course_session.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_session_unit_id_without_course_session_id_fails(self):
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.post(
+            reverse("kolibri:core:trackprogress-list"),
+            data={
+                "unit_id": uuid.uuid4().hex,
+                "test_type": "pre",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_session_unit_id_with_node_id_fails(self):
+        course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self._make_request(
+            {
+                "unit_id": uuid.uuid4().hex,
+                "test_type": "pre",
+                "course_session_id": course_session.id,
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_session_unit_id_with_quiz_id_fails(self):
+        quiz = create_assigned_quiz_for_user(self.user)
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.post(
+            reverse("kolibri:core:trackprogress-list"),
+            data={
+                "unit_id": uuid.uuid4().hex,
+                "test_type": "pre",
+                "quiz_id": quiz.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_start_session_node_id_has_mastery_model_not_exercise_fails(self):
         self.client.login(
             username=self.user.username,

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -779,6 +779,36 @@ class ProgressTrackingPrePostTestSessionTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_mastery_log_has_negative_mastery_level(self):
+        """Pre/post tests use negative mastery_level like quizzes."""
+        self._start_pre_post_session("pre")
+        mastery_log = MasteryLog.objects.get()
+        self.assertLess(mastery_log.mastery_level, 0)
+
+    def test_session_resumption_returns_existing_mastery_log(self):
+        """Re-starting the same test resumes the existing mastery log."""
+        r1 = self._start_pre_post_session("pre")
+        mastery_level_1 = r1.json()["context"]["mastery_level"]
+        r2 = self._start_pre_post_session("pre")
+        mastery_level_2 = r2.json()["context"]["mastery_level"]
+        self.assertEqual(mastery_level_1, mastery_level_2)
+        self.assertEqual(MasteryLog.objects.count(), 1)
+
+    def test_pre_and_post_create_separate_mastery_logs(self):
+        """Pre-test and post-test create separate mastery logs (different content_ids)."""
+        self._start_pre_post_session("pre")
+        self._start_pre_post_session("post")
+        self.assertEqual(MasteryLog.objects.count(), 2)
+
+    def test_response_includes_pastattempts_and_totalattempts(self):
+        """Response includes attempt tracking fields."""
+        response = self._start_pre_post_session("pre")
+        result = response.json()
+        self.assertIn("pastattempts", result)
+        self.assertIn("totalattempts", result)
+        self.assertEqual(result["totalattempts"], 0)
+        self.assertEqual(result["complete"], False)
+
 
 class ProgressTrackingViewSetStartSessionResumeTestCase(APITestCase):
     databases = "__all__"

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -662,6 +662,124 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
         self.client.logout()
 
 
+class ProgressTrackingPrePostTestSessionTestCase(APITestCase):
+    """Tests for the pre/post test progress tracking entry path."""
+
+    databases = "__all__"
+
+    def setUp(self):
+        self.facility = FacilityFactory.create()
+        provision_device()
+        self.user = FacilityUserFactory.create(facility=self.facility)
+        self.channel_id = uuid.uuid4().hex
+        self.content_id = uuid.uuid4().hex
+        self.course_session = create_assigned_course_for_user(
+            self.user, channel_id=self.channel_id, content_id=self.content_id
+        )
+        self.unit_id = uuid.uuid4().hex
+        self.client.login(
+            username=self.user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    def _start_pre_post_session(self, test_type="pre", unit_id=None):
+        return self.client.post(
+            reverse("kolibri:core:trackprogress-list"),
+            data={
+                "unit_id": unit_id or self.unit_id,
+                "test_type": test_type,
+                "course_session_id": self.course_session.id,
+            },
+            format="json",
+        )
+
+    def test_start_pre_test_session_succeeds(self):
+        response = self._start_pre_post_session("pre")
+        self.assertEqual(response.status_code, 200)
+
+    def test_start_post_test_session_succeeds(self):
+        response = self._start_pre_post_session("post")
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_contains_mastery_criterion(self):
+        response = self._start_pre_post_session("pre")
+        result = response.json()
+        mastery = result["mastery_criterion"]
+        self.assertEqual(mastery["type"], "pre_post_test")
+        self.assertIn(mastery["version"], ("A", "B"))
+        self.assertEqual(mastery["test_type"], "pre")
+
+    def test_response_contains_context_with_unit_id(self):
+        response = self._start_pre_post_session("pre")
+        result = response.json()
+        self.assertEqual(result["context"]["unit_id"], self.unit_id)
+        self.assertEqual(result["context"]["course_session_id"], self.course_session.id)
+        self.assertNotIn("node_id", result["context"])
+
+    def test_ab_version_is_deterministic(self):
+        """Same inputs always produce the same A/B version."""
+        r1 = self._start_pre_post_session("pre")
+        r2 = self._start_pre_post_session("pre")
+        self.assertEqual(
+            r1.json()["mastery_criterion"]["version"],
+            r2.json()["mastery_criterion"]["version"],
+        )
+
+    def test_pre_and_post_get_opposite_versions(self):
+        """If pre is A, post must be B, and vice versa."""
+        r_pre = self._start_pre_post_session("pre")
+        r_post = self._start_pre_post_session("post")
+        pre_version = r_pre.json()["mastery_criterion"]["version"]
+        post_version = r_post.json()["mastery_criterion"]["version"]
+        self.assertNotEqual(pre_version, post_version)
+        self.assertEqual({pre_version, post_version}, {"A", "B"})
+
+    def test_synthetic_content_id_is_deterministic(self):
+        """Same inputs always produce the same synthetic content_id."""
+        self._start_pre_post_session("pre")
+        log1 = ContentSummaryLog.objects.get(user=self.user)
+        content_id_1 = log1.content_id
+        # Delete and re-start — should get the same content_id
+        ContentSessionLog.objects.all().delete()
+        ContentSummaryLog.objects.all().delete()
+        MasteryLog.objects.all().delete()
+        self._start_pre_post_session("pre")
+        log2 = ContentSummaryLog.objects.get(user=self.user)
+        self.assertEqual(content_id_1, log2.content_id)
+
+    def test_pre_and_post_get_distinct_content_ids(self):
+        """Pre-test and post-test for the same unit get different content_ids."""
+        self._start_pre_post_session("pre")
+        self._start_pre_post_session("post")
+        summary_logs = ContentSummaryLog.objects.filter(user=self.user)
+        content_ids = list(summary_logs.values_list("content_id", flat=True))
+        self.assertEqual(len(content_ids), 2)
+        self.assertNotEqual(content_ids[0], content_ids[1])
+
+    def test_session_creates_logs_with_quiz_kind_and_no_channel(self):
+        """Pre/post test logs use kind=QUIZ and channel_id=None like coach quizzes."""
+        self._start_pre_post_session("pre")
+        session_log = ContentSessionLog.objects.get()
+        self.assertEqual(session_log.kind, content_kinds.QUIZ)
+        self.assertIsNone(session_log.channel_id)
+        summary_log = ContentSummaryLog.objects.get(user=self.user)
+        self.assertEqual(summary_log.kind, content_kinds.QUIZ)
+
+    def test_anonymous_user_fails(self):
+        self.client.logout()
+        response = self.client.post(
+            reverse("kolibri:core:trackprogress-list"),
+            data={
+                "unit_id": self.unit_id,
+                "test_type": "pre",
+                "course_session_id": self.course_session.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+
 class ProgressTrackingViewSetStartSessionResumeTestCase(APITestCase):
     databases = "__all__"
 


### PR DESCRIPTION
## Summary

Adds a new entry path to the progress tracking API (`ProgressTrackingViewSet`) for pre/post tests within course sessions. When a learner starts a pre-test or post-test, the system:

- Accepts `unit_id`, `test_type` (pre/post), and `course_session_id` as a new mutually exclusive entry path alongside `node_id` and `quiz_id`
- Computes a deterministic A/B quiz version via MD5 hash of `(user_id, course_session_id, unit_id)` — even last hex digit gives pre=A/post=B, odd reverses
- Generates a synthetic `content_id` as UUID5 from the hash + test_type, ensuring pre and post tests always get distinct content_ids
- Constructs a `mastery_model` with `type: PRE_POST_TEST`, `version` (A/B), and `test_type` (pre/post)
- Uses negative `mastery_level` values (like coach quizzes) to prevent older Kolibri versions from deserializing these logs
- Stores `unit_id` and `course_session_id` in the session context

Closes #14133

## Changes

### `kolibri/core/logger/api.py`
- **StartSessionSerializer**: Added `unit_id` and `test_type` fields with validation — `unit_id` requires both `test_type` and `course_session_id`, and is mutually exclusive with `node_id`/`quiz_id`
- **LogContext**: Added `unit_id` slot
- **`_get_context`**: New `else` branch for pre/post tests with hash-based A/B determination and synthetic content_id generation
- **`_get_or_create_masterylog`**: Broadened `is_quiz` check to include `PRE_POST_TEST`
- **`_start_assessment_session`**: Broadened quiz attempt log retrieval to include `PRE_POST_TEST`

### `kolibri/core/logger/test/test_integrated_api.py`
- 4 validation tests (missing test_type, missing course_session_id, combined with node_id, combined with quiz_id)
- 14 integration tests in new `ProgressTrackingPrePostTestSessionTestCase` covering: session start, mastery criterion shape, context contents, A/B determinism, opposite versions, content_id stability/distinctness, quiz kind, negative mastery_level, session resumption, separate mastery logs for pre/post, response shape, anonymous rejection

## Test plan

- [x] All 157 tests in `test_integrated_api.py` pass
- [x] 18 new tests cover all acceptance criteria from the issue
- [x] Manual verification: start a pre-test session via the API and confirm the response includes correct `mastery_criterion` with `type`, `version`, and `test_type`
- [x] Manual verification: start the same pre-test again and confirm session resumption (same `mastery_level`)
- [x] Manual verification: start a post-test for the same unit and confirm it gets the opposite A/B version and a different `content_id`
