### PR TITLE
Fix course unit navigation issues

### DIFF
--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/index.vue
@@ -187,9 +187,7 @@
   import Modalities from 'kolibri-constants/Modalities';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import LearningActivityIcon from 'kolibri-common/components/ResourceDisplayAndSearch/LearningActivityIcon.vue';
-  import { useRoute, useRouter } from 'vue-router/composables';
   import TimeDuration from 'kolibri-common/components/TimeDuration.vue';
-  import { PageNames } from '../../../constants';
   import { injectCourseContentProgress } from '../useCourseContentProgressTracking';
   import useContentNodeProgress from '../../../composables/useContentNodeProgress';
   import useBookmarks from '../../../composables/useBookmarks';
@@ -205,9 +203,6 @@
       TimeDuration,
     },
     setup(props, { emit }) {
-      const router = useRouter();
-      const route = useRoute();
-
       const {
         sessionReady: currentResourceProgressSessionReady,
         handleUpdateProgress: handleUpdateCurrentResourceProgress,
@@ -245,14 +240,7 @@
       };
 
       const onResourceClick = resource => {
-        router.replace({
-          name: PageNames.COURSE_CONTENT__RESOURCE,
-          params: {
-            ...route.params,
-            resourceId: resource.id,
-            lessonId: resource.parent,
-          },
-        });
+        emit('navigateToResource', resource);
       };
 
       const onCompleteClick = () => {

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <ResourceLayout>
+  <ResourceLayout ref="resourceLayoutRef">
     <template #topBar>
       <div class="course-title">
         <KIconButton
@@ -62,6 +62,7 @@
         :currentResourceId="currentResource && currentResource.id"
         :currentLessonId="currentLesson && currentLesson.id"
         @finished="onResourceFinished"
+        @navigateToResource="handleNavigateToResource"
       />
     </template>
     <template
@@ -104,7 +105,7 @@
   import store from 'kolibri/store';
   import { useRouter } from 'vue-router/composables';
   import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource.js';
-  import { computed, nextTick, toRef, watch } from 'vue';
+  import { computed, nextTick, ref, toRef, watch } from 'vue';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings.js';
   import Modalities from 'kolibri-constants/Modalities';
   import useFetch from 'kolibri-common/composables/useFetch.js';
@@ -128,6 +129,7 @@
     },
     setup(props) {
       const router = useRouter();
+      const resourceLayoutRef = ref(null);
 
       const fetchCourseWithUnits = async () => {
         const courseData = await LearnerCourseResource.fetchModel({
@@ -621,6 +623,12 @@
         return false;
       };
 
+      const onSidePanelNavigation = () => {
+        if (resourceLayoutRef.value) {
+          resourceLayoutRef.value.onSidePanelNavigation();
+        }
+      };
+
       const handlePrev = () => {
         if (!prevEnabled.value) {
           return;
@@ -636,6 +644,7 @@
             resourceId: newResource.id,
           },
         });
+        onSidePanelNavigation();
       };
 
       const handleNext = () => {
@@ -653,6 +662,20 @@
             resourceId: newResource.id,
           },
         });
+        onSidePanelNavigation();
+      };
+
+      const handleNavigateToResource = resource => {
+        router.replace({
+          name: PageNames.COURSE_CONTENT__RESOURCE,
+          params: {
+            courseId: props.courseId,
+            unitId: props.unitId,
+            resourceId: resource.id,
+            lessonId: resource.parent,
+          },
+        });
+        onSidePanelNavigation();
       };
 
       const goToNextUnit = () => {
@@ -666,6 +689,7 @@
             unitId: nextUnit.value.id,
           },
         });
+        onSidePanelNavigation();
       };
 
       const { courseNameLabel$, resourcesProgressLabel$, unitNumberLabel$, upNextLabel$ } =
@@ -745,10 +769,12 @@
         prevEnabled,
         nextEnabled,
         maxResourceLft,
+        resourceLayoutRef,
         handlePrev,
         handleNext,
         onResourceFinished,
         goToNextUnit,
+        handleNavigateToResource,
 
         upNextLabel$,
         courseNameLabel$,

--- a/kolibri/plugins/learn/frontend/views/ResourceLayout/index.vue
+++ b/kolibri/plugins/learn/frontend/views/ResourceLayout/index.vue
@@ -1,6 +1,6 @@
 <script>
 
-  import { h, ref } from 'vue';
+  import { computed, h, ref } from 'vue';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import SidePanelModal from 'kolibri-common/components/courses/sidePanel/SidePanelModal';
@@ -27,13 +27,17 @@
    * @slot bottomBar      - Bottom bar content (claimable by nested ResourceLayouts)
    * @slot sidePanelTopBar   - Side panel header/title area (non-claimable)
    * @slot sidePanelFooter   - Side panel footer (claimable by nested ResourceLayouts)
+   *
+   * Exposes:
+   * - onSidePanelNavigation() - to be called by parent components when navigation occurs due to
+   *   an action on the side panel, so the panel can be closed in modal mode.
    */
   export default {
     name: 'ResourceLayout',
     components: {
       SidePanelModal,
     },
-    setup(props, { slots }) {
+    setup(props, { slots, expose }) {
       const { windowBreakpoint } = useKResponsiveWindow();
       const $themeTokens = themeTokens();
 
@@ -168,6 +172,21 @@
         }
       }
 
+      const isSidePanelModalMode = computed(() => windowBreakpoint.value <= 2);
+
+      /**
+       * Public method to close the side panel if open and in modal mode.
+       * Called by parent components when navigation occurs due to an action on the
+       * side panel.
+       */
+      function onSidePanelNavigation() {
+        if (sidePanelOpen.value && isSidePanelModalMode.value) {
+          closeSidePanel();
+        }
+      }
+
+      expose({ onSidePanelNavigation });
+
       return () => {
         // Nested ResourceLayouts: register slots with parent and render only default content
         if (isNested) {
@@ -193,9 +212,9 @@
         // === TOP-LEVEL RENDERING ===
         const hasSidePanelContent = sidePanel.hasContent();
         const showPushPanel =
-          hasSidePanelContent && sidePanelOpen.value && windowBreakpoint.value > 2;
+          hasSidePanelContent && sidePanelOpen.value && !isSidePanelModalMode.value;
         const showModalPanel =
-          hasSidePanelContent && sidePanelOpen.value && windowBreakpoint.value <= 2;
+          hasSidePanelContent && sidePanelOpen.value && isSidePanelModalMode.value;
         const hasTopBar = slots.topBar || hasSidePanelContent;
 
         // === TOP BAR with KToolbar ===


### PR DESCRIPTION
## Summary

* Exposes a `onSidePanelNavigation` public method from ResourceLayout, so that if the parent component calls this method, the ResourceLayout component will close the side panel if it was in modal mode.
  * Is the name of this method okay? Tried to be abstract about the required behavior, but we can also call it something more specific, like "closeSidePanelIfModalMode".
* Call this method on resource/unit navigation in CourseUnitView. 

https://github.com/user-attachments/assets/361b6dd9-4dc6-4665-8663-607cb6478283


## References
Closes #14221.

## Reviewer guidance
Replicate #14221.

## AI usage
* Asked Gemini how to expose a method inside the `setup` method.