### PR TITLE
[Bugfix] Change user 

### DIFF
--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -715,3 +715,131 @@ class TestLocalEventHandler(TestCase):
         context = CompositeSessionContext([network_context1, network_context2])
         _local_event_handler(self.method)(context)
         self.mock_method.assert_not_called()
+
+
+class GetRemoteUserInfoErrorPathsTestCase(TestCase):
+    """
+    Tests error handling in get_remote_user_info for different failure types.
+    """
+
+    def setUp(self):
+        self.client = mock.Mock()
+        self.facility_id = "test-facility-id"
+        self.admin_username = "admin"
+        self.admin_password = "password"
+        self.user_id = "test-user-id"
+
+    def _call(self):
+        from kolibri.core.auth.utils.users import get_remote_user_info
+
+        return get_remote_user_info(
+            self.client,
+            self.facility_id,
+            self.admin_username,
+            self.admin_password,
+            self.user_id,
+        )
+
+    def test_connection_failure_raises_resource_gone(self):
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationConnectionFailure,
+        )
+        from kolibri.core.discovery.utils.network.errors import ResourceGoneError
+
+        self.client.get.side_effect = NetworkLocationConnectionFailure("unreachable")
+        with self.assertRaises(ResourceGoneError):
+            self._call()
+
+    def test_response_failure_401_raises_authentication_failed(self):
+        from rest_framework.exceptions import AuthenticationFailed
+
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationResponseFailure,
+        )
+
+        response = mock.Mock(status_code=401)
+        self.client.get.side_effect = NetworkLocationResponseFailure(
+            "auth failed", response=response
+        )
+        with self.assertRaises(AuthenticationFailed):
+            self._call()
+
+    def test_response_failure_403_raises_authentication_failed(self):
+        from rest_framework.exceptions import AuthenticationFailed
+
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationResponseFailure,
+        )
+
+        response = mock.Mock(status_code=403)
+        self.client.get.side_effect = NetworkLocationResponseFailure(
+            "forbidden", response=response
+        )
+        with self.assertRaises(AuthenticationFailed):
+            self._call()
+
+    def test_response_failure_500_raises_resource_gone(self):
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationResponseFailure,
+        )
+        from kolibri.core.discovery.utils.network.errors import ResourceGoneError
+
+        response = mock.Mock(status_code=500)
+        self.client.get.side_effect = NetworkLocationResponseFailure(
+            "server error", response=response
+        )
+        with self.assertRaises(ResourceGoneError):
+            self._call()
+
+    def test_command_error_raises_resource_gone(self):
+        from kolibri.core.discovery.utils.network.errors import ResourceGoneError
+
+        self.client.get.side_effect = CommandError("command failed")
+        with self.assertRaises(ResourceGoneError):
+            self._call()
+
+
+class GetRemoteUsersInfoErrorPathsTestCase(TestCase):
+    """
+    Tests error handling in get_remote_users_info for different failure types.
+    """
+
+    def setUp(self):
+        self.client = mock.Mock()
+        self.facility_id = "test-facility-id"
+        self.username = "testuser"
+
+    def _call(self, password="testpassword"):
+        from kolibri.core.auth.utils.users import get_remote_users_info
+
+        return get_remote_users_info(
+            "http://test.example.com",
+            self.facility_id,
+            self.username,
+            password,
+            client=self.client,
+        )
+
+    def test_connection_failure_raises_resource_gone(self):
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationConnectionFailure,
+        )
+        from kolibri.core.discovery.utils.network.errors import ResourceGoneError
+
+        self.client.get.side_effect = NetworkLocationConnectionFailure("unreachable")
+        with self.assertRaises(ResourceGoneError):
+            self._call()
+
+    def test_response_failure_with_password_raises_authentication_failed(self):
+        from rest_framework.exceptions import AuthenticationFailed
+
+        from kolibri.core.discovery.utils.network.errors import (
+            NetworkLocationResponseFailure,
+        )
+
+        response = mock.Mock(status_code=401)
+        self.client.get.side_effect = NetworkLocationResponseFailure(
+            "auth failed", response=response
+        )
+        with self.assertRaises(AuthenticationFailed):
+            self._call(password="wrongpassword")

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -76,7 +76,10 @@ def get_remote_users_info(baseurl, facility_id, username, password, client=None)
                     detail="Password is required", code=error_constants.MISSING_PASSWORD
                 )
         else:
-            raise ResourceGoneError()
+            raise AuthenticationFailed(
+                detail="Authentication failed",
+                code=error_constants.AUTHENTICATION_FAILED,
+            )
     auth_info = response.json()
     if len(auth_info) > 1:
         user_info = [u for u in response.json() if u["username"] == username][0]

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -105,19 +105,36 @@ def get_remote_user_info(client, facility_id, adminUsername, adminPassword, user
     """
     user_info_url = reverse_path("kolibri:core:publicuser-detail", args=[user_id])
     params = {"facility_id": facility_id}
-    response = client.get(
-        user_info_url,
-        params=params,
-        auth=(
-            "username={}&{}={}".format(
-                adminUsername, FACILITY_CREDENTIAL_KEY, facility_id
+    try:
+        response = client.get(
+            user_info_url,
+            params=params,
+            auth=(
+                "username={}&{}={}".format(
+                    adminUsername, FACILITY_CREDENTIAL_KEY, facility_id
+                ),
+                adminPassword,
             ),
-            adminPassword,
-        ),
-    )
-    if response.status_code == 200:
-        return response.json()
-    elif response.status_code == 404:
-        raise NotFound()
-    else:
+        )
+        if response.status_code == 200:
+            return response.json()
+        elif response.status_code == 404:
+            raise NotFound()
+        elif response.status_code in (401, 403):
+            raise AuthenticationFailed(
+                detail="Authentication failed",
+                code=error_constants.AUTHENTICATION_FAILED,
+            )
+        else:
+            raise ResourceGoneError()
+    except NetworkLocationConnectionFailure:
+        raise ResourceGoneError()
+    except NetworkLocationResponseFailure as e:
+        if e.response is not None and e.response.status_code in (401, 403):
+            raise AuthenticationFailed(
+                detail="Authentication failed",
+                code=error_constants.AUTHENTICATION_FAILED,
+            )
+        raise ResourceGoneError()
+    except CommandError:
         raise ResourceGoneError()

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -50,10 +50,11 @@ def get_remote_users_info(baseurl, facility_id, username, password, client=None)
                 password,
             ),
         )
+    except NetworkLocationConnectionFailure:
+        raise ResourceGoneError()
     except (
         CommandError,
         NetworkLocationResponseFailure,
-        NetworkLocationConnectionFailure,
     ):
         if password == NOT_SPECIFIED or not password:
             facility_info_url = reverse_path(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

- Uses `AuthenticationError` in place of `ResourceGoneError` when remote authenticating

## References
<!--
 * references to related issues and PRs
-->

Closes #14318 


## AI usage

Claude helped in root cause identification <3 