### PR TITLE
Migrate epub viewer search tests to Vue Testing Library

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchButton.spec.js
@@ -9,7 +9,7 @@ describe('Search button', () => {
     expect(button).toBeInTheDocument();
   });
 
-  it('should emit an event when the button is clicked', async() => {
+  it('should emit an event when the button is clicked', async () => {
     const { emitted } = render(SearchButton);
 
     const button = screen.getByRole('button');

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchButton.spec.js
@@ -1,18 +1,20 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import SearchButton from '../SearchButton';
 
-function createWrapper() {
-  return mount(SearchButton);
-}
-
 describe('Search button', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('should render', () => {
+    render(SearchButton);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
   });
-  it('should emit an event when the button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeTruthy();
+
+  it('should emit an event when the button is clicked', async() => {
+    const { emitted } = render(SearchButton);
+
+    const button = screen.getByRole('button');
+    await fireEvent.click(button);
+
+    expect(emitted().click).toBeTruthy();
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -31,12 +31,13 @@ describe('Search side bar', () => {
           sidebarRef.value.focusOnInput();
         }
 
+        // eslint-disable-next-line vue/no-unused-properties
         return { sidebarRef, focusInput };
       },
       template: ` <div>
-          <SearchSideBar ref="sidebarRef" :book="{}" />
-          <button @click="focusInput">Focus</button>
-        </div> `,
+        <SearchSideBar ref="sidebarRef" :book="{}" />
+        <button @click="focusInput">Focus</button>
+      </div> `,
     });
 
     render(Parent, { attachTo: document.body });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue';
+import { defineComponent, ref } from 'vue';
 import SearchSideBar from '../SearchSideBar';
 
 describe('Search side bar', () => {
@@ -19,12 +20,31 @@ describe('Search side bar', () => {
   });
 
   it('should allow parent to focus on input box', async () => {
-    renderComponent();
+    // renderComponent();
+    const Parent = defineComponent({
+      components: { SearchSideBar },
+      setup() {
+        const sidebarRef = ref(null);
+
+        function focusInput() {
+          sidebarRef.value.focusOnInput();
+        }
+
+        return { sidebarRef, focusInput };
+      },
+      template: 
+      ` <div>
+          <SearchSideBar ref="sidebarRef" :book="{}" />
+          <button @click="focusInput">Focus</button>
+        </div> `,
+    });
+
+    render(Parent, { attachTo: document.body });
+
+    const button = screen.getByRole('button', { name: 'Focus' });
+    button.click();
 
     const input = screen.getByRole('searchbox');
-
-    input.focus();
-
     expect(document.activeElement).toBe(input);
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -1,27 +1,30 @@
-import { mount } from '@vue/test-utils';
+import { render, screen } from '@testing-library/vue';
 import SearchSideBar from '../SearchSideBar';
 
-function createWrapper() {
-  const node = document.createElement('app');
-  document.body.appendChild(node);
-  return mount(SearchSideBar, {
-    propsData: {
-      book: {},
-    },
-    attachTo: node,
-  });
-}
-
 describe('Search side bar', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  function renderComponent() {
+    return render(SearchSideBar, {
+      props: {
+        book: {},
+      },
+      attachTo: document.body,
+    });
+  }
+
+  it('should render', () => {
+    renderComponent();
+
+    const input = screen.getByRole('searchbox');
+    expect(input).toBeInTheDocument();
   });
 
-  it('should allow parent to focus on input box', () => {
-    const wrapper = createWrapper();
-    wrapper.vm.focusOnInput();
-    const elementThatIsFocused = document.activeElement;
-    expect(elementThatIsFocused).toHaveClass('search-input');
+  it('should allow parent to focus on input box', async () => {
+    renderComponent();
+
+    const input = screen.getByRole('searchbox');
+
+    input.focus();
+
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -20,7 +20,6 @@ describe('Search side bar', () => {
   });
 
   it('should allow parent to focus on input box', async () => {
-    // renderComponent();
     const Parent = defineComponent({
       components: { SearchSideBar },
       setup() {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -31,8 +31,7 @@ describe('Search side bar', () => {
 
         return { sidebarRef, focusInput };
       },
-      template: 
-      ` <div>
+      template: ` <div>
           <SearchSideBar ref="sidebarRef" :book="{}" />
           <button @click="focusInput">Focus</button>
         </div> `,
@@ -44,6 +43,6 @@ describe('Search side bar', () => {
     button.click();
 
     const input = screen.getByRole('searchbox');
-    expect(document.activeElement).toBe(input);
+    expect(input).toHaveFocus();
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -23,8 +23,10 @@ describe('Search side bar', () => {
     const Parent = defineComponent({
       components: { SearchSideBar },
       setup() {
+        // eslint-disable-next-line vue/no-unused-properties
         const sidebarRef = ref(null);
 
+        // eslint-disable-next-line vue/no-unused-properties
         function focusInput() {
           sidebarRef.value.focusOnInput();
         }


### PR DESCRIPTION
## Summary
This PR migrates the epub viewer search unit tests from `@vue/test-utils` to `@testing-library/vue`.

The following files were updated:
- `SearchButton.spec.js`
- `SearchSideBar.spec.js`

Changes include:
- Removed `@vue/test-utils` usage
- Rewrote tests to follow Testing Library principles
- Updated queries to prioritize user-facing interactions (e.g., `getByRole`)
- Removed direct access to component internals (`wrapper`, `vm`, etc.)

Manual verification
- Ran `pnpm run test-jest -- --testPathPattern epub_viewer`
- Confirmed all epub_viewer tests pass locally
<!---->

## References
Closes #14187
<!---->

## Reviewer guidance
- Reviewers can verify by running: `pnpm run test-jest -- --testPathPattern epub_viewer`
- Only two files were modified, no other files were changed.
<!---->