### PR TITLE
Patching Python 3.14 Support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -143,6 +143,27 @@ def forward_port_cgi_module():
     sys.modules["cgi"] = module
 
 
+def monkey_patch_pkgutil():
+    """
+    Monkey patch pkgutil.find_loader which was removed in Python 3.14.
+    django-filter 21.1 uses it at import time.
+    This can be removed when we upgrade to a version of django-filter
+    that is Python 3.14 compatible.
+    """
+    if sys.version_info < (3, 14):
+        return
+    import importlib.util
+    import pkgutil
+
+    def _find_loader(fullname):
+        spec = importlib.util.find_spec(fullname)
+        if spec is None:
+            return None
+        return spec.loader
+
+    pkgutil.find_loader = _find_loader
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -155,6 +176,7 @@ def set_env():
 
     monkey_patch_markdown()
     monkey_patch_distutils()
+    monkey_patch_pkgutil()
 
     from kolibri import dist as kolibri_dist  # noqa
 

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -164,6 +164,35 @@ def monkey_patch_pkgutil():
     pkgutil.find_loader = _find_loader
 
 
+def fix_django_template_context_copy():
+    """
+    Fix BaseContext.__copy__ in Django 3.2 for Python 3.14 compatibility.
+    Python 3.14 changed the behavior of copy(super()), which breaks the
+    original implementation in django/template/context.py.
+    This backports the fix from Django's main branch.
+    This can be removed when we upgrade to a version of Django that is
+    Python 3.14 compatible.
+    """
+    if sys.version_info < (3, 14):
+        return
+    try:
+        from copy import copy as _copy
+
+        from django.template.context import BaseContext
+    except ImportError:
+        # Django may not be installed yet (e.g. during pip install).
+        return
+
+    def _base_context_copy(self):
+        duplicate = BaseContext()
+        duplicate.__class__ = self.__class__
+        duplicate.__dict__ = _copy(self.__dict__)
+        duplicate.dicts = self.dicts[:]
+        return duplicate
+
+    BaseContext.__copy__ = _base_context_copy
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -188,6 +217,7 @@ def set_env():
 
     # Depends on Django, so we need to wait until our dist has been registered.
     forward_port_cgi_module()
+    fix_django_template_context_copy()
 
     # Set default env
     for key, value in ENVIRONMENT_VARIABLES.items():

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,8 +4,10 @@ norecursedirs = dist tmp* .svn .*
 # Settings for pytest-django
 django_find_project = false
 DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test
-# Settings for pytest-pythonpath
+# Settings for pytest-pythonpath (pytest <7, Python <3.10)
 python_paths = kolibri/dist
+# Built-in pythonpath (pytest 7+, Python >=3.10)
+pythonpath = kolibri/dist
 env =
     # cleaned up in conftest.py fixture
     KOLIBRI_HOME=./.pytest_kolibri_home

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ django-mptt==0.14.0
 requests==2.27.1  # latest version to support Python 3.6
 cheroot==10.0.1
 magicbus==4.1.2
-le-utils==0.2.13
+le-utils==0.2.13; python_version < "3.14"
 jsonfield==3.1.0
-morango==0.8.7
+morango==0.8.7; python_version < "3.14"
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0

--- a/requirements/cext.txt
+++ b/requirements/cext.txt
@@ -4,5 +4,7 @@
 # in other files to ensure they are properly
 # installed - as these dependencies are installed
 # without their dependencies.
-cffi==1.15.1
-cryptography==40.0.2
+cffi==1.15.1; python_version < "3.14"
+cffi>=2.0; python_version >= "3.14"
+cryptography==40.0.2; python_version < "3.14"
+cryptography>=42.0; python_version >= "3.14"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,13 +11,10 @@ pytest==6.2.5; python_version < "3.10"
 pytest-django==4.5.2; python_version < "3.10"
 pytest-env==0.6.2; python_version < "3.10"
 pytest-pythonpath==0.7.2; python_version < "3.10"
-# pytest 6 needs these older test factories
-factory-boy==2.7.0; python_version < "3.10"
-fake-factory==0.5.7; python_version < "3.10"
+factory-boy==2.7.0
+fake-factory==0.5.7
 
 # pytest 7+ for Python 3.10+ (supports 3.14, has built-in pythonpath)
 pytest>=7.0,<9; python_version >= "3.10"
 pytest-django>=4.5.2; python_version >= "3.10"
 pytest-env>=0.6.2; python_version >= "3.10"
-# factory-boy 2.7.0 + fake-factory don't work on newer Python
-factory-boy>=3.2; python_version >= "3.10"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,13 +1,23 @@
 setuptools
 # These are for testing
 beautifulsoup4==4.8.2
-factory-boy==2.7.0
-fake-factory==0.5.7
 mock==2.0.0
 mixer==6.0.1
-pytest==6.2.5
-pytest-django==4.5.2
-pytest-env==0.6.2
-pytest-pythonpath==0.7.2
-attrs==19.2.0
 parameterized==0.8.1
+attrs==19.2.0
+
+# pytest 6.x for older Python (uses ast.Str, removed in 3.14)
+pytest==6.2.5; python_version < "3.10"
+pytest-django==4.5.2; python_version < "3.10"
+pytest-env==0.6.2; python_version < "3.10"
+pytest-pythonpath==0.7.2; python_version < "3.10"
+# pytest 6 needs these older test factories
+factory-boy==2.7.0; python_version < "3.10"
+fake-factory==0.5.7; python_version < "3.10"
+
+# pytest 7+ for Python 3.10+ (supports 3.14, has built-in pythonpath)
+pytest>=7.0,<9; python_version >= "3.10"
+pytest-django>=4.5.2; python_version >= "3.10"
+pytest-env>=0.6.2; python_version >= "3.10"
+# factory-boy 2.7.0 + fake-factory don't work on newer Python
+factory-boy>=3.2; python_version >= "3.10"

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     cmdclass={"install_scripts": gen_windows_batch_files},
-    python_requires=">=3.6,  <3.14",
+    python_requires=">=3.6,  <3.15",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13}, postgres
+envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13,3.14}, postgres
 
 [testenv]
 usedevelop = True
@@ -22,10 +22,13 @@ basepython =
     py3.11: python3.11
     py3.12: python3.12
     py3.13: python3.13
+    py3.14: python3.14
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/cext.txt
+    le-utils @ git+https://github.com/learningequality/le-utils@py3.14-bump ; python_version >= "3.14"
+    morango @ git+https://github.com/learningequality/morango@py3.14-bump ; python_version >= "3.14"
 commands =
     sh -c 'kolibri manage makemigrations --check'
     # Run the actual tests


### PR DESCRIPTION
## Summary

Add Python 3.14 support to Kolibri using monkey patches for stdlib removals, without dropping support for Python 3.6–3.13.

Python 3.14 removed several stdlib APIs that our pinned dependencies rely on:
- **`pkgutil.find_loader`** (used by django-filter 21.1) — patched via `importlib.util.find_spec`
- **`ast.Str`** (used by pytest 6.x assertion rewriting) — handled by version-splitting test deps to use pytest 7+ on Python ≥3.10
- **`BaseContext.__copy__`** behavior change in Django 3.2 — patched with the fix from Django's main branch

Additionally:
- `le-utils` and `morango` have `python_requires <3.14` on PyPI (code works fine on 3.14). For py3.14, they're installed from `py3.14-bump` git branches with the constraint bumped to `<3.15`.
- Existing monkey patches for `cgi` and `distutils` (added for 3.12/3.13) already cover Django and redis on 3.14.

**Verification:**
- Full test suite (3729 tests) passes on Python 3.14.2 with pytest 8.4.2
- Full test suite (3729 tests) passes on Python 3.9.25 with pytest 6.2.5 (no regressions)

## References

Closes #13823

## Reviewer guidance

The changes are isolated to build/CI config and monkey patches:

1. **`kolibri/utils/env.py`** — Two new monkey patch functions (`monkey_patch_pkgutil` and `fix_django_template_context_copy`), both guarded by `sys.version_info < (3, 14)` so they're no-ops on older Python. They follow the exact same pattern as the existing `monkey_patch_distutils` and `forward_port_cgi_module` patches in the same file.

2. **`requirements/test.txt`** — pytest 6.x for Python <3.10, pytest 7+ for Python ≥3.10. The split is needed because pytest 6 uses `ast.Str` (removed in 3.14) and pytest 7+ is incompatible with `pytest-pythonpath`.

3. **`pytest.ini`** — Has both `python_paths` (for pytest-pythonpath on pytest <7) and `pythonpath` (built-in on pytest 7+). Each version warns about the other's config key but doesn't error.

4. **`requirements/base.txt` / `tox.ini`** — le-utils and morango get `python_version < "3.14"` markers on the PyPI pins, with git-based installs from `py3.14-bump` branches for py≥3.14 in tox deps.

**Risky areas:**
- The `fix_django_template_context_copy` patch is the least obvious — verify it's needed by reverting it and running tests on py3.14 if in doubt.
- The test dep version split means py≥3.10 now uses newer pytest and factory-boy — unlikely to cause issues but worth noting.

## AI usage

This PR was developed using Claude Code with a sub-agent driven workflow. I created the investigation plan and made key architectural decisions (monkey patching over conditional deps, version-split boundary at py3.10, scope limited to test-pass). Claude Code performed the empirical testing on a Python 3.14.2 venv to identify all compatibility issues, implemented each change via subagents with spec compliance and code quality reviews after each task, and ran the full test suite on both py3.14 and py3.9 to verify correctness and no regressions.
