### PR TITLE
Fix missing/mismatched string on course welcome page

### DIFF
--- a/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
@@ -182,8 +182,8 @@
                       </span>
                       <span>
                         <span class="unit-item-count">{{
-                          numberOfResources$({
-                            value: (lesson && lesson.on_device_resources) || 0,
+                          numResources$({
+                            num: (lesson && lesson.on_device_resources) || 0,
                           })
                         }}</span>
                         <KIcon
@@ -311,6 +311,7 @@
         numLessons$,
         numUnits$,
         numQuestions$,
+        numResources$,
         preTestLabel$,
         postTestLabel$,
         startCourseAction$,
@@ -509,6 +510,7 @@
         courseContentLabel$,
         numLessons$,
         numQuestions$,
+        numResources$,
         preTestLabel$,
         postTestLabel$,
         startCourseAction$,

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -148,6 +148,10 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: '{num, number} {num, plural, one {unit} other {units}}',
     context: 'Part of subtitle shown under the course title',
   },
+  numResources: {
+    message: '{num, number} {num, plural, one {resource} other {resources}}',
+    context: 'Part of course details on the heading for each lesson showing how many resources',
+  },
   courseContentLabel: {
     message: 'Course content',
     context: 'Label above list of units in course contents listing',


### PR DESCRIPTION
## Summary
Somewhere along the way with my course welcome fixes I think I introduced this bug with the accordions, where the string was missing and then the accordions wouldn't open 

Before:

https://github.com/user-attachments/assets/e1c5a716-f8e4-4ca7-a8e3-4e587a879adf


After:

https://github.com/user-attachments/assets/7a586c7f-24c3-4697-80f3-b0f0a217616b



## Reviewer guidance
Confirm that the accordions work, and that this is an appropriate place for the string to live (note, part of the intended fix was to ensure that the entire "coaches" strings were not loaded into this learn plugin welcome page unnecessarily, so I did add the numResources string to the feature strings file)
