### PR TITLE
Rename compat.py to modules.py and update imports

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -30,7 +30,7 @@ from kolibri.plugins import ConfigDict
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import KolibriHook
-from kolibri.utils.compat import module_exists
+from kolibri.utils.modules import module_exists
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.version import normalize_version_to_semver
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -21,7 +21,7 @@ from kolibri.plugins.utils import enable_default_plugins
 from kolibri.plugins.utils import enable_plugins
 from kolibri.plugins.utils import iterate_plugins
 from kolibri.utils import server
-from kolibri.utils.compat import module_exists
+from kolibri.utils.modules import module_exists
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.constants import installation_types
 from kolibri.utils.debian_check import check_debian_user

--- a/kolibri/utils/modules.py
+++ b/kolibri/utils/modules.py
@@ -1,5 +1,5 @@
 """
-Compatibility layer for Python 2+3
+Utility function for checking module availability.
 """
 from importlib.util import find_spec
 


### PR DESCRIPTION
## Summary
Renamed the `compat` module to improve clarity and consistency in naming.
Updated all related import statements across the codebase accordingly.
This change does not introduce any functional modifications.
Manual verification:
- Ran the test suite locally.
- Verified that the application imports correctly after the rename.

## References
Closes #14182 

## Reviewer guidance
This change is limited to renaming the module and updating import paths.
Reviewers can:
- Confirm that all references to the old module name have been updated.
- Run the test suite to verify no regressions were introduced.
