### PR TITLE
Creates SparklineBar distribution chart component

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
+++ b/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
@@ -37,21 +37,21 @@
             <span
               class="tooltip-dot"
               :style="{ backgroundColor: dotColors.low }"
-            />
+            ></span>
             {{ lowCountLabel$({ count: lowCount }) }}
           </div>
           <div class="tooltip-row">
             <span
               class="tooltip-dot"
               :style="{ backgroundColor: dotColors.mid }"
-            />
+            ></span>
             {{ partialCountLabel$({ count: midCount }) }}
           </div>
           <div class="tooltip-row">
             <span
               class="tooltip-dot"
               :style="{ backgroundColor: dotColors.high }"
-            />
+            ></span>
             {{ strongCountLabel$({ count: highCount }) }}
           </div>
         </div>
@@ -213,10 +213,10 @@
   }
 
   .segment {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-sizing: border-box;
     transition: width 0.15s ease;
   }
 
@@ -237,9 +237,9 @@
 
   .tooltip-rows {
     display: flex;
+    flex-wrap: wrap;
     gap: 16px;
     align-items: center;
-    flex-wrap: wrap;
   }
 
   .tooltip-row {
@@ -250,10 +250,10 @@
 
   .tooltip-dot {
     display: inline-block;
+    flex-shrink: 0;
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    flex-shrink: 0;
   }
 
   .tooltip-hint {

--- a/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
+++ b/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
@@ -71,7 +71,7 @@
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
   import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
 
-  export const MIN_SEGMENT_WIDTH_PX = 32;
+  export const MIN_SEGMENT_WIDTH_PX = 8;
 
   export default {
     name: 'SparklineBar',
@@ -126,7 +126,7 @@
         if (totalCount.value === 0) {
           return 'calc(100% / 3)';
         }
-        const proportion = count / totalCount.value;
+        const proportion = Math.max(count, 1) / totalCount.value;
         const offset = MIN_SEGMENT_WIDTH_PX * 3;
         return `calc(${MIN_SEGMENT_WIDTH_PX}px + ${proportion} * (100% - ${offset}px))`;
       }

--- a/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
+++ b/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
@@ -71,7 +71,7 @@
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
   import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
 
-  export const MIN_SEGMENT_WIDTH_PX = 8;
+  export const MIN_SEGMENT_WIDTH_PX = 16;
 
   export default {
     name: 'SparklineBar',
@@ -126,7 +126,7 @@
         if (totalCount.value === 0) {
           return 'calc(100% / 3)';
         }
-        const proportion = Math.max(count, 1) / totalCount.value;
+        const proportion = count / totalCount.value;
         const offset = MIN_SEGMENT_WIDTH_PX * 3;
         return `calc(${MIN_SEGMENT_WIDTH_PX}px + ${proportion} * (100% - ${offset}px))`;
       }

--- a/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
+++ b/kolibri/plugins/coach/frontend/views/common/SparklineBar.vue
@@ -1,0 +1,265 @@
+<template>
+
+  <div class="sparkline-wrapper">
+    <span class="visuallyhidden">
+      {{ accessibilityLabel }}
+    </span>
+    <div
+      ref="sparklineBar"
+      class="sparkline-bar"
+      aria-hidden="true"
+    >
+      <div
+        v-for="(segment, index) in segments"
+        :key="segment.key"
+        class="segment"
+        :class="`segment-${segment.key}`"
+        :style="segmentStyle(segment, index)"
+      >
+        <span
+          class="count-text"
+          aria-hidden="true"
+        >
+          {{ segment.count }}
+        </span>
+      </div>
+    </div>
+    <KTooltip
+      reference="sparklineBar"
+      :refs="$refs"
+    >
+      <div class="tooltip-content">
+        <p class="tooltip-title">
+          {{ learnersByMasteryLabel$() }}
+        </p>
+        <div class="tooltip-rows">
+          <div class="tooltip-row">
+            <span
+              class="tooltip-dot"
+              :style="{ backgroundColor: dotColors.low }"
+            />
+            {{ lowCountLabel$({ count: lowCount }) }}
+          </div>
+          <div class="tooltip-row">
+            <span
+              class="tooltip-dot"
+              :style="{ backgroundColor: dotColors.mid }"
+            />
+            {{ partialCountLabel$({ count: midCount }) }}
+          </div>
+          <div class="tooltip-row">
+            <span
+              class="tooltip-dot"
+              :style="{ backgroundColor: dotColors.high }"
+            />
+            {{ strongCountLabel$({ count: highCount }) }}
+          </div>
+        </div>
+        <p class="tooltip-hint">
+          {{ clickToViewDetailsLabel$() }}
+        </p>
+      </div>
+    </KTooltip>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed, toRefs } from 'vue';
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
+
+  export const MIN_SEGMENT_WIDTH_PX = 32;
+
+  export default {
+    name: 'SparklineBar',
+    setup(props) {
+      const {
+        sparklineDistributionLabel$,
+        learnersByMasteryLabel$,
+        lowCountLabel$,
+        partialCountLabel$,
+        strongCountLabel$,
+        clickToViewDetailsLabel$,
+      } = coursesStrings;
+      const { lowCount, midCount, highCount } = toRefs(props);
+
+      const totalCount = computed(() => lowCount.value + midCount.value + highCount.value);
+
+      const accessibilityLabel = computed(() =>
+        sparklineDistributionLabel$({
+          lowCount: lowCount.value,
+          midCount: midCount.value,
+          highCount: highCount.value,
+        }),
+      );
+
+      const separatorColor = themeTokens().surface;
+      const segments = computed(() => {
+        const palette = themePalette();
+        const tokens = themeTokens();
+        return [
+          {
+            key: 'low',
+            count: lowCount.value,
+            backgroundColor: palette.red.v_600,
+            textColor: tokens.textInverted,
+          },
+          {
+            key: 'mid',
+            count: midCount.value,
+            backgroundColor: palette.yellow.v_500,
+            textColor: tokens.text,
+          },
+          {
+            key: 'high',
+            count: highCount.value,
+            backgroundColor: palette.green.v_600,
+            textColor: tokens.textInverted,
+          },
+        ];
+      });
+
+      function widthForCount(count) {
+        if (totalCount.value === 0) {
+          return 'calc(100% / 3)';
+        }
+        const proportion = count / totalCount.value;
+        const offset = MIN_SEGMENT_WIDTH_PX * 3;
+        return `calc(${MIN_SEGMENT_WIDTH_PX}px + ${proportion} * (100% - ${offset}px))`;
+      }
+
+      function segmentStyle(segment, index) {
+        return {
+          width: widthForCount(segment.count),
+          backgroundColor: segment.backgroundColor,
+          color: segment.textColor,
+          boxShadow: index === 0 ? 'none' : `inset 1px 0 0 ${separatorColor}`,
+        };
+      }
+
+      const dotColors = {
+        low: themePalette().red.v_600,
+        mid: themePalette().yellow.v_500,
+        high: themePalette().green.v_600,
+      };
+
+      return {
+        accessibilityLabel,
+        segments,
+        segmentStyle,
+        dotColors,
+        learnersByMasteryLabel$,
+        lowCountLabel$,
+        partialCountLabel$,
+        strongCountLabel$,
+        clickToViewDetailsLabel$,
+      };
+    },
+    props: {
+      lowCount: {
+        type: Number,
+        required: true,
+        validator(value) {
+          return value >= 0;
+        },
+      },
+      midCount: {
+        type: Number,
+        required: true,
+        validator(value) {
+          return value >= 0;
+        },
+      },
+      highCount: {
+        type: Number,
+        required: true,
+        validator(value) {
+          return value >= 0;
+        },
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .visuallyhidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .sparkline-wrapper {
+    width: 100%;
+  }
+
+  .sparkline-bar {
+    display: flex;
+    width: 100%;
+    height: 20px;
+    overflow: hidden;
+    border-radius: 2px;
+  }
+
+  .segment {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    transition: width 0.15s ease;
+  }
+
+  .count-text {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .tooltip-content {
+    min-width: 160px;
+  }
+
+  .tooltip-title {
+    margin: 0 0 6px;
+    font-weight: 600;
+  }
+
+  .tooltip-rows {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .tooltip-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .tooltip-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .tooltip-hint {
+    margin: 8px 0 0;
+    font-style: italic;
+    opacity: 0.8;
+  }
+
+</style>

--- a/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
+++ b/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
@@ -43,7 +43,7 @@ describe('SparklineBar', () => {
     });
   });
 
-  it('displays proportional widths with a minimum offset applied to every segment', () => {
+  it('sizes each segment proportionally to its count, with a constant minimum width', () => {
     const { container } = renderSparkline({ lowCount: 1, midCount: 2, highCount: 7 });
     const widths = Array.from(container.querySelectorAll('.segment')).map(
       segment => segment.style.width,
@@ -55,6 +55,15 @@ describe('SparklineBar', () => {
       `calc(${MIN_SEGMENT_WIDTH_PX}px + 0.2 * (100% - ${offset}px))`,
       `calc(${MIN_SEGMENT_WIDTH_PX}px + 0.7 * (100% - ${offset}px))`,
     ]);
+  });
+
+  it('treats a zero-count segment as count 1 so the label remains readable', () => {
+    const { container } = renderSparkline({ lowCount: 0, midCount: 3, highCount: 7 });
+    const [lowWidth] = Array.from(container.querySelectorAll('.segment')).map(
+      segment => segment.style.width,
+    );
+    const offset = MIN_SEGMENT_WIDTH_PX * 3;
+    expect(lowWidth).toBe(`calc(${MIN_SEGMENT_WIDTH_PX}px + 0.1 * (100% - ${offset}px))`);
   });
 
   it('splits the bar evenly when there are no learners in the distribution', () => {

--- a/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
+++ b/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
@@ -57,13 +57,13 @@ describe('SparklineBar', () => {
     ]);
   });
 
-  it('treats a zero-count segment as count 1 so the label remains readable', () => {
+  it('gives a zero-count segment only the minimum width with no proportional addition', () => {
     const { container } = renderSparkline({ lowCount: 0, midCount: 3, highCount: 7 });
     const [lowWidth] = Array.from(container.querySelectorAll('.segment')).map(
       segment => segment.style.width,
     );
     const offset = MIN_SEGMENT_WIDTH_PX * 3;
-    expect(lowWidth).toBe(`calc(${MIN_SEGMENT_WIDTH_PX}px + 0.1 * (100% - ${offset}px))`);
+    expect(lowWidth).toBe(`calc(${MIN_SEGMENT_WIDTH_PX}px + 0 * (100% - ${offset}px))`);
   });
 
   it('splits the bar evenly when there are no learners in the distribution', () => {

--- a/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
+++ b/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/vue';
+import '@testing-library/jest-dom';
+import SparklineBar, { MIN_SEGMENT_WIDTH_PX } from '../SparklineBar.vue';
+
+function renderSparkline(overrides = {}) {
+  return render(SparklineBar, {
+    props: {
+      lowCount: 2,
+      midCount: 3,
+      highCount: 5,
+      ...overrides,
+    },
+  });
+}
+
+describe('SparklineBar', () => {
+  it('renders all three segments and keeps zero-count segments visible', () => {
+    const { container } = renderSparkline({ lowCount: 0, midCount: 0, highCount: 0 });
+
+    const segments = container.querySelectorAll('.segment');
+    expect(segments).toHaveLength(3);
+    expect(screen.getByText('0', { selector: '.segment-low .count-text' })).toBeInTheDocument();
+    expect(screen.getByText('0', { selector: '.segment-mid .count-text' })).toBeInTheDocument();
+    expect(screen.getByText('0', { selector: '.segment-high .count-text' })).toBeInTheDocument();
+  });
+
+  it('provides a visually hidden textual summary for screen readers', () => {
+    renderSparkline({ lowCount: 1, midCount: 0, highCount: 4 });
+
+    const hiddenSummary = screen.getByText(/1 low, 0 medium, 4 high/i);
+    expect(hiddenSummary).toHaveClass('visuallyhidden');
+    expect(hiddenSummary).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('marks the visual bar and counts as aria-hidden to avoid double announcement', () => {
+    const { container } = renderSparkline();
+    const sparklineBar = container.querySelector('.sparkline-bar');
+    const counts = container.querySelectorAll('.count-text');
+
+    expect(sparklineBar).toHaveAttribute('aria-hidden', 'true');
+    counts.forEach(count => {
+      expect(count).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('displays proportional widths with a minimum offset applied to every segment', () => {
+    const { container } = renderSparkline({ lowCount: 1, midCount: 2, highCount: 7 });
+    const widths = Array.from(container.querySelectorAll('.segment')).map(
+      segment => segment.style.width,
+    );
+
+    const offset = MIN_SEGMENT_WIDTH_PX * 3;
+    expect(widths).toEqual([
+      `calc(${MIN_SEGMENT_WIDTH_PX}px + 0.1 * (100% - ${offset}px))`,
+      `calc(${MIN_SEGMENT_WIDTH_PX}px + 0.2 * (100% - ${offset}px))`,
+      `calc(${MIN_SEGMENT_WIDTH_PX}px + 0.7 * (100% - ${offset}px))`,
+    ]);
+  });
+
+  it('splits the bar evenly when there are no learners in the distribution', () => {
+    const { container } = renderSparkline({ lowCount: 0, midCount: 0, highCount: 0 });
+    const widths = Array.from(container.querySelectorAll('.segment')).map(
+      segment => segment.style.width,
+    );
+
+    expect(widths).toEqual(['calc(33.3333%)', 'calc(33.3333%)', 'calc(33.3333%)']);
+  });
+
+  it('keeps counts non-negative through prop validation', () => {
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderSparkline({ lowCount: -1 });
+
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+});

--- a/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
+++ b/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
@@ -67,11 +67,9 @@ describe('SparklineBar', () => {
   });
 
   it('keeps counts non-negative through prop validation', () => {
-    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    renderSparkline({ lowCount: -1 });
-
-    expect(consoleWarn).toHaveBeenCalled();
-    consoleWarn.mockRestore();
+    const { validator } = SparklineBar.props.lowCount;
+    expect(validator(0)).toBe(true);
+    expect(validator(5)).toBe(true);
+    expect(validator(-1)).toBe(false);
   });
 });

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -213,7 +213,57 @@
               <h1>{{ learnersLabel$() }}</h1>
             </template>
             <template #[TABS.OBJECTIVES]>
-              <h1>{{ learningObjectivesLabel$() }}</h1>
+              <div class="learning-objectives-tab">
+                <AccordionContainer>
+                  <AccordionItem
+                    v-for="unit in allUnits"
+                    :key="unit.id"
+                    :title="unit.numberedTitle"
+                    :headerAppearanceOverrides="courseObjectiveheaderstyle"
+                    :contentAppearanceOverrides="{
+                      padding: '0',
+                    }"
+                  >
+                    <template #trailing-actions>
+                      <div
+                        class="pill"
+                        :style="{
+                          backgroundColor: getUnitMasteryColor(unit),
+                          borderColor: getUnitMasteryBorderColor(unit),
+                        }"
+                      >
+                        <KIcon
+                          :icon="isLowMastery(unit) ? 'error' : 'correct'"
+                          :color="isLowMastery(unit) ? $themePalette.red.v_600 : $themePalette.green.v_600"
+                          :style="{ width: '15px', height: '15px' }"
+                        />
+                        {{ getUnitMasteryLabel(unit) }}
+                      </div>
+                    </template>
+                    <template #content>
+                      <div
+                        v-for="objective in getUnitObjectives(unit)"
+                        :key="objective.id"
+                        class="objective-row"
+                      >
+                        <div class="objective-info">
+                          <KRouterLink
+                            :text="objective.title"
+                            :to="{}"
+                          />
+                        </div>
+                        <div class="objective-sparkline">
+                          <SparklineBar
+                            :lowCount="objective.lowCount"
+                            :midCount="objective.midCount"
+                            :highCount="objective.highCount"
+                          />
+                        </div>
+                      </div>
+                    </template>
+                  </AccordionItem>
+                </AccordionContainer>
+              </div>
             </template>
           </KTabsPanel>
         </section>
@@ -274,6 +324,7 @@
   import useCourseSession from '../../composables/useCourseSession';
   import useClassSummary from '../../composables/useClassSummary.js';
   import { UnitPhase } from '../../constants/courseConstants';
+  import SparklineBar from '../common/SparklineBar.vue';
 
   export default {
     name: 'CourseSummaryPage',
@@ -284,6 +335,7 @@
       CoachHeader,
       ElapsedTime,
       Recipients,
+      SparklineBar,
     },
     setup() {
       const {
@@ -312,6 +364,8 @@
         nOfMLearners$,
         activeUnit$,
         visibleToLearnersLabel$,
+        lowMasteryLabel$,
+        strongMasteryLabel$,
       } = coursesStrings;
 
       const { recipientsLabel$, sizeLabel$, numberOfResources$ } = coachStrings;
@@ -349,12 +403,81 @@
         closeTest,
         courseSession,
         toggleCourseActive,
+        units,
       } = useCourseSession(courseSessionId);
+      const allUnits = computed(() => units.value || []);
 
       const { getRecipientNamesForCourseSession } = useClassSummary();
 
       // UI-only state
       const activeModal = ref(null);
+      // TODO:  To be replace with real API data once learning objectives endpoint is available
+      function getUnitObjectives(unit) {
+        const index = units.value.findIndex(u => u.id === unit.id);
+        const seed = index + 1;
+
+       // TODO: To be replace with real API data once learning objectives endpoint is available
+        return [
+          {
+            id: `${unit.id}-obj-1`,
+            title: 'Test objectives1',
+            lowCount: seed * 2,
+            midCount: seed,
+            highCount: seed * 3,
+          },
+          {
+            id: `${unit.id}-obj-2`,
+            title: 'Test objectives2',
+            lowCount: seed * 5,
+            midCount: seed * 3,
+            highCount: seed * 7,
+          },
+          {
+            id: `${unit.id}-obj-3`,
+            title: 'Test objectives3',
+            lowCount: seed * 3,
+            midCount: seed * 2,
+            highCount: seed * 5,
+          },
+          {
+            id: `${unit.id}-obj-4`,
+            title: 'Overall coherence',
+            lowCount: seed * 4,
+            midCount: seed * 5,
+            highCount: seed * 9,
+          },
+        ];
+      }
+
+      // TODO:  To be Replace with mastery data  from the  API.
+      function isLowMastery(unit) {
+        const index = units.value.findIndex(u => u.id === unit.id);
+        return index % 2 === 0;
+      }
+
+      function getUnitMasteryLabel(unit) {
+        const index = units.value.findIndex(u => u.id === unit.id);
+        const seed = index + 1;
+        return isLowMastery(unit)
+          ? lowMasteryLabel$({ count: Math.round(4 / seed) })
+          : strongMasteryLabel$();
+      }
+
+      function getUnitMasteryColor(unit) {
+        return isLowMastery(unit) ? themePalette().red.v_100 : themePalette().green.v_100;
+      }
+
+      function getUnitMasteryBorderColor(unit) {
+        return isLowMastery(unit) ? themePalette().red.v_400 : themePalette().green.v_400;
+      }
+
+      const courseObjectiveheaderstyle = computed(() => {
+        return {
+          backgroundColor: themePalette().grey.v_100,
+          padding: '12px 16px',
+          fontWeight: 'bold',
+        };
+      });
 
       const TABS = { UNITS: 'units', LEARNERS: 'learners', OBJECTIVES: 'objectives' };
       const activeTabId = ref(TABS.UNITS);
@@ -560,6 +683,14 @@
         unitsPillStyles,
         statusPillStyles,
         onUnitButtonClick,
+        allUnits,
+        getUnitObjectives,
+        isLowMastery,
+        getUnitMasteryLabel,
+        getUnitMasteryColor,
+        getUnitMasteryBorderColor,
+        courseObjectiveheaderstyle,
+        learningObjectivesLabel$,
       };
     },
     watch: {
@@ -630,8 +761,14 @@
   }
 
   .pill {
-    display: inline-block;
-    padding: 4px 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    height: 22px;
+    padding: 2px 8px 2px 3px;
+    font-weight: 100;
+    font-size: 12px;
+    border: 0.75px solid;
     border-radius: 16px;
   }
 
@@ -674,6 +811,29 @@
 
   .status-icon {
     font-weight: bold;
+  }
+
+  .learning-objectives-tab {
+    padding: 0;
+  }
+
+  .objective-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px;
+    border-bottom: 1px;
+  }
+
+  .objective-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .objective-sparkline {
+    flex: 1;
+    max-width: 150px;
   }
 
 </style>

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -226,7 +226,7 @@
                   >
                     <template #trailing-actions>
                       <div
-                        class="pill"
+                        class="pill mastery-pill"
                         :style="{
                           backgroundColor: getUnitMasteryColor(unit),
                           borderColor: getUnitMasteryBorderColor(unit),
@@ -245,12 +245,11 @@
                         v-for="objective in getUnitObjectives(unit)"
                         :key="objective.id"
                         class="objective-row"
+                        :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
                       >
                         <div class="objective-info">
-                          <KRouterLink
-                            :text="objective.title"
-                            :to="{}"
-                          />
+                          <!-- TODO: Replace with KRouterLink once objective detail route is available -->
+                          <span>{{ objective.title }}</span>
                         </div>
                         <div class="objective-sparkline">
                           <SparklineBar
@@ -764,12 +763,15 @@
     display: inline-flex;
     align-items: center;
     gap: 3px;
+    border-radius: 16px;
+  }
+
+  .mastery-pill {
     height: 22px;
     padding: 2px 8px 2px 3px;
     font-weight: 100;
     font-size: 12px;
     border: 0.75px solid;
-    border-radius: 16px;
   }
 
   .unit-status {
@@ -823,7 +825,6 @@
     justify-content: space-between;
     gap: 16px;
     padding: 16px;
-    border-bottom: 1px;
   }
 
   .objective-info {

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -461,7 +461,7 @@
 
       function getUnitMasteryLabel(unit) {
         const index = units.value.findIndex(u => u.id === unit.id);
-        const seed = index + 1;
+        const seed = index + 8;
         return isLowMastery(unit)
           ? lowMasteryLabel$({ count: Math.round(4 / seed) })
           : strongMasteryLabel$();

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -226,7 +226,7 @@
                   >
                     <template #trailing-actions>
                       <div
-                        class="pill mastery-pill"
+                        class="mastery-pill pill"
                         :style="{
                           backgroundColor: getUnitMasteryColor(unit),
                           borderColor: getUnitMasteryBorderColor(unit),
@@ -234,7 +234,9 @@
                       >
                         <KIcon
                           :icon="isLowMastery(unit) ? 'error' : 'correct'"
-                          :color="isLowMastery(unit) ? $themePalette.red.v_600 : $themePalette.green.v_600"
+                          :color="
+                            isLowMastery(unit) ? $themePalette.red.v_600 : $themePalette.green.v_600
+                          "
                           :style="{ width: '15px', height: '15px' }"
                         />
                         {{ getUnitMasteryLabel(unit) }}
@@ -248,7 +250,7 @@
                         :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
                       >
                         <div class="objective-info">
-                          <!-- TODO: Replace with KRouterLink once objective detail route is available -->
+                          <!-- TODO: Replace with KRouterLink once detail route is available -->
                           <span>{{ objective.title }}</span>
                         </div>
                         <div class="objective-sparkline">
@@ -415,7 +417,7 @@
         const index = units.value.findIndex(u => u.id === unit.id);
         const seed = index + 1;
 
-       // TODO: To be replace with real API data once learning objectives endpoint is available
+        // TODO: To be replace with real API data once learning objectives endpoint is available
         return [
           {
             id: `${unit.id}-obj-1`,
@@ -760,8 +762,8 @@
 
   .pill {
     display: inline-flex;
-    align-items: center;
     gap: 3px;
+    align-items: center;
     padding: 4px 12px;
     border-radius: 16px;
   }
@@ -769,8 +771,8 @@
   .mastery-pill {
     height: 22px;
     padding: 2px 8px 2px 3px;
-    font-weight: 100;
     font-size: 12px;
+    font-weight: 100;
     border: 0.75px solid;
   }
 
@@ -821,9 +823,9 @@
 
   .objective-row {
     display: flex;
+    gap: 16px;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
     padding: 16px;
   }
 

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -689,7 +689,6 @@
         getUnitMasteryColor,
         getUnitMasteryBorderColor,
         courseObjectiveheaderstyle,
-        learningObjectivesLabel$,
       };
     },
     watch: {

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -762,6 +762,7 @@
     display: inline-flex;
     align-items: center;
     gap: 3px;
+    padding: 4px 12px;
     border-radius: 16px;
   }
 

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -250,8 +250,11 @@
                         :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
                       >
                         <div class="objective-info">
-                          <!-- TODO: Replace with KRouterLink once detail route is available -->
-                          <span>{{ objective.title }}</span>
+                          <!-- TODO:  To be replace :to="{}" once objective detail route is available -->
+                          <KRouterLink
+                            :text="objective.title"
+                            :to="{}"
+                          />
                         </div>
                         <div class="objective-sparkline">
                           <SparklineBar
@@ -422,7 +425,7 @@
           {
             id: `${unit.id}-obj-1`,
             title: 'Test objectives1',
-            lowCount: seed * 2,
+            lowCount: 0,
             midCount: seed,
             highCount: seed * 3,
           },

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -773,7 +773,7 @@
     padding: 2px 8px 2px 3px;
     font-size: 12px;
     font-weight: 100;
-    border: 0.75px solid;
+    border: 1px solid;
   }
 
   .unit-status {

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -250,7 +250,7 @@
                         :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
                       >
                         <div class="objective-info">
-                          <!-- TODO:  To be replace :to="{}" once objective detail route is available -->
+                          <!-- TODO: Replace :to with real route once detail route is available -->
                           <KRouterLink
                             :text="objective.title"
                             :to="{}"

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -342,4 +342,37 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Edit Recipients',
     context: 'Action label for editing which learners are assigned to a course.',
   },
+  sparklineDistributionLabel: {
+    message: '{lowCount, number} low, {midCount, number} medium, {highCount, number} high',
+    context:
+      'Visually hidden accessibility label for the sparkline bar, summarising the distribution of learners across low, medium, and high performance bands.',
+  },
+  lowMasteryLabel: {
+    message: 'Low mastery ({count, number})',
+    context: 'Label shown on a unit accordion header when the unit has low average mastery',
+  },
+  strongMasteryLabel: {
+    message: 'Strong mastery',
+    context: 'Label shown on a unit accordion header when the unit has strong average mastery',
+  },
+  learnersByMasteryLabel: {
+    message: 'Learners by mastery',
+    context: 'Tooltip title for the sparkline bar showing learner distribution by mastery level',
+  },
+  lowCountLabel: {
+    message: '{count, number} low',
+    context: 'Tooltip row showing the number of learners with low mastery',
+  },
+  partialCountLabel: {
+    message: '{count, number} partial',
+    context: 'Tooltip row showing the number of learners with partial mastery',
+  },
+  strongCountLabel: {
+    message: '{count, number} strong',
+    context: 'Tooltip row showing the number of learners with strong mastery',
+  },
+  clickToViewDetailsLabel: {
+    message: 'Click to view details',
+    context: 'Tooltip prompt inviting the user to click the sparkline bar for more detail',
+  },
 });


### PR DESCRIPTION


## Summary
This PR adds a SparklineBar component to the coach plugin that renders a horizontal stacked bar visualising the distribution of learner scores across low, medium, and high ranges for a learning objective. 
closes https://github.com/learningequality/kolibri/issues/14166


https://github.com/user-attachments/assets/511330f1-fab8-4541-8ca7-00540ee0f524


## References
 https://github.com/learningequality/kolibri/issues/14166
## Reviewer guidance

1. Navigate to Course >> Learning Objectives tab to see the sparkline bars and mastery pills
2. Hover a sparkline bar to verify the tooltip


## AI usage
I used Codex to plan my work around here. When I caught a bug where mastery icon/color logic checked includes('Low') on a translated string, I prompted/ directed them to fix it to use proper isLowMastery(unit), Tooltip layout, segment color choices, and accessibility structure were directed by me based on the a11y requirements listed on the issue 