### PR TITLE
Remove stale Python 2.7 references from comments and docstrings

### DIFF
--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -21,8 +21,6 @@ sandbox_injection = '<script type="text/javascript">{}</script>'.format(
 empty_content = "<html><head>{}</head><body></body></html>".format(sandbox_injection)
 
 # datetime.datetime(2016, 9, 10, 19, 14, 7) in time from EPOCH
-# do this to avoid having to backport `timestamp` method of datetime
-# to Python 2.7
 caching_http_date = http_date(1473560047.0)
 
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -316,8 +316,6 @@ def cache_option(value):
 class LazyImportFunction(object):
     """
     A function wrapper that will import a module when called.
-    We may be able to drop this when Python 2.7 support is dropped
-    and use Python LazyLoader module machinery instead.
     """
 
     def __init__(self, module_name):


### PR DESCRIPTION
## Summary
Removes outdated references to Python 2.7 from comments and docstrings.
Changes:
- Updated `LazyImportFunction` docstring in `kolibri/utils/options.py`
- Removed Python 2.7 backport comment from `kolibri/core/content/test/test_zipcontent.py`
No functional changes.

## References
Closes #14339

## Reviewer guidance
Changes are limited to comments and docstrings only. No code behavior was modified.