### PR TITLE
Fix UnboundLocalError in ClassroomNotificationsViewset.list when filter_queryset raises DatabaseError

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -194,8 +194,9 @@ class ClassroomNotificationsViewset(ValuesViewset):
         try:
             queryset = self.filter_queryset(self.get_queryset())
         except (OperationalError, DatabaseError):
-            repair_sqlite_db(connections[NOTIFICATIONS])
-            queryset = self.get_queryset().none()
+            if NOTIFICATIONS in connections:
+                repair_sqlite_db(connections[NOTIFICATIONS])
+            queryset = LearnerProgressNotification.objects.none()
 
         # L
         logging_interval = datetime.datetime.now() - datetime.timedelta(minutes=5)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -195,6 +195,7 @@ class ClassroomNotificationsViewset(ValuesViewset):
             queryset = self.filter_queryset(self.get_queryset())
         except (OperationalError, DatabaseError):
             repair_sqlite_db(connections[NOTIFICATIONS])
+            queryset = self.get_queryset().none()
 
         # L
         logging_interval = datetime.datetime.now() - datetime.timedelta(minutes=5)

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -104,3 +104,22 @@ class ClassroomNotificationsTestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+
+    def test_database_error_does_not_crash(self):
+        from unittest.mock import patch
+        from django.db.utils import DatabaseError
+
+        self.client.login(
+            username=self.classroom_coach.username, password=DUMMY_PASSWORD
+        )
+
+        with patch(
+            "kolibri.plugins.coach.api.ClassroomNotificationsViewset.filter_queryset",
+            side_effect=DatabaseError,
+        ):
+            response = self.client.get(
+                reverse(self.list_name), {"classroom_id": self.classroom.id}
+            )
+
+        self.assertEqual(response.status_code, 200)

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -1,10 +1,12 @@
 from django.urls import reverse
+from django.db.utils import DatabaseError
 from rest_framework.test import APITestCase
-
+from unittest.mock import patch
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.test.helpers import provision_device
+
 
 DUMMY_PASSWORD = "password"
 
@@ -107,9 +109,6 @@ class ClassroomNotificationsTestCase(APITestCase):
 
 
     def test_database_error_does_not_crash(self):
-        from unittest.mock import patch
-        from django.db.utils import DatabaseError
-
         self.client.login(
             username=self.classroom_coach.username, password=DUMMY_PASSWORD
         )

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -1,7 +1,9 @@
-from django.urls import reverse
-from django.db.utils import DatabaseError
-from rest_framework.test import APITestCase
 from unittest.mock import patch
+
+from django.db.utils import DatabaseError
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
@@ -106,7 +108,6 @@ class ClassroomNotificationsTestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-
 
     def test_database_error_does_not_crash(self):
         self.client.login(


### PR DESCRIPTION


## Summary
This PR fixes an issue in `ClassroomNotificationsViewset.list` where `queryset` can be referenced before it was assigned.
If `filter_queryset()` raises a `DatabaseError` or `OperationalError`,`repair_sqlite_db()` is triggered, but `queryset` is not reassigned before it is used later in the method, which results in an error :
                                    `UnboundLocalError: local variable 'queryset' referenced before assignment`
This change ensures that `queryset` is always defined by assigning an empty queryset after the database repair:
                     queryset = self.get_queryset().none()

With this fix, the `/coach/api/notifications/` endpoint no longer crashes
with a 500 error and instead returns a valid response.



## References
Fixes #14322



## Reviewer guidance
1. Start Kolibri locally from source.
2. Simulate a `DatabaseError` inside `filter_queryset()`.
3. Navigate to the Coach page.
4. Verify that the `/coach/api/notifications/` endpoint no longer raises
   `UnboundLocalError`.
5. Confirm that the endpoint returns a valid response instead of a 500 error.



