### PR TITLE
Import descendants metadata

### DIFF
--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -16,7 +16,7 @@ from kolibri.core.utils.pagination import ValuesViewsetCursorPagination
 
 
 class OptionalPagination(ValuesViewsetCursorPagination):
-    ordering = ("lft", "id")
+    ordering = ("lft",)
     page_size_query_param = "max_results"
 
 

--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -2,9 +2,8 @@ from uuid import UUID
 
 from django.db import connection
 from django.db.models import Q
-from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
-from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 from rest_framework.viewsets import GenericViewSet
@@ -13,10 +12,17 @@ from kolibri.core.content import models
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
 from kolibri.core.content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION
 from kolibri.core.content.utils.sqlalchemybridge import BASES
+from kolibri.core.utils.pagination import ValuesViewsetCursorPagination
+
+
+class OptionalPagination(ValuesViewsetCursorPagination):
+    ordering = ("lft", "id")
+    page_size_query_param = "max_results"
 
 
 class ImportMetadataViewset(GenericViewSet):
     queryset = models.ContentNode.objects.all()
+    pagination_class = OptionalPagination
 
     def get_serializer_class(self):
         """
@@ -43,50 +49,50 @@ class ImportMetadataViewset(GenericViewSet):
             )
         return error
 
-    def retrieve(self, request, pk=None):
-        """
-        An endpoint to retrieve all content metadata required for importing a content node
-        all of its ancestors, and any relevant needed metadata.
+    def _validate_depth(self, depth):
+        if depth is not None:
+            try:
+                depth = int(depth)
+                if depth < 0:
+                    raise ValueError
+            except ValueError:
+                raise ValidationError(
+                    {"error": "Depth parameter must be a non-negative integer."}
+                )
+        return depth
 
-        :param request: request object
-        :param pk: id parent node
-        :return: an object with keys for each content metadata table and a schema_version key
-        """
-        try:
-            UUID(pk)
-        except ValueError:
-            return Response(
-                {"error": "Invalid UUID format."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        content_schema = request.query_params.get(
-            "schema_version", self.default_content_schema
-        )
-
+    def _validate_content_schema(self, content_schema):
         try:
             if int(content_schema) > int(self.default_content_schema):
-                return HttpResponseBadRequest(self._error_message(False))
+                raise ValidationError(self._error_message(False))
             if int(content_schema) < int(self.min_content_schema):
-                return HttpResponseBadRequest(self._error_message(True))
-            base = BASES[content_schema]
+                raise ValidationError(self._error_message(True))
         except ValueError:
-            return HttpResponseBadRequest(
+            raise ValidationError(
                 "Schema version is not parseable by this version of Kolibri"
             )
         except AttributeError:
-            return HttpResponseBadRequest(
+            raise ValidationError(
                 "Schema version is not known by this version of Kolibri"
             )
+        return content_schema
 
-        # Get the model for the target node here - we do this so that we trigger a 404 immediately if the node
-        # does not exist.
+    def _get_retrieve_queryset(self):
+        pk = self.kwargs.get("pk")
+        depth = self.request.query_params.get("depth", None)
         node = get_object_or_404(models.ContentNode.objects.all(), pk=pk)
+        if depth is not None:
+            depth = self._validate_depth(depth)
+            queryset = node.get_descendants(include_self=True).filter(
+                level__lte=node.level + depth
+            )
+        else:
+            queryset = node.get_ancestors(include_self=True)
 
-        nodes = node.get_ancestors(include_self=True)
+        return queryset, node
 
+    def _serialize(self, nodes, node, content_schema):
         data = {}
-
         files = models.File.objects.filter(contentnode__in=nodes)
         through_tags = models.ContentNode.tags.through.objects.filter(
             contentnode__in=nodes
@@ -112,6 +118,8 @@ class ImportMetadataViewset(GenericViewSet):
         channel_metadata = models.ChannelMetadata.objects.filter(id=node.channel_id)
 
         cursor = connection.cursor()
+
+        base = BASES[content_schema]
 
         for qs in [
             nodes,
@@ -151,4 +159,33 @@ class ImportMetadataViewset(GenericViewSet):
 
         data["schema_version"] = content_schema
 
-        return Response(data)
+        return data
+
+    def retrieve(self, request, pk=None):
+        """
+        An endpoint to retrieve all content metadata required for importing a content node
+        all of its ancestors, and any relevant needed metadata.
+
+        :param request: request object
+        :param pk: id parent node
+        :return: an object with keys for each content metadata table and a schema_version key
+        """
+        try:
+            UUID(pk)
+        except ValueError:
+            raise ValidationError({"error": "Invalid UUID format."})
+
+        content_schema = request.query_params.get(
+            "schema_version", self.default_content_schema
+        )
+        self._validate_content_schema(content_schema)
+
+        queryset, node = self._get_retrieve_queryset()
+
+        page_queryset = self.paginate_queryset(queryset)
+
+        if page_queryset is not None:
+            data = self._serialize(page_queryset, node, content_schema)
+            return self.get_paginated_response(data)
+
+        return Response(self._serialize(queryset, node, content_schema))

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -120,3 +120,75 @@ class ImportMetadataTestCase(APITestCase):
             + "?schema_version={}".format(CONTENT_SCHEMA_VERSION)
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_import_metadata_with_depth_zero(self):
+        """Test that depth=0 returns only the node itself."""
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=0"
+        )
+        self.assertEqual(response.status_code, 200)
+        # With depth=0, should return only the root node itself
+        nodes_data = response.data[content.ContentNode._meta.db_table]
+        self.assertEqual(len(nodes_data), 1)
+        self.assertEqual(nodes_data[0]["id"], self.root.id)
+
+    def test_import_metadata_with_depth(self):
+        """Test that depth parameter returns descendants instead of ancestors."""
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=1"
+        )
+        self.assertEqual(response.status_code, 200)
+        # With depth=1, should return the root and its direct children
+        expected_nodes = self.root.get_descendants(include_self=True).filter(
+            level__lte=self.root.level + 1
+        )
+        nodes_data = response.data[content.ContentNode._meta.db_table]
+        self.assertEqual(len(nodes_data), expected_nodes.count())
+
+    def test_import_metadata_with_depth_negative(self):
+        """Test that negative depth returns 400."""
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=-1"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"], "Depth parameter must be a non-negative integer."
+        )
+
+    def test_import_metadata_with_depth_invalid(self):
+        """Test that non-integer depth returns 400."""
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=abc"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"], "Depth parameter must be a non-negative integer."
+        )
+
+    def test_import_metadata_with_pagination(self):
+        """Test that max_results enables pagination."""
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=10&max_results=2"
+        )
+        self.assertEqual(response.status_code, 200)
+        # Paginated response should have 'more' and 'results' keys
+        self.assertIn("more", response.data)
+        self.assertIn("results", response.data)
+        # Results should contain the content node table data
+        self.assertIn(content.ContentNode._meta.db_table, response.data["results"])
+
+    def test_import_metadata_pagination_respects_max_results(self):
+        """Test that pagination returns correct number of nodes."""
+        max_results = 2
+        response = self.client.get(
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
+            + "?depth=10&max_results={}".format(max_results)
+        )
+        self.assertEqual(response.status_code, 200)
+        nodes_data = response.data["results"][content.ContentNode._meta.db_table]
+        self.assertLessEqual(len(nodes_data), max_results)

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -6,24 +6,33 @@ from functools import partial
 import mock
 from django.test import TestCase
 from django.utils import timezone
+from le_utils.constants import modalities
 from morango.models.core import SyncSession
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import ContentRemovalRequest
 from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import File
+from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
+from kolibri.core.content.utils.content_request import _get_descendants_import_metadata
+from kolibri.core.content.utils.content_request import _get_import_metadata
+from kolibri.core.content.utils.content_request import _import_descendants_depth
+from kolibri.core.content.utils.content_request import _merge_import_metadata
 from kolibri.core.content.utils.content_request import _process_content_requests
 from kolibri.core.content.utils.content_request import _process_download
 from kolibri.core.content.utils.content_request import _total_size
 from kolibri.core.content.utils.content_request import completed_downloads_queryset
+from kolibri.core.content.utils.content_request import COURSES_DESCENDANTS_DEPTH
 from kolibri.core.content.utils.content_request import incomplete_downloads_queryset
 from kolibri.core.content.utils.content_request import incomplete_removals_queryset
 from kolibri.core.content.utils.content_request import InsufficientStorage
+from kolibri.core.content.utils.content_request import MAX_NODES_PER_REQUEST
 from kolibri.core.content.utils.content_request import PreferredDevices
 from kolibri.core.content.utils.content_request import PreferredDevicesWithClient
 from kolibri.core.content.utils.content_request import process_content_removal_requests
@@ -34,6 +43,7 @@ from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.errors import NetworkError
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 
 
@@ -1137,3 +1147,389 @@ class ProcessDownloadRequestTestCase(BaseQuerysetTestCase):
         )
         mock_import_manager.return_value.run.assert_called_once()
         self.assertTrue(result)
+
+
+class MergeImportMetadataTestCase(TestCase):
+    """Tests for _merge_import_metadata function"""
+
+    def test_merge_empty_list(self):
+        result = _merge_import_metadata([])
+        self.assertEqual(result, {})
+
+    def test_merge_single_metadata(self):
+        metadata = {
+            ContentNode._meta.db_table: [{"id": "node1"}],
+            File._meta.db_table: [{"id": "file1"}],
+            "schema_version": "5",
+        }
+        result = _merge_import_metadata([metadata])
+        self.assertEqual(result[ContentNode._meta.db_table], [{"id": "node1"}])
+        self.assertEqual(result[File._meta.db_table], [{"id": "file1"}])
+        self.assertEqual(result["schema_version"], "5")
+
+    def test_merge_multiple_metadata(self):
+        metadata1 = {
+            ContentNode._meta.db_table: [{"id": "node1"}],
+            File._meta.db_table: [{"id": "file1"}],
+            "schema_version": "5",
+        }
+        metadata2 = {
+            ContentNode._meta.db_table: [{"id": "node2"}, {"id": "node3"}],
+            File._meta.db_table: [{"id": "file2"}],
+            "schema_version": "5",
+        }
+        result = _merge_import_metadata([metadata1, metadata2])
+        self.assertEqual(len(result[ContentNode._meta.db_table]), 3)
+        self.assertEqual(len(result[File._meta.db_table]), 2)
+
+    def test_merge_ignores_non_dict(self):
+        metadata1 = {ContentNode._meta.db_table: [{"id": "node1"}]}
+        result = _merge_import_metadata([metadata1, None, "invalid"])
+        self.assertEqual(result[ContentNode._meta.db_table], [{"id": "node1"}])
+
+    def test_merge_preserves_simple_fields(self):
+        metadata1 = {"schema_version": "5", "some_bool": True, "some_int": 42}
+        metadata2 = {"schema_version": "5", "some_bool": False, "some_int": 100}
+        result = _merge_import_metadata([metadata1, metadata2])
+        # First value should be preserved for simple fields
+        self.assertEqual(result["schema_version"], "5")
+        self.assertEqual(result["some_bool"], True)
+        self.assertEqual(result["some_int"], 42)
+
+
+class ImportDescendantsDepthTestCase(TestCase):
+    """Tests for _import_descendants_depth function"""
+
+    def test_non_course_node_returns_zero(self):
+        import_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": "node1", "options": "{}"},
+            ]
+        }
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, 0)
+
+    def test_course_node_returns_depth(self):
+        options = '{"modality": "' + modalities.COURSE + '"}'
+        import_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": "node1", "options": options},
+            ]
+        }
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, COURSES_DESCENDANTS_DEPTH)
+
+    def test_node_not_found_returns_zero(self):
+        options = '{"modality": "' + modalities.COURSE + '"}'
+        import_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": "other_node", "options": options},
+            ]
+        }
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, 0)
+
+    def test_invalid_options_json_returns_zero(self):
+        import_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": "node1", "options": "invalid json"},
+            ]
+        }
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, 0)
+
+    def test_empty_metadata_returns_zero(self):
+        import_metadata = {ContentNode._meta.db_table: []}
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, 0)
+
+    def test_missing_options_returns_zero(self):
+        import_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": "node1"},
+            ]
+        }
+        result = _import_descendants_depth(import_metadata, "node1")
+        self.assertEqual(result, 0)
+
+
+@mock.patch(_module + "reverse_path")
+class GetDescendantsImportMetadataTestCase(TestCase):
+    """Tests for _get_descendants_import_metadata function"""
+
+    def setUp(self):
+        self.mock_client = mock.MagicMock()
+        self.contentnode_id = uuid.uuid4().hex
+
+    def test_single_page_response(self, mock_reverse_path):
+        """Test when response has no pagination (no 'more' key)"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        response_data = {
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child1"}],
+                File._meta.db_table: [{"id": "file1"}],
+                "schema_version": "5",
+            }
+        }
+        self.mock_client.get.return_value.json.return_value = response_data
+
+        result = _get_descendants_import_metadata(
+            self.mock_client, self.contentnode_id, depth=1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][ContentNode._meta.db_table], [{"id": "child1"}])
+        self.mock_client.get.assert_called_once()
+
+    def test_paginated_response(self, mock_reverse_path):
+        """Test when response has multiple pages with 'more' cursor"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        page1_response = {
+            "more": {
+                "schema_version": "5",
+                "depth": "1",
+                "max_results": "1",
+                "cursor": "cD00MQ==",
+            },
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child1"}],
+                "schema_version": "5",
+            },
+        }
+        page2_response = {
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child2"}],
+                "schema_version": "5",
+            }
+        }
+        self.mock_client.get.return_value.json.side_effect = [
+            page1_response,
+            page2_response,
+        ]
+
+        result = _get_descendants_import_metadata(
+            self.mock_client, self.contentnode_id, depth=1
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][ContentNode._meta.db_table], [{"id": "child1"}])
+        self.assertEqual(result[1][ContentNode._meta.db_table], [{"id": "child2"}])
+        self.assertEqual(self.mock_client.get.call_count, 2)
+
+    def test_500_error_raises(self, mock_reverse_path):
+        """Test that 500 errors are re-raised"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 500
+        error = NetworkLocationResponseFailure(response=mock_response)
+        self.mock_client.get.side_effect = error
+
+        with self.assertRaises(NetworkLocationResponseFailure):
+            _get_descendants_import_metadata(
+                self.mock_client, self.contentnode_id, depth=1
+            )
+
+    def test_initial_request_has_depth_and_max_results(self, mock_reverse_path):
+        """Test that the initial request includes depth and max_results params"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        response_data = {
+            "results": {
+                ContentNode._meta.db_table: [],
+                "schema_version": "5",
+            }
+        }
+        self.mock_client.get.return_value.json.return_value = response_data
+
+        _get_descendants_import_metadata(
+            self.mock_client, self.contentnode_id, depth=COURSES_DESCENDANTS_DEPTH
+        )
+
+        call_args = self.mock_client.get.call_args[0][0]
+        self.assertIn("depth={}".format(COURSES_DESCENDANTS_DEPTH), call_args)
+        self.assertIn("max_results={}".format(MAX_NODES_PER_REQUEST), call_args)
+
+    def test_empty_results(self, mock_reverse_path):
+        """Test handling of empty results"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        response_data = {"results": {}}
+        self.mock_client.get.return_value.json.return_value = response_data
+
+        result = _get_descendants_import_metadata(
+            self.mock_client, self.contentnode_id, depth=1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], {})
+
+    def test_subsequent_requests_use_cursor(self, mock_reverse_path):
+        """Test that subsequent requests use the cursor from 'more'"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        page1_response = {
+            "more": {
+                "schema_version": "5",
+                "depth": "1",
+                "max_results": "10",
+                "cursor": "cD00MQ==",
+            },
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child1"}],
+            },
+        }
+        page2_response = {
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child2"}],
+            }
+        }
+        self.mock_client.get.return_value.json.side_effect = [
+            page1_response,
+            page2_response,
+        ]
+
+        _get_descendants_import_metadata(self.mock_client, self.contentnode_id, depth=1)
+
+        # Check second call uses cursor params
+        second_call_url = self.mock_client.get.call_args_list[1][0][0]
+        self.assertIn("cursor=cD00MQ%3D%3D", second_call_url)
+
+
+class GetImportMetadataTestCase(TestCase):
+    """Tests for _get_import_metadata function"""
+
+    def setUp(self):
+        self.mock_client = mock.MagicMock()
+        self.contentnode_id = uuid.uuid4().hex
+
+    def _create_basic_metadata(self, contentnode_id, options="{}"):
+        return {
+            ContentNode._meta.db_table: [
+                {
+                    "id": contentnode_id,
+                    "title": "Test Node",
+                    "options": options,
+                }
+            ],
+            File._meta.db_table: [{"id": "file1"}],
+            LocalFile._meta.db_table: [{"id": "localfile1"}],
+            ChannelMetadata._meta.db_table: [{"id": "channel1"}],
+            "schema_version": "5",
+        }
+
+    def test_basic_metadata_retrieval(self):
+        """Test basic metadata retrieval without descendants"""
+        metadata = self._create_basic_metadata(self.contentnode_id)
+        self.mock_client.get.return_value.json.return_value = metadata
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        self.assertEqual(result, metadata)
+        self.mock_client.get.assert_called_once()
+
+    @mock.patch(_module + "_get_descendants_import_metadata")
+    def test_course_node_fetches_descendants(self, mock_get_descendants):
+        """Test that COURSE nodes trigger descendants fetching"""
+        options = '{"modality": "' + modalities.COURSE + '"}'
+        metadata = self._create_basic_metadata(self.contentnode_id, options=options)
+        descendants_metadata = {
+            ContentNode._meta.db_table: [{"id": "child1"}, {"id": "child2"}],
+            File._meta.db_table: [{"id": "child_file1"}],
+        }
+        self.mock_client.get.return_value.json.return_value = metadata
+        mock_get_descendants.return_value = [descendants_metadata]
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        mock_get_descendants.assert_called_once_with(
+            self.mock_client, self.contentnode_id, COURSES_DESCENDANTS_DEPTH
+        )
+        # Check merged results
+        self.assertEqual(len(result[ContentNode._meta.db_table]), 3)
+        self.assertEqual(len(result[File._meta.db_table]), 2)
+
+    @mock.patch(_module + "_get_descendants_import_metadata")
+    def test_non_course_node_does_not_fetch_descendants(self, mock_get_descendants):
+        """Test that non-COURSE nodes don't trigger descendants fetching"""
+        metadata = self._create_basic_metadata(self.contentnode_id)
+        self.mock_client.get.return_value.json.return_value = metadata
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        mock_get_descendants.assert_not_called()
+        self.assertEqual(result, metadata)
+
+    def test_404_returns_none(self):
+        """Test that 404 errors return None"""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        error = NetworkLocationResponseFailure(response=mock_response)
+        self.mock_client.get.side_effect = error
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        self.assertIsNone(result)
+
+    def test_400_returns_none(self):
+        """Test that 400 errors return None"""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 400
+        error = NetworkLocationResponseFailure(response=mock_response)
+        self.mock_client.get.side_effect = error
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        self.assertIsNone(result)
+
+    def test_500_error_raises(self):
+        """Test that 500 errors are re-raised"""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 500
+        error = NetworkLocationResponseFailure(response=mock_response)
+        self.mock_client.get.side_effect = error
+
+        with self.assertRaises(NetworkLocationResponseFailure):
+            _get_import_metadata(self.mock_client, self.contentnode_id)
+
+    @mock.patch(_module + "_get_descendants_import_metadata")
+    def test_merges_ancestor_and_descendant_metadata(self, mock_get_descendants):
+        """Test that ancestor and descendant metadata are properly merged"""
+        options = '{"modality": "' + modalities.COURSE + '"}'
+        ancestor_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": self.contentnode_id, "options": options},
+                {"id": "parent1"},
+            ],
+            File._meta.db_table: [{"id": "ancestor_file"}],
+            Language._meta.db_table: [{"id": "en"}],
+            "schema_version": "5",
+        }
+        page1_descendants = {
+            ContentNode._meta.db_table: [{"id": "child1"}],
+            File._meta.db_table: [{"id": "child_file1"}],
+        }
+        page2_descendants = {
+            ContentNode._meta.db_table: [{"id": "child2"}],
+            File._meta.db_table: [{"id": "child_file2"}],
+        }
+        self.mock_client.get.return_value.json.return_value = ancestor_metadata
+        mock_get_descendants.return_value = [page1_descendants, page2_descendants]
+
+        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+
+        # Should have: ancestor node + parent + child1 + child2 = 4 nodes
+        self.assertEqual(len(result[ContentNode._meta.db_table]), 4)
+        # Should have: ancestor_file + child_file1 + child_file2 = 3 files
+        self.assertEqual(len(result[File._meta.db_table]), 3)
+        # Language should be preserved
+        self.assertEqual(result[Language._meta.db_table], [{"id": "en"}])
+        self.assertEqual(result["schema_version"], "5")

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from functools import partial
 
 import mock
+from django.test import LiveServerTestCase
 from django.test import TestCase
 from django.utils import timezone
 from le_utils.constants import modalities
@@ -20,6 +21,7 @@ from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
+from kolibri.core.content.test.helpers import ChannelBuilder
 from kolibri.core.content.utils.content_request import _get_descendants_import_metadata
 from kolibri.core.content.utils.content_request import _get_import_metadata
 from kolibri.core.content.utils.content_request import _import_descendants_depth
@@ -42,6 +44,7 @@ from kolibri.core.content.utils.content_request import synchronize_content_reque
 from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
+from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkError
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
@@ -1533,3 +1536,90 @@ class GetImportMetadataTestCase(TestCase):
         # Language should be preserved
         self.assertEqual(result[Language._meta.db_table], [{"id": "en"}])
         self.assertEqual(result["schema_version"], "5")
+
+
+class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
+    """
+    Integration tests for _get_import_metadata against a live server.
+
+    Unlike the unit tests in GetDescendantsImportMetadataTestCase and
+    GetImportMetadataTestCase, these tests use a real NetworkClient making
+    actual HTTP requests to a live Django server, verifying the end-to-end
+    data flow including the correct format of data returned by the endpoint.
+
+    Two cases are covered:
+    - Non-course node: only ancestor metadata is returned
+    - Course node: ancestors are merged with paginated descendant metadata
+    """
+
+    databases = "__all__"
+
+    def setUp(self):
+        self.builder = ChannelBuilder()
+        self.builder.insert_into_default_db()
+        self.root = ContentNode.objects.get(id=self.builder.root_node["id"])
+        self.network_client = NetworkClient(self.live_server_url)
+
+    def tearDown(self):
+        self.network_client.close()
+
+    def test_non_course_node_returns_ancestor_metadata_only(self):
+        """
+        A non-course node returns the metadata for itself and its ancestors,
+        without fetching any descendants.
+        """
+        # Use a level-1 topic node that has both ancestors (root) and many descendants
+        topic_node = ContentNode.objects.filter(
+            channel_id=self.root.channel_id,
+            level=1,
+        ).first()
+
+        result = _get_import_metadata(self.network_client, topic_node.id)
+
+        self.assertIsNotNone(result)
+        returned_node_ids = {n["id"] for n in result[ContentNode._meta.db_table]}
+
+        # Should contain the topic node and its ancestors (root) only
+        expected_ancestor_ids = set(
+            topic_node.get_ancestors(include_self=True).values_list("id", flat=True)
+        )
+        self.assertEqual(returned_node_ids, expected_ancestor_ids)
+
+        # No descendants should be included
+        descendant_ids = set(topic_node.get_descendants().values_list("id", flat=True))
+        self.assertTrue(returned_node_ids.isdisjoint(descendant_ids))
+
+    def test_course_node_returns_merged_ancestor_and_descendant_metadata(self):
+        """
+        A course node triggers paginated descendant fetching via
+        _get_descendants_import_metadata. The final result contains nodes from
+        the ancestors call merged with all descendants up to
+        COURSES_DESCENDANTS_DEPTH levels deep.
+
+        The default ChannelBuilder tree has enough nodes to exceed
+        MAX_NODES_PER_REQUEST, so this exercises the pagination code path
+        end-to-end against a real server.
+        """
+        # Use a level-1 topic node that has both ancestors (root) and many descendants
+        topic_node = ContentNode.objects.filter(
+            channel_id=self.root.channel_id,
+            level=1,
+        ).first()
+        topic_node.options = {"modality": modalities.COURSE}
+        topic_node.save()
+
+        result = _get_import_metadata(self.network_client, topic_node.id)
+
+        self.assertIsNotNone(result)
+        returned_node_ids = {n["id"] for n in result[ContentNode._meta.db_table]}
+
+        expected_ancestor_ids = set(
+            topic_node.get_ancestors(include_self=True).values_list("id", flat=True)
+        )
+        expected_descendant_ids = set(
+            topic_node.get_descendants(include_self=True)
+            .filter(level__lte=topic_node.level + COURSES_DESCENDANTS_DEPTH)
+            .values_list("id", flat=True)
+        )
+        expected_node_ids = expected_ancestor_ids.union(expected_descendant_ids)
+        self.assertEqual(returned_node_ids, expected_node_ids)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import uuid
 from itertools import chain
+from urllib.parse import urlencode
 
 from django.db.models import BigIntegerField
 from django.db.models import BooleanField
@@ -15,6 +17,7 @@ from django.db.models import Value
 from django.db.models import When
 from django.db.models.expressions import CombinedExpression
 from django.db.models.functions import Coalesce
+from le_utils.constants import modalities
 from morango.models.core import SyncSession
 
 from kolibri.core.auth.models import Facility
@@ -508,6 +511,123 @@ def process_content_requests():
         logger.warning(str(e))
 
 
+def _merge_import_metadata(metadata_list):
+    """
+    import_metadata is a dictionary with keys for each model being imported,
+    and values that are lists of metadata for each instance of that model. This
+    function concatenates the lists for each model across multiple import_metadata dictionaries,
+    and return a single import_metadata with all lists concatenated.
+
+    :type metadata_list: list[dict]
+    :rtype: dict
+    """
+    merged_metadata = {}
+
+    for metadata in metadata_list:
+        if type(metadata) is not dict:
+            continue
+
+        for model_name, model_data in metadata.items():
+            if type(model_data) is list:
+                if model_name not in merged_metadata:
+                    merged_metadata[model_name] = []
+                merged_metadata[model_name].extend(model_data)
+
+            elif isinstance(model_data, (str, int, bool)):
+                # for simple fields, we can just take the first one we see, since they should all be the same
+                if model_name not in merged_metadata:
+                    merged_metadata[model_name] = model_data
+
+    return merged_metadata
+
+
+MAX_NODES_PER_REQUEST = 10
+COURSES_DESCENDANTS_DEPTH = 3
+
+
+def _get_descendants_import_metadata(client, contentnode_id, depth):
+    """
+    :type client: NetworkClient
+    :type contentnode_id: str
+    :type depth: int
+    :rtype: list[dict]
+    """
+    has_more = True
+    more = None
+    metadata_list = []
+
+    while has_more:
+        url_path = reverse_path(
+            "kolibri:core:importmetadata-detail",
+            kwargs={"pk": contentnode_id},
+        )
+        if more:
+            url_path += "?" + urlencode(more)
+        else:
+            url_path += "?" + urlencode(
+                {
+                    "depth": depth,
+                    "max_results": MAX_NODES_PER_REQUEST,
+                }
+            )
+
+        try:
+            response = client.get(url_path)
+            json_response = response.json()
+            import_metadata = json_response.get("results", {})
+            metadata_list.append(import_metadata)
+
+            more = json_response.get("more", None)
+            has_more = more is not None
+
+        except NetworkLocationResponseFailure as e:
+            # 400 level errors, like 404, are ignored
+            if e.response is not None and 400 <= e.response.status_code < 500:
+                logger.debug(
+                    "Metadata request failure: GET {} {}".format(
+                        url_path, e.response.status_code
+                    )
+                )
+                break
+            raise e
+
+    return metadata_list
+
+
+def _import_descendants_depth(import_metadata, contentnode_id):
+    """
+    Determines whether we should import the descendants of the content node being imported,
+    based on the import metadata.
+
+    :param import_metadata: The metadata result from the import metadata request for the
+                            content node
+    :type import_metadata: dict
+    :param contentnode_id: The ID of the content node being imported
+    :type contentnode_id: str
+    :return: A number representing the depth of the content node being imported, if 0
+            it means we should not import descendants
+    """
+    contentnodes_metadata = import_metadata.get(ContentNode._meta.db_table, [])
+
+    node_being_imported = next(
+        (
+            node_metadata
+            for node_metadata in contentnodes_metadata
+            if node_metadata["id"] == contentnode_id
+        ),
+        None,
+    )
+
+    try:
+        options_str = node_being_imported.get("options", "{}")
+        options = json.loads(options_str)
+        if options.get("modality") == modalities.COURSE:
+            return COURSES_DESCENDANTS_DEPTH
+        return 0
+    except (json.JSONDecodeError, AttributeError):
+        return 0
+
+
 def _get_import_metadata(client, contentnode_id):
     """
     :type client: NetworkClient
@@ -519,7 +639,21 @@ def _get_import_metadata(client, contentnode_id):
     )
     try:
         response = client.get(url_path)
-        return response.json()
+        import_metadata = response.json()
+
+        # Should we import contentnode's descendants? How far down the tree should we go?
+        descendants_depth_to_import = _import_descendants_depth(
+            import_metadata, contentnode_id
+        )
+        if descendants_depth_to_import > 0:
+            descendants_import_metadata = _get_descendants_import_metadata(
+                client, contentnode_id, descendants_depth_to_import
+            )
+            return _merge_import_metadata(
+                [import_metadata, *descendants_import_metadata]
+            )
+        else:
+            return import_metadata
     except NetworkLocationResponseFailure as e:
         # 400 level errors, like 404, are ignored
         if e.response is not None and 400 <= e.response.status_code < 500:


### PR DESCRIPTION
## Summary
- Adds cursor-based pagination to `ImportMetadataViewset.retrieve`.
- Adds support for `depth` query param to `ImportMetadataViewset.retrieve`. If defined, it will return the descendants of the requested node rather than returning the ancestors.
- Modifies `process_metadata_import` to query descendants if the tcontentnode of a ContentDownloadRequest is a course.

Note that I haven't implemented the pagination similar to the ContentNodeTree viewset as suggested in the issue, because I saw there was going to add more unnecessary complexity given that we could achieve the same by treating this as a plain list (given how the response object of the `ImportMetadataViewset` is structured).


## References

- Closes #14283.

## Reviewer guidance
(I verified this way)
- Create a `ContentDownloadRequest` for a course ContentNode on an LOD Device.
- Manually run `process_content_requests` on a Kolibri Shell.
- Verify that descendants of the Course ContentNode are now present in the ContentNode model.

## AI usage
I have used Claude to generate the test suites for the changes on the ImportMetadataViewset and changes on the utils/content_request.py module.