### PR TITLE
Tweaks to agent instructions and how tos.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,26 +13,25 @@ pip install -r requirements/dev.txt   # Python deps
 pnpm install                          # Node deps
 pre-commit install                    # Required — commits fail without this
 export KOLIBRI_RUN_MODE=dev
-kolibri manage migrate                # Database migrations
+kolibri configure setup               # Database migrations and updates
 ```
 
-Dev servers (run in separate terminals):
+Dev server:
 ```bash
-pnpm run python-devserver  # Django on port 8000
-pnpm run watch             # Webpack watcher
+pnpm devserver             # Django on port 8000 + Webpack watcher + sandbox dev server
 ```
 
-→ Full setup: `docs/getting_started.rst` | Architecture: `docs/stack.rst`
+→ Full setup: `docs/getting_started.rst` | Architecture: `docs/stack.rst` | Dev data: `docs/howtos/dev_data_setup.md`
 
 ## Critical Gotchas
 
 ### ⚠️ BEFORE Writing Any Vue Component, Search for Existing Ones
 Do not create a new component without first searching for an existing solution:
 1. **Kolibri Design System** ([docs](https://design-system.learningequality.org/)) — `KButton`, `KCircularLoader`, `KTextbox`, `KSelect`, `KModal`, `KCheckbox`, `KIcon`, etc.
-2. **`packages/kolibri/components/`** — `CoreTable`, `AuthMessage`, `BottomAppBar`, `AppBar`, etc.
+2. **`packages/kolibri/components/`** — `AuthMessage`, `BottomAppBar`, `AppBar`, etc.
 3. **`packages/kolibri-common/components/`** — `AccordionContainer`, `BaseToolbar`, etc.
 
-Use existing components (e.g., `CoreTable` for tabular data, `KCircularLoader` for loading states). If one does 80% of what you need, wrap it — do not rewrite.
+Use existing components (e.g., `KTable` for tabular data, `KCircularLoader` for loading states). If one does 80% of what you need, wrap it — do not rewrite.
 
 ### ⚠️ Use Theme Tokens, Not Hard-Coded Colors
 Never use raw color values. Access theme colors via `$themeTokens` and `$themePalette`:
@@ -121,7 +120,7 @@ kolibri/
 
 ## Key Conventions
 
-**Python:** F-strings preferred. One import per line. `DateTimeTzField` for timestamps (not Django's `DateTimeField`). `UUIDField` from morango for syncable models. Descriptive migration names (no `_auto_`).
+**Python:** F-strings preferred. One import per line. `DateTimeTzField` for timestamps (not Django's `DateTimeField`). `UUIDField` from morango for syncable models. Descriptive migration names (no `_auto_`). All imports at file top — inline imports are only permitted to prevent circular imports.
 
 **Vue:** PascalCase filenames. Component `name` must match filename. Use `computed()` for derived values.
 
@@ -134,13 +133,13 @@ kolibri/
 ```bash
 pytest kolibri/path/to/test/                          # Python (directory)
 pytest kolibri/core/auth/test/ -k test_login          # Python (filter by name)
-pnpm run test-jest -- path/to/file.spec.js            # Frontend (single file)
-pnpm run test-jest -- --testPathPattern learn          # Frontend (filter by pattern)
+pnpm test-jest path/to/file.spec.js                # Frontend (single file)
+pnpm test-jest --testPathPattern learn              # Frontend (filter by pattern)
 pre-commit run --all-files                            # Lint (all files)
 pre-commit run --files path/to/File.vue               # Lint (specific file)
 ```
 
-Always use `pre-commit` as the single entry point for linting — do not invoke ESLint or other linters directly.
+Do NOT use `npx jest` or invoke Jest directly — always use `pnpm test-jest`. Always use `pre-commit` as the single entry point for linting — do not invoke ESLint or other linters directly.
 
 ## Docs Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,7 @@ These supplement the gotchas in AGENTS.md. With Claude's large context window, t
 - **Constants**: Uppercase strings in dedicated modules with `choices` tuples for model fields (see `kolibri/core/auth/constants/`).
 - **Model permissions**: Syncable models use declarative `RoleBasedPermissions`. Viewsets use `KolibriAuthPermissions` from `kolibri.core.auth.api`.
 - **Error constants**: API validation errors use codes from `kolibri/core/error_constants.py`, mirrored in frontend.
-- **Inline imports**: Only for circular import prevention. All other imports at file top.
 
 ### Multi-Agent / Multi-Worktree Isolation
 
-→ See `docs/howtos/multi_agent_setup.md` for full setup including KOLIBRI_HOME isolation, unique ports, and provisioning commands.
+→ See `docs/howtos/multi_agent_setup.md` for full setup including KOLIBRI_HOME isolation and unique ports.

--- a/docs/howtos/dev_data_setup.md
+++ b/docs/howtos/dev_data_setup.md
@@ -1,0 +1,14 @@
+# Provisioning and Seeding Dev Data
+
+A fresh `KOLIBRI_HOME` needs device provisioning, users, and content to be useful. The `integration_testing/load_testing/` toolkit handles all of this via the REST API.
+
+Start the Kolibri server first, then provision and seed:
+
+```bash
+cd integration_testing/load_testing
+python loadtest.py --server http://localhost:8000 --username admin --password admin setup
+```
+
+This creates a superuser (`admin`/`admin`), a "Load Test Facility" with a "Load Test Class" classroom, 10 learner accounts (`load_test_1` through `load_test_10`, password: `password`), imports the QA channel from Studio, and creates a lesson with diverse content types.
+
+See `integration_testing/load_testing/kolibri_client.py` for the API client that can also be used programmatically.

--- a/docs/howtos/multi_agent_setup.md
+++ b/docs/howtos/multi_agent_setup.md
@@ -16,38 +16,18 @@ Each agent needs a unique Kolibri server port and a unique webpack dev server po
 
 ```bash
 # Terminal 1: webpack dev server on custom port
-pnpm run watch -- --port 3001
+pnpm watch --port 3001
 
-# Terminal 2: Kolibri server with matching CSP and custom server port
-WEBPACK_DEV_SERVER_PORT=3001 kolibri start --foreground --port=8001 --settings=kolibri.deployment.default.settings.dev
+# Terminal 2: sandbox dev server
+pnpm sandbox-dev
+
+# Terminal 3: Kolibri server with matching CSP and custom server port
+WEBPACK_DEV_SERVER_PORT=3001 kolibri start --debug --foreground --port=8001 --settings=kolibri.deployment.default.settings.dev
 ```
 
-## 3. Provision and Seed via Load Testing Toolkit
+## 3. Provision and Seed
 
-Starting the Kolibri server automatically runs database migrations, but a fresh `KOLIBRI_HOME` still needs device provisioning, users, and content to be useful. The `integration_testing/load_testing/` toolkit handles all of this via the REST API.
-
-Start the Kolibri server first, then provision and seed:
-
-```bash
-cd integration_testing/load_testing
-
-# Provision device and create facility
-python loadtest.py provision --server http://localhost:8001 --username admin --password admin
-python loadtest.py setup-facility --server http://localhost:8001 --username admin --password admin
-
-# Create learners enrolled in a classroom
-python loadtest.py import-users --server http://localhost:8001 --username admin --password admin --users 10
-
-# Import QA channel content (downloads from Studio — requires internet)
-python loadtest.py import-channel --server http://localhost:8001 --username admin --password admin
-
-# Create a lesson with mixed content types
-python loadtest.py create-lesson --server http://localhost:8001 --username admin --password admin
-```
-
-This creates a superuser (`admin`/`admin`), a "Load Test Facility" with a "Load Test Class" classroom, 10 learner accounts (`load_test_1` through `load_test_10`, password: `password`), imports the QA channel from Studio, and creates a lesson with diverse content types.
-
-See `integration_testing/load_testing/kolibri_client.py` for the API client that can also be used programmatically.
+A fresh `KOLIBRI_HOME` needs device provisioning, users, and content. See `docs/howtos/dev_data_setup.md` for full instructions. Adjust the `--server` URL to match the port used above (e.g., `http://localhost:8001`).
 
 ## Complete Isolated Setup Example
 
@@ -57,18 +37,17 @@ export KOLIBRI_HOME="$(pwd)/.kolibri_home"
 export KOLIBRI_RUN_MODE=dev
 
 # 2. Start webpack dev server on a unique port
-pnpm run watch -- --port 3001
+pnpm watch --port 3001
 
-# 3. In another terminal: start Kolibri server (runs migrations automatically on first start)
+# 3. In another terminal: start sandbox dev server
 export KOLIBRI_HOME="$(pwd)/.kolibri_home"
 export KOLIBRI_RUN_MODE=dev
-WEBPACK_DEV_SERVER_PORT=3001 kolibri start --foreground --port=8001 --settings=kolibri.deployment.default.settings.dev
+pnpm sandbox-dev
 
-# 4. In another terminal: provision and seed
-cd integration_testing/load_testing
-python loadtest.py provision --server http://localhost:8001 --username admin --password admin
-python loadtest.py setup-facility --server http://localhost:8001 --username admin --password admin
-python loadtest.py import-users --server http://localhost:8001 --username admin --password admin --users 10
-python loadtest.py import-channel --server http://localhost:8001 --username admin --password admin
-python loadtest.py create-lesson --server http://localhost:8001 --username admin --password admin
+# 4. In another terminal: start Kolibri server (runs migrations automatically on first start)
+export KOLIBRI_HOME="$(pwd)/.kolibri_home"
+export KOLIBRI_RUN_MODE=dev
+WEBPACK_DEV_SERVER_PORT=3001 kolibri start --debug --foreground --port=8001 --settings=kolibri.deployment.default.settings.dev
+
+# 5. Provision and seed — see docs/howtos/dev_data_setup.md (use --server http://localhost:8001)
 ```

--- a/integration_testing/load_testing/loadtest.py
+++ b/integration_testing/load_testing/loadtest.py
@@ -32,7 +32,6 @@ from logger import plain
 from logger import section
 from logger import step
 from logger import success
-from recorder import capture_manual_flow
 
 
 # Constants
@@ -191,6 +190,8 @@ def capture(ctx):
 
     os.makedirs(HAR_FILES_DIR, exist_ok=True)
 
+    from recorder import capture_manual_flow
+
     info(f"Manual capture mode for Kolibri {kolibri_version}...")
     capture_manual_flow(ctx.obj["server"], har_path)
     success(f"✓ HAR file captured: {har_path}")
@@ -293,6 +294,28 @@ def run(ctx):
         threading.Thread(target=open_browser, daemon=True).start()
 
     subprocess.run(cmd, env=env)
+
+
+@cli.command()
+@click.pass_context
+def setup(ctx):
+    """Provision device, create facility, import users, import channel, and create lesson"""
+    step(1, 5, "Checking device provisioning...")
+    ctx.invoke(provision)
+
+    step(2, 5, "Setting up facility...")
+    ctx.invoke(setup_facility)
+
+    step(3, 5, "Importing users...")
+    ctx.invoke(import_users)
+
+    step(4, 5, "Importing QA channel...")
+    ctx.invoke(import_channel)
+
+    step(5, 5, "Creating comprehensive lesson...")
+    ctx.invoke(create_lesson)
+
+    success("Setup complete")
 
 
 def full(ctx):


### PR DESCRIPTION
## Summary
Small tweaks to our agent setup instructions to fix commonly recurring issues.
* Update all devserver running references to be accurate, complete, and functional
* Make loadtesting provisioning script runnable without playwright using an inline import
* Add a simple setup command to make provisioning for testing a 1 liner.
* Update all pnpm invocations to not use `run` and to skip `--` argument separators that are unnecessary and actually break some argument passing
* Downgrade the prominence of CoreTable in favour of KTable
* Shout louder against inline imports in Python

## Reviewer guidance
Check a few of the invocations, make sure they work.
I have tested all of these locally, and hopefully they should prevent some unhelpful behaviours from agents.

## AI usage
I identified all of these behaviours from looking at common patterns in AI agents (both ones locally running and others), and then had Claude make the appropriate updates in the code. I reviewed all the changes and made some manual tweaks on top for clarity.