### PR TITLE
Fix ResourceLayout remounting default slot on side panel toggle

### DIFF
--- a/kolibri/plugins/learn/frontend/views/ResourceLayout/__tests__/ResourceLayout.spec.js
+++ b/kolibri/plugins/learn/frontend/views/ResourceLayout/__tests__/ResourceLayout.spec.js
@@ -1843,4 +1843,258 @@ describe('ResourceLayout', () => {
       expect(screen.queryByTestId('uncle-side-panel')).not.toBeInTheDocument();
     });
   });
+
+  describe('default slot stability', () => {
+    it('does not remount the default slot when toggling the side panel open', async () => {
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      expect(mountCount).toHaveBeenCalledTimes(1);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+
+      // Open the side panel
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(1);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not remount the default slot when toggling the side panel closed', async () => {
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      // Open the side panel
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      mountCount.mockClear();
+      unmountCount.mockClear();
+
+      // Close the side panel
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(0);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not remount the default slot when toggling the side panel open in modal mode', async () => {
+      setBreakpoint(1); // Modal mode
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      expect(mountCount).toHaveBeenCalledTimes(1);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+
+      // Open the side panel (modal mode)
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(1);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not remount the default slot when toggling the side panel closed in modal mode', async () => {
+      setBreakpoint(1); // Modal mode
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      // Open the side panel (modal mode)
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      mountCount.mockClear();
+      unmountCount.mockClear();
+
+      // Close the side panel (modal mode - click the close button inside the modal)
+      const modal = screen.getByTestId('side-panel-modal');
+      const closeBtn = modal.querySelector('[data-testid="side-panel-toggle"]');
+      await fireEvent.click(closeBtn);
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(0);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not remount the default slot when breakpoint changes from push to modal mode', async () => {
+      setBreakpoint(4); // Start in push mode
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      // Open side panel in push mode
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      mountCount.mockClear();
+      unmountCount.mockClear();
+
+      // Switch to modal mode
+      setBreakpoint(1);
+      await waitFor(() => {
+        expect(screen.getByTestId('side-panel-modal')).toBeInTheDocument();
+      });
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(0);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not remount the default slot when breakpoint changes from modal to push mode', async () => {
+      setBreakpoint(1); // Start in modal mode
+      const mountCount = jest.fn();
+      const unmountCount = jest.fn();
+
+      const TrackedComponent = {
+        name: 'TrackedComponent',
+        setup() {
+          const { onMounted, onUnmounted } = require('vue');
+          onMounted(() => mountCount());
+          onUnmounted(() => unmountCount());
+          return () => require('vue').h('div', { attrs: { 'data-testid': 'tracked' } }, 'tracked');
+        },
+      };
+
+      const Wrapper = {
+        name: 'Wrapper',
+        components: { ResourceLayout, TrackedComponent },
+        template: `
+          <ResourceLayout>
+            <template #default><TrackedComponent /></template>
+            <template #sidePanel><div>Side Panel Content</div></template>
+          </ResourceLayout>
+        `,
+      };
+
+      render(Wrapper);
+
+      // Open side panel in modal mode
+      await fireEvent.click(screen.getByTestId('side-panel-toggle'));
+
+      mountCount.mockClear();
+      unmountCount.mockClear();
+
+      // Switch to push mode
+      setBreakpoint(4);
+      await waitFor(() => {
+        expect(screen.getByTestId('side-panel')).toBeInTheDocument();
+      });
+
+      // The default slot should NOT have been remounted
+      expect(mountCount).toHaveBeenCalledTimes(0);
+      expect(unmountCount).toHaveBeenCalledTimes(0);
+    });
+  });
 });

--- a/kolibri/plugins/learn/frontend/views/ResourceLayout/index.vue
+++ b/kolibri/plugins/learn/frontend/views/ResourceLayout/index.vue
@@ -261,37 +261,34 @@
         const mainColumn = h('div', { class: 'main-column' }, mainColumnChildren);
 
         // === ASSEMBLE LAYOUT ===
-        let mainLayout;
-
+        // Always use the same VNode tree structure so that toggling the side
+        // panel does not cause Vue to remount the default slot content.
+        const mainArea = h('div', { class: 'main-area' }, [topBar, mainColumn].filter(Boolean));
+        const bodyChildren = [mainArea];
         if (showPushPanel) {
-          // Push mode: wrap topBar + mainColumn in main-area so the
-          // aside spans the full height of the layout alongside it.
-          const mainArea = h('div', { class: 'main-area' }, [topBar, mainColumn].filter(Boolean));
-          const body = h('div', { attrs: { 'data-testid': 'body' }, class: 'body' }, [
-            mainArea,
-            renderSidePanelAside('menu'),
-          ]);
-          mainLayout = h('div', { class: 'resource-layout' }, [body]);
-        } else {
-          const body = h('div', { attrs: { 'data-testid': 'body' }, class: 'body' }, [mainColumn]);
-          mainLayout = h('div', { class: 'resource-layout' }, [topBar, body].filter(Boolean));
+          bodyChildren.push(renderSidePanelAside('menu'));
         }
+        const body = h('div', { attrs: { 'data-testid': 'body' }, class: 'body' }, bodyChildren);
+        const mainLayout = h('div', { class: 'resource-layout' }, [body]);
 
         // === MODAL MODE ===
+        // Always return the same root structure so the VNode path to the
+        // default slot stays stable across modal/push transitions.
+        const layoutChildren = [mainLayout];
         if (showModalPanel) {
-          const sidePanelModal = h(
-            SidePanelModal,
-            {
-              props: { alignment: 'right', width: SIDE_PANEL_WIDTH },
-              on: { closePanel: closeSidePanel },
-            },
-            [renderSidePanelAside('close', true)],
+          layoutChildren.push(
+            h(
+              SidePanelModal,
+              {
+                props: { alignment: 'right', width: SIDE_PANEL_WIDTH },
+                on: { closePanel: closeSidePanel },
+              },
+              [renderSidePanelAside('close', true)],
+            ),
           );
-
-          return h('div', {}, [mainLayout, sidePanelModal]);
         }
 
-        return mainLayout;
+        return h('div', {}, layoutChildren);
       };
     },
   };


### PR DESCRIPTION
## Summary

- Fix ResourceLayout remounting its default slot when the side panel is opened/closed (#14357)
- The render function used two different VNode tree structures depending on side panel state, causing Vue to unmount/remount the default slot content on every toggle. Now always wraps `topBar + mainColumn` in a `main-area` div regardless of panel state, keeping the VNode path stable.
- Verified by Claude in a headless browser session by injecting a DOM stability marker and MutationObserver — confirmed no remount on open/close toggle. Additionally verified manually by adding `onMounted`/`onBeforeUnmounted` console log statements to confirm no lifecycle re-triggering on side panel toggle.

| Panel closed | Panel open |
|------------|------------|
| ![Panel closed](https://i.imgur.com/Z6vxcYU.png) | ![Panel open](https://i.imgur.com/3tlsZ7S.png) |

https://github.com/user-attachments/assets/42a6b98a-aacd-4f9c-870d-39912c67153d

## References

Fixes #14357

## Reviewer guidance

- The key change is in `ResourceLayout/index.vue:264-272` — the conditional VNode tree structure was replaced with a single consistent structure. The `main-area` wrapper is now always present, which means the CSS for `.main-area` applies even when the side panel is closed. Verify this doesn't affect layout when there's no side panel at all (e.g. a ResourceLayout with no `sidePanel` slot).
- The two new tests in `ResourceLayout.spec.js` use lifecycle hooks (`onMounted`/`onUnmounted`) to detect remounting — review that these accurately capture the bug scenario described in the issue.

## AI usage

Claude Code (Opus 4.6) was used to implement this fix using TDD. Claude identified the root cause (conditional VNode tree restructuring in the render function), wrote failing tests first, then implemented the minimal fix. Claude also performed manual browser verification using Playwright. The implementation was reviewed and additionally verified manually by adding lifecycle hook console logs.