### PR TITLE
Refined prev/next buttons in course viewer

### DIFF
--- a/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
+++ b/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
@@ -4,7 +4,7 @@
     <!-- Prev button on the left -->
     <KButton
       class="btn-flex"
-      appearance="flat-button"
+      appearance="raised-button"
       data-testid="prev-button"
       :disabled="!canGoPrev"
       :aria-label="previousLabel$()"

--- a/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
+++ b/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
@@ -3,19 +3,22 @@
   <div class="prev-next-bar">
     <!-- Prev button on the left -->
     <KButton
-      data-testid="prev-button"
-      :disabled="!canGoPrev"
+      class="btn-flex"
       appearance="flat-button"
+      data-testid="prev-button"
+      :style="{ gap: showButtonLabels ? '8px' : '0px' }"
+      :disabled="!canGoPrev"
       :aria-label="previousLabel$()"
+      :text="showButtonLabels ? previousLabel$() : ''"
       @click="handlePrev"
     >
-      <div class="btn-flex">
+      <template #icon>
         <KIcon
-          class="icon"
           icon="back"
+          class="btn-icon"
+          :color="$themeTokens.text"
         />
-        <span v-if="showButtonLabels">{{ previousLabel$() }}</span>
-      </div>
+      </template>
     </KButton>
 
     <!-- Progress/status in the center -->
@@ -37,19 +40,22 @@
         <slot name="actions"></slot>
       </div>
       <KButton
+        primary
+        class="btn-flex"
         data-testid="next-button"
+        :style="{ gap: showButtonLabels ? '8px' : '0px' }"
         :disabled="!canGoNext"
-        appearance="flat-button"
         :aria-label="nextLabel$()"
+        :text="showButtonLabels ? nextLabel$() : ''"
         @click="handleNext"
       >
-        <div class="btn-flex">
-          <span v-if="showButtonLabels">{{ nextLabel$() }}</span>
+        <template #iconAfter>
           <KIcon
-            class="icon"
+            class="btn-icon hotfixed"
             icon="forward"
+            :color="$themeTokens.textInverted"
           />
-        </div>
+        </template>
       </KButton>
     </div>
   </div>
@@ -168,12 +174,22 @@
 
   .btn-flex {
     display: flex;
-    gap: 4px;
     align-items: center;
     justify-content: center;
+    padding: 8px;
+    font-weight: 600;
+    line-height: 135%;
 
-    .icon {
-      top: 0;
+    .btn-icon {
+      top: -2px;
+      flex-grow: 1;
+      width: 16px;
+      height: 16px;
+
+      &.hotfixed {
+        // Remove when https://github.com/learningequality/kolibri-design-system/pull/1219 is in KDS release
+        top: -1px;
+      }
     }
   }
 

--- a/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
+++ b/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
@@ -6,7 +6,6 @@
       class="btn-flex"
       appearance="flat-button"
       data-testid="prev-button"
-      :style="{ gap: showButtonLabels ? '8px' : '0px' }"
       :disabled="!canGoPrev"
       :aria-label="previousLabel$()"
       :text="showButtonLabels ? previousLabel$() : ''"
@@ -43,7 +42,6 @@
         primary
         class="btn-flex"
         data-testid="next-button"
-        :style="{ gap: showButtonLabels ? '8px' : '0px' }"
         :disabled="!canGoNext"
         :aria-label="nextLabel$()"
         :text="showButtonLabels ? nextLabel$() : ''"
@@ -149,6 +147,8 @@
 
 <style lang="scss" scoped>
 
+  @import '../buttons';
+
   .prev-next-bar {
     display: flex;
     align-items: center;
@@ -173,23 +173,7 @@
   }
 
   .btn-flex {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 8px;
-    font-weight: 600;
-    line-height: 135%;
-
-    .btn-icon {
-      top: -2px;
-      width: 16px;
-      height: 16px;
-
-      &.hotfixed {
-        // Remove when https://github.com/learningequality/kolibri-design-system/pull/1219 is in KDS release
-        top: 0;
-      }
-    }
+    @include btn-flex;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
+++ b/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue
@@ -182,13 +182,12 @@
 
     .btn-icon {
       top: -2px;
-      flex-grow: 1;
       width: 16px;
       height: 16px;
 
       &.hotfixed {
         // Remove when https://github.com/learningequality/kolibri-design-system/pull/1219 is in KDS release
-        top: -1px;
+        top: 0;
       }
     }
   }

--- a/kolibri/plugins/learn/frontend/views/buttons.scss
+++ b/kolibri/plugins/learn/frontend/views/buttons.scss
@@ -1,0 +1,30 @@
+/*
+ * Styles shared across Course feature for buttons w/ properly aligned icons and text.
+ * These styles may be useful elsewhere and may be worth considering in any KButton refactor
+ */
+@mixin btn-flex {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  font-weight: 600;
+  line-height: 135%;
+
+  > :empty {
+    // Added because KButton at the moment will render empty spans
+    // that cause the flex gaps to appear between them
+    display: none;
+  }
+
+  .btn-icon {
+    top: -2px;
+    width: 16px;
+    height: 16px;
+
+    &.hotfixed {
+      // Remove when https://github.com/learningequality/kolibri-design-system/pull/1219 is in KDS release
+      top: 0;
+    }
+  }
+}

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -124,6 +124,7 @@
             <transition mode="out-in">
               <KButton
                 v-if="!complete"
+                class="btn-flex"
                 :text="$tr('check')"
                 :primary="!hasNextResource"
                 :class="{ shaking: shake }"
@@ -133,6 +134,7 @@
               <KButton
                 v-else
                 ref="nextButton"
+                class="btn-flex"
                 :text="hasNextResource ? practiceAction$() : $tr('next')"
                 :primary="!hasNextResource"
                 @click="nextQuestion"
@@ -141,10 +143,19 @@
           </div>
           <KButton
             v-if="hasNextResource"
+            class="btn-flex"
             primary
             :text="nextLabel$()"
             @click="$emit('nextResource')"
-          />
+          >
+            <template #iconAfter>
+              <KIcon
+                class="btn-icon hotfixed"
+                icon="forward"
+                :color="$themeTokens.textInverted"
+              />
+            </template>
+          </KButton>
         </div>
       </div>
     </template>
@@ -533,6 +544,7 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
+  @import '../../buttons';
 
   .assesment-wrapper-content {
     display: flex;
@@ -656,6 +668,10 @@
 
   /deep/ .framework-perseus {
     margin: 0 !important;
+  }
+
+  .btn-flex {
+    @include btn-flex;
   }
 
 </style>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -76,8 +76,8 @@
         <div class="navigation-buttons-wrapper">
           <KButton
             class="btn-flex"
+            primary
             :disabled="questionNumber === questionsTotal - 1"
-            :primary="true"
             :aria-label="$tr('nextQuestion')"
             :text="displayNavigationButtonLabel ? $tr('nextQuestion') : ''"
             @click="goToQuestion(questionNumber + 1)"
@@ -85,7 +85,7 @@
             <template #iconAfter>
               <KIcon
                 icon="forward"
-                :color="$themeTokens.textInverted"
+                :color="$themeTokens.text"
                 class="btn-icon hotfixed"
               />
             </template>
@@ -93,7 +93,6 @@
           <KButton
             class="btn-flex"
             :disabled="questionNumber === 0"
-            :primary="true"
             :aria-label="$tr('previousQuestion')"
             :text="displayNavigationButtonLabel ? $tr('previousQuestion') : ''"
             @click="goToQuestion(questionNumber - 1)"
@@ -101,7 +100,7 @@
             <template #icon>
               <KIcon
                 icon="back"
-                :color="$themeTokens.textInverted"
+                :color="$themeTokens.text"
                 class="btn-icon"
               />
             </template>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -85,7 +85,7 @@
             <template #iconAfter>
               <KIcon
                 icon="forward"
-                :color="$themeTokens.text"
+                :color="$themeTokens.textInverted"
                 class="btn-icon hotfixed"
               />
             </template>

--- a/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/QuizRenderer/index.vue
@@ -75,36 +75,36 @@
       >
         <div class="navigation-buttons-wrapper">
           <KButton
+            class="btn-flex"
             :disabled="questionNumber === questionsTotal - 1"
             :primary="true"
             :aria-label="$tr('nextQuestion')"
-            :appearanceOverrides="navigationButtonStyle"
+            :text="displayNavigationButtonLabel ? $tr('nextQuestion') : ''"
             @click="goToQuestion(questionNumber + 1)"
           >
-            <div class="btn-flex">
-              <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
+            <template #iconAfter>
               <KIcon
                 icon="forward"
-                color="white"
-                class="icon"
+                :color="$themeTokens.textInverted"
+                class="btn-icon hotfixed"
               />
-            </div>
+            </template>
           </KButton>
           <KButton
+            class="btn-flex"
             :disabled="questionNumber === 0"
             :primary="true"
-            :appearanceOverrides="navigationButtonStyle"
             :aria-label="$tr('previousQuestion')"
+            :text="displayNavigationButtonLabel ? $tr('previousQuestion') : ''"
             @click="goToQuestion(questionNumber - 1)"
           >
-            <div class="btn-flex">
+            <template #icon>
               <KIcon
                 icon="back"
-                color="white"
-                class="icon"
+                :color="$themeTokens.textInverted"
+                class="btn-icon"
               />
-              <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
-            </div>
+            </template>
           </KButton>
         </div>
 
@@ -117,7 +117,7 @@
             :text="isSurvey ? $tr('submitSurvey') : $tr('submitExam')"
             :primary="false"
             appearance="flat-button"
-            class="submit-button"
+            class="btn-flex submit-button"
             @click="toggleModal"
           />
         </div>
@@ -297,11 +297,6 @@
       },
       displayNavigationButtonLabel() {
         return this.windowBreakpoint > 0;
-      },
-      navigationButtonStyle() {
-        return this.displayNavigationButtonLabel
-          ? {}
-          : { minWidth: '36px', width: '36px', padding: 0 };
       },
     },
     watch: {
@@ -485,6 +480,8 @@
 
 <style lang="scss" scoped>
 
+  @import '../../buttons';
+
   .bottom-bar {
     display: flex;
     // Using row-reverse to make the navigation buttons come first in the DOM order for better
@@ -548,14 +545,7 @@
   }
 
   .btn-flex {
-    display: flex;
-    gap: 4px;
-    align-items: center;
-    justify-content: center;
-
-    .icon {
-      top: 0;
-    }
+    @include btn-flex;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

Applies styles to match those in the Figma for PrevNextBar.vue and aligns arrow icons w/ their text. Some specific changes I gleaned from Figma and other notes:

- 8px gap between text & icon 
- 8px padding all around (vs 0 16px previously)
- font weight semibold now (which I think looks aces)
- icons are 2px smaller in size than default KIcon
- icon needs -2px top value (hotfix to -3px due to https://github.com/learningequality/kolibri-design-system/pull/1219)

|Looks good big & small :+1: |
|---|
|<img width="1346" height="1254" alt="image" src="https://github.com/user-attachments/assets/5c775fb3-e8f2-48e1-8b23-59d4f54b4478" />|
|<img width="265" height="150" alt="image" src="https://github.com/user-attachments/assets/4f0c4b63-627b-4a01-b607-04caa1d8ba7c" />|

| **No More Eye Twitches** |
|---|
|<img width="1114" height="130" alt="image" src="https://github.com/user-attachments/assets/eb53a545-d484-4b41-bc6c-76868ed8f0ce" />|



## References
<!--
 * references to related issues and PRs
-->

Closes #14220 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check out a course as a learner and see the sweet new button styles!