### PR TITLE
Use useGoBack for course back navigation instead of hardcoded HOME

### DIFF
--- a/kolibri/plugins/learn/frontend/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/frontend/routes/classesRoutes.js
@@ -89,10 +89,11 @@ export default [
   {
     path: '/course',
     component: CourseRootPage,
-    handler: () => {
+    beforeEnter: (to, from, next) => {
       if (noClassesGuard()) {
-        return noClassesGuard();
+        return;
       }
+      next();
     },
     children: [
       {

--- a/kolibri/plugins/learn/frontend/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/frontend/routes/classesRoutes.js
@@ -9,6 +9,7 @@ import { showExam } from '../modules/examViewer/handlers';
 import { showExamReport } from '../modules/examReportViewer/handlers';
 import { inClasses } from '../composables/useCoreLearn';
 import ExamPage from '../views/ExamPage/index.vue';
+import CourseRootPage from '../views/CourseRootPage.vue';
 import CourseUnitView from '../views/CourseUnitView/index.vue';
 import CourseWelcomePage from '../views/CourseWelcomePage';
 import ExamReportViewer from '../views/LearnExamReportViewer';
@@ -86,69 +87,50 @@ export default [
     component: ExamReportViewer,
   },
   {
-    name: PageNames.COURSE_WELCOME,
-    path: '/course/:courseSessionId([a-f0-9]{32})/welcome',
-    component: CourseWelcomePage,
+    path: '/course',
+    component: CourseRootPage,
     handler: () => {
       if (noClassesGuard()) {
         return noClassesGuard();
       }
     },
-    props: true,
-  },
-  {
-    name: PageNames.COURSE_CONTENT__RESOURCE,
-    path: '/course/:courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/l/:lessonId([a-f0-9]{32})/r/:resourceId([a-f0-9]{32})',
-    handler: () => {
-      if (noClassesGuard()) {
-        return noClassesGuard();
-      }
-    },
-    component: CourseUnitView,
-    props: true,
-  },
-  {
-    name: PageNames.COURSE_CONTENT__LESSON,
-    path: '/course/:courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/l/:lessonId([a-f0-9]{32})',
-    handler: () => {
-      if (noClassesGuard()) {
-        return noClassesGuard();
-      }
-    },
-    component: CourseUnitView,
-    props: true,
-  },
-  {
-    name: PageNames.COURSE_CONTENT_TEST,
-    path: '/course/:courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/t/:testType(pre|post)',
-    handler: () => {
-      if (noClassesGuard()) {
-        return noClassesGuard();
-      }
-    },
-    component: CourseUnitView,
-    props: true,
-  },
-  {
-    name: PageNames.COURSE_CONTENT__UNIT,
-    path: '/course/:courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})',
-    handler: () => {
-      if (noClassesGuard()) {
-        return noClassesGuard();
-      }
-    },
-    component: CourseUnitView,
-    props: true,
-  },
-  {
-    name: PageNames.COURSE_CONTENT__COURSE,
-    path: '/course/:courseId([a-f0-9]{32})',
-    handler: () => {
-      if (noClassesGuard()) {
-        return noClassesGuard();
-      }
-    },
-    component: CourseUnitView,
-    props: true,
+    children: [
+      {
+        name: PageNames.COURSE_WELCOME,
+        path: ':courseSessionId([a-f0-9]{32})/welcome',
+        component: CourseWelcomePage,
+        props: true,
+      },
+      {
+        name: PageNames.COURSE_CONTENT__RESOURCE,
+        path: ':courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/l/:lessonId([a-f0-9]{32})/r/:resourceId([a-f0-9]{32})',
+        component: CourseUnitView,
+        props: true,
+      },
+      {
+        name: PageNames.COURSE_CONTENT__LESSON,
+        path: ':courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/l/:lessonId([a-f0-9]{32})',
+        component: CourseUnitView,
+        props: true,
+      },
+      {
+        name: PageNames.COURSE_CONTENT_TEST,
+        path: ':courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})/t/:testType(pre|post)',
+        component: CourseUnitView,
+        props: true,
+      },
+      {
+        name: PageNames.COURSE_CONTENT__UNIT,
+        path: ':courseId([a-f0-9]{32})/u/:unitId([a-f0-9]{32})',
+        component: CourseUnitView,
+        props: true,
+      },
+      {
+        name: PageNames.COURSE_CONTENT__COURSE,
+        path: ':courseId([a-f0-9]{32})',
+        component: CourseUnitView,
+        props: true,
+      },
+    ],
   },
 ];

--- a/kolibri/plugins/learn/frontend/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/frontend/routes/classesRoutes.js
@@ -89,6 +89,7 @@ export default [
   {
     path: '/course',
     component: CourseRootPage,
+    redirect: '/',
     beforeEnter: (to, from, next) => {
       if (noClassesGuard()) {
         return;

--- a/kolibri/plugins/learn/frontend/views/CourseRootPage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseRootPage.vue
@@ -1,0 +1,19 @@
+<template>
+
+  <router-view />
+
+</template>
+
+
+<script>
+
+  import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
+
+  export default {
+    name: 'CourseRootPage',
+    setup() {
+      usePreviousRoute();
+    },
+  };
+
+</script>

--- a/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
@@ -1,13 +1,13 @@
 <template>
 
   <ImmersivePage
-    :route="homePageLink"
     :appBarTitle="(course && course.title) || ''"
     :loading="loading"
     icon="back"
     :appBarBgColor="$themeTokens.surface"
     :appBarHoverBgColor="$themePalette.grey.v_100"
     :appearanceOverrides="{ backgroundColor: $themeTokens.surface }"
+    @navIconClick="goBack"
   >
     <KCircularLoader v-if="loading" />
     <div v-else>
@@ -269,6 +269,7 @@
   import SlotTruncator from 'kolibri-common/components/SlotTruncator';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { useGoBack } from 'kolibri-common/composables/usePreviousRoute';
   import useLearnerResources from '../composables/useLearnerResources';
   import { PageNames } from '../constants';
   import ChannelThumbnail from './ChannelThumbnail.vue';
@@ -297,6 +298,7 @@
         isCourseLessonAvailable,
         isCurrentCourseLesson,
       } = useLearnerResources();
+      const goBack = useGoBack({ fallbackRoute: { name: PageNames.HOME } });
 
       const loading = ref(true);
       const course = ref(null);
@@ -442,12 +444,6 @@
         );
       };
 
-      const homePageLink = computed(() => {
-        return {
-          name: PageNames.HOME,
-        };
-      });
-
       const courseSubtitle = computed(() => {
         if (loading.value) {
           return '';
@@ -490,7 +486,7 @@
         courseStarted,
         courseSubtitle,
         windowIsLarge,
-        homePageLink,
+        goBack,
         lockedColor,
         lockedUnitItemStyle,
         activeUnitItemStyle,


### PR DESCRIPTION
## Summary

CourseWelcomePage hardcoded its back arrow to always navigate to the Home page,
regardless of where the user came from. This fix adopts the existing
`useGoBack` / `usePreviousRoute` pattern (used in Facility and Coach plugins)
for course navigation:

1. New `CourseRootPage` wrapper component calls `usePreviousRoute()` and renders `<router-view />`
2. Course routes are nested as children of `CourseRootPage`, enabling previous route tracking
3. `CourseWelcomePage` uses `useGoBack({ fallbackRoute: HOME })` instead of a hardcoded HOME link

This follows the same pattern as `UsersRootPage` (Facility), `QuizResourceSelection` and
`LessonResourceSelection` (Coach).

## References

Fixes #14222

## Review guidance

#### QA guidance

> I took these steps to confirm the fix

Setup prerequisites:
- A facility with at least one class
- A learner enrolled in that class
- At least one course assigned to that class
- Content channels imported so the course has content

**Test path 1: From Classes page**
1. Sign in as a learner with assigned courses
2. Navigate to Classes > [Your Class]
3. Click a course card
4. On the CourseWelcomePage, click the back arrow
5. Expected: returns to the class page, not Home

**Test path 2: From Home page**
1. Sign in as the same learner
2. From the Home page, click a course card
3. On the CourseWelcomePage, click the back arrow
4. Expected: returns to Home

**Test path 3: Regression tests on 'no classes guard'**
> This is to ensure that we still correctly redirect people who are not in the class given in their URL
1. 'Signin' as a user by way of the "Explore without account" in an incognito window
2. Copy the URL to a course or class page from a regular browser and try to access it as the anonymous user in incognito
3. See that the user is simply redirected to the Library (this is expected as they are not in any class)

Note that the other case I tested was for a logged-in user trying to go to a class URL for a class they're not in and it resulted in a 404 Error which is right because to the user not in the class, the class doesn't exist.


#### Code Reviewer notes (from Claude)

- `CourseRootPage` is a thin wrapper (~15 lines) following an established pattern — compare with
  `UsersRootPage` in Facility or `QuizResourceSelection` in Coach
- Course routes were restructured from flat to nested under `CourseRootPage`, with the
  `noClassesGuard` handler consolidated on the parent route. URL paths are unchanged.
- We initially explored the `useContentLink` query-param approach (used by TopicsPage for deep
  content browsing), but `useGoBack` is a better fit here — CourseWelcomePage is simple
  "go back one level" navigation, not deep content browsing
- The `useGoBack` pattern relies on `onBeforeRouteUpdate` firing on `CourseRootPage` when
  `CourseUnitView` does `router.replace` to `CourseWelcomePage` (both are child routes).
  This sets `previousRoute`, enabling `router.back()` to return to the correct origin page.
  When no previous route exists (direct link/refresh), it falls back to HOME.

## AI usage

I used Claude Code to investigate the root cause, trace the navigation chain, and explore
two approaches: query-param threading via `useContentLink` and the `useGoBack` /
`usePreviousRoute` pattern. After testing both, we chose `useGoBack` as the better fit
for this use case. I reviewed the generated code and verified it follows the same pattern
used elsewhere in the codebase.