### PR TITLE
Enqueue automatic daily KDP sync after facility registration

### DIFF
--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -30,6 +30,7 @@ from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
 
 from .utils.portal import registerfacility
 from kolibri.core.auth.models import Facility
+from kolibri.core.auth.tasks import enqueue_automatic_kdp_sync
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
@@ -44,6 +45,7 @@ class KolibriDataPortalViewSet(viewsets.ViewSet):
             response = registerfacility(request.data.get("token"), facility)
         except NetworkLocationResponseFailure as e:  # bubble up any response error
             return Response(e.response.json(), status=e.response.status_code)
+        enqueue_automatic_kdp_sync(facility)
         return Response(status=response.status_code)
 
     @action(detail=False, methods=["get"])

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -308,6 +308,42 @@ def dataportalsync(command, **kwargs):
     call_command(command, **kwargs)
 
 
+# 24 hours in seconds
+KDP_SYNC_INTERVAL = 60 * 60 * 24
+# 1 hour in seconds
+KDP_SYNC_RETRY_INTERVAL = 60 * 60
+
+
+def enqueue_automatic_kdp_sync(facility):
+    """
+    Enqueue a recurring daily sync with KDP for the given facility.
+    Uses a deterministic job ID to prevent duplicate schedules.
+    Retries hourly on failure (e.g. when KDP is unreachable).
+    """
+    validator = SyncJobValidator(
+        data={
+            "type": "kolibri.core.auth.tasks.dataportalsync",
+            "facility": facility.id,
+        }
+    )
+    validator.is_valid(raise_exception=True)
+    job_data = validator.validated_data
+    job_data.pop("enqueue_args", None)
+    try:
+        # Use enqueue_in (not enqueue) because only enqueue_in supports
+        # interval/repeat/retry_interval for recurring scheduling.
+        dataportalsync.enqueue_in(
+            datetime.timedelta(seconds=0),
+            interval=KDP_SYNC_INTERVAL,
+            repeat=None,
+            retry_interval=KDP_SYNC_RETRY_INTERVAL,
+            job_id="kdp_sync_{}".format(facility.id),
+            **job_data,
+        )
+    except JobRunning:
+        logger.info("KDP sync already running for facility {}".format(facility.name))
+
+
 class PeerSyncJobValidator(SyncJobValidator):
     baseurl = serializers.URLField(required=False)
     device_id = serializers.PrimaryKeyRelatedField(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -34,6 +34,7 @@ from ..models import Facility
 from .helpers import create_superuser
 from .helpers import DUMMY_PASSWORD
 from .helpers import provision_device
+from .helpers import setup_device
 from kolibri.core import error_constants
 from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants import demographics
@@ -2704,3 +2705,24 @@ class DeleteImportedUserTestCase(APITransactionTestCase):
         # as we should not propagate deletion of these models to remote devices
         self.assertFalse(DeletedModels.objects.exists())
         self.assertFalse(HardDeletedModels.objects.exists())
+
+
+class KolibriDataPortalViewSetTestCase(APITestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.facility, self.superuser = setup_device()
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+
+    @patch("kolibri.core.api.enqueue_automatic_kdp_sync")
+    @patch("kolibri.core.api.registerfacility")
+    def test_register_enqueues_automatic_sync(
+        self, mock_registerfacility, mock_enqueue_sync
+    ):
+        mock_registerfacility.return_value.status_code = 200
+        self.client.post(
+            reverse("kolibri:core:portal-register"),
+            {"facility_id": self.facility.id, "token": "test-token"},
+            format="json",
+        )
+        mock_enqueue_sync.assert_called_once_with(self.facility)

--- a/kolibri/core/auth/upgrade.py
+++ b/kolibri/core/auth/upgrade.py
@@ -6,6 +6,8 @@ import os
 import shutil
 
 from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.tasks import enqueue_automatic_kdp_sync
 from kolibri.core.upgrade import version_upgrade
 from kolibri.utils import conf
 
@@ -45,3 +47,13 @@ def cleanup_legacy_file_sessions():
             )
         except OSError:
             logger.warning("Failed to remove legacy sessions directory %s", session_dir)
+
+
+@version_upgrade(old_version="<0.19.3")
+def enqueue_kdp_sync_for_registered_facilities():
+    """
+    For facilities already registered with KDP, enqueue automatic daily syncing.
+    Previously, registration did not set up recurring syncs.
+    """
+    for facility in Facility.objects.filter(dataset__registered=True):
+        enqueue_automatic_kdp_sync(facility)


### PR DESCRIPTION
## Summary

After KDP registration, enqueue a recurring daily sync task that retries hourly on failure. An upgrade task handles facilities that were already registered before this change.

## References

In support of the attendance tracking functionality.

## Reviewer guidance

- `kolibri/core/auth/tasks.py:332-339` — the `enqueue_in` with `timedelta(0)` gives immediate first sync plus daily repeat; verify the `schedule()` semantics handle this correctly
- `kolibri/core/auth/upgrade.py:52-59` — upgrade task targets `<0.19.3`; confirm this version range is correct for the release
- Manual testing: Register a facility on KDP, and confirm from the development server logs that it immediately syncs after registering

## AI usage

Implemented with Claude Code. Reviewed generated code iteratively, removing unnecessary arguments (chunk_size, noninteractive) and refactoring to use SyncJobValidator to avoid duplicating job data construction.