### PR TITLE
Update class attendance block to fix weird state bug with classes

### DIFF
--- a/kolibri/plugins/coach/frontend/views/home/HomePage/AttendanceBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/AttendanceBlock.vue
@@ -77,6 +77,7 @@
   import { attendanceStrings } from 'kolibri-common/strings/attendanceStrings';
   import store from 'kolibri/store';
   import { useAttendance } from '../../../composables/useAttendance';
+  import useCoreCoach from '../../../composables/useCoreCoach';
   import commonCoach from '../../common';
   import { PageNames } from '../../../constants';
   import Block from './Block';
@@ -90,6 +91,7 @@
     },
     mixins: [commonCoach],
     setup() {
+      const { classId } = useCoreCoach();
       const { recentSessions, fetchRecentSessions, formatAttendanceDateTime } = useAttendance();
       const {
         attendanceLabel$,
@@ -107,8 +109,7 @@
       const absentColor = palette.red.v_500;
 
       onMounted(() => {
-        const classId = store.state.classSummary.id;
-        fetchRecentSessions(classId)
+        fetchRecentSessions(classId.value)
           .catch(error => {
             store.dispatch('handleApiError', { error });
           })

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/AttendanceBlock.spec.js
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/AttendanceBlock.spec.js
@@ -8,6 +8,15 @@ import { useAttendance, useAttendanceMock } from '../../../../composables/useAtt
 import AttendanceBlock from '../AttendanceBlock.vue';
 
 jest.mock('../../../../composables/useAttendance');
+jest.mock('../../../../composables/useCoreCoach', () => {
+  const { computed } = require('vue');
+  return () => ({
+    classId: computed(() => 'test-class-id'),
+    pageTitle: computed(() => ''),
+    appBarTitle: computed(() => ''),
+    authorized: computed(() => true),
+  });
+});
 jest.mock('kolibri/router', () => ({
   getRoute: jest.fn((name, params) => ({ name, params })),
 }));
@@ -78,7 +87,6 @@ function makeWrapper({ sessions = [], pendingFetch = false, rejectWith = null } 
   useAttendance.mockImplementation(() => mockValues);
 
   const testStore = makeStore();
-  testStore.state.classSummary.id = 'test-class-id';
 
   // Point the kolibri/store singleton state at the test store state
   store.replaceState(testStore.state);


### PR DESCRIPTION
## Summary
There was a weird bug that @akolson noticed on the attendance history block on the class home page where sometimes the attendance history would not be properly filtered by class (to only the current class). I was able to reproduce the bug by manually refreshing the page, which caused all attendance history to show. The state management problem didn't exist on the "Attendance History" page, only on the block. 

I had claude do some debugging, and the result was: 
> AttendanceBlock.vue was reading classId from store.state.classSummary.id — a Vuex state that's populated  
  asynchronously via initClassInfo. In certain navigation scenarios (e.g., an admin managing multiple classes switching 
  between them, or edge cases where the store state lags the current route), this value could be stale or from the wrong
   class. When collection: classId is sent with the wrong value, the backend's KolibriAuthPermissionsFilter returns all
  sessions the user can read across all classes without the collection filter narrowing it down correctly.    

Which I don't think I would have figured out myself very quickly! 


## Reviewer guidance

Confirm that the attendance history block on the class home page only contains sessions for that class, on initial navigation and on page refresh.

before: 

https://github.com/user-attachments/assets/b9d86fe5-beec-4614-ae23-aa315e0c71ec


After: 

https://github.com/user-attachments/assets/bd13c29a-edc4-463b-ad8c-5d9a45d83532



## AI usage
It was really all claude, i was just here to ask questions and confirm the fixes with manual testing.