### PR TITLE
Allow saving of attendance tracking facility setting. Add to facility settings page. Gate to English only.

### DIFF
--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -184,6 +184,7 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
             "learner_can_delete_account",
             "learner_can_login_with_no_password",
             "show_download_button_in_learn",
+            "enable_mark_attendance",
             "extra_fields",
             "description",
             "location",

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/index.vue
@@ -7,7 +7,7 @@
       </KGridItem>
       <KGridItem :layout12="{ span: 6 }">
         <KGrid gutter="16">
-          <KGridItem v-if="facilityConfig.enable_mark_attendance">
+          <KGridItem v-if="currentLanguage === 'en' && facilityConfig.enable_mark_attendance">
             <AttendanceBlock />
           </KGridItem>
           <KGridItem>
@@ -29,6 +29,7 @@
 
 <script>
 
+  import { currentLanguage } from 'kolibri/utils/i18n';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import commonCoach from '../../common';
@@ -56,6 +57,7 @@
 
       return {
         facilityConfig,
+        currentLanguage,
       };
     },
   };

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -198,7 +198,7 @@
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
-  import { createTranslator } from 'kolibri/utils/i18n';
+  import { createTranslator, currentLanguage } from 'kolibri/utils/i18n';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import RemovePinModal from './RemovePinModal';
   import ChangePinModal from './ChangePinModal';
@@ -281,7 +281,8 @@
       ]),
       ...mapGetters(['facilityPageLinks']),
       ...mapGetters('facilityConfig', ['getFacilityDataLoading']),
-      settingsList: () => settingsList,
+      settingsList: () =>
+        currentLanguage === 'en' ? settingsList.concat('enable_mark_attendance') : settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);
       },
@@ -430,6 +431,10 @@
       showDownloadButtonInLearn: {
         message: "Show 'download' button with resources",
         context: "Option on 'Facility settings' page.\n",
+      },
+      enableMarkAttendance: {
+        message: 'Allow coaches to take attendance (English only)',
+        context: "Option on 'Facility settings' page.",
       },
       /* eslint-enable kolibri/vue-no-unused-translations */
       saveFailure: {

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -39,7 +39,7 @@ describe('facility config page view', () => {
   it('has all of the settings', () => {
     const wrapper = makeWrapper();
     const checkboxes = wrapper.findAllComponents({ name: 'KCheckbox' });
-    expect(checkboxes.length).toEqual(6);
+    expect(checkboxes.length).toEqual(7);
     const labels = [
       'Allow learners to edit their username',
       'Allow learners to edit their full name',
@@ -47,6 +47,7 @@ describe('facility config page view', () => {
       'Require password for learners',
       'Allow learners to edit their password when signed in',
       "Show 'download' button with resources",
+      'Allow coaches to take attendance (English only)',
     ];
     labels.forEach((label, idx) => {
       expect(checkboxes.at(idx).props().label).toEqual(label);


### PR DESCRIPTION
## Summary
Instead of trying to remote-feature flag the attendance tracking feature, instead add the visible facility setting
Allow saving of the facility setting via the serializer
Only show facility setting and the feature (even when enabled) when the locale is set to English

## References
None

## Reviewer guidance
* Go to Facility Settings with the UI in English, confirm you see the new setting.
* Switch to a different language, confirm it is absent
* Switch back to English, turn the setting on and save
* Go to coach home page, confirm the attendance block appears
* Switch to different language confirm absent
* Turn setting back off, confirm absent on coach page in both English and other language


## AI usage
I used a highly trained generative organic world model to generate these changes - artisanally from my brain to yours!