### PR TITLE
Hide mark attendance button when no learners are enrolled

### DIFF
--- a/kolibri/plugins/coach/frontend/views/home/HomePage/AttendanceBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/AttendanceBlock.vue
@@ -9,7 +9,7 @@
       {{ attendanceLabel$() }}
     </template>
 
-    <div>
+    <div v-if="learners.length">
       <KRouterLink
         :text="markAttendanceAction$()"
         :primary="true"
@@ -20,9 +20,14 @@
 
     <KCircularLoader v-if="loading" />
 
-    <p v-else-if="sessions.length === 0">
-      {{ noSessionsMessage$() }}
-    </p>
+    <div v-else-if="sessions.length === 0">
+      <p v-if="learners.length">
+        {{ noSessionsMessage$() }}
+      </p>
+      <p v-else>
+        {{ noSessionsEnrollMessage$() }}
+      </p>
+    </div>
 
     <template v-else>
       <BlockItem
@@ -100,6 +105,7 @@
         noSessionsMessage$,
         presentCount$,
         absentCount$,
+        noSessionsEnrollMessage$,
       } = attendanceStrings;
 
       const loading = ref(true);
@@ -107,6 +113,8 @@
       const palette = themePalette();
       const presentColor = palette.green.v_500;
       const absentColor = palette.red.v_500;
+
+      const learners = computed(() => store.getters['classSummary/learners']);
 
       onMounted(() => {
         fetchRecentSessions(classId.value)
@@ -152,6 +160,8 @@
         presentCount$,
         absentCount$,
         PageNames,
+        learners,
+        noSessionsEnrollMessage$,
       };
     },
   };

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/AttendanceBlock.spec.js
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/AttendanceBlock.spec.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router';
 import { ref } from 'vue';
 import store from 'kolibri/store';
 import makeStore from '../../../../__tests__/utils/makeStore';
+import classSummaryModule from '../../../../modules/classSummary';
 // eslint-disable-next-line import/named
 import { useAttendance, useAttendanceMock } from '../../../../composables/useAttendance';
 import AttendanceBlock from '../AttendanceBlock.vue';
@@ -69,7 +70,17 @@ const STUBS = {
   KLabeledIcon: { name: 'KLabeledIcon', template: '<span><slot /></span>' },
 };
 
-function makeWrapper({ sessions = [], pendingFetch = false, rejectWith = null } = {}) {
+const MOCK_LEARNERS = [
+  { id: 'learner-1', name: 'Learner One', username: 'learner1' },
+  { id: 'learner-2', name: 'Learner Two', username: 'learner2' },
+];
+
+function makeWrapper({
+  sessions = [],
+  learners = MOCK_LEARNERS,
+  pendingFetch = false,
+  rejectWith = null,
+} = {}) {
   const recentSessions = ref(sessions);
   let fetchRecentSessions;
   if (rejectWith) {
@@ -87,6 +98,19 @@ function makeWrapper({ sessions = [], pendingFetch = false, rejectWith = null } 
   useAttendance.mockImplementation(() => mockValues);
 
   const testStore = makeStore();
+
+  // Populate learnerMap so the component's learners computed property works
+  const learnerMap = {};
+  learners.forEach(l => {
+    learnerMap[l.id] = l;
+  });
+  testStore.state.classSummary.learnerMap = learnerMap;
+
+  // Ensure the classSummary module is registered on the singleton store
+  // so that store.getters['classSummary/learners'] is available
+  if (!store.hasModule('classSummary')) {
+    store.registerModule('classSummary', classSummaryModule);
+  }
 
   // Point the kolibri/store singleton state at the test store state
   store.replaceState(testStore.state);
@@ -122,10 +146,18 @@ describe('AttendanceBlock', () => {
     expect(wrapper.find('[data-test="loader"]').exists()).toBe(true);
   });
 
-  it('renders empty state when no sessions exist', async () => {
-    const { wrapper } = makeWrapper({ sessions: [] });
+  it('renders empty state when no sessions exist but learners are enrolled', async () => {
+    const { wrapper } = makeWrapper({ sessions: [], learners: MOCK_LEARNERS });
     await global.flushPromises();
     expect(wrapper.text()).toContain('No attendance sessions yet');
+    expect(wrapper.text()).not.toContain('Enroll learners');
+  });
+
+  it('renders enroll message when no sessions and no learners are enrolled', async () => {
+    const { wrapper } = makeWrapper({ sessions: [], learners: [] });
+    await global.flushPromises();
+    expect(wrapper.text()).toContain('No attendance sessions yet');
+    expect(wrapper.text()).toContain('Enroll learners to mark attendance');
   });
 
   it('renders sessions with present and absent counts', async () => {

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -181,6 +181,6 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
   noSessionsEnrollMessage: {
     message: 'No attendance sessions yet. Enroll learners to mark attendance',
     context:
-      'Empty state message when no attendance sessions exist and no learners are enrolled in the class',
+      'Empty state message when no attendance sessions exist and no learners are enrolled in the class.',
   },
 });

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -181,6 +181,6 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
   noSessionsEnrollMessage: {
     message: 'No attendance sessions yet. Enroll learners to mark attendance',
     context:
-      'Empty state message when no attendance sessions exist and no learners are enrolled in the class.',
+      'Empty state message when no attendance sessions exist and no learners are enrolled in the class',
   },
 });

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -174,10 +174,6 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
     message: 'Absent',
     context: 'Column header for the count of learners absent',
   },
-  enrollLearnersMessage: {
-    message: 'Enroll learners to mark attendance',
-    context: 'Empty state message when there are no learners enrolled in the class',
-  },
   noSessionsEnrollMessage: {
     message: 'No attendance sessions yet. Enroll learners to mark attendance',
     context:

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -174,4 +174,13 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
     message: 'Absent',
     context: 'Column header for the count of learners absent',
   },
+  enrollLearnersMessage: {
+    message: 'Enroll learners to mark attendance',
+    context: 'Empty state message when there are no learners enrolled in the class',
+  },
+  noSessionsEnrollMessage: {
+    message: 'No attendance sessions yet. Enroll learners to mark attendance',
+    context:
+      'Empty state message when no attendance sessions exist and no learners are enrolled in the class',
+  },
 });


### PR DESCRIPTION
## Summary

Fixes a bug where the "Mark attendance" button was visible on the class home page even when no learners were enrolled in the class. This is inconsistent with the behavior of other blocks on the same page, which hide their action buttons when there's no data to act on.

Changes:
- Gate the "Mark attendance" button behind a `v-if="learners.length"` check so it only renders when the class has enrolled learners
- Show a more helpful empty state message (`"No attendance sessions yet. Enroll learners to mark attendance"`) instead of `"No attendance sessions yet"` when there are zero learners

| State | Screenshot |
|-------|------------|
| Class with 0 learners (button hidden, helpful message shown) |<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/53ecf228-7d06-4e2c-a19e-20772896d77b" />|
| Class with learners (button shown as expected) | <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/b60d3c88-08eb-4e0a-9266-d1542c49befa" />|

## References

Fixes #14412

## Reviewer guidance

- Test with a class that has 0 enrolled learners: the "Mark attendance" button should not appear
- Test with a class that has ≥1 enrolled learners: the "Mark attendance" button should appear as before
- The empty state message differs between the two states — verify both messages render correctly

## AI usage

I used Claude Code to implement this change, guiding it to use the existing `learners` computed from `classSummary/learners` in the Vuex store and wrap the button in a `v-if` conditional. I reviewed the generated code, verified the logic against the issue description, and confirmed the fix works in both the empty-class and populated-class scenarios.