### PR TITLE
Add unit learning objectives report API endpoint

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import uuid as uuid_module
 from datetime import timedelta
 from itertools import groupby
 from math import ceil
@@ -54,6 +53,7 @@ from kolibri.core.logger.constants import interaction_types
 from kolibri.core.logger.constants.exercise_attempts import MAPPING
 from kolibri.core.logger.evaluation import attempts_diff
 from kolibri.core.logger.evaluation import LOG_ORDER_BY
+from kolibri.core.logger.utils.pre_post_test import get_synthetic_content_id
 from kolibri.core.notifications.api import create_summarylog
 from kolibri.core.notifications.api import parse_attemptslog
 from kolibri.core.notifications.api import parse_summarylog
@@ -389,10 +389,8 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 "test_type": test_type,
             }
 
-            # Synthetic content_id: UUID5 so pre and post are distinct
-            content_id = uuid_module.uuid5(
-                uuid_module.UUID(deterministic_hash), test_type
-            ).hex
+            # Synthetic content_id: shared across all learners for this test instance.
+            content_id = get_synthetic_content_id(course_session_id, unit_id, test_type)
             channel_id = None
             kind = content_kinds.QUIZ
 

--- a/kolibri/core/logger/utils/pre_post_test.py
+++ b/kolibri/core/logger/utils/pre_post_test.py
@@ -1,0 +1,13 @@
+"""
+Single authoritative implementation of get_synthetic_content_id, shared between
+the learner-side logger API (kolibri.core.logger.api) and the coach-side unit
+report API (kolibri.plugins.coach.unit_report_api).
+"""
+import uuid
+
+_SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c")
+
+
+def get_synthetic_content_id(course_session_id, unit_id, test_type):
+    key = "{}:{}:{}".format(course_session_id, unit_id, test_type)
+    return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex

--- a/kolibri/core/logger/utils/pre_post_test.py
+++ b/kolibri/core/logger/utils/pre_post_test.py
@@ -5,9 +5,11 @@ report API (kolibri.plugins.coach.unit_report_api).
 """
 import uuid
 
-_SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c")
+_PRE_POST_TEST_SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID(
+    "7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c"
+)
 
 
 def get_synthetic_content_id(course_session_id, unit_id, test_type):
     key = "{}:{}:{}".format(course_session_id, unit_id, test_type)
-    return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex
+    return uuid.uuid5(_PRE_POST_TEST_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex

--- a/kolibri/plugins/coach/api_urls.py
+++ b/kolibri/plugins/coach/api_urls.py
@@ -8,6 +8,7 @@ from .api import LessonReportViewset
 from .api import PracticeQuizDifficultQuestionsViewset
 from .api import QuizDifficultQuestionsViewset
 from .class_summary_api import ClassSummaryViewSet
+from .unit_report_api import UnitReportViewSet
 
 router = routers.DefaultRouter()
 
@@ -30,4 +31,11 @@ router.register(
     basename="practicequizdifficulties",
 )
 
-urlpatterns = [re_path(r"^", include(router.urls))]
+urlpatterns = [
+    re_path(r"^", include(router.urls)),
+    re_path(
+        r"^coursesession/(?P<course_session_id>[0-9a-fA-F]{32})/unit/(?P<unit_contentnode_id>[0-9a-fA-F]{32})/report/$",
+        UnitReportViewSet.as_view({"get": "retrieve"}),
+        name="unitreport",
+    ),
+]

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -619,3 +619,77 @@ class ComputeTestScoresTests(TestCase):
         # Most recent log has 0 correct — scores dict should be present but empty.
         self.assertIn(lid, result)
         self.assertEqual(result[lid], {})
+
+
+# ---------------------------------------------------------------------------
+# API integration tests
+# ---------------------------------------------------------------------------
+
+
+class UnitReportAPIBase(APITestCase):
+    """Shared setup for API-level tests."""
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        from kolibri.core.auth.test.test_api import FacilityFactory
+
+        cls.facility = FacilityFactory.create()
+        cls.classroom = Classroom.objects.create(name="classroom", parent=cls.facility)
+
+        cls.facility_admin = helpers.create_facility_admin("fadmin", DUMMY_PASSWORD, cls.facility)
+        cls.facility_coach = helpers.create_coach(
+            "fcoach", DUMMY_PASSWORD, cls.facility, is_facility_coach=True
+        )
+        cls.classroom_coach = helpers.create_coach(
+            "ccoach", DUMMY_PASSWORD, cls.facility, classroom=cls.classroom
+        )
+        cls.other_classroom = Classroom.objects.create(name="other", parent=cls.facility)
+        cls.other_coach = helpers.create_coach(
+            "ocoach", DUMMY_PASSWORD, cls.facility, classroom=cls.other_classroom
+        )
+        cls.learner1 = helpers.create_learner("l1", DUMMY_PASSWORD, cls.facility, cls.classroom)
+        cls.learner2 = helpers.create_learner("l2", DUMMY_PASSWORD, cls.facility, cls.classroom)
+        cls.learner3 = helpers.create_learner("l3", DUMMY_PASSWORD, cls.facility, cls.classroom)
+
+        # Course node (parent) and unit node
+        cls.course_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            title="Test Course",
+            kind=content_kinds.TOPIC,
+            modality=modalities.COURSE,
+            available=True,
+        )
+        cls.unit_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            title="Unit 1: Fractions",
+            kind=content_kinds.EXERCISE,
+            modality=modalities.UNIT,
+            options=UNIT_OPTIONS,
+            available=True,
+            parent=cls.course_node,
+        )
+
+        # Course session for the classroom
+        cls.course_session = CourseSession.objects.create(
+            course=cls.course_node.id,
+            title="Spring 2025",
+            collection=cls.classroom,
+            created_by=cls.facility_admin,
+            is_active=True,
+        )
+        # Assign the whole classroom to the course session
+        CourseSessionAssignment.objects.create(
+            course_session=cls.course_session,
+            collection=cls.classroom,
+            assigned_by=cls.facility_admin,
+        )
+
+    def _get_url(self):
+        return _make_url(self.course_session.id, self.unit_node.id)

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -163,3 +163,33 @@ def _create_attempt(learner, course_session_id, unit_id, test_type, items_correc
         )
 
     return mastery_log
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: pure logic (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class GetTestVersionTests(SimpleTestCase):
+    """get_test_version returns deterministic 'a' or 'b'."""
+
+    def test_deterministic(self):
+        lid = uuid.uuid4().hex
+        sid = uuid.uuid4().hex
+        uid = uuid.uuid4().hex
+        v1 = get_test_version(lid, sid, uid)
+        v2 = get_test_version(lid, sid, uid)
+        self.assertEqual(v1, v2)
+        self.assertIn(v1, ("a", "b"))
+
+    def test_hash_byte_below_128_returns_version_a(self):
+        # Directly exercise the branch: first SHA-256 byte < 128 → "a".
+        with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
+            mock_hashlib.sha256.return_value.digest.return_value = bytes([0]) + b"\x00" * 31
+            self.assertEqual(get_test_version("lid", "sid", "uid"), "a")
+
+    def test_hash_byte_128_or_above_returns_version_b(self):
+        # Directly exercise the branch: first SHA-256 byte >= 128 → "b".
+        with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
+            mock_hashlib.sha256.return_value.digest.return_value = bytes([255]) + b"\x00" * 31
+            self.assertEqual(get_test_version("lid", "sid", "uid"), "b")

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -47,9 +47,6 @@ def _make_url(course_session_id, unit_contentnode_id):
     )
 
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
 
 # Fixed UUIDs so test failures are reproducible across runs.
 LO1_ID = "00000000000000000000000000000011"
@@ -58,12 +55,12 @@ LO2_ID = "00000000000000000000000000000022"
 # Version A items: 2 for LO1, 1 for LO2
 ITEM_A1 = "0000000000000000000000000000a001"
 ITEM_A2 = "0000000000000000000000000000a002"
-ITEM_A3 = "0000000000000000000000000000a003"  # maps to LO2
+ITEM_A3 = "0000000000000000000000000000a003" 
 
 # Version B items: 2 for LO1, 1 for LO2
 ITEM_B1 = "0000000000000000000000000000b001"
 ITEM_B2 = "0000000000000000000000000000b002"
-ITEM_B3 = "0000000000000000000000000000b003"  # maps to LO2
+ITEM_B3 = "0000000000000000000000000000b003" 
 
 ASSESSMENT_OBJECTIVES = {
     ITEM_A1: LO1_ID,
@@ -165,10 +162,6 @@ def _create_attempt(learner, course_session_id, unit_id, test_type, items_correc
     return mastery_log
 
 
-# ---------------------------------------------------------------------------
-# Unit tests: pure logic (no HTTP)
-# ---------------------------------------------------------------------------
-
 
 class GetTestVersionTests(SimpleTestCase):
     """get_test_version returns deterministic 'a' or 'b'."""
@@ -224,3 +217,405 @@ class GetTestStatusTests(SimpleTestCase):
         """An assignment that exists but has never been opened must not be reported as closed."""
         a = self._make_assignment(False, TestStatus.NotStarted)
         self.assertEqual(_get_test_status([a]), TEST_STATUS_NOT_ACTIVATED)
+
+
+class ComputeTestScoresTests(TestCase):
+    """_compute_all_test_scores aggregation logic without HTTP layer."""
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        from kolibri.core.auth.test.test_api import FacilityFactory
+
+        cls.facility = FacilityFactory.create()
+        cls.classroom = Classroom.objects.create(name="cls", parent=cls.facility)
+        cls.learner_a = helpers.create_learner("la", DUMMY_PASSWORD, cls.facility, cls.classroom)
+        cls.learner_b = helpers.create_learner("lb", DUMMY_PASSWORD, cls.facility, cls.classroom)
+
+    def setUp(self):
+        # Generate fresh IDs per test so that each test's synthetic content_ids
+        # are unique, eliminating any risk of ContentSummaryLog UNIQUE-constraint
+        # collisions between tests that share the same learner objects.
+        self.course_session_id = uuid.uuid4().hex
+        self.unit_id = uuid.uuid4().hex
+
+    def test_no_learners_returns_empty(self):
+        result = _compute_all_test_scores([], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES)
+        self.assertEqual(result["pre"], {})
+        self.assertEqual(result["post"], {})
+
+    def test_unattempted_learner_absent_from_scores(self):
+        result = _compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )
+        self.assertNotIn(str(self.learner_a.id), result["pre"])
+        self.assertNotIn(str(self.learner_a.id), result["post"])
+
+    def test_correct_answers_counted_per_lo(self):
+        # Determine which version learner_a will get
+        version = get_test_version(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
+        )
+        if version == "a":
+            items_correct = [ITEM_A1, ITEM_A2]  # 2 correct for LO1
+            items_incorrect = [ITEM_A3]          # 0 correct for LO2
+        else:
+            items_correct = [ITEM_B1, ITEM_B2]
+            items_incorrect = [ITEM_B3]
+
+        _create_attempt(
+            self.learner_a,
+            self.course_session_id,
+            self.unit_id,
+            "pre",
+            items_correct=items_correct,
+            items_incorrect=items_incorrect,
+        )
+        result = _compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["pre"]
+        lid = str(self.learner_a.id)
+        self.assertIn(lid, result)
+        self.assertEqual(result[lid].get(LO1_ID, 0), 2)
+        self.assertEqual(result[lid].get(LO2_ID, 0), 0)
+
+    def test_attempted_with_zero_correct_included_as_empty_dict(self):
+        version = get_test_version(
+            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id)
+        )
+        if version == "a":
+            items_incorrect = [ITEM_A1, ITEM_A2, ITEM_A3]
+        else:
+            items_incorrect = [ITEM_B1, ITEM_B2, ITEM_B3]
+
+        _create_attempt(
+            self.learner_b,
+            self.course_session_id,
+            self.unit_id,
+            "pre",
+            items_correct=[],
+            items_incorrect=items_incorrect,
+        )
+        result = _compute_all_test_scores(
+            [self.learner_b.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["pre"]
+        # Learner attempted but got 0 correct – should appear with empty scores dict
+        self.assertIn(str(self.learner_b.id), result)
+        self.assertEqual(result[str(self.learner_b.id)], {})
+
+    def test_only_complete_mastery_logs_counted(self):
+        """Incomplete (in-progress) mastery logs are ignored."""
+        synthetic_cid = get_synthetic_content_id(
+            str(self.learner_a.id),
+            str(self.course_session_id),
+            str(self.unit_id),
+            "post",
+        )
+        now = timezone.now()
+        channel_id = uuid.uuid4().hex
+        summary_log = ContentSummaryLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            kind=content_kinds.EXERCISE,
+        )
+        session_log = ContentSessionLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            kind=content_kinds.EXERCISE,
+        )
+        incomplete_mastery = MasteryLog.objects.create(
+            user=self.learner_a,
+            summarylog=summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            mastery_level=-2,
+            complete=False,  # still in progress
+        )
+        version = get_test_version(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
+        )
+        item = ITEM_A1 if version == "a" else ITEM_B1
+        AttemptLog.objects.create(
+            masterylog=incomplete_mastery,
+            sessionlog=session_log,
+            user=self.learner_a,
+            item=item,
+            start_timestamp=now - datetime.timedelta(minutes=5),
+            end_timestamp=now,
+            correct=1,
+        )
+
+        result = _compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["post"]
+        self.assertNotIn(str(self.learner_a.id), result)
+
+    def test_pre_and_post_are_independent(self):
+        """Pre-test data does not bleed into post-test scores."""
+        version = get_test_version(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
+        )
+        items_correct = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+
+        _create_attempt(
+            self.learner_a,
+            self.course_session_id,
+            self.unit_id,
+            "pre",
+            items_correct=items_correct,
+        )
+
+        post_result = _compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["post"]
+        self.assertNotIn(str(self.learner_a.id), post_result)
+
+    def test_duplicate_attempt_items_counted_once(self):
+        """When the same item appears twice in a mastery log, only the most recent attempt counts."""
+        version = get_test_version(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
+        )
+        item = ITEM_A1 if version == "a" else ITEM_B1
+
+        synthetic_cid = get_synthetic_content_id(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id), "pre"
+        )
+        now = timezone.now()
+        channel_id = uuid.uuid4().hex
+        summary_log = ContentSummaryLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+            progress=1.0,
+        )
+        session_log = ContentSessionLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+        )
+        mastery_log = MasteryLog.objects.create(
+            user=self.learner_a,
+            summarylog=summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            completion_timestamp=now,
+            mastery_level=-1,
+            complete=True,
+        )
+        # First attempt on the item: incorrect (earlier timestamp)
+        AttemptLog.objects.create(
+            masterylog=mastery_log,
+            sessionlog=session_log,
+            user=self.learner_a,
+            item=item,
+            start_timestamp=now - datetime.timedelta(minutes=20),
+            end_timestamp=now - datetime.timedelta(minutes=19),
+            correct=0,
+        )
+        # Second attempt on the same item: correct (later timestamp — this one should win)
+        AttemptLog.objects.create(
+            masterylog=mastery_log,
+            sessionlog=session_log,
+            user=self.learner_a,
+            item=item,
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            end_timestamp=now - datetime.timedelta(minutes=9),
+            correct=1,
+        )
+
+        result = _compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["pre"]
+        lid = str(self.learner_a.id)
+        self.assertIn(lid, result)
+        # The most-recent attempt is correct, so LO1 should have exactly 1 (not 2).
+        self.assertEqual(result[lid].get(LO1_ID, 0), 1)
+
+    def test_partial_credit_not_counted(self):
+        """correct=0.5 (partial credit) is excluded; only correct==1 counts."""
+        synthetic_cid = get_synthetic_content_id(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id), "pre"
+        )
+        now = timezone.now()
+        channel_id = uuid.uuid4().hex
+        summary_log = ContentSummaryLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+            progress=1.0,
+        )
+        session_log = ContentSessionLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+        )
+        mastery_log = MasteryLog.objects.create(
+            user=self.learner_a,
+            summarylog=summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            completion_timestamp=now,
+            mastery_level=-1,
+            complete=True,
+        )
+        version = get_test_version(
+            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
+        )
+        item = ITEM_A1 if version == "a" else ITEM_B1
+        AttemptLog.objects.create(
+            masterylog=mastery_log,
+            sessionlog=session_log,
+            user=self.learner_a,
+            item=item,
+            start_timestamp=now - datetime.timedelta(minutes=20),
+            end_timestamp=now - datetime.timedelta(minutes=19),
+            correct=0.5,  # partial credit — must NOT count
+        )
+        result = _compute_all_test_scores(
+            [self.learner_a.id], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES
+        )["pre"]
+        lid = str(self.learner_a.id)
+        # Learner appears (complete mastery log) but LO1 score is 0 — partial credit excluded.
+        self.assertIn(lid, result)
+        self.assertEqual(result[lid].get(LO1_ID, 0), 0)
+
+    def test_only_most_recent_complete_mastery_log_used(self):
+        """When a learner has multiple complete mastery logs (retakes), only the most recent is used."""
+        version = get_test_version(
+            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id)
+        )
+        # All items for this version — used in both mastery logs (correct in the
+        # first, incorrect in the second).  Named all_items, not items_correct, to
+        # avoid confusion when they're iterated with correct=0 below.
+        all_items = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+
+        # Build both mastery logs manually so they share the same ContentSummaryLog
+        # (which is required — two ContentSummaryLogs for the same content_id would
+        # violate the morango UNIQUE constraint on source_id = content_id).
+        synthetic_cid = get_synthetic_content_id(
+            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id), "post"
+        )
+        now = timezone.now()
+        later = now + datetime.timedelta(hours=1)
+        channel_id = uuid.uuid4().hex
+
+        shared_summary_log = ContentSummaryLog.objects.create(
+            user=self.learner_b,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=later,
+            kind=content_kinds.EXERCISE,
+            progress=1.0,
+        )
+        session_log1 = ContentSessionLog.objects.create(
+            user=self.learner_b,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+        )
+        session_log2 = ContentSessionLog.objects.create(
+            user=self.learner_b,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=later - datetime.timedelta(minutes=30),
+            end_timestamp=later,
+            kind=content_kinds.EXERCISE,
+        )
+
+        # First (earlier) mastery log: all correct
+        mastery_log1 = MasteryLog.objects.create(
+            user=self.learner_b,
+            summarylog=shared_summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=now - datetime.timedelta(minutes=30),
+            end_timestamp=now,
+            completion_timestamp=now,
+            mastery_level=-1,
+            complete=True,
+        )
+        for i, item in enumerate(all_items):
+            offset = datetime.timedelta(minutes=i * 2)
+            AttemptLog.objects.create(
+                masterylog=mastery_log1,
+                sessionlog=session_log1,
+                user=self.learner_b,
+                item=item,
+                start_timestamp=now - datetime.timedelta(minutes=30) + offset,
+                end_timestamp=now - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+                correct=1,
+            )
+
+        # Second (later) mastery log on the same summary log: all incorrect
+        mastery_log2 = MasteryLog.objects.create(
+            user=self.learner_b,
+            summarylog=shared_summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=later - datetime.timedelta(minutes=30),
+            end_timestamp=later,
+            completion_timestamp=later,
+            mastery_level=-2,  # different level to avoid source_id collision
+            complete=True,
+        )
+        for i, item in enumerate(all_items):
+            offset = datetime.timedelta(minutes=i * 2)
+            AttemptLog.objects.create(
+                masterylog=mastery_log2,
+                sessionlog=session_log2,
+                user=self.learner_b,
+                item=item,
+                start_timestamp=later - datetime.timedelta(minutes=30) + offset,
+                end_timestamp=later - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+                correct=0,
+            )
+
+        result = _compute_all_test_scores(
+            [self.learner_b.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["post"]
+        lid = str(self.learner_b.id)
+        # Most recent log has 0 correct — scores dict should be present but empty.
+        self.assertIn(lid, result)
+        self.assertEqual(result[lid], {})

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -299,8 +299,59 @@ class ComputeTestScoresTests(TestCase):
         self.assertIn(str(self.learner_b.id), result)
         self.assertEqual(result[str(self.learner_b.id)], {})
 
-    def test_only_complete_mastery_logs_counted(self):
-        """Incomplete (in-progress) mastery logs are ignored."""
+    def test_incomplete_mastery_log_excluded(self):
+        """Mastery logs with complete=False are ignored even when end_timestamp is set."""
+        synthetic_cid = get_synthetic_content_id(
+            str(self.course_session_id),
+            str(self.unit_id),
+            "post",
+        )
+        now = timezone.now()
+        channel_id = uuid.uuid4().hex
+        summary_log = ContentSummaryLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            end_timestamp=now,
+            kind=content_kinds.EXERCISE,
+        )
+        session_log = ContentSessionLog.objects.create(
+            user=self.learner_a,
+            content_id=synthetic_cid,
+            channel_id=channel_id,
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            kind=content_kinds.EXERCISE,
+        )
+        incomplete_mastery = MasteryLog.objects.create(
+            user=self.learner_a,
+            summarylog=summary_log,
+            mastery_criterion={"type": "quiz"},
+            start_timestamp=now - datetime.timedelta(minutes=10),
+            end_timestamp=now,  # has end_timestamp but complete=False
+            mastery_level=-2,
+            complete=False,  # still in progress — must be excluded
+        )
+        AttemptLog.objects.create(
+            masterylog=incomplete_mastery,
+            sessionlog=session_log,
+            user=self.learner_a,
+            item=ITEM_A1,
+            start_timestamp=now - datetime.timedelta(minutes=5),
+            end_timestamp=now,
+            correct=1,
+        )
+
+        result = compute_all_test_scores(
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
+        )["post"]
+        self.assertNotIn(str(self.learner_a.id), result)
+
+    def test_mastery_log_without_end_timestamp_excluded(self):
+        """Mastery logs with complete=True but no end_timestamp are ignored."""
         synthetic_cid = get_synthetic_content_id(
             str(self.course_session_id),
             str(self.unit_id),
@@ -322,16 +373,17 @@ class ComputeTestScoresTests(TestCase):
             start_timestamp=now - datetime.timedelta(minutes=10),
             kind=content_kinds.EXERCISE,
         )
-        incomplete_mastery = MasteryLog.objects.create(
+        mastery_no_end = MasteryLog.objects.create(
             user=self.learner_a,
             summarylog=summary_log,
             mastery_criterion={"type": "quiz"},
             start_timestamp=now - datetime.timedelta(minutes=10),
+            # end_timestamp intentionally omitted — must be excluded
             mastery_level=-2,
-            complete=False,  # still in progress
+            complete=True,
         )
         AttemptLog.objects.create(
-            masterylog=incomplete_mastery,
+            masterylog=mastery_no_end,
             sessionlog=session_log,
             user=self.learner_a,
             item=ITEM_A1,
@@ -368,58 +420,28 @@ class ComputeTestScoresTests(TestCase):
 
     def test_duplicate_attempt_items_counted_once(self):
         """When the same item appears twice in a mastery log, only the most recent attempt counts."""
-        synthetic_cid = get_synthetic_content_id(
-            str(self.course_session_id),
-            str(self.unit_id),
+        # Set up a complete mastery log with ITEM_A1 answered incorrectly.
+        mastery_log = _create_attempt(
+            self.learner_a,
+            self.course_session_id,
+            self.unit_id,
             "pre",
+            items_correct=[],
+            items_incorrect=[ITEM_A1],
         )
+        # Add a second (later, correct) attempt on the same item to the same mastery log.
+        session_log = ContentSessionLog.objects.filter(
+            user=self.learner_a,
+            content_id=mastery_log.summarylog.content_id,
+        ).first()
         now = timezone.now()
-        channel_id = uuid.uuid4().hex
-        summary_log = ContentSummaryLog.objects.create(
-            user=self.learner_a,
-            content_id=synthetic_cid,
-            channel_id=channel_id,
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            kind=content_kinds.EXERCISE,
-            progress=1.0,
-        )
-        session_log = ContentSessionLog.objects.create(
-            user=self.learner_a,
-            content_id=synthetic_cid,
-            channel_id=channel_id,
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            kind=content_kinds.EXERCISE,
-        )
-        mastery_log = MasteryLog.objects.create(
-            user=self.learner_a,
-            summarylog=summary_log,
-            mastery_criterion={"type": "quiz"},
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            completion_timestamp=now,
-            mastery_level=-1,
-            complete=True,
-        )
-        # First attempt on the item: incorrect (earlier timestamp)
         AttemptLog.objects.create(
             masterylog=mastery_log,
             sessionlog=session_log,
             user=self.learner_a,
             item=ITEM_A1,
-            start_timestamp=now - datetime.timedelta(minutes=20),
-            end_timestamp=now - datetime.timedelta(minutes=19),
-            correct=0,
-        )
-        # Second attempt on the same item: correct (later timestamp — this one should win)
-        AttemptLog.objects.create(
-            masterylog=mastery_log,
-            sessionlog=session_log,
-            user=self.learner_a,
-            item=ITEM_A1,
-            start_timestamp=now - datetime.timedelta(minutes=10),
-            end_timestamp=now - datetime.timedelta(minutes=9),
+            start_timestamp=now,
+            end_timestamp=now + datetime.timedelta(minutes=1),
             correct=1,
         )
 
@@ -436,47 +458,27 @@ class ComputeTestScoresTests(TestCase):
 
     def test_partial_credit_not_counted(self):
         """correct=0.5 (partial credit) is excluded; only correct==1 counts."""
-        synthetic_cid = get_synthetic_content_id(
-            str(self.course_session_id),
-            str(self.unit_id),
+        # Set up a complete mastery log with ITEM_A2 correct (LO1) to confirm the
+        # learner appears in results, then add a partial-credit attempt on ITEM_A1.
+        mastery_log = _create_attempt(
+            self.learner_a,
+            self.course_session_id,
+            self.unit_id,
             "pre",
+            items_correct=[ITEM_A2],
         )
+        session_log = ContentSessionLog.objects.filter(
+            user=self.learner_a,
+            content_id=mastery_log.summarylog.content_id,
+        ).first()
         now = timezone.now()
-        channel_id = uuid.uuid4().hex
-        summary_log = ContentSummaryLog.objects.create(
-            user=self.learner_a,
-            content_id=synthetic_cid,
-            channel_id=channel_id,
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            kind=content_kinds.EXERCISE,
-            progress=1.0,
-        )
-        session_log = ContentSessionLog.objects.create(
-            user=self.learner_a,
-            content_id=synthetic_cid,
-            channel_id=channel_id,
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            kind=content_kinds.EXERCISE,
-        )
-        mastery_log = MasteryLog.objects.create(
-            user=self.learner_a,
-            summarylog=summary_log,
-            mastery_criterion={"type": "quiz"},
-            start_timestamp=now - datetime.timedelta(minutes=30),
-            end_timestamp=now,
-            completion_timestamp=now,
-            mastery_level=-1,
-            complete=True,
-        )
         AttemptLog.objects.create(
             masterylog=mastery_log,
             sessionlog=session_log,
             user=self.learner_a,
             item=ITEM_A1,
-            start_timestamp=now - datetime.timedelta(minutes=20),
-            end_timestamp=now - datetime.timedelta(minutes=19),
+            start_timestamp=now,
+            end_timestamp=now + datetime.timedelta(minutes=1),
             correct=0.5,  # partial credit — must NOT count
         )
         result = compute_all_test_scores(
@@ -486,9 +488,11 @@ class ComputeTestScoresTests(TestCase):
             ASSESSMENT_OBJECTIVES,
         )["pre"]
         lid = str(self.learner_a.id)
-        # Learner appears (complete mastery log) but LO1 score is 0 — partial credit excluded.
+        # Learner appears (complete mastery log); ITEM_A2 counts (1), ITEM_A1 partial does not.
         self.assertIn(lid, result)
-        self.assertEqual(result[lid].get(LO1_ID, 0), 0)
+        self.assertEqual(
+            result[lid].get(LO1_ID, 0), 1
+        )  # ITEM_A2 correct, ITEM_A1 excluded
 
     def test_only_most_recent_complete_mastery_log_used(self):
         """When a learner has multiple complete mastery logs (retakes), only the most recent is used."""

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -22,13 +22,13 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
-from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
-from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
-from kolibri.plugins.coach.unit_report_api import TEST_STATUS_OPEN
 from kolibri.plugins.coach.unit_report_api import _compute_all_test_scores
 from kolibri.plugins.coach.unit_report_api import _get_test_status
 from kolibri.plugins.coach.unit_report_api import get_synthetic_content_id
 from kolibri.plugins.coach.unit_report_api import get_test_version
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_OPEN
 
 DUMMY_PASSWORD = "password"
 
@@ -46,7 +46,6 @@ def _make_url(course_session_id, unit_contentnode_id):
     )
 
 
-
 # Fixed UUIDs so test failures are reproducible across runs.
 LO1_ID = "00000000000000000000000000000011"
 LO2_ID = "00000000000000000000000000000022"
@@ -54,12 +53,12 @@ LO2_ID = "00000000000000000000000000000022"
 # Version A items: 2 for LO1, 1 for LO2
 ITEM_A1 = "0000000000000000000000000000a001"
 ITEM_A2 = "0000000000000000000000000000a002"
-ITEM_A3 = "0000000000000000000000000000a003" 
+ITEM_A3 = "0000000000000000000000000000a003"
 
 # Version B items: 2 for LO1, 1 for LO2
 ITEM_B1 = "0000000000000000000000000000b001"
 ITEM_B2 = "0000000000000000000000000000b002"
-ITEM_B3 = "0000000000000000000000000000b003" 
+ITEM_B3 = "0000000000000000000000000000b003"
 
 ASSESSMENT_OBJECTIVES = {
     ITEM_A1: LO1_ID,
@@ -79,7 +78,14 @@ UNIT_OPTIONS = {
     "completion_criteria": {
         "threshold": {
             "pre_post_test": {
-                "assessment_item_ids": [ITEM_A1, ITEM_A2, ITEM_A3, ITEM_B1, ITEM_B2, ITEM_B3],
+                "assessment_item_ids": [
+                    ITEM_A1,
+                    ITEM_A2,
+                    ITEM_A3,
+                    ITEM_B1,
+                    ITEM_B2,
+                    ITEM_B3,
+                ],
                 "version_a_item_ids": [ITEM_A1, ITEM_A2, ITEM_A3],
                 "version_b_item_ids": [ITEM_B1, ITEM_B2, ITEM_B3],
             }
@@ -102,7 +108,9 @@ def _make_content_node(parent_id=None):
     return node
 
 
-def _create_attempt(learner, course_session_id, unit_id, test_type, items_correct, items_incorrect=None):
+def _create_attempt(
+    learner, course_session_id, unit_id, test_type, items_correct, items_incorrect=None
+):
     """
     Create ContentSummaryLog + MasteryLog + AttemptLogs for a learner's test attempt.
 
@@ -154,12 +162,14 @@ def _create_attempt(learner, course_session_id, unit_id, test_type, items_correc
             user=learner,
             item=item,
             start_timestamp=now - datetime.timedelta(minutes=30) + offset,
-            end_timestamp=now - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+            end_timestamp=now
+            - datetime.timedelta(minutes=30)
+            + offset
+            + datetime.timedelta(minutes=1),
             correct=correct,
         )
 
     return mastery_log
-
 
 
 class GetTestVersionTests(SimpleTestCase):
@@ -177,13 +187,17 @@ class GetTestVersionTests(SimpleTestCase):
     def test_hash_byte_below_128_returns_version_a(self):
         # Directly exercise the branch: first SHA-256 byte < 128 → "a".
         with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
-            mock_hashlib.sha256.return_value.digest.return_value = bytes([0]) + b"\x00" * 31
+            mock_hashlib.sha256.return_value.digest.return_value = (
+                bytes([0]) + b"\x00" * 31
+            )
             self.assertEqual(get_test_version("lid", "sid", "uid"), "a")
 
     def test_hash_byte_128_or_above_returns_version_b(self):
         # Directly exercise the branch: first SHA-256 byte >= 128 → "b".
         with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
-            mock_hashlib.sha256.return_value.digest.return_value = bytes([255]) + b"\x00" * 31
+            mock_hashlib.sha256.return_value.digest.return_value = (
+                bytes([255]) + b"\x00" * 31
+            )
             self.assertEqual(get_test_version("lid", "sid", "uid"), "b")
 
 
@@ -224,8 +238,12 @@ class ComputeTestScoresTests(TestCase):
 
         cls.facility = FacilityFactory.create()
         cls.classroom = Classroom.objects.create(name="cls", parent=cls.facility)
-        cls.learner_a = helpers.create_learner("la", DUMMY_PASSWORD, cls.facility, cls.classroom)
-        cls.learner_b = helpers.create_learner("lb", DUMMY_PASSWORD, cls.facility, cls.classroom)
+        cls.learner_a = helpers.create_learner(
+            "la", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
+        cls.learner_b = helpers.create_learner(
+            "lb", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
 
     def setUp(self):
         # Generate fresh IDs per test so that each test's synthetic content_ids
@@ -235,7 +253,9 @@ class ComputeTestScoresTests(TestCase):
         self.unit_id = uuid.uuid4().hex
 
     def test_no_learners_returns_empty(self):
-        result = _compute_all_test_scores([], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES)
+        result = _compute_all_test_scores(
+            [], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES
+        )
         self.assertEqual(result["pre"], {})
         self.assertEqual(result["post"], {})
 
@@ -256,7 +276,7 @@ class ComputeTestScoresTests(TestCase):
         )
         if version == "a":
             items_correct = [ITEM_A1, ITEM_A2]  # 2 correct for LO1
-            items_incorrect = [ITEM_A3]          # 0 correct for LO2
+            items_incorrect = [ITEM_A3]  # 0 correct for LO2
         else:
             items_correct = [ITEM_B1, ITEM_B2]
             items_incorrect = [ITEM_B3]
@@ -366,7 +386,11 @@ class ComputeTestScoresTests(TestCase):
         version = get_test_version(
             str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
         )
-        items_correct = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+        items_correct = (
+            [ITEM_A1, ITEM_A2, ITEM_A3]
+            if version == "a"
+            else [ITEM_B1, ITEM_B2, ITEM_B3]
+        )
 
         _create_attempt(
             self.learner_a,
@@ -392,7 +416,10 @@ class ComputeTestScoresTests(TestCase):
         item = ITEM_A1 if version == "a" else ITEM_B1
 
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id), "pre"
+            str(self.learner_a.id),
+            str(self.course_session_id),
+            str(self.unit_id),
+            "pre",
         )
         now = timezone.now()
         channel_id = uuid.uuid4().hex
@@ -458,7 +485,10 @@ class ComputeTestScoresTests(TestCase):
     def test_partial_credit_not_counted(self):
         """correct=0.5 (partial credit) is excluded; only correct==1 counts."""
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id), "pre"
+            str(self.learner_a.id),
+            str(self.course_session_id),
+            str(self.unit_id),
+            "pre",
         )
         now = timezone.now()
         channel_id = uuid.uuid4().hex
@@ -503,7 +533,10 @@ class ComputeTestScoresTests(TestCase):
             correct=0.5,  # partial credit — must NOT count
         )
         result = _compute_all_test_scores(
-            [self.learner_a.id], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES
+            [self.learner_a.id],
+            self.course_session_id,
+            self.unit_id,
+            ASSESSMENT_OBJECTIVES,
         )["pre"]
         lid = str(self.learner_a.id)
         # Learner appears (complete mastery log) but LO1 score is 0 — partial credit excluded.
@@ -518,13 +551,20 @@ class ComputeTestScoresTests(TestCase):
         # All items for this version — used in both mastery logs (correct in the
         # first, incorrect in the second).  Named all_items, not items_correct, to
         # avoid confusion when they're iterated with correct=0 below.
-        all_items = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+        all_items = (
+            [ITEM_A1, ITEM_A2, ITEM_A3]
+            if version == "a"
+            else [ITEM_B1, ITEM_B2, ITEM_B3]
+        )
 
         # Build both mastery logs manually so they share the same ContentSummaryLog
         # (which is required — two ContentSummaryLogs for the same content_id would
         # violate the morango UNIQUE constraint on source_id = content_id).
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id), "post"
+            str(self.learner_b.id),
+            str(self.course_session_id),
+            str(self.unit_id),
+            "post",
         )
         now = timezone.now()
         later = now + datetime.timedelta(hours=1)
@@ -575,7 +615,10 @@ class ComputeTestScoresTests(TestCase):
                 user=self.learner_b,
                 item=item,
                 start_timestamp=now - datetime.timedelta(minutes=30) + offset,
-                end_timestamp=now - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+                end_timestamp=now
+                - datetime.timedelta(minutes=30)
+                + offset
+                + datetime.timedelta(minutes=1),
                 correct=1,
             )
 
@@ -598,7 +641,10 @@ class ComputeTestScoresTests(TestCase):
                 user=self.learner_b,
                 item=item,
                 start_timestamp=later - datetime.timedelta(minutes=30) + offset,
-                end_timestamp=later - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+                end_timestamp=later
+                - datetime.timedelta(minutes=30)
+                + offset
+                + datetime.timedelta(minutes=1),
                 correct=0,
             )
 
@@ -632,20 +678,30 @@ class UnitReportAPIBase(APITestCase):
         cls.facility = FacilityFactory.create()
         cls.classroom = Classroom.objects.create(name="classroom", parent=cls.facility)
 
-        cls.facility_admin = helpers.create_facility_admin("fadmin", DUMMY_PASSWORD, cls.facility)
+        cls.facility_admin = helpers.create_facility_admin(
+            "fadmin", DUMMY_PASSWORD, cls.facility
+        )
         cls.facility_coach = helpers.create_coach(
             "fcoach", DUMMY_PASSWORD, cls.facility, is_facility_coach=True
         )
         cls.classroom_coach = helpers.create_coach(
             "ccoach", DUMMY_PASSWORD, cls.facility, classroom=cls.classroom
         )
-        cls.other_classroom = Classroom.objects.create(name="other", parent=cls.facility)
+        cls.other_classroom = Classroom.objects.create(
+            name="other", parent=cls.facility
+        )
         cls.other_coach = helpers.create_coach(
             "ocoach", DUMMY_PASSWORD, cls.facility, classroom=cls.other_classroom
         )
-        cls.learner1 = helpers.create_learner("l1", DUMMY_PASSWORD, cls.facility, cls.classroom)
-        cls.learner2 = helpers.create_learner("l2", DUMMY_PASSWORD, cls.facility, cls.classroom)
-        cls.learner3 = helpers.create_learner("l3", DUMMY_PASSWORD, cls.facility, cls.classroom)
+        cls.learner1 = helpers.create_learner(
+            "l1", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
+        cls.learner2 = helpers.create_learner(
+            "l2", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
+        cls.learner3 = helpers.create_learner(
+            "l3", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
 
         # Course node (parent) and unit node
         cls.course_node = ContentNode.objects.create(
@@ -706,29 +762,39 @@ class UnitReportPermissionTests(UnitReportAPIBase):
         self.assertEqual(response.status_code, 403)
 
     def test_classroom_coach_can_access(self):
-        self.client.login(username=self.classroom_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.classroom_coach.username, password=DUMMY_PASSWORD
+        )
         response = self.client.get(self._get_url())
         self.assertEqual(response.status_code, 200)
 
     def test_facility_coach_can_access(self):
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
         response = self.client.get(self._get_url())
         self.assertEqual(response.status_code, 200)
 
     def test_facility_admin_can_access(self):
-        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_admin.username, password=DUMMY_PASSWORD
+        )
         response = self.client.get(self._get_url())
         self.assertEqual(response.status_code, 200)
 
     def test_nonexistent_course_session_returns_403(self):
         url = _make_url(uuid.uuid4().hex, self.unit_node.id)
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
     def test_nonexistent_unit_returns_404(self):
         url = _make_url(self.course_session.id, uuid.uuid4().hex)
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
@@ -737,7 +803,9 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
     """Verify the response structure matches the spec."""
 
     def setUp(self):
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
 
     def test_top_level_keys(self):
         response = self.client.get(self._get_url())
@@ -796,7 +864,9 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
         """No UnitTestAssignment records → both tests are not_activated."""
         response = self.client.get(self._get_url())
         self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
-        self.assertEqual(response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
+        self.assertEqual(
+            response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED
+        )
 
     def test_open_status_when_assignment_is_active(self):
         UnitTestAssignment.objects.create(
@@ -809,7 +879,9 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
         )
         response = self.client.get(self._get_url())
         self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_OPEN)
-        self.assertEqual(response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
+        self.assertEqual(
+            response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED
+        )
 
     def test_closed_status_when_assignment_is_ended(self):
         UnitTestAssignment.objects.create(
@@ -847,7 +919,9 @@ class UnitReportScoringTests(UnitReportAPIBase):
     """Verify per-LO score aggregation and learner sorting."""
 
     def setUp(self):
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
 
     def test_unattempted_learner_absent_from_scores_map(self):
         """Learner with no attempt is in learners list but not in scores."""
@@ -874,7 +948,7 @@ class UnitReportScoringTests(UnitReportAPIBase):
             self.course_session.id,
             self.unit_node.id,
             "pre",
-            items_correct=all_items[:2],   # both LO1 items correct
+            items_correct=all_items[:2],  # both LO1 items correct
             items_incorrect=all_items[2:],  # LO2 item incorrect
         )
 
@@ -897,11 +971,17 @@ class UnitReportScoringTests(UnitReportAPIBase):
             items = [ITEM_B1, ITEM_B2, ITEM_B3]
 
         _create_attempt(
-            self.learner3, self.course_session.id, self.unit_node.id, "pre",
+            self.learner3,
+            self.course_session.id,
+            self.unit_node.id,
+            "pre",
             items_correct=items[:1],
         )
         _create_attempt(
-            self.learner3, self.course_session.id, self.unit_node.id, "post",
+            self.learner3,
+            self.course_session.id,
+            self.unit_node.id,
+            "post",
             items_correct=items[:2],
         )
 
@@ -919,10 +999,19 @@ class UnitReportScoringTests(UnitReportAPIBase):
         # The loop index i is the number of correct answers for that learner.
         learners = [self.learner1, self.learner2, self.learner3]
         for i, learner in enumerate(learners):
-            version = get_test_version(str(learner.id), str(course_session_id), str(unit_id))
-            all_items = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+            version = get_test_version(
+                str(learner.id), str(course_session_id), str(unit_id)
+            )
+            all_items = (
+                [ITEM_A1, ITEM_A2, ITEM_A3]
+                if version == "a"
+                else [ITEM_B1, ITEM_B2, ITEM_B3]
+            )
             _create_attempt(
-                learner, course_session_id, unit_id, "pre",
+                learner,
+                course_session_id,
+                unit_id,
+                "pre",
                 items_correct=all_items[:i],
                 items_incorrect=all_items[i:],
             )
@@ -949,7 +1038,9 @@ class UnitReportLearnerGroupTests(UnitReportAPIBase):
     databases = "__all__"
 
     def setUp(self):
-        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
+        )
 
     def test_learner_group_members_included(self):
         """
@@ -960,8 +1051,11 @@ class UnitReportLearnerGroupTests(UnitReportAPIBase):
         group = LearnerGroup.objects.create(name="Group A", parent=self.classroom)
         # Kolibri requires classroom membership before LearnerGroup membership.
         group_learner = helpers.create_learner(
-            "gl1", DUMMY_PASSWORD, self.facility,
-            classroom=self.classroom, learner_group=group,
+            "gl1",
+            DUMMY_PASSWORD,
+            self.facility,
+            classroom=self.classroom,
+            learner_group=group,
         )
 
         # Assign the group (not the whole classroom) to a new course session.

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -193,3 +193,34 @@ class GetTestVersionTests(SimpleTestCase):
         with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
             mock_hashlib.sha256.return_value.digest.return_value = bytes([255]) + b"\x00" * 31
             self.assertEqual(get_test_version("lid", "sid", "uid"), "b")
+
+
+class GetTestStatusTests(SimpleTestCase):
+    """_get_test_status maps UnitTestAssignment state to response strings."""
+
+    def _make_assignment(self, is_active, status):
+        a = UnitTestAssignment.__new__(UnitTestAssignment)
+        a.is_active = is_active
+        a.status = status
+        return a
+
+    def test_no_assignments_returns_not_activated(self):
+        self.assertEqual(_get_test_status([]), TEST_STATUS_NOT_ACTIVATED)
+
+    def test_active_assignment_returns_open(self):
+        a = self._make_assignment(True, TestStatus.Active)
+        self.assertEqual(_get_test_status([a]), TEST_STATUS_OPEN)
+
+    def test_ended_assignment_returns_closed(self):
+        a = self._make_assignment(False, TestStatus.Ended)
+        self.assertEqual(_get_test_status([a]), TEST_STATUS_CLOSED)
+
+    def test_mixed_active_ended_returns_open(self):
+        a1 = self._make_assignment(True, TestStatus.Active)
+        a2 = self._make_assignment(False, TestStatus.Ended)
+        self.assertEqual(_get_test_status([a1, a2]), TEST_STATUS_OPEN)
+
+    def test_not_started_assignment_returns_not_activated(self):
+        """An assignment that exists but has never been opened must not be reported as closed."""
+        a = self._make_assignment(False, TestStatus.NotStarted)
+        self.assertEqual(_get_test_status([a]), TEST_STATUS_NOT_ACTIVATED)

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -1,0 +1,165 @@
+import datetime
+import uuid
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from le_utils.constants import content_kinds
+from le_utils.constants import modalities
+from rest_framework.test import APITestCase
+
+from . import helpers
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
+from kolibri.core.courses.models import TestStatus
+from kolibri.core.courses.models import UnitTestAssignment
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
+from kolibri.plugins.coach.unit_report_api import TEST_STATUS_OPEN
+from kolibri.plugins.coach.unit_report_api import _compute_all_test_scores
+from kolibri.plugins.coach.unit_report_api import _get_test_status
+from kolibri.plugins.coach.unit_report_api import get_synthetic_content_id
+from kolibri.plugins.coach.unit_report_api import get_test_version
+
+DUMMY_PASSWORD = "password"
+
+URL_NAME = "kolibri:kolibri.plugins.coach:unitreport"
+
+
+def _make_url(course_session_id, unit_contentnode_id):
+    # Strip dashes so the IDs match the [0-9a-f]{32} pattern in api_urls.py.
+    return reverse(
+        URL_NAME,
+        kwargs={
+            "course_session_id": course_session_id.replace("-", ""),
+            "unit_contentnode_id": unit_contentnode_id.replace("-", ""),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+# Fixed UUIDs so test failures are reproducible across runs.
+LO1_ID = "00000000000000000000000000000011"
+LO2_ID = "00000000000000000000000000000022"
+
+# Version A items: 2 for LO1, 1 for LO2
+ITEM_A1 = "0000000000000000000000000000a001"
+ITEM_A2 = "0000000000000000000000000000a002"
+ITEM_A3 = "0000000000000000000000000000a003"  # maps to LO2
+
+# Version B items: 2 for LO1, 1 for LO2
+ITEM_B1 = "0000000000000000000000000000b001"
+ITEM_B2 = "0000000000000000000000000000b002"
+ITEM_B3 = "0000000000000000000000000000b003"  # maps to LO2
+
+ASSESSMENT_OBJECTIVES = {
+    ITEM_A1: LO1_ID,
+    ITEM_A2: LO1_ID,
+    ITEM_A3: LO2_ID,
+    ITEM_B1: LO1_ID,
+    ITEM_B2: LO1_ID,
+    ITEM_B3: LO2_ID,
+}
+
+UNIT_OPTIONS = {
+    "learning_objectives": [
+        {"id": LO1_ID, "text": "Understand fractions"},
+        {"id": LO2_ID, "text": "Add fractions"},
+    ],
+    "assessment_objectives": ASSESSMENT_OBJECTIVES,
+    "completion_criteria": {
+        "threshold": {
+            "pre_post_test": {
+                "assessment_item_ids": [ITEM_A1, ITEM_A2, ITEM_A3, ITEM_B1, ITEM_B2, ITEM_B3],
+                "version_a_item_ids": [ITEM_A1, ITEM_A2, ITEM_A3],
+                "version_b_item_ids": [ITEM_B1, ITEM_B2, ITEM_B3],
+            }
+        }
+    },
+}
+
+
+def _make_content_node(parent_id=None):
+    node = ContentNode.objects.create(
+        id=uuid.uuid4().hex,
+        content_id=uuid.uuid4().hex,
+        channel_id=uuid.uuid4().hex,
+        title="Test Unit",
+        kind=content_kinds.EXERCISE,
+        modality=modalities.UNIT,
+        options=UNIT_OPTIONS,
+        available=True,
+    )
+    return node
+
+
+def _create_attempt(learner, course_session_id, unit_id, test_type, items_correct, items_incorrect=None):
+    """
+    Create ContentSummaryLog + MasteryLog + AttemptLogs for a learner's test attempt.
+
+    items_correct: list of item IDs answered correctly
+    items_incorrect: list of item IDs answered incorrectly (optional)
+    """
+    synthetic_cid = get_synthetic_content_id(
+        str(learner.id), str(course_session_id), str(unit_id), test_type
+    )
+    now = timezone.now()
+    channel_id = uuid.uuid4().hex
+
+    summary_log = ContentSummaryLog.objects.create(
+        user=learner,
+        content_id=synthetic_cid,
+        channel_id=channel_id,
+        start_timestamp=now - datetime.timedelta(minutes=30),
+        end_timestamp=now,
+        kind=content_kinds.EXERCISE,
+        progress=1.0,
+    )
+    session_log = ContentSessionLog.objects.create(
+        user=learner,
+        content_id=synthetic_cid,
+        channel_id=channel_id,
+        start_timestamp=now - datetime.timedelta(minutes=30),
+        end_timestamp=now,
+        kind=content_kinds.EXERCISE,
+    )
+    mastery_log = MasteryLog.objects.create(
+        user=learner,
+        summarylog=summary_log,
+        mastery_criterion={"type": "quiz"},
+        start_timestamp=now - datetime.timedelta(minutes=30),
+        end_timestamp=now,
+        completion_timestamp=now,
+        mastery_level=-1,
+        complete=True,
+    )
+
+    all_items = [(item, 1) for item in (items_correct or [])]
+    all_items += [(item, 0) for item in (items_incorrect or [])]
+
+    for i, (item, correct) in enumerate(all_items):
+        offset = datetime.timedelta(minutes=i * 2)
+        AttemptLog.objects.create(
+            masterylog=mastery_log,
+            sessionlog=session_log,
+            user=learner,
+            item=item,
+            start_timestamp=now - datetime.timedelta(minutes=30) + offset,
+            end_timestamp=now - datetime.timedelta(minutes=30) + offset + datetime.timedelta(minutes=1),
+            correct=correct,
+        )
+
+    return mastery_log

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -738,3 +738,115 @@ class UnitReportPermissionTests(UnitReportAPIBase):
         self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+
+
+class UnitReportResponseShapeTests(UnitReportAPIBase):
+    """Verify the response structure matches the spec."""
+
+    def setUp(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+
+    def test_top_level_keys(self):
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        self.assertIn("unit_title", data)
+        self.assertIn("learning_objectives", data)
+        self.assertIn("learners", data)
+        self.assertIn("pre_test", data)
+        self.assertIn("post_test", data)
+
+    def test_unit_title(self):
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.data["unit_title"], "Unit 1: Fractions")
+
+    def test_learning_objectives_shape(self):
+        response = self.client.get(self._get_url())
+        los = response.data["learning_objectives"]
+        self.assertEqual(len(los), 2)
+        lo = los[0]
+        self.assertIn("id", lo)
+        self.assertIn("text", lo)
+        self.assertIn("num_questions", lo)
+
+    def test_num_questions_counts_version_a_items(self):
+        """num_questions should equal the number of version-A items per LO."""
+        response = self.client.get(self._get_url())
+        lo_map = {lo["id"]: lo for lo in response.data["learning_objectives"]}
+        # LO1 has 2 version-A items; LO2 has 1
+        self.assertEqual(lo_map[LO1_ID]["num_questions"], 2)
+        self.assertEqual(lo_map[LO2_ID]["num_questions"], 1)
+
+    def test_learner_shape(self):
+        response = self.client.get(self._get_url())
+        learners = response.data["learners"]
+        self.assertGreater(len(learners), 0)
+        learner = learners[0]
+        self.assertIn("id", learner)
+        self.assertIn("username", learner)
+        self.assertIn("name", learner)
+
+    def test_all_assigned_learners_present(self):
+        response = self.client.get(self._get_url())
+        learner_ids = {lr["id"] for lr in response.data["learners"]}
+        self.assertIn(str(self.learner1.id), learner_ids)
+        self.assertIn(str(self.learner2.id), learner_ids)
+        self.assertIn(str(self.learner3.id), learner_ids)
+
+    def test_test_status_keys(self):
+        response = self.client.get(self._get_url())
+        for key in ("pre_test", "post_test"):
+            self.assertIn("status", response.data[key])
+            self.assertIn("scores", response.data[key])
+
+    def test_not_activated_status_when_no_assignments(self):
+        """No UnitTestAssignment records → both tests are not_activated."""
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
+        self.assertEqual(response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
+
+    def test_open_status_when_assignment_is_active(self):
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type="pre",
+            is_active=True,
+            status=TestStatus.Active,
+            activated_by=self.facility_coach,
+        )
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_OPEN)
+        self.assertEqual(response.data["post_test"]["status"], TEST_STATUS_NOT_ACTIVATED)
+
+    def test_closed_status_when_assignment_is_ended(self):
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type="pre",
+            is_active=False,
+            status=TestStatus.Ended,
+            activated_by=self.facility_coach,
+        )
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_CLOSED)
+
+    def test_unit_with_null_options_returns_valid_response(self):
+        """ContentNode.options = None is handled gracefully by the 'or {}' guard."""
+        bare_unit = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+            title="Bare Unit",
+            kind=content_kinds.EXERCISE,
+            modality=modalities.UNIT,
+            options=None,
+            available=True,
+        )
+        url = _make_url(self.course_session.id, bare_unit.id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["learning_objectives"], [])
+        self.assertEqual(response.data["pre_test"]["scores"], {})
+        self.assertEqual(response.data["post_test"]["scores"], {})

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -693,3 +693,48 @@ class UnitReportAPIBase(APITestCase):
 
     def _get_url(self):
         return _make_url(self.course_session.id, self.unit_node.id)
+
+
+class UnitReportPermissionTests(UnitReportAPIBase):
+    """Verify who can and cannot access the endpoint."""
+
+    def test_anon_cannot_access(self):
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access(self):
+        self.client.login(username=self.learner1.username, password=DUMMY_PASSWORD)
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 403)
+
+    def test_coach_of_different_classroom_cannot_access(self):
+        self.client.login(username=self.other_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 403)
+
+    def test_classroom_coach_can_access(self):
+        self.client.login(username=self.classroom_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_coach_can_access(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_facility_admin_can_access(self):
+        self.client.login(username=self.facility_admin.username, password=DUMMY_PASSWORD)
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_nonexistent_course_session_returns_403(self):
+        url = _make_url(uuid.uuid4().hex, self.unit_node.id)
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_nonexistent_unit_returns_404(self):
+        url = _make_url(self.course_session.id, uuid.uuid4().hex)
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -720,13 +720,13 @@ class UnitReportPermissionTests(UnitReportAPIBase):
         response = self.client.get(self._get_url())
         self.assertEqual(response.status_code, 200)
 
-    def test_nonexistent_course_session_returns_403(self):
+    def test_nonexistent_course_session_returns_404(self):
         url = _make_url("0" * 32, self.unit_node.id)
         self.client.login(
             username=self.facility_coach.username, password=DUMMY_PASSWORD
         )
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
     def test_nonexistent_unit_returns_404(self):
         url = _make_url(self.course_session.id, uuid.uuid4().hex)

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -833,18 +833,6 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
         response = self.client.get(self._get_url())
         self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_CLOSED)
 
-    def test_dual_role_user_excluded_from_learners(self):
-        """A user who is both a classroom member and a coach is not in the learners list."""
-        dual_role = helpers.create_learner(
-            "dual_role_excl", DUMMY_PASSWORD, self.facility, classroom=self.classroom
-        )
-        self.classroom.add_coach(dual_role)
-
-        response = self.client.get(self._get_url())
-        self.assertEqual(response.status_code, 200)
-        learner_ids = {lr["id"] for lr in response.data["learners"]}
-        self.assertNotIn(str(dual_role.id), learner_ids)
-
     def test_unit_with_null_options_returns_valid_response(self):
         """ContentNode.options = None is handled gracefully by the 'or {}' guard."""
         bare_unit = ContentNode.objects.create(

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -1,9 +1,6 @@
 import datetime
 import uuid
-from types import SimpleNamespace
-from unittest.mock import patch
 
-from django.test import SimpleTestCase
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -24,10 +21,9 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.utils.pre_post_test import get_synthetic_content_id
 from kolibri.plugins.coach.unit_report_api import compute_all_test_scores
-from kolibri.plugins.coach.unit_report_api import get_synthetic_content_id
 from kolibri.plugins.coach.unit_report_api import get_test_status
-from kolibri.plugins.coach.unit_report_api import get_test_version
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_OPEN
@@ -96,20 +92,6 @@ UNIT_OPTIONS = {
 }
 
 
-def _make_content_node(parent_id=None):
-    node = ContentNode.objects.create(
-        id=uuid.uuid4().hex,
-        content_id=uuid.uuid4().hex,
-        channel_id=uuid.uuid4().hex,
-        title="Test Unit",
-        kind=content_kinds.EXERCISE,
-        modality=modalities.UNIT,
-        options=UNIT_OPTIONS,
-        available=True,
-    )
-    return node
-
-
 def _create_attempt(
     learner, course_session_id, unit_id, test_type, items_correct, items_incorrect=None
 ):
@@ -120,7 +102,7 @@ def _create_attempt(
     items_incorrect: list of item IDs answered incorrectly (optional)
     """
     synthetic_cid = get_synthetic_content_id(
-        str(learner.id), str(course_session_id), str(unit_id), test_type
+        str(course_session_id), str(unit_id), test_type
     )
     now = timezone.now()
     channel_id = uuid.uuid4().hex
@@ -176,61 +158,65 @@ def _create_attempt(
     return mastery_log
 
 
-class GetTestVersionTests(SimpleTestCase):
-    """get_test_version returns deterministic 'a' or 'b'."""
+class GetTestStatusTests(TestCase):
+    """get_test_status maps a UnitTestAssignment queryset to a response string."""
 
-    def test_deterministic(self):
-        lid = uuid.uuid4().hex
-        sid = uuid.uuid4().hex
-        uid = uuid.uuid4().hex
-        v1 = get_test_version(lid, sid, uid)
-        v2 = get_test_version(lid, sid, uid)
-        self.assertEqual(v1, v2)
-        self.assertIn(v1, ("a", "b"))
+    databases = "__all__"
 
-    def test_hash_byte_below_128_returns_version_a(self):
-        # Directly exercise the branch: first SHA-256 byte < 128 → "a".
-        with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
-            mock_hashlib.sha256.return_value.digest.return_value = (
-                bytes([0]) + b"\x00" * 31
-            )
-            self.assertEqual(get_test_version("lid", "sid", "uid"), "a")
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.classroom = Classroom.objects.create(name="cls", parent=cls.facility)
+        cls.group = LearnerGroup.objects.create(name="grp", parent=cls.classroom)
+        cls.coach = helpers.create_coach(
+            "status_coach", DUMMY_PASSWORD, cls.facility, cls.classroom
+        )
+        cls.course_session = CourseSession.objects.create(
+            course=uuid.uuid4().hex,
+            title="Status Test",
+            collection=cls.classroom,
+            created_by=cls.coach,
+        )
+        cls.unit_id = uuid.uuid4().hex
 
-    def test_hash_byte_128_or_above_returns_version_b(self):
-        # Directly exercise the branch: first SHA-256 byte >= 128 → "b".
-        with patch("kolibri.plugins.coach.unit_report_api.hashlib") as mock_hashlib:
-            mock_hashlib.sha256.return_value.digest.return_value = (
-                bytes([255]) + b"\x00" * 31
-            )
-            self.assertEqual(get_test_version("lid", "sid", "uid"), "b")
+    def _qs(self):
+        return UnitTestAssignment.objects.filter(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_id,
+            test_type="pre",
+        )
 
-
-class GetTestStatusTests(SimpleTestCase):
-    """get_test_status maps UnitTestAssignment state to response strings."""
-
-    def _make_assignment(self, closed):
-        return SimpleNamespace(closed=closed)
+    def _make_assignment(self, closed, collection=None):
+        return UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_id,
+            collection=collection or self.classroom,
+            test_type="pre",
+            closed=closed,
+            activated_by=self.coach,
+        )
 
     def test_no_assignments_returns_not_activated(self):
-        self.assertEqual(get_test_status([]), TEST_STATUS_NOT_ACTIVATED)
+        self.assertEqual(get_test_status(self._qs()), TEST_STATUS_NOT_ACTIVATED)
 
     def test_active_assignment_returns_open(self):
-        a = self._make_assignment(closed=False)
-        self.assertEqual(get_test_status([a]), TEST_STATUS_OPEN)
+        self._make_assignment(closed=False)
+        self.assertEqual(get_test_status(self._qs()), TEST_STATUS_OPEN)
 
-    def test_closed_assignment_returns_closed_status(self):
-        a = self._make_assignment(closed=True)
-        self.assertEqual(get_test_status([a]), TEST_STATUS_CLOSED)
+    def test_closed_assignment_returns_closed(self):
+        self._make_assignment(closed=True)
+        self.assertEqual(get_test_status(self._qs()), TEST_STATUS_CLOSED)
 
     def test_all_closed_assignments_returns_closed(self):
-        a1 = self._make_assignment(closed=True)
-        a2 = self._make_assignment(closed=True)
-        self.assertEqual(get_test_status([a1, a2]), TEST_STATUS_CLOSED)
+        self._make_assignment(closed=True)
+        self._make_assignment(closed=True, collection=self.group)
+        self.assertEqual(get_test_status(self._qs()), TEST_STATUS_CLOSED)
 
-    def test_mixed_active_ended_returns_open(self):
-        a1 = self._make_assignment(closed=False)
-        a2 = self._make_assignment(closed=True)
-        self.assertEqual(get_test_status([a1, a2]), TEST_STATUS_OPEN)
+    def test_mixed_returns_open(self):
+        self._make_assignment(closed=False)
+        self._make_assignment(closed=True, collection=self.group)
+        self.assertEqual(get_test_status(self._qs()), TEST_STATUS_OPEN)
 
 
 class ComputeTestScoresTests(TestCase):
@@ -275,24 +261,13 @@ class ComputeTestScoresTests(TestCase):
         self.assertNotIn(str(self.learner_a.id), result["post"])
 
     def test_correct_answers_counted_per_lo(self):
-        # Determine which version learner_a will get
-        version = get_test_version(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
-        )
-        if version == "a":
-            items_correct = [ITEM_A1, ITEM_A2]  # 2 correct for LO1
-            items_incorrect = [ITEM_A3]  # 0 correct for LO2
-        else:
-            items_correct = [ITEM_B1, ITEM_B2]
-            items_incorrect = [ITEM_B3]
-
         _create_attempt(
             self.learner_a,
             self.course_session_id,
             self.unit_id,
             "pre",
-            items_correct=items_correct,
-            items_incorrect=items_incorrect,
+            items_correct=[ITEM_A1, ITEM_A2],  # 2 correct for LO1
+            items_incorrect=[ITEM_A3],  # 0 correct for LO2
         )
         result = compute_all_test_scores(
             [self.learner_a.id],
@@ -306,21 +281,13 @@ class ComputeTestScoresTests(TestCase):
         self.assertEqual(result[lid].get(LO2_ID, 0), 0)
 
     def test_attempted_with_zero_correct_included_as_empty_dict(self):
-        version = get_test_version(
-            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id)
-        )
-        if version == "a":
-            items_incorrect = [ITEM_A1, ITEM_A2, ITEM_A3]
-        else:
-            items_incorrect = [ITEM_B1, ITEM_B2, ITEM_B3]
-
         _create_attempt(
             self.learner_b,
             self.course_session_id,
             self.unit_id,
             "pre",
             items_correct=[],
-            items_incorrect=items_incorrect,
+            items_incorrect=[ITEM_A1, ITEM_A2, ITEM_A3],
         )
         result = compute_all_test_scores(
             [self.learner_b.id],
@@ -335,7 +302,6 @@ class ComputeTestScoresTests(TestCase):
     def test_only_complete_mastery_logs_counted(self):
         """Incomplete (in-progress) mastery logs are ignored."""
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_a.id),
             str(self.course_session_id),
             str(self.unit_id),
             "post",
@@ -364,15 +330,11 @@ class ComputeTestScoresTests(TestCase):
             mastery_level=-2,
             complete=False,  # still in progress
         )
-        version = get_test_version(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
-        )
-        item = ITEM_A1 if version == "a" else ITEM_B1
         AttemptLog.objects.create(
             masterylog=incomplete_mastery,
             sessionlog=session_log,
             user=self.learner_a,
-            item=item,
+            item=ITEM_A1,
             start_timestamp=now - datetime.timedelta(minutes=5),
             end_timestamp=now,
             correct=1,
@@ -388,21 +350,12 @@ class ComputeTestScoresTests(TestCase):
 
     def test_pre_and_post_are_independent(self):
         """Pre-test data does not bleed into post-test scores."""
-        version = get_test_version(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
-        )
-        items_correct = (
-            [ITEM_A1, ITEM_A2, ITEM_A3]
-            if version == "a"
-            else [ITEM_B1, ITEM_B2, ITEM_B3]
-        )
-
         _create_attempt(
             self.learner_a,
             self.course_session_id,
             self.unit_id,
             "pre",
-            items_correct=items_correct,
+            items_correct=[ITEM_A1, ITEM_A2, ITEM_A3],
         )
 
         post_result = compute_all_test_scores(
@@ -415,13 +368,7 @@ class ComputeTestScoresTests(TestCase):
 
     def test_duplicate_attempt_items_counted_once(self):
         """When the same item appears twice in a mastery log, only the most recent attempt counts."""
-        version = get_test_version(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
-        )
-        item = ITEM_A1 if version == "a" else ITEM_B1
-
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_a.id),
             str(self.course_session_id),
             str(self.unit_id),
             "pre",
@@ -460,7 +407,7 @@ class ComputeTestScoresTests(TestCase):
             masterylog=mastery_log,
             sessionlog=session_log,
             user=self.learner_a,
-            item=item,
+            item=ITEM_A1,
             start_timestamp=now - datetime.timedelta(minutes=20),
             end_timestamp=now - datetime.timedelta(minutes=19),
             correct=0,
@@ -470,7 +417,7 @@ class ComputeTestScoresTests(TestCase):
             masterylog=mastery_log,
             sessionlog=session_log,
             user=self.learner_a,
-            item=item,
+            item=ITEM_A1,
             start_timestamp=now - datetime.timedelta(minutes=10),
             end_timestamp=now - datetime.timedelta(minutes=9),
             correct=1,
@@ -490,7 +437,6 @@ class ComputeTestScoresTests(TestCase):
     def test_partial_credit_not_counted(self):
         """correct=0.5 (partial credit) is excluded; only correct==1 counts."""
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_a.id),
             str(self.course_session_id),
             str(self.unit_id),
             "pre",
@@ -524,15 +470,11 @@ class ComputeTestScoresTests(TestCase):
             mastery_level=-1,
             complete=True,
         )
-        version = get_test_version(
-            str(self.learner_a.id), str(self.course_session_id), str(self.unit_id)
-        )
-        item = ITEM_A1 if version == "a" else ITEM_B1
         AttemptLog.objects.create(
             masterylog=mastery_log,
             sessionlog=session_log,
             user=self.learner_a,
-            item=item,
+            item=ITEM_A1,
             start_timestamp=now - datetime.timedelta(minutes=20),
             end_timestamp=now - datetime.timedelta(minutes=19),
             correct=0.5,  # partial credit — must NOT count
@@ -550,23 +492,12 @@ class ComputeTestScoresTests(TestCase):
 
     def test_only_most_recent_complete_mastery_log_used(self):
         """When a learner has multiple complete mastery logs (retakes), only the most recent is used."""
-        version = get_test_version(
-            str(self.learner_b.id), str(self.course_session_id), str(self.unit_id)
-        )
-        # All items for this version — used in both mastery logs (correct in the
-        # first, incorrect in the second).  Named all_items, not items_correct, to
-        # avoid confusion when they're iterated with correct=0 below.
-        all_items = (
-            [ITEM_A1, ITEM_A2, ITEM_A3]
-            if version == "a"
-            else [ITEM_B1, ITEM_B2, ITEM_B3]
-        )
+        all_items = [ITEM_A1, ITEM_A2, ITEM_A3]
 
         # Build both mastery logs manually so they share the same ContentSummaryLog
         # (which is required — two ContentSummaryLogs for the same content_id would
         # violate the morango UNIQUE constraint on source_id = content_id).
         synthetic_cid = get_synthetic_content_id(
-            str(self.learner_b.id),
             str(self.course_session_id),
             str(self.unit_id),
             "post",
@@ -786,7 +717,7 @@ class UnitReportPermissionTests(UnitReportAPIBase):
         self.assertEqual(response.status_code, 200)
 
     def test_nonexistent_course_session_returns_403(self):
-        url = _make_url(uuid.uuid4().hex, self.unit_node.id)
+        url = _make_url("0" * 32, self.unit_node.id)
         self.client.login(
             username=self.facility_coach.username, password=DUMMY_PASSWORD
         )
@@ -949,22 +880,13 @@ class UnitReportScoringTests(UnitReportAPIBase):
 
     def test_per_lo_correct_count_in_scores(self):
         """Correct answers are tallied per LO for both pre and post tests."""
-        version = get_test_version(
-            str(self.learner2.id), str(self.course_session.id), str(self.unit_node.id)
-        )
-        # Get all 3 items for the correct version
-        if version == "a":
-            all_items = [ITEM_A1, ITEM_A2, ITEM_A3]
-        else:
-            all_items = [ITEM_B1, ITEM_B2, ITEM_B3]
-
         _create_attempt(
             self.learner2,
             self.course_session.id,
             self.unit_node.id,
             "pre",
-            items_correct=all_items[:2],  # both LO1 items correct
-            items_incorrect=all_items[2:],  # LO2 item incorrect
+            items_correct=[ITEM_A1, ITEM_A2],  # both LO1 items correct
+            items_incorrect=[ITEM_A3],  # LO2 item incorrect
         )
 
         response = self.client.get(self._get_url())
@@ -977,27 +899,19 @@ class UnitReportScoringTests(UnitReportAPIBase):
 
     def test_both_tests_in_single_response(self):
         """A learner who attempted both tests has scores in both sections."""
-        version = get_test_version(
-            str(self.learner3.id), str(self.course_session.id), str(self.unit_node.id)
-        )
-        if version == "a":
-            items = [ITEM_A1, ITEM_A2, ITEM_A3]
-        else:
-            items = [ITEM_B1, ITEM_B2, ITEM_B3]
-
         _create_attempt(
             self.learner3,
             self.course_session.id,
             self.unit_node.id,
             "pre",
-            items_correct=items[:1],
+            items_correct=[ITEM_A1],
         )
         _create_attempt(
             self.learner3,
             self.course_session.id,
             self.unit_node.id,
             "post",
-            items_correct=items[:2],
+            items_correct=[ITEM_A1, ITEM_A2],
         )
 
         response = self.client.get(self._get_url())
@@ -1012,16 +926,9 @@ class UnitReportScoringTests(UnitReportAPIBase):
 
         # Assign scores 0, 1, 2 correct to learner1, learner2, learner3 respectively.
         # The loop index i is the number of correct answers for that learner.
+        all_items = [ITEM_A1, ITEM_A2, ITEM_A3]
         learners = [self.learner1, self.learner2, self.learner3]
         for i, learner in enumerate(learners):
-            version = get_test_version(
-                str(learner.id), str(course_session_id), str(unit_id)
-            )
-            all_items = (
-                [ITEM_A1, ITEM_A2, ITEM_A3]
-                if version == "a"
-                else [ITEM_B1, ITEM_B2, ITEM_B3]
-            )
             _create_attempt(
                 learner,
                 course_session_id,
@@ -1037,6 +944,9 @@ class UnitReportScoringTests(UnitReportAPIBase):
 
         # learner1 scored 0, learner2 scored 1, learner3 scored 2.
         # Ascending sort means learner1 < learner2 < learner3 in position.
+        # Tie-breaking: Python's sorted() is stable, so equal-score learners
+        # preserve the DB query order (which is undefined).  This test uses
+        # strictly different scores so no tie-breaking is exercised.
         pos1 = actual_order.index(str(self.learner1.id))
         pos2 = actual_order.index(str(self.learner2.id))
         pos3 = actual_order.index(str(self.learner3.id))
@@ -1049,8 +959,6 @@ class UnitReportLearnerGroupTests(UnitReportAPIBase):
     Verify that learners assigned via a LearnerGroup (sub-collection) are
     resolved correctly and appear in the response.
     """
-
-    databases = "__all__"
 
     def setUp(self):
         self.client.login(

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -850,3 +850,100 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
         self.assertEqual(response.data["learning_objectives"], [])
         self.assertEqual(response.data["pre_test"]["scores"], {})
         self.assertEqual(response.data["post_test"]["scores"], {})
+
+
+class UnitReportScoringTests(UnitReportAPIBase):
+    """Verify per-LO score aggregation and learner sorting."""
+
+    def setUp(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+
+    def test_unattempted_learner_absent_from_scores_map(self):
+        """Learner with no attempt is in learners list but not in scores."""
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+        learner_ids = {lr["id"] for lr in response.data["learners"]}
+        self.assertIn(str(self.learner1.id), learner_ids)
+        self.assertNotIn(str(self.learner1.id), response.data["pre_test"]["scores"])
+        self.assertNotIn(str(self.learner1.id), response.data["post_test"]["scores"])
+
+    def test_per_lo_correct_count_in_scores(self):
+        """Correct answers are tallied per LO for both pre and post tests."""
+        version = get_test_version(
+            str(self.learner2.id), str(self.course_session.id), str(self.unit_node.id)
+        )
+        # Get all 3 items for the correct version
+        if version == "a":
+            all_items = [ITEM_A1, ITEM_A2, ITEM_A3]
+        else:
+            all_items = [ITEM_B1, ITEM_B2, ITEM_B3]
+
+        _create_attempt(
+            self.learner2,
+            self.course_session.id,
+            self.unit_node.id,
+            "pre",
+            items_correct=all_items[:2],   # both LO1 items correct
+            items_incorrect=all_items[2:],  # LO2 item incorrect
+        )
+
+        response = self.client.get(self._get_url())
+        lid = str(self.learner2.id)
+        pre_scores = response.data["pre_test"]["scores"]
+        self.assertIn(lid, pre_scores)
+        lo_scores = pre_scores[lid]
+        self.assertEqual(lo_scores.get(LO1_ID, 0), 2)
+        self.assertEqual(lo_scores.get(LO2_ID, 0), 0)
+
+    def test_both_tests_in_single_response(self):
+        """A learner who attempted both tests has scores in both sections."""
+        version = get_test_version(
+            str(self.learner3.id), str(self.course_session.id), str(self.unit_node.id)
+        )
+        if version == "a":
+            items = [ITEM_A1, ITEM_A2, ITEM_A3]
+        else:
+            items = [ITEM_B1, ITEM_B2, ITEM_B3]
+
+        _create_attempt(
+            self.learner3, self.course_session.id, self.unit_node.id, "pre",
+            items_correct=items[:1],
+        )
+        _create_attempt(
+            self.learner3, self.course_session.id, self.unit_node.id, "post",
+            items_correct=items[:2],
+        )
+
+        response = self.client.get(self._get_url())
+        lid = str(self.learner3.id)
+        self.assertIn(lid, response.data["pre_test"]["scores"])
+        self.assertIn(lid, response.data["post_test"]["scores"])
+
+    def test_learners_sorted_ascending_by_total_score(self):
+        """Learner with lowest combined score appears first."""
+        course_session_id = self.course_session.id
+        unit_id = self.unit_node.id
+
+        # Assign scores 0, 1, 2 correct to learner1, learner2, learner3 respectively.
+        # The loop index i is the number of correct answers for that learner.
+        learners = [self.learner1, self.learner2, self.learner3]
+        for i, learner in enumerate(learners):
+            version = get_test_version(str(learner.id), str(course_session_id), str(unit_id))
+            all_items = [ITEM_A1, ITEM_A2, ITEM_A3] if version == "a" else [ITEM_B1, ITEM_B2, ITEM_B3]
+            _create_attempt(
+                learner, course_session_id, unit_id, "pre",
+                items_correct=all_items[:i],
+                items_incorrect=all_items[i:],
+            )
+
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+        actual_order = [lr["id"] for lr in response.data["learners"]]
+
+        # learner1 scored 0, learner2 scored 1, learner3 scored 2.
+        # Ascending sort means learner1 < learner2 < learner3 in position.
+        pos1 = actual_order.index(str(self.learner1.id))
+        pos2 = actual_order.index(str(self.learner2.id))
+        pos3 = actual_order.index(str(self.learner3.id))
+        self.assertLess(pos1, pos2)
+        self.assertLess(pos2, pos3)

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -14,6 +15,7 @@ from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.courses.models import CourseSessionAssignment
@@ -22,9 +24,9 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
-from kolibri.plugins.coach.unit_report_api import _compute_all_test_scores
-from kolibri.plugins.coach.unit_report_api import _get_test_status
+from kolibri.plugins.coach.unit_report_api import compute_all_test_scores
 from kolibri.plugins.coach.unit_report_api import get_synthetic_content_id
+from kolibri.plugins.coach.unit_report_api import get_test_status
 from kolibri.plugins.coach.unit_report_api import get_test_version
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
@@ -132,6 +134,8 @@ def _create_attempt(
         kind=content_kinds.EXERCISE,
         progress=1.0,
     )
+    # ContentSessionLog is required to satisfy the AttemptLog FK; it is not
+    # queried by the system under test.
     session_log = ContentSessionLog.objects.create(
         user=learner,
         content_id=synthetic_cid,
@@ -202,40 +206,41 @@ class GetTestVersionTests(SimpleTestCase):
 
 
 class GetTestStatusTests(SimpleTestCase):
-    """_get_test_status maps UnitTestAssignment state to response strings."""
+    """get_test_status maps UnitTestAssignment state to response strings."""
 
     def _make_assignment(self, closed):
-        a = UnitTestAssignment.__new__(UnitTestAssignment)
-        a.closed = closed
-        return a
+        return SimpleNamespace(closed=closed)
 
     def test_no_assignments_returns_not_activated(self):
-        self.assertEqual(_get_test_status([]), TEST_STATUS_NOT_ACTIVATED)
+        self.assertEqual(get_test_status([]), TEST_STATUS_NOT_ACTIVATED)
 
     def test_active_assignment_returns_open(self):
         a = self._make_assignment(closed=False)
-        self.assertEqual(_get_test_status([a]), TEST_STATUS_OPEN)
+        self.assertEqual(get_test_status([a]), TEST_STATUS_OPEN)
 
-    def test_ended_assignment_returns_closed(self):
+    def test_closed_assignment_returns_closed_status(self):
         a = self._make_assignment(closed=True)
-        self.assertEqual(_get_test_status([a]), TEST_STATUS_CLOSED)
+        self.assertEqual(get_test_status([a]), TEST_STATUS_CLOSED)
+
+    def test_all_closed_assignments_returns_closed(self):
+        a1 = self._make_assignment(closed=True)
+        a2 = self._make_assignment(closed=True)
+        self.assertEqual(get_test_status([a1, a2]), TEST_STATUS_CLOSED)
 
     def test_mixed_active_ended_returns_open(self):
         a1 = self._make_assignment(closed=False)
         a2 = self._make_assignment(closed=True)
-        self.assertEqual(_get_test_status([a1, a2]), TEST_STATUS_OPEN)
+        self.assertEqual(get_test_status([a1, a2]), TEST_STATUS_OPEN)
 
 
 class ComputeTestScoresTests(TestCase):
-    """_compute_all_test_scores aggregation logic without HTTP layer."""
+    """compute_all_test_scores aggregation logic without HTTP layer."""
 
     databases = "__all__"
 
     @classmethod
     def setUpTestData(cls):
         provision_device()
-        from kolibri.core.auth.test.test_api import FacilityFactory
-
         cls.facility = FacilityFactory.create()
         cls.classroom = Classroom.objects.create(name="cls", parent=cls.facility)
         cls.learner_a = helpers.create_learner(
@@ -253,14 +258,14 @@ class ComputeTestScoresTests(TestCase):
         self.unit_id = uuid.uuid4().hex
 
     def test_no_learners_returns_empty(self):
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [], self.course_session_id, self.unit_id, ASSESSMENT_OBJECTIVES
         )
         self.assertEqual(result["pre"], {})
         self.assertEqual(result["post"], {})
 
     def test_unattempted_learner_absent_from_scores(self):
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -289,7 +294,7 @@ class ComputeTestScoresTests(TestCase):
             items_correct=items_correct,
             items_incorrect=items_incorrect,
         )
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -317,7 +322,7 @@ class ComputeTestScoresTests(TestCase):
             items_correct=[],
             items_incorrect=items_incorrect,
         )
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_b.id],
             self.course_session_id,
             self.unit_id,
@@ -373,7 +378,7 @@ class ComputeTestScoresTests(TestCase):
             correct=1,
         )
 
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -400,7 +405,7 @@ class ComputeTestScoresTests(TestCase):
             items_correct=items_correct,
         )
 
-        post_result = _compute_all_test_scores(
+        post_result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -471,7 +476,7 @@ class ComputeTestScoresTests(TestCase):
             correct=1,
         )
 
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -532,7 +537,7 @@ class ComputeTestScoresTests(TestCase):
             end_timestamp=now - datetime.timedelta(minutes=19),
             correct=0.5,  # partial credit — must NOT count
         )
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_a.id],
             self.course_session_id,
             self.unit_id,
@@ -648,7 +653,7 @@ class ComputeTestScoresTests(TestCase):
                 correct=0,
             )
 
-        result = _compute_all_test_scores(
+        result = compute_all_test_scores(
             [self.learner_b.id],
             self.course_session_id,
             self.unit_id,
@@ -673,8 +678,6 @@ class UnitReportAPIBase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         provision_device()
-        from kolibri.core.auth.test.test_api import FacilityFactory
-
         cls.facility = FacilityFactory.create()
         cls.classroom = Classroom.objects.create(name="classroom", parent=cls.facility)
 
@@ -894,6 +897,18 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
         )
         response = self.client.get(self._get_url())
         self.assertEqual(response.data["pre_test"]["status"], TEST_STATUS_CLOSED)
+
+    def test_dual_role_user_excluded_from_learners(self):
+        """A user who is both a classroom member and a coach is not in the learners list."""
+        dual_role = helpers.create_learner(
+            "dual_role_excl", DUMMY_PASSWORD, self.facility, classroom=self.classroom
+        )
+        self.classroom.add_coach(dual_role)
+
+        response = self.client.get(self._get_url())
+        self.assertEqual(response.status_code, 200)
+        learner_ids = {lr["id"] for lr in response.data["learners"]}
+        self.assertNotIn(str(dual_role.id), learner_ids)
 
     def test_unit_with_null_options_returns_valid_response(self):
         """ContentNode.options = None is handled gracefully by the 'or {}' guard."""

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -17,7 +17,6 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.courses.models import CourseSessionAssignment
-from kolibri.core.courses.models import TestStatus
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
@@ -191,32 +190,26 @@ class GetTestVersionTests(SimpleTestCase):
 class GetTestStatusTests(SimpleTestCase):
     """_get_test_status maps UnitTestAssignment state to response strings."""
 
-    def _make_assignment(self, is_active, status):
+    def _make_assignment(self, closed):
         a = UnitTestAssignment.__new__(UnitTestAssignment)
-        a.is_active = is_active
-        a.status = status
+        a.closed = closed
         return a
 
     def test_no_assignments_returns_not_activated(self):
         self.assertEqual(_get_test_status([]), TEST_STATUS_NOT_ACTIVATED)
 
     def test_active_assignment_returns_open(self):
-        a = self._make_assignment(True, TestStatus.Active)
+        a = self._make_assignment(closed=False)
         self.assertEqual(_get_test_status([a]), TEST_STATUS_OPEN)
 
     def test_ended_assignment_returns_closed(self):
-        a = self._make_assignment(False, TestStatus.Ended)
+        a = self._make_assignment(closed=True)
         self.assertEqual(_get_test_status([a]), TEST_STATUS_CLOSED)
 
     def test_mixed_active_ended_returns_open(self):
-        a1 = self._make_assignment(True, TestStatus.Active)
-        a2 = self._make_assignment(False, TestStatus.Ended)
+        a1 = self._make_assignment(closed=False)
+        a2 = self._make_assignment(closed=True)
         self.assertEqual(_get_test_status([a1, a2]), TEST_STATUS_OPEN)
-
-    def test_not_started_assignment_returns_not_activated(self):
-        """An assignment that exists but has never been opened must not be reported as closed."""
-        a = self._make_assignment(False, TestStatus.NotStarted)
-        self.assertEqual(_get_test_status([a]), TEST_STATUS_NOT_ACTIVATED)
 
 
 class ComputeTestScoresTests(TestCase):
@@ -811,8 +804,7 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
             test_type="pre",
-            is_active=True,
-            status=TestStatus.Active,
+            closed=False,
             activated_by=self.facility_coach,
         )
         response = self.client.get(self._get_url())
@@ -825,8 +817,7 @@ class UnitReportResponseShapeTests(UnitReportAPIBase):
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
             test_type="pre",
-            is_active=False,
-            status=TestStatus.Ended,
+            closed=True,
             activated_by=self.facility_coach,
         )
         response = self.client.get(self._get_url())

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -947,3 +947,51 @@ class UnitReportScoringTests(UnitReportAPIBase):
         pos3 = actual_order.index(str(self.learner3.id))
         self.assertLess(pos1, pos2)
         self.assertLess(pos2, pos3)
+
+
+class UnitReportLearnerGroupTests(UnitReportAPIBase):
+    """
+    Verify that learners assigned via a LearnerGroup (sub-collection) are
+    resolved correctly and appear in the response.
+    """
+
+    databases = "__all__"
+
+    def setUp(self):
+        self.client.login(username=self.facility_coach.username, password=DUMMY_PASSWORD)
+
+    def test_learner_group_members_included(self):
+        """
+        A CourseSessionAssignment targeting a LearnerGroup should surface all
+        members of that group in the learners list.
+        """
+        # Create a LearnerGroup inside the existing classroom and add a new learner.
+        group = LearnerGroup.objects.create(name="Group A", parent=self.classroom)
+        # Kolibri requires classroom membership before LearnerGroup membership.
+        group_learner = helpers.create_learner(
+            "gl1", DUMMY_PASSWORD, self.facility,
+            classroom=self.classroom, learner_group=group,
+        )
+
+        # Assign the group (not the whole classroom) to a new course session.
+        group_session = CourseSession.objects.create(
+            course=self.course_node.id,
+            title="Group Session",
+            collection=self.classroom,
+            created_by=self.facility_admin,
+            is_active=True,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=group_session,
+            collection=group,
+            assigned_by=self.facility_admin,
+        )
+
+        url = _make_url(group_session.id, self.unit_node.id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        learner_ids = {lr["id"] for lr in response.data["learners"]}
+        self.assertIn(str(group_learner.id), learner_ids)
+        # Learners from the classroom-level assignment are NOT in this session.
+        self.assertNotIn(str(self.learner1.id), learner_ids)

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -39,7 +39,7 @@ def _chunked(lst, size):
 # (NAMESPACE_DNS, NAMESPACE_URL, etc.).
 _SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c")
 
-# Status strings returned by _get_test_status and surfaced in the API response.
+# Status strings returned by get_test_status and surfaced in the API response.
 # Exported as constants so callers can import them instead of duplicating literals.
 TEST_STATUS_NOT_ACTIVATED = "not_activated"
 TEST_STATUS_OPEN = "open"
@@ -76,29 +76,112 @@ def get_synthetic_content_id(
     return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex
 
 
-def _get_test_status(assignments):
+def get_test_status(assignments):
     """
     Derive a display status from a list of UnitTestAssignment objects.
 
-    Returns one of:
-      - "not_activated": no assignment exists, or all assignments are still in
-                         the not_started state (created but not yet opened)
-      - "open":          at least one assignment is currently active
-      - "closed":        at least one assignment has been ended (and none active)
+    UnitTestAssignment has a single ``closed: BooleanField``.  The possible
+    return values are:
 
-    Checking closed == True explicitly avoids misclassifying an assignment
-    that was never opened as "closed".
+      - "not_activated": no assignment exists yet
+      - "open":          at least one assignment has closed=False (still active)
+      - "closed":        assignments exist and all have closed=True
     """
     if not assignments:
         return TEST_STATUS_NOT_ACTIVATED
     if any(not a.closed for a in assignments):
         return TEST_STATUS_OPEN
-    if any(a.closed for a in assignments):
-        return TEST_STATUS_CLOSED
-    return TEST_STATUS_NOT_ACTIVATED
+    return TEST_STATUS_CLOSED
 
 
-def _compute_all_test_scores(
+def _fetch_mastery_logs(content_id_to_meta):
+    """
+    *content_id_to_meta* is a dict mapping synthetic content_id → meta dict.
+    For each key, find the most recent complete MasteryLog via a correlated DB
+    subquery (max end_timestamp per content_id).  Chunked to stay within
+    SQLite's variable limit.
+
+    Returns (mastery_log_ids, mastery_log_to_meta) where mastery_log_to_meta
+    maps mastery log id → {learner_id, test_type}.
+    """
+    # Correlated subquery: picks the latest completed MasteryLog per
+    # summarylog content_id, avoiding a race with Python-side sort dedup.
+    # The seen_content_ids guard handles the rare identical-timestamp tie.
+    latest_ts_subquery = (
+        MasteryLog.objects.filter(
+            summarylog__content_id=OuterRef("summarylog__content_id"),
+            complete=True,
+            end_timestamp__isnull=False,
+        )
+        .order_by("-end_timestamp")
+        .values("end_timestamp")[:1]
+    )
+
+    mastery_log_ids = []
+    mastery_log_to_meta = {}
+    seen_content_ids = set()
+
+    for chunk in _chunked(list(content_id_to_meta.keys()), _IN_CHUNK_SIZE):
+        for ml in MasteryLog.objects.filter(
+            summarylog__content_id__in=chunk,
+            complete=True,
+            end_timestamp__isnull=False,
+            end_timestamp=Subquery(latest_ts_subquery),
+        ).values("id", "summarylog__content_id"):
+            cid = ml["summarylog__content_id"]
+            if cid not in seen_content_ids:
+                seen_content_ids.add(cid)
+                mastery_log_ids.append(ml["id"])
+                mastery_log_to_meta[ml["id"]] = content_id_to_meta[cid]
+
+    return mastery_log_ids, mastery_log_to_meta
+
+
+def _fetch_deduplicated_attempts(mastery_log_ids):
+    """
+    Fetch AttemptLogs for the given mastery log ids and deduplicate per
+    (masterylog_id, item) by keeping the attempt with the latest end_timestamp.
+    Done in Python rather than via ORDER BY to avoid sensitivity to DB ordering
+    behaviour (ties/NULLs).  Chunked to stay within SQLite's variable limit.
+
+    Returns {(masterylog_id, item): log_dict}.
+    """
+    item_latest = {}
+    for chunk in _chunked(mastery_log_ids, _IN_CHUNK_SIZE):
+        for log in AttemptLog.objects.filter(masterylog_id__in=chunk).values(
+            "masterylog_id", "item", "correct", "end_timestamp"
+        ):
+            key = (log["masterylog_id"], log["item"])
+            existing = item_latest.get(key)
+            if existing is None or log["end_timestamp"] > existing["end_timestamp"]:
+                item_latest[key] = log
+    return item_latest
+
+
+def _accumulate_scores(
+    results, item_latest, mastery_log_to_meta, assessment_objectives
+):
+    """
+    Accumulate correct counts per learner per LO per test type into *results*.
+
+    Only fully-correct attempts (correct == 1.0) contribute; partial credit
+    (0 < correct < 1) is intentionally excluded.
+    """
+    for (ml_id, item), log in item_latest.items():
+        if log["correct"] != 1:  # only fully-correct (1.0); partial credit excluded
+            continue
+        meta = mastery_log_to_meta.get(ml_id)
+        if meta is None:
+            continue
+        lo_id = assessment_objectives.get(item)
+        if lo_id is None:
+            continue
+        lo_scores = results[meta["test_type"]].setdefault(str(meta["learner_id"]), {})
+        lo_id_str = str(lo_id)
+        lo_scores[lo_id_str] = lo_scores.get(lo_id_str, 0) + 1
+
+
+def compute_all_test_scores(
     learner_ids, course_session_id, unit_contentnode_id, assessment_objectives
 ):
     """
@@ -106,17 +189,9 @@ def _compute_all_test_scores(
     single pair of DB queries.
 
     For each learner × test_type, generates a synthetic content_id and looks up
-    the most recent complete MasteryLog with that content_id, selected via a
-    correlated DB subquery (max end_timestamp per content_id) to avoid a race
-    condition that a Python-side sort over a large result set would have.
-    AttemptLogs are mapped to learning objectives via assessment_objectives;
-    when the same item appears more than once in a mastery log, the most recent
-    attempt (by end_timestamp) wins — resolved entirely in Python to avoid
-    relying on database-level ordering guarantees.
-
-    Only fully-correct attempts (correct == 1.0) contribute to the score.
-    Partial-credit values (0 < correct < 1) are intentionally excluded; for
-    pre/post quiz assessments the data model uses 0 or 1 exclusively.
+    the most recent complete MasteryLog with that content_id.  AttemptLogs are
+    mapped to learning objectives via assessment_objectives; when the same item
+    appears more than once in a mastery log, the most recent attempt wins.
 
     Returns:
         {
@@ -124,19 +199,14 @@ def _compute_all_test_scores(
             "post": { learner_id_str: { lo_id_str: correct_count }, ... },
         }
 
-    Absence in the returned dict has two distinct causes:
-      - No MasteryLog at all: the learner has not started the test.
-      - MasteryLog exists but complete=False: the learner started but has not
-        finished; in-progress logs are intentionally excluded so partial
-        in-flight data does not skew the coach view.
-    In both cases the learner will not appear in the inner dict for that test
-    type.  A learner who finished (complete=True) is always present, even when
-    every answer was wrong (empty scores dict).
+    A learner who completed the test is always present in the inner dict (even
+    if every answer was wrong).  A learner who never started, or whose
+    MasteryLog is still in-progress (complete=False), is absent.
     """
     if not learner_ids:
         return {"pre": {}, "post": {}}
 
-    # Build synthetic content_id → (learner_id, test_type) for both test types
+    # Build synthetic content_id → (learner_id, test_type) for both test types.
     content_id_to_meta = {}
     for learner_id in learner_ids:
         for test_type in ("pre", "post"):
@@ -151,83 +221,19 @@ def _compute_all_test_scores(
                 "test_type": test_type,
             }
 
-    # Correlated subquery: for a given MasteryLog row, return the maximum
-    # end_timestamp among all complete, non-null MasteryLogs that share the
-    # same summarylog content_id.  Filtering the outer query to only rows
-    # where end_timestamp = Subquery(...) picks the most-recent log per
-    # learner × test_type atomically in the DB, avoiding a race condition
-    # that Python-side sort deduplication would be subject to.  This matters
-    # because a learner can retake a test: each retake produces a new
-    # MasteryLog against the same ContentSummaryLog, and only the latest
-    # completed attempt should count.
-    # The seen_content_ids guard handles the rare tie (identical timestamps).
-    _latest_ts_subquery = (
-        MasteryLog.objects.filter(
-            summarylog__content_id=OuterRef("summarylog__content_id"),
-            complete=True,
-            end_timestamp__isnull=False,
-        )
-        .order_by("-end_timestamp")
-        .values("end_timestamp")[:1]
-    )
-
-    mastery_log_ids = []
-    mastery_log_to_meta = {}
-    seen_content_ids = set()
-
-    # Chunk the content_id IN list to stay within SQLite's variable limit.
-    for chunk in _chunked(list(content_id_to_meta.keys()), _IN_CHUNK_SIZE):
-        for ml in MasteryLog.objects.filter(
-            summarylog__content_id__in=chunk,
-            complete=True,
-            end_timestamp__isnull=False,
-            end_timestamp=Subquery(_latest_ts_subquery),
-        ).values("id", "summarylog__content_id"):
-            cid = ml["summarylog__content_id"]
-            if cid not in seen_content_ids:
-                seen_content_ids.add(cid)
-                mastery_log_ids.append(ml["id"])
-                mastery_log_to_meta[ml["id"]] = content_id_to_meta[cid]
+    mastery_log_ids, mastery_log_to_meta = _fetch_mastery_logs(content_id_to_meta)
 
     results = {"pre": {}, "post": {}}
-
     if not mastery_log_ids:
         return results
 
     # Initialise every learner that has a complete mastery log so they appear
-    # in the results even if they answered every question incorrectly.
+    # even if they answered every question incorrectly.
     for meta in mastery_log_to_meta.values():
         results[meta["test_type"]].setdefault(str(meta["learner_id"]), {})
 
-    # Fetch all attempt logs and deduplicate per (masterylog, item) by keeping
-    # the attempt with the latest end_timestamp.  Done in Python rather than
-    # via ORDER BY so it is not sensitive to DB ordering behaviour (ties/NULLs).
-    # The mastery_log_ids list is chunked to avoid SQLite variable-count limits.
-    item_latest = {}  # (masterylog_id, item) -> log dict
-    for chunk in _chunked(mastery_log_ids, _IN_CHUNK_SIZE):
-        for log in AttemptLog.objects.filter(masterylog_id__in=chunk).values(
-            "masterylog_id", "item", "correct", "end_timestamp"
-        ):
-            key = (log["masterylog_id"], log["item"])
-            existing = item_latest.get(key)
-            if existing is None or log["end_timestamp"] > existing["end_timestamp"]:
-                item_latest[key] = log
-
-    # Accumulate correct counts per learner per LO per test type.
-    for (ml_id, item), log in item_latest.items():
-        if log["correct"] != 1:  # only fully-correct (1.0); partial credit excluded
-            continue
-        meta = mastery_log_to_meta.get(ml_id)
-        if meta is None:
-            continue
-        lo_id = assessment_objectives.get(item)
-        if lo_id is None:
-            continue
-        test_type = meta["test_type"]
-        learner_id_str = str(meta["learner_id"])
-        lo_id_str = str(lo_id)
-        lo_scores = results[test_type].setdefault(learner_id_str, {})
-        lo_scores[lo_id_str] = lo_scores.get(lo_id_str, 0) + 1
+    item_latest = _fetch_deduplicated_attempts(mastery_log_ids)
+    _accumulate_scores(results, item_latest, mastery_log_to_meta, assessment_objectives)
 
     return results
 
@@ -265,6 +271,11 @@ class UnitReportViewSet(viewsets.ViewSet):
     broken down by learning objective.
 
     GET /api/coach/coursesession/{course_session_id}/unit/{unit_contentnode_id}/report/
+
+    Note: Uses ``viewsets.ViewSet`` rather than ``ReadOnlyValuesViewset`` because
+    the response is a deeply nested structure (per-learner scores keyed by LO id)
+    that cannot be expressed as a flat ``values`` tuple.  The single ``retrieve``
+    action makes this a read-only endpoint in practice.
     """
 
     permission_classes = (permissions.IsAuthenticated, UnitReportPermissions)
@@ -323,6 +334,10 @@ class UnitReportViewSet(viewsets.ViewSet):
         # Exclude users who hold a coach or admin role in the assigned
         # collections so that a dual-role user (enrolled as a member AND
         # holding a coach role) does not appear in the learner list.
+        # Note: this exclusion is scoped to the assignment collections only.
+        # A facility-level admin who is not a member of any assignment collection
+        # will not appear here (correct); one who IS a member would be excluded
+        # by the coach_admin_ids filter below (also correct).
         coach_admin_ids = Role.objects.filter(
             collection_id__in=assignment_collection_ids,
             kind__in=[role_kinds.COACH, role_kinds.ADMIN, role_kinds.ASSIGNABLE_COACH],
@@ -347,11 +362,11 @@ class UnitReportViewSet(viewsets.ViewSet):
         pre_assignments = [a for a in all_assignments if a.test_type == "pre"]
         post_assignments = [a for a in all_assignments if a.test_type == "post"]
 
-        pre_status = _get_test_status(pre_assignments)
-        post_status = _get_test_status(post_assignments)
+        pre_status = get_test_status(pre_assignments)
+        post_status = get_test_status(post_assignments)
 
         # Compute scores for both tests in a single DB pass.
-        all_scores = _compute_all_test_scores(
+        all_scores = compute_all_test_scores(
             learner_ids, course_session_id, unit_contentnode_id, assessment_objectives
         )
         pre_scores = all_scores["pre"]

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -45,3 +45,31 @@ _SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4
 TEST_STATUS_NOT_ACTIVATED = "not_activated"
 TEST_STATUS_OPEN = "open"
 TEST_STATUS_CLOSED = "closed"
+
+
+def get_test_version(learner_id, course_session_id, unit_contentnode_id):
+    """
+    Returns 'a' or 'b' based on a deterministic hash of
+    (learner_id, course_session_id, unit_contentnode_id).
+    Implements the A/B split logic defined in issue #14133.
+
+    This function is the canonical definition shared by the learner-side client
+    (which imports it to decide which item set to present) and by server-side
+    tests.  The coach report API itself does not call it directly — instead it
+    queries for both synthetic content_ids (pre and post, versions a and b) in a
+    single pass — but it must live here so that both sides stay in sync.
+    """
+    key = "{}:{}:{}".format(learner_id, course_session_id, unit_contentnode_id)
+    hash_byte = hashlib.sha256(key.encode()).digest()[0]
+    return "a" if hash_byte < 128 else "b"
+
+
+def get_synthetic_content_id(learner_id, course_session_id, unit_contentnode_id, test_type):
+    """
+    Generate a deterministic UUID5 content_id for MasteryLog/AttemptLog tracking.
+    Must match the generation logic used on the learner side (issue #14133).
+    """
+    key = "{}:{}:{}:{}".format(
+        learner_id, course_session_id, unit_contentnode_id, test_type
+    )
+    return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -3,11 +3,10 @@ from collections import defaultdict
 from django.db.models import F
 from django.shortcuts import get_object_or_404
 from le_utils.constants import modalities
-from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
@@ -191,25 +190,6 @@ def compute_all_test_scores(
     return results
 
 
-class UnitReportPermissions(permissions.BasePermission):
-    """
-    Allow access only to admins and coaches for the classroom associated
-    with the given course session.
-    """
-
-    def has_permission(self, request, view):
-        # Guard first: AnonymousUser has no has_role_for method.
-        if not request.user.is_authenticated:
-            return False
-        course_session_id = view.kwargs.get("course_session_id")
-        allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
-        try:
-            course_session = CourseSession.objects.get(pk=course_session_id)
-            return request.user.has_role_for(allowed_roles, course_session.collection)
-        except (CourseSession.DoesNotExist, ValueError):
-            return False
-
-
 class UnitReportViewSet(viewsets.ViewSet):
     """
     Returns aggregated learner performance data for a unit's pre/post tests,
@@ -223,13 +203,14 @@ class UnitReportViewSet(viewsets.ViewSet):
     action makes this a read-only endpoint in practice.
     """
 
-    permission_classes = (UnitReportPermissions,)
+    permission_classes = (KolibriAuthPermissions,)
 
     def retrieve(self, request, **kwargs):
         course_session_id = self.kwargs["course_session_id"]
         unit_contentnode_id = self.kwargs["unit_contentnode_id"]
 
         course_session = get_object_or_404(CourseSession, pk=course_session_id)
+        self.check_object_permissions(request, course_session)
         unit = get_object_or_404(
             ContentNode, pk=unit_contentnode_id, modality=modalities.UNIT
         )

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.models import Role
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.logger.models import AttemptLog
@@ -206,8 +205,6 @@ class UnitReportPermissions(permissions.BasePermission):
         allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
         try:
             course_session = CourseSession.objects.get(pk=course_session_id)
-            # Cache on the view so retrieve() can reuse it without a second DB hit.
-            view._course_session = course_session
             return request.user.has_role_for(allowed_roles, course_session.collection)
         except (CourseSession.DoesNotExist, ValueError):
             return False
@@ -226,21 +223,13 @@ class UnitReportViewSet(viewsets.ViewSet):
     action makes this a read-only endpoint in practice.
     """
 
-    # UnitReportPermissions rejects unauthenticated requests as its first guard,
-    # so IsAuthenticated is not listed separately.
     permission_classes = (UnitReportPermissions,)
 
     def retrieve(self, request, **kwargs):
         course_session_id = self.kwargs["course_session_id"]
         unit_contentnode_id = self.kwargs["unit_contentnode_id"]
 
-        # _course_session is set by UnitReportPermissions.has_permission()
-        # before this method is called.
-        assert hasattr(self, "_course_session"), (
-            "_course_session must be set by UnitReportPermissions.has_permission() "
-            "before retrieve() is called"
-        )
-        course_session = self._course_session
+        course_session = get_object_or_404(CourseSession, pk=course_session_id)
         unit = get_object_or_404(
             ContentNode, pk=unit_contentnode_id, modality=modalities.UNIT
         )
@@ -283,18 +272,10 @@ class UnitReportViewSet(viewsets.ViewSet):
         assignment_collection_ids = list(
             course_session.assignments.values_list("collection_id", flat=True)
         )
-        # Exclude users who hold a coach or admin role in the assigned
-        # collections so that a dual-role user (enrolled as a member AND
-        # holding a coach role) does not appear in the learner list.
-        coach_admin_ids = Role.objects.filter(
-            collection_id__in=assignment_collection_ids,
-            kind__in=[role_kinds.COACH, role_kinds.ADMIN, role_kinds.ASSIGNABLE_COACH],
-        ).values_list("user_id", flat=True)
         learners = list(
             FacilityUser.objects.filter(
                 memberships__collection_id__in=assignment_collection_ids
             )
-            .exclude(id__in=coach_admin_ids)
             .distinct()
             .values("id", "username", name=F("full_name"))
         )

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -236,6 +236,10 @@ class UnitReportViewSet(viewsets.ViewSet):
 
         # _course_session is set by UnitReportPermissions.has_permission()
         # before this method is called.
+        assert hasattr(self, "_course_session"), (
+            "_course_session must be set by UnitReportPermissions.has_permission() "
+            "before retrieve() is called"
+        )
         course_session = self._course_session
         unit = get_object_or_404(
             ContentNode, pk=unit_contentnode_id, modality=modalities.UNIT

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -1,0 +1,47 @@
+import hashlib  # used by get_test_version (canonical A/B split definition)
+import uuid
+from collections import defaultdict
+
+from django.db.models import F
+from django.db.models import OuterRef
+from django.db.models import Subquery
+from django.shortcuts import get_object_or_404
+from rest_framework import permissions
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import Role
+from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
+from kolibri.core.courses.models import TestStatus
+from kolibri.core.courses.models import UnitTestAssignment
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import MasteryLog
+
+# Conservative upper bound for SQL IN-clause list lengths.  SQLite's default
+# SQLITE_MAX_VARIABLE_NUMBER is 999; staying under 900 leaves headroom for
+# other bind parameters in the same query.
+_IN_CHUNK_SIZE = 900
+
+
+def _chunked(lst, size):
+    """Yield successive sublists of at most *size* items."""
+    for i in range(0, len(lst), size):
+        yield lst[i : i + size]
+
+
+# Private namespace UUID for synthetic content_id generation (issue #14133).
+# Generated once with uuid.uuid4() and pinned here.  Using a project-private
+# namespace prevents collisions with IDs produced by any code that happens to
+# use the same uuid5(key) pattern over one of the well-known standard namespaces
+# (NAMESPACE_DNS, NAMESPACE_URL, etc.).
+_SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c")
+
+# Status strings returned by _get_test_status and surfaced in the API response.
+# Exported as constants so callers can import them instead of duplicating literals.
+TEST_STATUS_NOT_ACTIVATED = "not_activated"
+TEST_STATUS_OPEN = "open"
+TEST_STATUS_CLOSED = "closed"

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -16,7 +16,6 @@ from kolibri.core.auth.models import Role
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.courses.models import CourseSessionAssignment
-from kolibri.core.courses.models import TestStatus
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import MasteryLog
@@ -85,15 +84,14 @@ def _get_test_status(assignments):
       - "open":          at least one assignment is currently active
       - "closed":        at least one assignment has been ended (and none active)
 
-    Checking status == TestStatus.Ended explicitly (rather than relying on
-    is_active == False) avoids misclassifying a not_started assignment as
-    "closed".
+    Checking closed == True explicitly avoids misclassifying an assignment
+    that was never opened as "closed".
     """
     if not assignments:
         return TEST_STATUS_NOT_ACTIVATED
-    if any(a.is_active for a in assignments):
+    if any(not a.closed for a in assignments):
         return TEST_STATUS_OPEN
-    if any(a.status == TestStatus.Ended for a in assignments):
+    if any(a.closed for a in assignments):
         return TEST_STATUS_CLOSED
     return TEST_STATUS_NOT_ACTIVATED
 

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -255,3 +255,133 @@ class UnitReportPermissions(permissions.BasePermission):
             return False
         except (CourseSession.DoesNotExist, ValueError):
             return False
+
+
+class UnitReportViewSet(viewsets.ViewSet):
+    """
+    Returns aggregated learner performance data for a unit's pre/post tests,
+    broken down by learning objective.
+
+    GET /api/coach/coursesession/{course_session_id}/unit/{unit_contentnode_id}/report/
+    """
+
+    permission_classes = (permissions.IsAuthenticated, UnitReportPermissions)
+
+    def retrieve(self, request, **kwargs):
+        course_session_id = self.kwargs["course_session_id"]
+        unit_contentnode_id = self.kwargs["unit_contentnode_id"]
+
+        # Reuse the CourseSession already fetched and validated by
+        # UnitReportPermissions to avoid a redundant DB query.
+        course_session = getattr(self, "_course_session", None) or get_object_or_404(
+            CourseSession, pk=course_session_id
+        )
+        unit = get_object_or_404(ContentNode, pk=unit_contentnode_id)
+
+        options = unit.options or {}
+
+        # Learning objectives list: [{id, text, metadata?}, ...]
+        raw_los = options.get("learning_objectives") or []
+
+        # Maps assessment item IDs → LO IDs.  Guard against null in the DB.
+        assessment_objectives = options.get("assessment_objectives") or {}
+
+        # Mastery criteria / A-B item lists (schema-mastery_criteria.json)
+        pre_post_test_config = (
+            (options.get("completion_criteria") or {})
+            .get("threshold") or {}
+        ).get("pre_post_test") or {}
+        version_a_item_ids = pre_post_test_config.get("version_a_item_ids") or []
+
+        # num_questions per LO: count of version A items that map to each LO.
+        # Version A is used as the canonical reference; both versions are expected
+        # to cover the same LOs with the same number of questions.
+        lo_question_count = defaultdict(int)
+        version_a_set = set(version_a_item_ids)
+        for item_id, lo_id in assessment_objectives.items():
+            if lo_id is None:
+                continue  # skip malformed entries: str(None) would silently produce "None"
+            if item_id in version_a_set:
+                lo_question_count[str(lo_id)] += 1
+
+        learning_objectives = [
+            {
+                "id": lo["id"],
+                "text": lo["text"],
+                "num_questions": lo_question_count.get(str(lo["id"]), 0),
+            }
+            for lo in raw_los
+        ]
+
+        # Determine assigned learners via CourseSessionAssignment (canonical source).
+        assignment_collection_ids = list(
+            CourseSessionAssignment.objects.filter(
+                course_session=course_session
+            ).values_list("collection_id", flat=True)
+        )
+        # Exclude users who hold a coach or admin role in the assigned
+        # collections so that a dual-role user (enrolled as a member AND
+        # holding a coach role) does not appear in the learner list.
+        coach_admin_ids = Role.objects.filter(
+            collection_id__in=assignment_collection_ids,
+            kind__in=[role_kinds.COACH, role_kinds.ADMIN, role_kinds.ASSIGNABLE_COACH],
+        ).values_list("user_id", flat=True)
+        learners = list(
+            FacilityUser.objects.filter(
+                memberships__collection_id__in=assignment_collection_ids
+            )
+            .exclude(id__in=coach_admin_ids)
+            .distinct()
+            .values("id", "username", name=F("full_name"))
+        )
+        learner_ids = [lr["id"] for lr in learners]
+
+        # Determine test state from UnitTestAssignment records.
+        all_assignments = list(
+            UnitTestAssignment.objects.filter(
+                course_session=course_session,
+                unit_contentnode_id=unit_contentnode_id,
+            )
+        )
+        pre_assignments = [a for a in all_assignments if a.test_type == "pre"]
+        post_assignments = [a for a in all_assignments if a.test_type == "post"]
+
+        pre_status = _get_test_status(pre_assignments)
+        post_status = _get_test_status(post_assignments)
+
+        # Compute scores for both tests in a single DB pass.
+        all_scores = _compute_all_test_scores(
+            learner_ids, course_session_id, unit_contentnode_id, assessment_objectives
+        )
+        pre_scores = all_scores["pre"]
+        post_scores = all_scores["post"]
+
+        # Sort learners ascending by total score (pre + post combined), so that
+        # learners who need the most help appear first.
+        def _total_score(learner):
+            lid = str(learner["id"])
+            return sum(pre_scores.get(lid, {}).values()) + sum(
+                post_scores.get(lid, {}).values()
+            )
+
+        learners_sorted = sorted(learners, key=_total_score)
+
+        # Ensure learner IDs are plain strings in the output.
+        for learner in learners_sorted:
+            learner["id"] = str(learner["id"])
+
+        return Response(
+            {
+                "unit_title": unit.title,
+                "learning_objectives": learning_objectives,
+                "learners": learners_sorted,
+                "pre_test": {
+                    "status": pre_status,
+                    "scores": pre_scores,
+                },
+                "post_test": {
+                    "status": post_status,
+                    "scores": post_scores,
+                },
+            }
+        )

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -228,3 +228,30 @@ def _compute_all_test_scores(learner_ids, course_session_id, unit_contentnode_id
         lo_scores[lo_id_str] = lo_scores.get(lo_id_str, 0) + 1
 
     return results
+
+
+class UnitReportPermissions(permissions.BasePermission):
+    """
+    Allow access only to admins and coaches for the classroom associated
+    with the given course session.
+
+    Side effect: on success, caches the validated ``CourseSession`` instance
+    on the view as ``view._course_session`` so that ``UnitReportViewSet.retrieve``
+    can reuse it without a second DB round-trip.
+    """
+
+    def has_permission(self, request, view):
+        # Guard first: AnonymousUser has no has_role_for method.
+        if not request.user.is_authenticated:
+            return False
+        course_session_id = view.kwargs.get("course_session_id")
+        allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
+        try:
+            course_session = CourseSession.objects.get(pk=course_session_id)
+            if request.user.has_role_for(allowed_roles, course_session.collection):
+                # Cache so the view can reuse it without a second DB query.
+                view._course_session = course_session
+                return True
+            return False
+        except (CourseSession.DoesNotExist, ValueError):
+            return False

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -96,3 +96,135 @@ def _get_test_status(assignments):
     if any(a.status == TestStatus.Ended for a in assignments):
         return TEST_STATUS_CLOSED
     return TEST_STATUS_NOT_ACTIVATED
+
+
+def _compute_all_test_scores(learner_ids, course_session_id, unit_contentnode_id, assessment_objectives):
+    """
+    Compute per-learner, per-LO correct counts for both pre and post tests in a
+    single pair of DB queries.
+
+    For each learner × test_type, generates a synthetic content_id and looks up
+    the most recent complete MasteryLog with that content_id, selected via a
+    correlated DB subquery (max end_timestamp per content_id) to avoid a race
+    condition that a Python-side sort over a large result set would have.
+    AttemptLogs are mapped to learning objectives via assessment_objectives;
+    when the same item appears more than once in a mastery log, the most recent
+    attempt (by end_timestamp) wins — resolved entirely in Python to avoid
+    relying on database-level ordering guarantees.
+
+    Only fully-correct attempts (correct == 1.0) contribute to the score.
+    Partial-credit values (0 < correct < 1) are intentionally excluded; for
+    pre/post quiz assessments the data model uses 0 or 1 exclusively.
+
+    Returns:
+        {
+            "pre":  { learner_id_str: { lo_id_str: correct_count }, ... },
+            "post": { learner_id_str: { lo_id_str: correct_count }, ... },
+        }
+
+    Absence in the returned dict has two distinct causes:
+      - No MasteryLog at all: the learner has not started the test.
+      - MasteryLog exists but complete=False: the learner started but has not
+        finished; in-progress logs are intentionally excluded so partial
+        in-flight data does not skew the coach view.
+    In both cases the learner will not appear in the inner dict for that test
+    type.  A learner who finished (complete=True) is always present, even when
+    every answer was wrong (empty scores dict).
+    """
+    if not learner_ids:
+        return {"pre": {}, "post": {}}
+
+    # Build synthetic content_id → (learner_id, test_type) for both test types
+    content_id_to_meta = {}
+    for learner_id in learner_ids:
+        for test_type in ("pre", "post"):
+            synthetic_cid = get_synthetic_content_id(
+                str(learner_id), str(course_session_id), str(unit_contentnode_id), test_type
+            )
+            content_id_to_meta[synthetic_cid] = {
+                "learner_id": learner_id,
+                "test_type": test_type,
+            }
+
+    # Correlated subquery: for a given MasteryLog row, return the maximum
+    # end_timestamp among all complete, non-null MasteryLogs that share the
+    # same summarylog content_id.  Filtering the outer query to only rows
+    # where end_timestamp = Subquery(...) picks the most-recent log per
+    # learner × test_type atomically in the DB, avoiding a race condition
+    # that Python-side sort deduplication would be subject to.  This matters
+    # because a learner can retake a test: each retake produces a new
+    # MasteryLog against the same ContentSummaryLog, and only the latest
+    # completed attempt should count.
+    # The seen_content_ids guard handles the rare tie (identical timestamps).
+    _latest_ts_subquery = (
+        MasteryLog.objects.filter(
+            summarylog__content_id=OuterRef("summarylog__content_id"),
+            complete=True,
+            end_timestamp__isnull=False,
+        )
+        .order_by("-end_timestamp")
+        .values("end_timestamp")[:1]
+    )
+
+    mastery_log_ids = []
+    mastery_log_to_meta = {}
+    seen_content_ids = set()
+
+    # Chunk the content_id IN list to stay within SQLite's variable limit.
+    for chunk in _chunked(list(content_id_to_meta.keys()), _IN_CHUNK_SIZE):
+        for ml in (
+            MasteryLog.objects.filter(
+                summarylog__content_id__in=chunk,
+                complete=True,
+                end_timestamp__isnull=False,
+                end_timestamp=Subquery(_latest_ts_subquery),
+            )
+            .values("id", "summarylog__content_id")
+        ):
+            cid = ml["summarylog__content_id"]
+            if cid not in seen_content_ids:
+                seen_content_ids.add(cid)
+                mastery_log_ids.append(ml["id"])
+                mastery_log_to_meta[ml["id"]] = content_id_to_meta[cid]
+
+    results = {"pre": {}, "post": {}}
+
+    if not mastery_log_ids:
+        return results
+
+    # Initialise every learner that has a complete mastery log so they appear
+    # in the results even if they answered every question incorrectly.
+    for meta in mastery_log_to_meta.values():
+        results[meta["test_type"]].setdefault(str(meta["learner_id"]), {})
+
+    # Fetch all attempt logs and deduplicate per (masterylog, item) by keeping
+    # the attempt with the latest end_timestamp.  Done in Python rather than
+    # via ORDER BY so it is not sensitive to DB ordering behaviour (ties/NULLs).
+    # The mastery_log_ids list is chunked to avoid SQLite variable-count limits.
+    item_latest = {}  # (masterylog_id, item) -> log dict
+    for chunk in _chunked(mastery_log_ids, _IN_CHUNK_SIZE):
+        for log in AttemptLog.objects.filter(masterylog_id__in=chunk).values(
+            "masterylog_id", "item", "correct", "end_timestamp"
+        ):
+            key = (log["masterylog_id"], log["item"])
+            existing = item_latest.get(key)
+            if existing is None or log["end_timestamp"] > existing["end_timestamp"]:
+                item_latest[key] = log
+
+    # Accumulate correct counts per learner per LO per test type.
+    for (ml_id, item), log in item_latest.items():
+        if log["correct"] != 1:  # only fully-correct (1.0); partial credit excluded
+            continue
+        meta = mastery_log_to_meta.get(ml_id)
+        if meta is None:
+            continue
+        lo_id = assessment_objectives.get(item)
+        if lo_id is None:
+            continue
+        test_type = meta["test_type"]
+        learner_id_str = str(meta["learner_id"])
+        lo_id_str = str(lo_id)
+        lo_scores = results[test_type].setdefault(learner_id_str, {})
+        lo_scores[lo_id_str] = lo_scores.get(lo_id_str, 0) + 1
+
+    return results

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -73,3 +73,26 @@ def get_synthetic_content_id(learner_id, course_session_id, unit_contentnode_id,
         learner_id, course_session_id, unit_contentnode_id, test_type
     )
     return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex
+
+
+def _get_test_status(assignments):
+    """
+    Derive a display status from a list of UnitTestAssignment objects.
+
+    Returns one of:
+      - "not_activated": no assignment exists, or all assignments are still in
+                         the not_started state (created but not yet opened)
+      - "open":          at least one assignment is currently active
+      - "closed":        at least one assignment has been ended (and none active)
+
+    Checking status == TestStatus.Ended explicitly (rather than relying on
+    is_active == False) avoids misclassifying a not_started assignment as
+    "closed".
+    """
+    if not assignments:
+        return TEST_STATUS_NOT_ACTIVATED
+    if any(a.is_active for a in assignments):
+        return TEST_STATUS_OPEN
+    if any(a.status == TestStatus.Ended for a in assignments):
+        return TEST_STATUS_CLOSED
+    return TEST_STATUS_NOT_ACTIVATED

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -6,6 +6,7 @@ from django.db.models import F
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.shortcuts import get_object_or_404
+from le_utils.constants import modalities
 from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -285,11 +286,15 @@ class UnitReportViewSet(viewsets.ViewSet):
         unit_contentnode_id = self.kwargs["unit_contentnode_id"]
 
         # Reuse the CourseSession already fetched and validated by
-        # UnitReportPermissions to avoid a redundant DB query.
+        # UnitReportPermissions to avoid a redundant DB query.  The fallback
+        # get_object_or_404 fires only if UnitReportPermissions is not in the
+        # permission chain (e.g. during testing or future refactors).
         course_session = getattr(self, "_course_session", None) or get_object_or_404(
             CourseSession, pk=course_session_id
         )
-        unit = get_object_or_404(ContentNode, pk=unit_contentnode_id)
+        unit = get_object_or_404(
+            ContentNode, pk=unit_contentnode_id, modality=modalities.UNIT
+        )
 
         options = unit.options or {}
 

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -1,10 +1,6 @@
-import hashlib  # used by get_test_version (canonical A/B split definition)
-import uuid
 from collections import defaultdict
 
 from django.db.models import F
-from django.db.models import OuterRef
-from django.db.models import Subquery
 from django.shortcuts import get_object_or_404
 from le_utils.constants import modalities
 from rest_framework import permissions
@@ -16,14 +12,14 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Role
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
-from kolibri.core.courses.models import CourseSessionAssignment
-from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.utils.pre_post_test import get_synthetic_content_id
 
 # Conservative upper bound for SQL IN-clause list lengths.  SQLite's default
 # SQLITE_MAX_VARIABLE_NUMBER is 999; staying under 900 leaves headroom for
-# other bind parameters in the same query.
+# other bind parameters in the same query (e.g. _fetch_mastery_logs uses 900
+# user IDs + 2 content_ids = 902 bind vars per chunk).
 _IN_CHUNK_SIZE = 900
 
 
@@ -33,13 +29,6 @@ def _chunked(lst, size):
         yield lst[i : i + size]
 
 
-# Private namespace UUID for synthetic content_id generation (issue #14133).
-# Generated once with uuid.uuid4() and pinned here.  Using a project-private
-# namespace prevents collisions with IDs produced by any code that happens to
-# use the same uuid5(key) pattern over one of the well-known standard namespaces
-# (NAMESPACE_DNS, NAMESPACE_URL, etc.).
-_SYNTHETIC_CONTENT_ID_NAMESPACE = uuid.UUID("7c9e4b1a-3d5f-4a8e-9c2b-6d0e1f2a3b4c")
-
 # Status strings returned by get_test_status and surfaced in the API response.
 # Exported as constants so callers can import them instead of duplicating literals.
 TEST_STATUS_NOT_ACTIVATED = "not_activated"
@@ -47,39 +36,9 @@ TEST_STATUS_OPEN = "open"
 TEST_STATUS_CLOSED = "closed"
 
 
-def get_test_version(learner_id, course_session_id, unit_contentnode_id):
+def get_test_status(assignments_qs):
     """
-    Returns 'a' or 'b' based on a deterministic hash of
-    (learner_id, course_session_id, unit_contentnode_id).
-    Implements the A/B split logic defined in issue #14133.
-
-    This function is the canonical definition shared by the learner-side client
-    (which imports it to decide which item set to present) and by server-side
-    tests.  The coach report API itself does not call it directly — instead it
-    queries for both synthetic content_ids (pre and post, versions a and b) in a
-    single pass — but it must live here so that both sides stay in sync.
-    """
-    key = "{}:{}:{}".format(learner_id, course_session_id, unit_contentnode_id)
-    hash_byte = hashlib.sha256(key.encode()).digest()[0]
-    return "a" if hash_byte < 128 else "b"
-
-
-def get_synthetic_content_id(
-    learner_id, course_session_id, unit_contentnode_id, test_type
-):
-    """
-    Generate a deterministic UUID5 content_id for MasteryLog/AttemptLog tracking.
-    Must match the generation logic used on the learner side (issue #14133).
-    """
-    key = "{}:{}:{}:{}".format(
-        learner_id, course_session_id, unit_contentnode_id, test_type
-    )
-    return uuid.uuid5(_SYNTHETIC_CONTENT_ID_NAMESPACE, key).hex
-
-
-def get_test_status(assignments):
-    """
-    Derive a display status from a list of UnitTestAssignment objects.
+    Derive a display status from a UnitTestAssignment queryset.
 
     UnitTestAssignment has a single ``closed: BooleanField``.  The possible
     return values are:
@@ -88,52 +47,53 @@ def get_test_status(assignments):
       - "open":          at least one assignment has closed=False (still active)
       - "closed":        assignments exist and all have closed=True
     """
-    if not assignments:
+    if not assignments_qs.exists():
         return TEST_STATUS_NOT_ACTIVATED
-    if any(not a.closed for a in assignments):
+    if assignments_qs.filter(closed=False).exists():
         return TEST_STATUS_OPEN
     return TEST_STATUS_CLOSED
 
 
-def _fetch_mastery_logs(content_id_to_meta):
+def _fetch_mastery_logs(learner_ids, pre_cid, post_cid):
     """
-    *content_id_to_meta* is a dict mapping synthetic content_id → meta dict.
-    For each key, find the most recent complete MasteryLog via a correlated DB
-    subquery (max end_timestamp per content_id).  Chunked to stay within
-    SQLite's variable limit.
+    Find the most recent complete MasteryLog per (learner, test_type) for the
+    given synthetic content_ids.  Ordered by end_timestamp descending so the
+    first occurrence of each (learner, content_id) key in the Python loop is
+    always the most recent.  Chunked on learner_ids to stay within SQLite's
+    variable limit.
 
     Returns (mastery_log_ids, mastery_log_to_meta) where mastery_log_to_meta
     maps mastery log id → {learner_id, test_type}.
     """
-    # Correlated subquery: picks the latest completed MasteryLog per
-    # summarylog content_id, avoiding a race with Python-side sort dedup.
-    # The seen_content_ids guard handles the rare identical-timestamp tie.
-    latest_ts_subquery = (
-        MasteryLog.objects.filter(
-            summarylog__content_id=OuterRef("summarylog__content_id"),
-            complete=True,
-            end_timestamp__isnull=False,
-        )
-        .order_by("-end_timestamp")
-        .values("end_timestamp")[:1]
-    )
-
+    cid_to_test_type = {pre_cid: "pre", post_cid: "post"}
     mastery_log_ids = []
     mastery_log_to_meta = {}
-    seen_content_ids = set()
+    seen = set()
 
-    for chunk in _chunked(list(content_id_to_meta.keys()), _IN_CHUNK_SIZE):
-        for ml in MasteryLog.objects.filter(
-            summarylog__content_id__in=chunk,
-            complete=True,
-            end_timestamp__isnull=False,
-            end_timestamp=Subquery(latest_ts_subquery),
-        ).values("id", "summarylog__content_id"):
-            cid = ml["summarylog__content_id"]
-            if cid not in seen_content_ids:
-                seen_content_ids.add(cid)
+    # Each learner appears in exactly one chunk, so order_by within the chunk
+    # picks the most recent log per (learner, content_id).
+    for chunk in _chunked(list(learner_ids), _IN_CHUNK_SIZE):
+        for ml in (
+            MasteryLog.objects.filter(
+                summarylog__content_id__in=[pre_cid, post_cid],
+                summarylog__user_id__in=chunk,
+                complete=True,
+                # end_timestamp is set when the mastery log is submitted; an
+                # isnull guard excludes in-progress logs that have complete=True
+                # but no recorded end time.
+                end_timestamp__isnull=False,
+            )
+            .order_by("-end_timestamp")
+            .values("id", "summarylog__content_id", "summarylog__user_id")
+        ):
+            key = (ml["summarylog__user_id"], ml["summarylog__content_id"])
+            if key not in seen:
+                seen.add(key)
                 mastery_log_ids.append(ml["id"])
-                mastery_log_to_meta[ml["id"]] = content_id_to_meta[cid]
+                mastery_log_to_meta[ml["id"]] = {
+                    "learner_id": ml["summarylog__user_id"],
+                    "test_type": cid_to_test_type[ml["summarylog__content_id"]],
+                }
 
     return mastery_log_ids, mastery_log_to_meta
 
@@ -169,7 +129,7 @@ def _accumulate_scores(
     (0 < correct < 1) is intentionally excluded.
     """
     for (ml_id, item), log in item_latest.items():
-        if log["correct"] != 1:  # only fully-correct (1.0); partial credit excluded
+        if log["correct"] != 1.0:  # only fully-correct; partial credit excluded
             continue
         meta = mastery_log_to_meta.get(ml_id)
         if meta is None:
@@ -186,8 +146,7 @@ def compute_all_test_scores(
     learner_ids, course_session_id, unit_contentnode_id, assessment_objectives
 ):
     """
-    Compute per-learner, per-LO correct counts for both pre and post tests in a
-    single pair of DB queries.
+    Compute per-learner, per-LO correct counts for both pre and post tests.
 
     For each learner × test_type, generates a synthetic content_id and looks up
     the most recent complete MasteryLog with that content_id.  AttemptLogs are
@@ -207,22 +166,16 @@ def compute_all_test_scores(
     if not learner_ids:
         return {"pre": {}, "post": {}}
 
-    # Build synthetic content_id → (learner_id, test_type) for both test types.
-    content_id_to_meta = {}
-    for learner_id in learner_ids:
-        for test_type in ("pre", "post"):
-            synthetic_cid = get_synthetic_content_id(
-                str(learner_id),
-                str(course_session_id),
-                str(unit_contentnode_id),
-                test_type,
-            )
-            content_id_to_meta[synthetic_cid] = {
-                "learner_id": learner_id,
-                "test_type": test_type,
-            }
+    pre_cid = get_synthetic_content_id(
+        str(course_session_id), str(unit_contentnode_id), "pre"
+    )
+    post_cid = get_synthetic_content_id(
+        str(course_session_id), str(unit_contentnode_id), "post"
+    )
 
-    mastery_log_ids, mastery_log_to_meta = _fetch_mastery_logs(content_id_to_meta)
+    mastery_log_ids, mastery_log_to_meta = _fetch_mastery_logs(
+        learner_ids, pre_cid, post_cid
+    )
 
     results = {"pre": {}, "post": {}}
     if not mastery_log_ids:
@@ -243,10 +196,6 @@ class UnitReportPermissions(permissions.BasePermission):
     """
     Allow access only to admins and coaches for the classroom associated
     with the given course session.
-
-    Side effect: on success, caches the validated ``CourseSession`` instance
-    on the view as ``view._course_session`` so that ``UnitReportViewSet.retrieve``
-    can reuse it without a second DB round-trip.
     """
 
     def has_permission(self, request, view):
@@ -257,11 +206,9 @@ class UnitReportPermissions(permissions.BasePermission):
         allowed_roles = [role_kinds.ADMIN, role_kinds.COACH]
         try:
             course_session = CourseSession.objects.get(pk=course_session_id)
-            if request.user.has_role_for(allowed_roles, course_session.collection):
-                # Cache so the view can reuse it without a second DB query.
-                view._course_session = course_session
-                return True
-            return False
+            # Cache on the view so retrieve() can reuse it without a second DB hit.
+            view._course_session = course_session
+            return request.user.has_role_for(allowed_roles, course_session.collection)
         except (CourseSession.DoesNotExist, ValueError):
             return False
 
@@ -279,19 +226,17 @@ class UnitReportViewSet(viewsets.ViewSet):
     action makes this a read-only endpoint in practice.
     """
 
-    permission_classes = (permissions.IsAuthenticated, UnitReportPermissions)
+    # UnitReportPermissions rejects unauthenticated requests as its first guard,
+    # so IsAuthenticated is not listed separately.
+    permission_classes = (UnitReportPermissions,)
 
     def retrieve(self, request, **kwargs):
         course_session_id = self.kwargs["course_session_id"]
         unit_contentnode_id = self.kwargs["unit_contentnode_id"]
 
-        # Reuse the CourseSession already fetched and validated by
-        # UnitReportPermissions to avoid a redundant DB query.  The fallback
-        # get_object_or_404 fires only if UnitReportPermissions is not in the
-        # permission chain (e.g. during testing or future refactors).
-        course_session = getattr(self, "_course_session", None) or get_object_or_404(
-            CourseSession, pk=course_session_id
-        )
+        # _course_session is set by UnitReportPermissions.has_permission()
+        # before this method is called.
+        course_session = self._course_session
         unit = get_object_or_404(
             ContentNode, pk=unit_contentnode_id, modality=modalities.UNIT
         )
@@ -330,19 +275,13 @@ class UnitReportViewSet(viewsets.ViewSet):
             for lo in raw_los
         ]
 
-        # Determine assigned learners via CourseSessionAssignment (canonical source).
+        # Determine assigned learners via the course session's assignments.
         assignment_collection_ids = list(
-            CourseSessionAssignment.objects.filter(
-                course_session=course_session
-            ).values_list("collection_id", flat=True)
+            course_session.assignments.values_list("collection_id", flat=True)
         )
         # Exclude users who hold a coach or admin role in the assigned
         # collections so that a dual-role user (enrolled as a member AND
         # holding a coach role) does not appear in the learner list.
-        # Note: this exclusion is scoped to the assignment collections only.
-        # A facility-level admin who is not a member of any assignment collection
-        # will not appear here (correct); one who IS a member would be excluded
-        # by the coach_admin_ids filter below (also correct).
         coach_admin_ids = Role.objects.filter(
             collection_id__in=assignment_collection_ids,
             kind__in=[role_kinds.COACH, role_kinds.ADMIN, role_kinds.ASSIGNABLE_COACH],
@@ -357,18 +296,12 @@ class UnitReportViewSet(viewsets.ViewSet):
         )
         learner_ids = [lr["id"] for lr in learners]
 
-        # Determine test state from UnitTestAssignment records.
-        all_assignments = list(
-            UnitTestAssignment.objects.filter(
-                course_session=course_session,
-                unit_contentnode_id=unit_contentnode_id,
-            )
+        # Determine test state from the course session's unit test assignments.
+        unit_test_qs = course_session.unit_test_assignments.filter(
+            unit_contentnode_id=unit_contentnode_id,
         )
-        pre_assignments = [a for a in all_assignments if a.test_type == "pre"]
-        post_assignments = [a for a in all_assignments if a.test_type == "post"]
-
-        pre_status = get_test_status(pre_assignments)
-        post_status = get_test_status(post_assignments)
+        pre_status = get_test_status(unit_test_qs.filter(test_type="pre"))
+        post_status = get_test_status(unit_test_qs.filter(test_type="post"))
 
         # Compute scores for both tests in a single DB pass.
         all_scores = compute_all_test_scores(
@@ -378,14 +311,16 @@ class UnitReportViewSet(viewsets.ViewSet):
         post_scores = all_scores["post"]
 
         # Sort learners ascending by total score (pre + post combined), so that
-        # learners who need the most help appear first.
-        def _total_score(learner):
+        # learners who need the most help appear first.  Tie-break on id for
+        # a deterministic, stable ordering.
+        def _sort_key(learner):
             lid = str(learner["id"])
-            return sum(pre_scores.get(lid, {}).values()) + sum(
+            total = sum(pre_scores.get(lid, {}).values()) + sum(
                 post_scores.get(lid, {}).values()
             )
+            return (total, lid)
 
-        learners_sorted = sorted(learners, key=_total_score)
+        learners_sorted = sorted(learners, key=_sort_key)
 
         # Ensure learner IDs are plain strings in the output.
         for learner in learners_sorted:

--- a/kolibri/plugins/coach/unit_report_api.py
+++ b/kolibri/plugins/coach/unit_report_api.py
@@ -63,7 +63,9 @@ def get_test_version(learner_id, course_session_id, unit_contentnode_id):
     return "a" if hash_byte < 128 else "b"
 
 
-def get_synthetic_content_id(learner_id, course_session_id, unit_contentnode_id, test_type):
+def get_synthetic_content_id(
+    learner_id, course_session_id, unit_contentnode_id, test_type
+):
     """
     Generate a deterministic UUID5 content_id for MasteryLog/AttemptLog tracking.
     Must match the generation logic used on the learner side (issue #14133).
@@ -96,7 +98,9 @@ def _get_test_status(assignments):
     return TEST_STATUS_NOT_ACTIVATED
 
 
-def _compute_all_test_scores(learner_ids, course_session_id, unit_contentnode_id, assessment_objectives):
+def _compute_all_test_scores(
+    learner_ids, course_session_id, unit_contentnode_id, assessment_objectives
+):
     """
     Compute per-learner, per-LO correct counts for both pre and post tests in a
     single pair of DB queries.
@@ -137,7 +141,10 @@ def _compute_all_test_scores(learner_ids, course_session_id, unit_contentnode_id
     for learner_id in learner_ids:
         for test_type in ("pre", "post"):
             synthetic_cid = get_synthetic_content_id(
-                str(learner_id), str(course_session_id), str(unit_contentnode_id), test_type
+                str(learner_id),
+                str(course_session_id),
+                str(unit_contentnode_id),
+                test_type,
             )
             content_id_to_meta[synthetic_cid] = {
                 "learner_id": learner_id,
@@ -170,15 +177,12 @@ def _compute_all_test_scores(learner_ids, course_session_id, unit_contentnode_id
 
     # Chunk the content_id IN list to stay within SQLite's variable limit.
     for chunk in _chunked(list(content_id_to_meta.keys()), _IN_CHUNK_SIZE):
-        for ml in (
-            MasteryLog.objects.filter(
-                summarylog__content_id__in=chunk,
-                complete=True,
-                end_timestamp__isnull=False,
-                end_timestamp=Subquery(_latest_ts_subquery),
-            )
-            .values("id", "summarylog__content_id")
-        ):
+        for ml in MasteryLog.objects.filter(
+            summarylog__content_id__in=chunk,
+            complete=True,
+            end_timestamp__isnull=False,
+            end_timestamp=Subquery(_latest_ts_subquery),
+        ).values("id", "summarylog__content_id"):
             cid = ml["summarylog__content_id"]
             if cid not in seen_content_ids:
                 seen_content_ids.add(cid)
@@ -286,8 +290,7 @@ class UnitReportViewSet(viewsets.ViewSet):
 
         # Mastery criteria / A-B item lists (schema-mastery_criteria.json)
         pre_post_test_config = (
-            (options.get("completion_criteria") or {})
-            .get("threshold") or {}
+            (options.get("completion_criteria") or {}).get("threshold") or {}
         ).get("pre_post_test") or {}
         version_a_item_ids = pre_post_test_config.get("version_a_item_ids") or []
 


### PR DESCRIPTION


## Summary

This PR adds a new endpoint that returns aggregated` pre/post `test scores for every learner assigned to a unit, broken down by learning objective. Learner test attempts are located via UUID5 synthetic content IDs (derived from learner, course session, and unit IDs) that encode the A/B item-set split.

The endpoint is restricted to coach/admin roles and is accompanied by a comprehensive test suite covering permissions, response shape, scoring logic, and learner-group filtering.
closes #14165
## References
 #14165
## Reviewer guidance

1.  Confirm that `GET /api/coach/coursesession/<id>/unit/<id>/report/` returns 403 for an unauthenticated request and 200 for the coach.
2. Verify the response contains per-learner, per-LO correct-answer counts under both `"pre_test" `and "`post_test" `keys.
3. Confirm a learner who has not attempted either test is present in learners but absent from the score maps (not present as a null entry).
4. Confirm the `pre_test. status / post_test.status` fields reflect the closed state of the corresponding `UnitTestAssignment `records

## AI usage
Gemini and Cloud AI helped in refining my thinking and testing my hypothesis 

