### PR TITLE
Fix attendance history CSV export to include all pages

### DIFF
--- a/kolibri/core/logger/management/commands/generateuserdata.py
+++ b/kolibri/core/logger/management/commands/generateuserdata.py
@@ -81,6 +81,13 @@ class Command(BaseCommand):
             dest="max_channels",
             help="Maximum number of channels to add activities to.",
         )
+        parser.add_argument(
+            "--num-attendance-sessions",
+            type=int,
+            default=25,
+            dest="num_attendance_sessions",
+            help="Number of attendance sessions to be created per class.",
+        )
         # TODO(cpauya):
         # parser.add_argument(
         #     "--num-groups",
@@ -121,6 +128,7 @@ class Command(BaseCommand):
         num_content_items = options["num_content_items"]
         num_lessons = options["num_lessons"]
         num_exams = options["num_exams"]
+        num_attendance_sessions = options["num_attendance_sessions"]
         max_channels = options["max_channels"]
         device_name = options["device_name"]
         verbosity = options.get("verbosity", 1)
@@ -253,6 +261,15 @@ class Command(BaseCommand):
                     exams=num_exams,
                     now=now,
                     device_name=device_name,
+                    verbosity=verbosity,
+                )
+
+                # create attendance sessions
+                utils.create_attendance_for_classroom(
+                    classroom=classroom,
+                    facility=facility,
+                    sessions=num_attendance_sessions,
+                    now=now,
                     verbosity=verbosity,
                 )
 

--- a/kolibri/core/logger/test/test_generateuserdata.py
+++ b/kolibri/core/logger/test/test_generateuserdata.py
@@ -1,6 +1,8 @@
 from django.core.management import call_command
 from django.test import TestCase
 
+from kolibri.core.attendance.models import AttendanceRecord
+from kolibri.core.attendance.models import AttendanceSession
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -51,6 +53,18 @@ class GenerateUserDataTest(TestCase):
 
     def test_lessons_created(self):
         self.assertEqual(Lesson.objects.count(), n_lessons * n_classes * n_facilities)
+
+    def test_attendance_sessions_created(self):
+        for classroom in Classroom.objects.all():
+            self.assertTrue(
+                AttendanceSession.objects.filter(collection=classroom).exists()
+            )
+
+    def test_attendance_records_created(self):
+        for session in AttendanceSession.objects.all():
+            self.assertTrue(
+                AttendanceRecord.objects.filter(attendance_session=session).exists()
+            )
 
     def test_no_spacey_names(self):
         for user in FacilityUser.objects.all():

--- a/kolibri/core/logger/utils/user_data.py
+++ b/kolibri/core/logger/utils/user_data.py
@@ -10,6 +10,8 @@ from django.db.utils import IntegrityError
 from django.utils import timezone
 from le_utils.constants import content_kinds
 
+from kolibri.core.attendance.models import AttendanceRecord
+from kolibri.core.attendance.models import AttendanceSession
 from kolibri.core.auth.constants import demographics
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
@@ -590,6 +592,53 @@ def create_exams_for_classrooms(**options):
                     masterylog=masterylog,
                     sessionlog=sessionlog,
                 )
+
+
+def create_attendance_for_classroom(**options):
+    classroom = options["classroom"]
+    facility = options["facility"]
+    num_sessions = options["sessions"]
+    now = options["now"]
+    verbosity = options.get("verbosity", 1)
+
+    coaches = facility.get_coaches()
+    if coaches:
+        coach = random.choice(coaches)
+    else:
+        members = facility.get_members()
+        if not members:
+            return
+        coach = random.choice(members)
+        facility.add_coach(coach)
+
+    learners = list(classroom.get_members())
+    if not learners:
+        return
+
+    for i in range(num_sessions):
+        session_time = now - datetime.timedelta(days=i, hours=random.randint(0, 6))
+        session = AttendanceSession(
+            collection=classroom,
+            created_by=coach,
+            session_start_datetime=session_time,
+            dataset=classroom.dataset,
+        )
+        session.save()
+
+        for learner in learners:
+            AttendanceRecord(
+                attendance_session=session,
+                user=learner,
+                present=random.random() > 0.2,
+                dataset=classroom.dataset,
+            ).save()
+
+    logger_info(
+        "    Created {} attendance sessions for {}".format(
+            num_sessions, classroom.name
+        ),
+        verbosity=verbosity,
+    )
 
 
 # TODO(cpauya): WIP

--- a/kolibri/plugins/coach/frontend/composables/useCoreCoach.js
+++ b/kolibri/plugins/coach/frontend/composables/useCoreCoach.js
@@ -17,6 +17,7 @@ export default function useCoreCoach(store) {
   const appBarTitle = computed(() => getAppBarTitle());
   const authorized = computed(() => store.getters.userIsAuthorizedForCoach);
   const classId = computed(() => get(route).params.classId);
+  const className = computed(() => store.state.classSummary.name);
   const groups = computed(() => store.getters['classSummary/groups']);
   const { isSuperuser } = useUser();
   const { facilities } = useFacilities();
@@ -95,6 +96,7 @@ export default function useCoreCoach(store) {
     initClassInfo,
     refreshClassSummary,
     classId,
+    className,
     groups,
     authorized,
     pageTitle,

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
@@ -93,6 +93,7 @@
   import { ref, computed, watch } from 'vue';
   import { coreString } from 'kolibri/uiText/commonCoreStrings';
   import { attendanceStrings } from 'kolibri-common/strings/attendanceStrings';
+  import AttendanceSessionResource from 'kolibri-common/apiResources/AttendanceSessionResource';
   import PaginationActions from 'kolibri-common/components/PaginationActions';
   import usePagination from 'kolibri-common/composables/usePagination';
   import KDateRange from 'kolibri-design-system/lib/KDateRange';
@@ -124,7 +125,7 @@
       ReportsControls,
     },
     setup() {
-      const { classId } = useCoreCoach();
+      const { classId, className } = useCoreCoach();
 
       const { attendanceLoading, sessions, totalPages, sessionCount, fetchSessions } =
         useAttendance();
@@ -264,8 +265,8 @@
         minute: 'numeric',
       };
 
-      const processedSessions = computed(() => {
-        return sessions.value.map(session => {
+      function processSessionData(rawSessions) {
+        return rawSessions.map(session => {
           const totalCount = session.total_count || 0;
           const presentCount = session.present_count || 0;
           return {
@@ -274,20 +275,45 @@
             absent: totalCount - presentCount,
           };
         });
+      }
+
+      const processedSessions = computed(() => {
+        return processSessionData(sessions.value);
       });
 
       const tableRows = computed(() => {
         return processedSessions.value.map(row => [row.date, row.present, row.absent]);
       });
 
+      function fetchAllSessionPages(params) {
+        const pageNumbers = Array.from({ length: totalPages.value }, (_, i) => i + 1);
+        return Promise.all(
+          pageNumbers.map(page =>
+            AttendanceSessionResource.fetchCollection({
+              getParams: { collection: classId.value, ...params, page },
+              force: true,
+            }).then(data => data.results),
+          ),
+        ).then(pages => pages.flat());
+      }
+
       function exportCSV() {
-        const columns = [
-          { name: dateLabel$(), key: 'date' },
-          { name: presentColumnHeader$(), key: 'present' },
-          { name: absentColumnHeader$(), key: 'absent' },
-        ];
-        const exporter = new CSVExporter(columns, attendanceHistoryTitle$());
-        exporter.export(processedSessions.value);
+        const dateParams = getDateRange(selectedDateRange.value.value);
+        const params = { ...dateParams, page_size: PAGE_SIZE };
+
+        fetchAllSessionPages(params).then(allSessions => {
+          const columns = [
+            { name: dateLabel$(), key: 'date' },
+            { name: presentColumnHeader$(), key: 'present' },
+            { name: absentColumnHeader$(), key: 'absent' },
+          ];
+          const exporter = new CSVExporter(columns, className.value);
+          exporter.addNames({
+            report: attendanceHistoryTitle$(),
+            date: $formatDate(today, { year: 'numeric', month: 'short', day: 'numeric' }),
+          });
+          exporter.export(processSessionData(allSessions));
+        });
       }
 
       // Fetch sessions whenever page changes (immediate: true handles initial load)

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router';
 import { ref } from 'vue';
 import store from 'kolibri/store';
 import { DateRangeFilters } from 'kolibri-common/constants/DateRangeFilters';
+import AttendanceSessionResource from 'kolibri-common/apiResources/AttendanceSessionResource';
 import makeStore from '../../../__tests__/utils/makeStore';
 // eslint-disable-next-line import/named
 import { useAttendance, useAttendanceMock } from '../../../composables/useAttendance';
@@ -10,8 +11,9 @@ import CSVExporter from '../../../csv/exporter';
 import AttendanceHistoryPage from '../AttendanceHistoryPage.vue';
 
 jest.mock('../../../composables/useAttendance');
+jest.mock('kolibri-common/apiResources/AttendanceSessionResource');
 jest.mock('../../../csv/exporter', () => {
-  const MockCSVExporter = jest.fn(() => ({ export: jest.fn() }));
+  const MockCSVExporter = jest.fn(() => ({ export: jest.fn(), addNames: jest.fn() }));
   return { __esModule: true, default: MockCSVExporter };
 });
 jest.mock('kolibri-common/composables/usePagination', () => {
@@ -26,8 +28,10 @@ jest.mock('kolibri-common/composables/usePagination', () => {
 });
 jest.mock('../../../composables/useCoreCoach', () => {
   const { computed } = require('vue');
+  const store = require('kolibri/store').default;
   return () => ({
     classId: computed(() => 'class-123'),
+    className: computed(() => store.state.classSummary.name || ''),
     pageTitle: computed(() => ''),
     appBarTitle: computed(() => ''),
     authorized: computed(() => true),
@@ -111,7 +115,13 @@ const MOCK_SESSIONS = [
   },
 ];
 
-function makeWrapper({ sessions = [], totalPages = 1, sessionCount = null, loading = false } = {}) {
+function makeWrapper({
+  sessions = [],
+  totalPages = 1,
+  sessionCount = null,
+  loading = false,
+  className = 'Test Class',
+} = {}) {
   const mockValues = useAttendanceMock({
     sessions: ref(sessions),
     totalPages: ref(totalPages),
@@ -122,6 +132,7 @@ function makeWrapper({ sessions = [], totalPages = 1, sessionCount = null, loadi
 
   const testStore = makeStore();
   testStore.state.classSummary.id = 'class-123';
+  testStore.state.classSummary.name = className;
   store.replaceState(testStore.state);
 
   const wrapper = mount(AttendanceHistoryPage, {
@@ -168,12 +179,47 @@ describe('AttendanceHistoryPage', () => {
       expect(wrapper.findComponent({ name: 'ReportsControls' }).exists()).toBe(true);
     });
 
+    it('includes class name and export date in CSV filename', async () => {
+      CSVExporter.mockClear();
+      const { wrapper } = makeWrapper({ sessions: MOCK_SESSIONS, className: 'My Class' });
+
+      AttendanceSessionResource.fetchCollection.mockResolvedValue({
+        results: MOCK_SESSIONS,
+        total_pages: 1,
+        count: 2,
+      });
+
+      const controls = wrapper.findComponent({ name: 'ReportsControls' });
+      controls.vm.$emit('export');
+      await global.flushPromises();
+
+      // CSVExporter constructor receives the class name as the base filename
+      expect(CSVExporter).toHaveBeenCalledWith(expect.any(Array), 'My Class');
+
+      // addNames is called with the report title and export date
+      const exporterInstance = CSVExporter.mock.results[0].value;
+      expect(exporterInstance.addNames).toHaveBeenCalledWith(
+        expect.objectContaining({
+          report: 'Attendance History',
+          date: expect.stringContaining('2026'),
+        }),
+      );
+    });
+
     it('exports CSV with session data when ReportsControls emits export', async () => {
       CSVExporter.mockClear();
       const { wrapper } = makeWrapper({ sessions: MOCK_SESSIONS });
+
+      // Mock the resource to return a paginated response for the single-page export
+      AttendanceSessionResource.fetchCollection.mockResolvedValue({
+        results: MOCK_SESSIONS,
+        total_pages: 1,
+        count: 2,
+      });
+
       const controls = wrapper.findComponent({ name: 'ReportsControls' });
       controls.vm.$emit('export');
-      await wrapper.vm.$nextTick();
+      await global.flushPromises();
 
       expect(CSVExporter).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -188,6 +234,96 @@ describe('AttendanceHistoryPage', () => {
         expect.arrayContaining([
           expect.objectContaining({ present: 15, absent: 5 }),
           expect.objectContaining({ present: 18, absent: 2 }),
+        ]),
+      );
+    });
+
+    it('exports all pages of session data when multiple pages exist', async () => {
+      CSVExporter.mockClear();
+      const page1Sessions = [
+        {
+          id: 'session-1',
+          session_start_datetime: '2026-03-10T09:00:00Z',
+          present_count: 15,
+          total_count: 20,
+        },
+        {
+          id: 'session-2',
+          session_start_datetime: '2026-03-09T09:00:00Z',
+          present_count: 18,
+          total_count: 20,
+        },
+      ];
+      const page2Sessions = [
+        {
+          id: 'session-3',
+          session_start_datetime: '2026-03-08T09:00:00Z',
+          present_count: 10,
+          total_count: 20,
+        },
+        {
+          id: 'session-4',
+          session_start_datetime: '2026-03-07T09:00:00Z',
+          present_count: 12,
+          total_count: 20,
+        },
+      ];
+      const page3Sessions = [
+        {
+          id: 'session-5',
+          session_start_datetime: '2026-03-06T09:00:00Z',
+          present_count: 5,
+          total_count: 20,
+        },
+      ];
+
+      const { wrapper } = makeWrapper({
+        sessions: page1Sessions,
+        totalPages: 3,
+        sessionCount: 5,
+      });
+
+      // Mock the resource to return page-specific paginated responses
+      AttendanceSessionResource.fetchCollection.mockImplementation(({ getParams }) => {
+        const pageData = {
+          1: page1Sessions,
+          2: page2Sessions,
+          3: page3Sessions,
+        };
+        return Promise.resolve({
+          results: pageData[getParams.page] || [],
+          total_pages: 3,
+          count: 5,
+        });
+      });
+
+      const controls = wrapper.findComponent({ name: 'ReportsControls' });
+      controls.vm.$emit('export');
+      await global.flushPromises();
+
+      // Should have fetched all 3 pages
+      expect(AttendanceSessionResource.fetchCollection).toHaveBeenCalledTimes(3);
+      expect(AttendanceSessionResource.fetchCollection).toHaveBeenCalledWith(
+        expect.objectContaining({ getParams: expect.objectContaining({ page: 1 }) }),
+      );
+      expect(AttendanceSessionResource.fetchCollection).toHaveBeenCalledWith(
+        expect.objectContaining({ getParams: expect.objectContaining({ page: 2 }) }),
+      );
+      expect(AttendanceSessionResource.fetchCollection).toHaveBeenCalledWith(
+        expect.objectContaining({ getParams: expect.objectContaining({ page: 3 }) }),
+      );
+
+      // Should have exported exactly 5 sessions from all 3 pages
+      const exporterInstance = CSVExporter.mock.results[0].value;
+      const exportedData = exporterInstance.export.mock.calls[0][0];
+      expect(exportedData).toHaveLength(5);
+      expect(exportedData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ present: 15, absent: 5 }),
+          expect.objectContaining({ present: 18, absent: 2 }),
+          expect.objectContaining({ present: 10, absent: 10 }),
+          expect.objectContaining({ present: 12, absent: 8 }),
+          expect.objectContaining({ present: 5, absent: 15 }),
         ]),
       );
     });


### PR DESCRIPTION
## Summary

CSV export on the Attendance History page only exported the current page (10 rows) instead of all sessions matching the date filter. Now fetches all pages in parallel and exports the complete dataset. Also includes the class name and export date in the CSV filename.

`generateuserdata` now creates attendance sessions and records per class, so the bug is reproducible out of the box.

## References

Closes #14418

## Reviewer guidance

https://github.com/user-attachments/assets/4700b409-ea3c-482e-a664-8bb3e6544917

1. Generate test data: `kolibri manage generateuserdata`
2. Navigate to Coach > Class home > [a class] > Attendance history
3. Click "Export as CSV" and verify all rows are included (not just the first 10)
4. Check the filename includes the class name and export date

The export fetches pages in parallel using `AttendanceSessionResource.fetchCollection` directly rather than the composable's `fetchSessions`, to avoid mutating shared table state during export.

## AI usage

Implementation was done collaboratively with Claude Code using TDD. Claude wrote the failing tests, implementation, and iterated on code review feedback (shared state corruption from parallel `fetchSessions` calls was caught and fixed by switching to direct resource calls). All changes were manually verified in a running dev server.