### PR TITLE
Fix custom date range filter excluding sessions on end date

### DIFF
--- a/kolibri/core/attendance/test/test_api.py
+++ b/kolibri/core/attendance/test/test_api.py
@@ -370,6 +370,30 @@ class AttendanceSessionAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
+    def test_filter_by_end_date_includes_sessions_on_end_date(self):
+        """Sessions on the end date are included when end_date is next day midnight.
+
+        Regression test for #14424: the frontend must send midnight of the day
+        AFTER the user-selected end date so the exclusive lt filter includes all
+        sessions on the selected date.
+        """
+        session = self._create_session()
+        session.session_start_datetime = now().replace(
+            hour=14, minute=30, second=0, microsecond=0
+        )
+        session.save()
+
+        self._login(self.admin)
+        # Simulate what the frontend should send: midnight of the next day
+        next_day_midnight = now().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + timedelta(days=1)
+        response = self.client.get(
+            _session_list_url(), {"end_date": next_day_midnight.isoformat()}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
     # ---- DEFAULT ORDERING ----
 
     def test_default_ordering_is_newest_first(self):

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
@@ -190,9 +190,14 @@
 
       function getDateRange(filterValue) {
         if (filterValue === DateRangeFilters.CUSTOM_APPLIED) {
+          // KDateRange returns dates at midnight (start of day). The backend
+          // end_date filter uses exclusive lt, so we send midnight of the NEXT
+          // day to include all sessions on the selected end date (#14424).
+          const exclusiveEnd = new Date(customEndDate.value);
+          exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);
           return {
             start_date: customStartDate.value.toISOString(),
-            end_date: customEndDate.value.toISOString(),
+            end_date: exclusiveEnd.toISOString(),
           };
         }
         if (filterValue === DateRangeFilters.ALL_TIME) {

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
@@ -321,12 +321,17 @@ describe('AttendanceHistoryPage', () => {
       // KDateRange should be hidden after submit
       expect(wrapper.findComponent({ name: 'KDateRange' }).exists()).toBe(false);
 
+      // end_date should be the start of the NEXT day so the backend's
+      // exclusive "lt" filter includes the entire end date (#14424)
+      const expectedEndDate = new Date(endDate);
+      expectedEndDate.setDate(expectedEndDate.getDate() + 1);
+
       // Should have re-fetched with ISO datetime params
       expect(mock.fetchSessions).toHaveBeenCalledWith(
         'class-123',
         expect.objectContaining({
           start_date: startDate.toISOString(),
-          end_date: endDate.toISOString(),
+          end_date: expectedEndDate.toISOString(),
           page: 1,
         }),
       );


### PR DESCRIPTION
## Summary

Custom date range filter in Attendance History excluded all sessions on the selected end date. `KDateRange` returns Date objects at midnight (start of day), and the backend `end_date` filter uses exclusive `lt`. Sending midnight of the selected date meant `session_start_datetime < midnight` excluded the entire day.

Fix: add one day to the custom end date before sending, so the exclusive `lt` boundary includes all sessions on the selected date.

| Screenshot |
|------------|
| ![Custom date filter showing today's session](https://i.imgur.com/1MQk0gX.png) |

## References

Fixes #14424

## Reviewer guidance

1. Mark attendance for a class
2. Go to Attendance History, select Custom date range, pick today as both start and end date
3. Verify today's session appears in the results

The change is in `getDateRange()` in `AttendanceHistoryPage.vue:191-200` — only the custom date range path is affected. Preset ranges (Last 7/30/365 days) already use `now()` which works correctly with the `lt` filter.

## AI usage

This PR was implemented by Claude Code using TDD. Tests were written first, verified failing, then the fix was applied and verified passing. Manual verification was done via Playwright browser automation and confirmed independently by me in my own browser session.