### PR TITLE
annotate attendance with historical learner references

### DIFF
--- a/kolibri/core/attendance/api.py
+++ b/kolibri/core/attendance/api.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 from django.db.models import Count
+from django.db.models import F
 from django.db.models import Q
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
@@ -129,7 +130,20 @@ class AttendanceRecordViewSet(ReadOnlyValuesViewset):
     filter_backends = (KolibriAuthPermissionsFilter, DjangoFilterBackend)
     filterset_class = AttendanceRecordFilter
 
-    values = ("id", "user", "present", "attendance_session")
+    values = (
+        "id",
+        "user",
+        "present",
+        "attendance_session",
+        "user_name",
+        "user_username",
+    )
+
+    def annotate_queryset(self, queryset):
+        return queryset.annotate(
+            user_name=F("user__full_name"),
+            user_username=F("user__username"),
+        )
 
     def get_queryset(self):
         return AttendanceRecord.objects.all()
@@ -179,7 +193,9 @@ class AttendanceRecordViewSet(ReadOnlyValuesViewset):
                     records_to_create.append(record)
             if records_to_create:
                 AttendanceRecord.objects.bulk_create(records_to_create)
-        all_records = AttendanceRecord.objects.filter(
-            attendance_session=session, user_id__in=user_ids
+        all_records = self.annotate_queryset(
+            AttendanceRecord.objects.filter(
+                attendance_session=session, user_id__in=user_ids
+            )
         ).values(*self.values)
         return Response(list(all_records))

--- a/kolibri/core/attendance/test/test_api.py
+++ b/kolibri/core/attendance/test/test_api.py
@@ -624,6 +624,57 @@ class AttendanceRecordAPITestCase(APITestCase):
         self.assertTrue(record["present"])
         self.assertEqual(record["attendance_session"], session.id)
 
+    def test_list_records_includes_user_name_and_username(self):
+        self.learner1.full_name = "Alice Smith"
+        self.learner1.save()
+        session = self._create_session()
+        AttendanceRecord.objects.create(
+            attendance_session=session, user=self.learner1, present=True
+        )
+        self._login(self.coach)
+        response = self.client.get(
+            _record_list_url(), {"attendance_session": session.id}
+        )
+        self.assertEqual(response.status_code, 200)
+        record = response.data[0]
+        self.assertEqual(record["user_name"], "Alice Smith")
+        self.assertEqual(record["user_username"], self.learner1.username)
+
+    def test_list_records_preserves_user_name_after_learner_removed_from_class(self):
+        self.learner1.full_name = "Bob Jones"
+        self.learner1.save()
+        session = self._create_session()
+        AttendanceRecord.objects.create(
+            attendance_session=session, user=self.learner1, present=True
+        )
+        # Remove learner1 from the class — their record and name must still be accessible.
+        Membership.objects.filter(
+            user=self.learner1, collection=self.classroom
+        ).delete()
+        self._login(self.coach)
+        response = self.client.get(
+            _record_list_url(), {"attendance_session": session.id}
+        )
+        self.assertEqual(response.status_code, 200)
+        record = response.data[0]
+        self.assertEqual(record["user_name"], "Bob Jones")
+        self.assertEqual(record["user"], self.learner1.id)
+
+    def test_bulk_update_response_includes_user_name_and_username(self):
+        self.learner1.full_name = "Charlie Brown"
+        self.learner1.save()
+        session = self._create_session()
+        self._login(self.coach)
+        data = {
+            "attendance_session": session.id,
+            "records": [{"user": self.learner1.id, "present": True}],
+        }
+        response = self.client.post(_record_bulk_update_url(), data, format="json")
+        self.assertEqual(response.status_code, 200)
+        record = response.data[0]
+        self.assertEqual(record["user_name"], "Charlie Brown")
+        self.assertEqual(record["user_username"], self.learner1.username)
+
     def test_learner_cannot_bulk_update(self):
         session = self._create_session()
         self._login(self.learner1)

--- a/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
+++ b/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
@@ -23,6 +23,8 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
   const { classId } = useCoreCoach();
 
   const attendanceMap = ref({});
+  const previouslyEnrolledMap = ref({});
+  const enrolledLearnerIds = ref(null);
   const showMarkAllModal = ref(false);
   const pendingRoute = ref(null);
 
@@ -33,8 +35,14 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
 
   const sortedLearners = computed(() => {
     const learners = store.getters['classSummary/learners'] || [];
-    return [...learners].sort((a, b) => localeCompare(a.name, b.name));
+    return [...learners]
+      .filter(l => enrolledLearnerIds.value === null || enrolledLearnerIds.value.has(l.id))
+      .sort((a, b) => localeCompare(a.name, b.name));
   });
+
+  function setEnrolledLearnerIds(ids) {
+    enrolledLearnerIds.value = ids;
+  }
 
   function isPresent(learnerId) {
     return !!attendanceMap.value[learnerId];
@@ -48,11 +56,43 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
     if (onChange) onChange();
   }
 
-  const presentCount = computed(() => Object.values(attendanceMap.value).filter(Boolean).length);
-  const absentCount = computed(() => sortedLearners.value.length - presentCount.value);
+  const sortedPreviouslyEnrolled = computed(() =>
+    Object.values(previouslyEnrolledMap.value).sort((a, b) => localeCompare(a.name, b.name)),
+  );
+
+  function setPreviouslyEnrolled(records) {
+    const map = {};
+    records.forEach(r => {
+      map[r.user] = {
+        id: r.user,
+        name: r.user_name || '',
+        username: r.user_username || '',
+        present: r.present,
+      };
+    });
+    previouslyEnrolledMap.value = map;
+  }
+
+  const currentPresentCount = computed(
+    () => sortedLearners.value.filter(l => !!attendanceMap.value[l.id]).length,
+  );
+  const removedPresentCount = computed(
+    () => Object.values(previouslyEnrolledMap.value).filter(r => r.present).length,
+  );
+  const presentCount = computed(() => currentPresentCount.value + removedPresentCount.value);
+  const currentAbsentCount = computed(
+    () => sortedLearners.value.length - currentPresentCount.value,
+  );
+  const absentCount = computed(
+    () =>
+      sortedLearners.value.length +
+      Object.keys(previouslyEnrolledMap.value).length -
+      presentCount.value,
+  );
 
   const allPresent = computed(
-    () => sortedLearners.value.length > 0 && presentCount.value === sortedLearners.value.length,
+    () =>
+      sortedLearners.value.length > 0 && currentPresentCount.value === sortedLearners.value.length,
   );
 
   function setAllLearners(value) {
@@ -117,8 +157,12 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
     attendanceMap,
     backRoute,
     sortedLearners,
+    sortedPreviouslyEnrolled,
+    setPreviouslyEnrolled,
+    setEnrolledLearnerIds,
     presentCount,
     absentCount,
+    currentAbsentCount,
     allPresent,
     showMarkAllModal,
     pendingRoute,

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
@@ -175,7 +175,9 @@
               removedRecords.push(record);
             }
           });
-          form.setEnrolledLearnerIds(new Set(Object.keys(currentMap)));
+          if (Object.keys(currentMap).length > 0) {
+            form.setEnrolledLearnerIds(new Set(Object.keys(currentMap)));
+          }
           form.attendanceMap.value = currentMap;
           originalAttendanceMap.value = { ...currentMap };
           form.setPreviouslyEnrolled(removedRecords);

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
@@ -13,8 +13,18 @@
       >
         <h1>{{ pageTitle }}</h1>
 
-        <AttendanceFormTable :form="form">
-          <template #action-button>
+        <p v-if="!hasAnyLearners">
+          {{ noLearnersInClassMessage$() }}
+        </p>
+
+        <AttendanceFormTable
+          v-else
+          :form="form"
+        >
+          <template
+            v-if="hasCurrentLearners"
+            #action-button
+          >
             <KButton
               :text="coreString('saveAction')"
               :primary="true"
@@ -78,6 +88,7 @@
         submitErrorMessage$,
         presentCount$,
         absentCount$,
+        noLearnersInClassMessage$,
       } = attendanceStrings;
 
       const loading = ref(true);
@@ -95,6 +106,12 @@
         },
         submitting: saving,
       });
+
+      const hasCurrentLearners = computed(() => form.sortedLearners.value.length > 0);
+      const hasAnyLearners = computed(
+        () =>
+          form.sortedLearners.value.length > 0 || form.sortedPreviouslyEnrolled.value.length > 0,
+      );
 
       const changedRecords = computed(() => {
         const changed = [];
@@ -136,7 +153,8 @@
         showSaveModal.value = false;
       }
 
-      // Load session and records
+      // Load session and records — split into current learners (editable) and
+      // previously enrolled (read-only, shown at the bottom of the form).
       async function loadData(sessionId) {
         loading.value = true;
         try {
@@ -147,12 +165,20 @@
           const { date, time } = formatAttendanceDateTime(session.session_start_datetime);
           pageTitle.value = editPageHeading$({ date, time });
 
-          const map = {};
+          const currentLearnerIds = new Set(form.sortedLearners.value.map(l => l.id));
+          const currentMap = {};
+          const removedRecords = [];
           records.forEach(record => {
-            map[record.user] = record.present;
+            if (currentLearnerIds.has(record.user)) {
+              currentMap[record.user] = record.present;
+            } else {
+              removedRecords.push(record);
+            }
           });
-          form.attendanceMap.value = map;
-          originalAttendanceMap.value = { ...map };
+          form.setEnrolledLearnerIds(new Set(Object.keys(currentMap)));
+          form.attendanceMap.value = currentMap;
+          originalAttendanceMap.value = { ...currentMap };
+          form.setPreviouslyEnrolled(removedRecords);
         } catch (_err) {
           createSnackbar(submitErrorMessage$());
           form.navigateBack();
@@ -181,9 +207,12 @@
         cancelSave,
         form,
         backRoute: form.backRoute,
+        hasCurrentLearners,
+        hasAnyLearners,
         saveConfirmationTitle$,
         presentCount$,
         absentCount$,
+        noLearnersInClassMessage$,
       };
     },
     beforeRouteLeave(to, from, next) {

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
@@ -102,7 +102,7 @@
                 class="previously-enrolled-name"
                 :style="{ color: $themeTokens.annotation }"
               >
-                {{ learner.name }} {{ previouslyEnrolledLabel$() }}
+                {{ previouslyEnrolledLabel$({ name: learner.name }) }}
               </span>
               <div class="status-cell">
                 <span
@@ -139,7 +139,7 @@
             class="previously-enrolled-name"
             :style="{ color: $themeTokens.annotation }"
           >
-            {{ learner.name }} {{ previouslyEnrolledLabel$() }}
+            {{ previouslyEnrolledLabel$({ name: learner.name }) }}
           </span>
           <div class="status-cell">
             <span

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
@@ -6,8 +6,8 @@
       :style="{ borderColor: $themeTokens.fineLine, backgroundColor: $themePalette.grey.v_100 }"
     >
       <PaginatedListContainer
-        v-if="sortedLearners.length > 0"
-        :items="sortedLearners"
+        v-if="allItems.length > 0"
+        :items="allItems"
         :filterPlaceholder="searchPlaceholder$()"
         :itemsPerPage="50"
         :searchFieldBlock="true"
@@ -15,6 +15,7 @@
       >
         <template #default="{ items }">
           <div
+            v-if="sortedLearners.length > 0"
             class="mark-all-row"
             :style="{
               borderBottom: `1px solid ${$themeTokens.fineLine}`,
@@ -47,117 +48,60 @@
                 <span class="visuallyhidden">{{ header.label }}</span>
               </template>
               <template #cell="{ content, colIndex }">
-                <span
-                  v-if="colIndex === 0"
-                  :id="`learner-name-${content.id}`"
-                >{{ content.name }}</span>
+                <template v-if="colIndex === 0">
+                  <span
+                    v-if="content.previouslyEnrolled"
+                    :id="`learner-name-removed-${content.id}`"
+                    class="previously-enrolled-name"
+                    :style="{ color: $themeTokens.annotation }"
+                  >
+                    {{ previouslyEnrolledLabel$({ name: content.name }) }}
+                  </span>
+                  <span
+                    v-else
+                    :id="`learner-name-${content.id}`"
+                  >{{ content.name }}</span>
+                </template>
                 <div
                   v-else
                   class="status-cell"
                 >
-                  <span
-                    v-if="isPresent(content.id)"
-                    class="present-label"
-                    :style="{ color: $themeTokens.primary }"
-                  >
-                    {{ presentLabel$() }}
-                  </span>
-                  <KSwitch
-                    :name="`attendance-${content.id}`"
-                    :value="isPresent(content.id)"
-                    :ariaLabelledBy="`learner-name-${content.id}`"
-                    @change="toggleLearner(content.id)"
-                  />
+                  <template v-if="content.previouslyEnrolled">
+                    <span
+                      v-if="content.present"
+                      class="present-label"
+                      :style="{ color: $themeTokens.annotation }"
+                    >
+                      {{ presentLabel$() }}
+                    </span>
+                    <KSwitch
+                      :name="`attendance-removed-${content.id}`"
+                      :value="content.present"
+                      :disabled="true"
+                      :ariaLabelledBy="`learner-name-removed-${content.id}`"
+                    />
+                  </template>
+                  <template v-else>
+                    <span
+                      v-if="isPresent(content.id)"
+                      class="present-label"
+                      :style="{ color: $themeTokens.primary }"
+                    >
+                      {{ presentLabel$() }}
+                    </span>
+                    <KSwitch
+                      :name="`attendance-${content.id}`"
+                      :value="isPresent(content.id)"
+                      :ariaLabelledBy="`learner-name-${content.id}`"
+                      @change="toggleLearner(content.id)"
+                    />
+                  </template>
                 </div>
               </template>
             </KTable>
           </div>
         </template>
       </PaginatedListContainer>
-
-      <!--
-        Previously enrolled learners: read-only.
-        When current learners also exist they appear as a static list at the bottom.
-        When there are NO current learners they get their own PaginatedListContainer
-        so the coach can search through them (handled by the v-else-if below).
-      -->
-      <PaginatedListContainer
-        v-else-if="sortedPreviouslyEnrolled.length > 0"
-        :items="sortedPreviouslyEnrolled"
-        :filterPlaceholder="searchPlaceholder$()"
-        :itemsPerPage="50"
-        :searchFieldBlock="true"
-        position="top"
-      >
-        <template #default="{ items }">
-          <div :style="{ backgroundColor: $themeTokens.surface }">
-            <div
-              v-for="learner in items"
-              :key="learner.id"
-              class="previously-enrolled-row"
-              :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
-            >
-              <span
-                :id="`learner-name-removed-${learner.id}`"
-                class="previously-enrolled-name"
-                :style="{ color: $themeTokens.annotation }"
-              >
-                {{ previouslyEnrolledLabel$({ name: learner.name }) }}
-              </span>
-              <div class="status-cell">
-                <span
-                  v-if="learner.present"
-                  class="present-label"
-                  :style="{ color: $themeTokens.annotation }"
-                >
-                  {{ presentLabel$() }}
-                </span>
-                <KSwitch
-                  :name="`attendance-removed-${learner.id}`"
-                  :value="learner.present"
-                  :disabled="true"
-                  :ariaLabelledBy="`learner-name-removed-${learner.id}`"
-                />
-              </div>
-            </div>
-          </div>
-        </template>
-      </PaginatedListContainer>
-
-      <div
-        v-if="sortedLearners.length > 0 && sortedPreviouslyEnrolled.length > 0"
-        :style="{ backgroundColor: $themeTokens.surface }"
-      >
-        <div
-          v-for="learner in sortedPreviouslyEnrolled"
-          :key="learner.id"
-          class="previously-enrolled-row"
-          :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
-        >
-          <span
-            :id="`learner-name-removed-${learner.id}`"
-            class="previously-enrolled-name"
-            :style="{ color: $themeTokens.annotation }"
-          >
-            {{ previouslyEnrolledLabel$({ name: learner.name }) }}
-          </span>
-          <div class="status-cell">
-            <span
-              v-if="learner.present"
-              class="present-label"
-              :style="{ color: $themeTokens.annotation }"
-            >
-              {{ presentLabel$() }}
-            </span>
-            <KSwitch
-              :name="`attendance-removed-${learner.id}`"
-              :value="learner.present"
-              :disabled="true"
-              :ariaLabelledBy="`learner-name-removed-${learner.id}`"
-            />
-          </div>
-        </div>
-      </div>
     </div>
 
     <BottomAppBar>
@@ -219,6 +163,7 @@
 
 <script>
 
+  import { computed } from 'vue';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { coreString } from 'kolibri/uiText/commonCoreStrings';
@@ -271,6 +216,11 @@
         cancelLeave,
       } = props.form;
 
+      const allItems = computed(() => [
+        ...sortedLearners.value.map(l => ({ ...l, previouslyEnrolled: false })),
+        ...sortedPreviouslyEnrolled.value.map(l => ({ ...l, previouslyEnrolled: true })),
+      ]);
+
       const confirmButtonStyles = {
         color: themeTokens().textInverted,
         backgroundColor: themePalette().red.v_600,
@@ -298,8 +248,8 @@
       return {
         coreString,
         confirmButtonStyles,
+        allItems,
         sortedLearners,
-        sortedPreviouslyEnrolled,
         allPresent,
         presentCount: presentCountValue,
         absentCount: absentCountValue,
@@ -382,15 +332,7 @@
     font-weight: bold;
   }
 
-  .previously-enrolled-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 4px 16px;
-  }
-
   .previously-enrolled-name {
-    flex: 1;
     font-size: 0.9375em;
   }
 

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
@@ -6,6 +6,7 @@
       :style="{ borderColor: $themeTokens.fineLine, backgroundColor: $themePalette.grey.v_100 }"
     >
       <PaginatedListContainer
+        v-if="sortedLearners.length > 0"
         :items="sortedLearners"
         :filterPlaceholder="searchPlaceholder$()"
         :itemsPerPage="50"
@@ -73,6 +74,90 @@
           </div>
         </template>
       </PaginatedListContainer>
+
+      <!--
+        Previously enrolled learners: read-only.
+        When current learners also exist they appear as a static list at the bottom.
+        When there are NO current learners they get their own PaginatedListContainer
+        so the coach can search through them (handled by the v-else-if below).
+      -->
+      <PaginatedListContainer
+        v-else-if="sortedPreviouslyEnrolled.length > 0"
+        :items="sortedPreviouslyEnrolled"
+        :filterPlaceholder="searchPlaceholder$()"
+        :itemsPerPage="50"
+        :searchFieldBlock="true"
+        position="top"
+      >
+        <template #default="{ items }">
+          <div :style="{ backgroundColor: $themeTokens.surface }">
+            <div
+              v-for="learner in items"
+              :key="learner.id"
+              class="previously-enrolled-row"
+              :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
+            >
+              <span
+                :id="`learner-name-removed-${learner.id}`"
+                class="previously-enrolled-name"
+                :style="{ color: $themeTokens.annotation }"
+              >
+                {{ learner.name }} {{ previouslyEnrolledLabel$() }}
+              </span>
+              <div class="status-cell">
+                <span
+                  v-if="learner.present"
+                  class="present-label"
+                  :style="{ color: $themeTokens.annotation }"
+                >
+                  {{ presentLabel$() }}
+                </span>
+                <KSwitch
+                  :name="`attendance-removed-${learner.id}`"
+                  :value="learner.present"
+                  :disabled="true"
+                  :ariaLabelledBy="`learner-name-removed-${learner.id}`"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </PaginatedListContainer>
+
+      <div
+        v-if="sortedLearners.length > 0 && sortedPreviouslyEnrolled.length > 0"
+        :style="{ backgroundColor: $themeTokens.surface }"
+      >
+        <div
+          v-for="learner in sortedPreviouslyEnrolled"
+          :key="learner.id"
+          class="previously-enrolled-row"
+          :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
+        >
+          <span
+            :id="`learner-name-removed-${learner.id}`"
+            class="previously-enrolled-name"
+            :style="{ color: $themeTokens.annotation }"
+          >
+            {{ learner.name }} {{ previouslyEnrolledLabel$() }}
+          </span>
+          <div class="status-cell">
+            <span
+              v-if="learner.present"
+              class="present-label"
+              :style="{ color: $themeTokens.annotation }"
+            >
+              {{ presentLabel$() }}
+            </span>
+            <KSwitch
+              :name="`attendance-removed-${learner.id}`"
+              :value="learner.present"
+              :disabled="true"
+              :ariaLabelledBy="`learner-name-removed-${learner.id}`"
+            />
+          </div>
+        </div>
+      </div>
     </div>
 
     <BottomAppBar>
@@ -100,7 +185,7 @@
       :title="markAllModalTitle$({ count: sortedLearners.length })"
       @cancel="cancelMarkAll"
     >
-      <p>{{ markAllModalDescription$({ count: absentCount }) }}</p>
+      <p>{{ markAllModalDescription$({ count: currentAbsentCount }) }}</p>
       <template #actions>
         <KButtonGroup>
           <KButton
@@ -164,13 +249,16 @@
         markAllPresentAction$,
         learnersLabel$,
         markAttendanceAction$,
+        previouslyEnrolledLabel$,
       } = attendanceStrings;
 
       const {
         sortedLearners,
+        sortedPreviouslyEnrolled,
         allPresent,
         presentCount: presentCountValue,
         absentCount: absentCountValue,
+        currentAbsentCount: currentAbsentCountValue,
         showMarkAllModal,
         pendingRoute,
         isPresent,
@@ -211,9 +299,11 @@
         coreString,
         confirmButtonStyles,
         sortedLearners,
+        sortedPreviouslyEnrolled,
         allPresent,
         presentCount: presentCountValue,
         absentCount: absentCountValue,
+        currentAbsentCount: currentAbsentCountValue,
         showMarkAllModal,
         pendingRoute,
         isPresent,
@@ -238,6 +328,7 @@
         markAllPresentAction$,
         learnersLabel$,
         markAttendanceAction$,
+        previouslyEnrolledLabel$,
         tableHeaders,
         getTableRows,
       };
@@ -289,6 +380,18 @@
 
   .mark-all-label {
     font-weight: bold;
+  }
+
+  .previously-enrolled-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 16px;
+  }
+
+  .previously-enrolled-name {
+    flex: 1;
+    font-size: 0.9375em;
   }
 
   .status-cell {

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
@@ -134,9 +134,9 @@ const MOCK_SESSION = {
 };
 
 const MOCK_RECORDS = [
-  { user: 'learner-a', present: true },
-  { user: 'learner-b', present: false },
-  { user: 'learner-c', present: true },
+  { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+  { user: 'learner-b', present: false, user_name: 'Bob', user_username: 'bob' },
+  { user: 'learner-c', present: true, user_name: 'Charlie', user_username: 'charlie' },
 ];
 
 function renderEditPage({
@@ -516,5 +516,160 @@ describe('AttendanceEditPage', () => {
 
     expect(createSnackbar).toHaveBeenCalled();
     expect(router.currentRoute.name).toBe(initialRoute);
+  });
+
+  it('shows no-learners message when the session has no records at all', async () => {
+    renderEditPage({ learners: [], records: [] });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('There are no learners in this class')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('shows previously enrolled section (no save button) when all learners are removed but records exist', async () => {
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+    ];
+    renderEditPage({ learners: [], records });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('There are no learners in this class')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('does not show learners added after the session was created', async () => {
+    // learner-a was in the class in January and has a record.
+    // learner-b was added in July and has no record for this session.
+    // learner-b should not appear on the edit page at all.
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+    ];
+    renderEditPage({
+      learners: [
+        { id: 'learner-a', name: 'Alice', username: 'alice' },
+        { id: 'learner-b', name: 'Bob', username: 'bob' },
+      ],
+      records,
+    });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // Bob joined after this session — should not appear at all
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bob (Previously enrolled)')).not.toBeInTheDocument();
+  });
+
+  it('shows searchable list for previously enrolled when no current learners exist', async () => {
+    // All learners removed — previously enrolled should get their own PaginatedListContainer
+    // with a search box, not just a static list.
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+      { user: 'learner-b', present: false, user_name: 'Bob', user_username: 'bob' },
+    ];
+    renderEditPage({ learners: [], records });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
+      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+    });
+
+    // Search box should be present for filtering previously enrolled learners
+    expect(screen.getByPlaceholderText('Search for a learner')).toBeInTheDocument();
+
+    // Both previously enrolled toggles should be disabled
+    const aliceSwitch = document.querySelector('input[name="attendance-removed-learner-a"]');
+    const bobSwitch = document.querySelector('input[name="attendance-removed-learner-b"]');
+    expect(aliceSwitch.disabled).toBe(true);
+    expect(bobSwitch.disabled).toBe(true);
+  });
+
+  it('shows previously enrolled learners at the bottom with "(Previously enrolled)" label', async () => {
+    // learner-b and learner-c have been removed from the class; their records survive.
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+      { user: 'learner-b', present: true, user_name: 'Bob', user_username: 'bob' },
+      { user: 'learner-c', present: false, user_name: 'Charlie', user_username: 'charlie' },
+    ];
+    renderEditPage({
+      learners: [{ id: 'learner-a', name: 'Alice', username: 'alice' }],
+      records,
+    });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+      expect(screen.getByText('Charlie (Previously enrolled)')).toBeInTheDocument();
+    });
+  });
+
+  it('previously enrolled toggles are disabled', async () => {
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+      { user: 'learner-b', present: true, user_name: 'Bob', user_username: 'bob' },
+    ];
+    renderEditPage({
+      learners: [{ id: 'learner-a', name: 'Alice', username: 'alice' }],
+      records,
+    });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+    });
+
+    const removedSwitch = document.querySelector('input[name="attendance-removed-learner-b"]');
+    expect(removedSwitch).not.toBeNull();
+    expect(removedSwitch.disabled).toBe(true);
+  });
+
+  it('includes previously enrolled learners in present and absent counts', async () => {
+    // Alice (current, present) + Bob (removed, present) + Charlie (removed, absent)
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+      { user: 'learner-b', present: true, user_name: 'Bob', user_username: 'bob' },
+      { user: 'learner-c', present: false, user_name: 'Charlie', user_username: 'charlie' },
+    ];
+    renderEditPage({
+      learners: [{ id: 'learner-a', name: 'Alice', username: 'alice' }],
+      records,
+    });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('2 present')).toBeInTheDocument();
+      expect(screen.getByText('1 absent')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show negative absent count when records include removed learners', async () => {
+    // All 3 learners were present; 2 of 3 have since been removed.
+    // Total: 3 present, 0 absent — previously enrolled are included in the count.
+    const records = [
+      { user: 'learner-a', present: true, user_name: 'Alice', user_username: 'alice' },
+      { user: 'learner-b', present: true, user_name: 'Bob', user_username: 'bob' },
+      { user: 'learner-c', present: true, user_name: 'Charlie', user_username: 'charlie' },
+    ];
+    renderEditPage({ learners: [{ id: 'learner-a', name: 'Alice', username: 'alice' }], records });
+    await global.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // 3 total present (Alice current + Bob and Charlie previously enrolled), 0 absent.
+    expect(screen.getByText('3 present')).toBeInTheDocument();
+    expect(screen.getByText('0 absent')).toBeInTheDocument();
   });
 });

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -175,9 +175,9 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
     context: 'Column header for the count of learners absent',
   },
   previouslyEnrolledLabel: {
-    message: '(Previously enrolled)',
+    message: '{name} (Previously enrolled)',
     context:
-      'Suffix appended to a learner name in attendance history when that learner is no longer enrolled in the class',
+      'Learner name with suffix in attendance history when that learner is no longer enrolled in the class. The name placeholder allows translators to reorder the components.',
   },
   noLearnersInClassMessage: {
     message: 'There are no learners in this class',

--- a/packages/kolibri-common/strings/attendanceStrings.js
+++ b/packages/kolibri-common/strings/attendanceStrings.js
@@ -174,6 +174,16 @@ export const attendanceStrings = createTranslator('AttendanceStrings', {
     message: 'Absent',
     context: 'Column header for the count of learners absent',
   },
+  previouslyEnrolledLabel: {
+    message: '(Previously enrolled)',
+    context:
+      'Suffix appended to a learner name in attendance history when that learner is no longer enrolled in the class',
+  },
+  noLearnersInClassMessage: {
+    message: 'There are no learners in this class',
+    context:
+      'Message shown on the attendance form or history page when the class currently has no learners',
+  },
   noSessionsEnrollMessage: {
     message: 'No attendance sessions yet. Enroll learners to mark attendance',
     context:


### PR DESCRIPTION
# Summary
Fixes #14413 

This PR adds an annotation to attendance history, so users can be tracked over time even when their membership in a given class changes.


## Reviewer guidance
I think there is still room for further improvement and different permutations, but for the near term, I think this covers more of the likely edge cases around learner unenrollment and "late additions" to the class.


Editing Attendance: 
- New "previously enrolled" category. When viewing/editing a historical session, learners who have since been removed from the class appear at the bottom of the table. They sorted alphabetically, with  "(Previously enrolled)" appended to the name. The record is read-only.                                                                                           
  - Newly enrolled learners are hidden from historical sessions. This means that learners added to the class **after** a session was created no longer appear on that session's edit page. Only learners who were enrolled at the time of the session are shown.

Attendance History:                               
  - Present/absent counts include previously enrolled learners. The bottom bar counts (e.g. "3 present · 1 absent") reflect all learners in the session, including those since removed, based on their recorded state at the time.                                                          
  - If a session has attendance records but all enrolled learners have since been removed, the edit page now shows those records as previously enrolled rather than an empty table.                                 
  - Search available for previously enrolled learners when no current learners exist                                                                                              

New attendance session:
The "Mark attendance" form for new sessions shows only current enrollees (this is not changed)

NOTE: this is not rebased off of Samson's PR to remove the "mark attendance" button if no learners, so you can get to a blank new attendance page for no learners enrolled (but that will be resolved by his PR)

## References

Here are two screencasts showing the updated UI: 

https://github.com/user-attachments/assets/3267ea89-2eaa-4280-83a2-5279ebf2a7aa


https://github.com/user-attachments/assets/9d4ec0bc-11b9-4d43-9b36-553b44122512



## AI usage
Written with claude, code reviewed and manually QA'd. I maybe have been a bit overly permissive with the claude comments I have retained, as i think they might be helpful in explaining some of the scenarios. I have done some comment clean up.