### PR TITLE
Batch ContentSummaryLog queries in _consolidate_courses_data

### DIFF
--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -131,29 +131,42 @@ def _consolidate_courses_data(request, courses):
         ),
     )
 
-    course_data_map = {}
-
+    # Gather each course's non-topic descendant content ids in one pass, then
+    # look up the user's completed content across all courses in a single query
+    # rather than running one ContentSummaryLog count per course.
+    course_meta = {}
+    all_content_ids = set()
     for course_node in course_nodes:
-        content_qs = (
+        descendant_ids = list(
             course_node.get_descendants()
             .exclude(kind=content_kinds.TOPIC)
             .values_list("content_id", flat=True)
         )
+        course_meta[course_node.id] = (
+            course_node.unit_count,
+            course_node.lesson_count,
+            descendant_ids,
+        )
+        all_content_ids.update(descendant_ids)
 
-        total_content = content_qs.count()
+    completed_content_ids = set(
+        ContentSummaryLog.objects.filter(
+            user=request.user, progress=1, content_id__in=all_content_ids
+        ).values_list("content_id", flat=True)
+    )
 
-        user_completed_content = 0
+    course_data_map = {}
+    for course_id, (unit_count, lesson_count, descendant_ids) in course_meta.items():
+        total_content = len(descendant_ids)
         if total_content:
-            user_completed_content = ContentSummaryLog.objects.filter(
-                user=request.user, progress=1, content_id__in=content_qs
-            ).count()
+            user_completed_content = len(set(descendant_ids) & completed_content_ids)
             progress = user_completed_content / total_content
         else:
             progress = 0
 
-        course_data_map[course_node.id] = {
-            "unit_count": course_node.unit_count,
-            "lesson_count": course_node.lesson_count,
+        course_data_map[course_id] = {
+            "unit_count": unit_count,
+            "lesson_count": lesson_count,
             "progress": progress,
         }
 


### PR DESCRIPTION
## Summary
Reduces database queries in the learn plugin at `_consolidate_courses_data` from 2N to N+1, where N is the number of courses a learner is enrolled in. Previously, for each course node the function issued two separate queries: one `COUNT` for non-topic descendants and one `COUNT` on `ContentSummaryLog` for completed content. On a learner's home page or course list with 10 enrolled courses, this produced 20 queries.

## References
Closes #14453.

## Reviewer guidance
- The only changed function is `_consolidate_courses_data` in
  `kolibri/plugins/learn/viewsets.py`.
- Run `pytest kolibri/plugins/learn/test/test_learner_course.py` and
  `pytest kolibri/plugins/learn/test/test_learner_classroom.py` to
  confirm all existing tests pass.
- Completed content is counted as the distinct set of matching
  `ContentSummaryLog` content_ids (`set(descendant_ids) & completed`),
  preserving the original `filter(content_id__in=...).count()` semantics
  when a course contains the same content_id in more than one node.

## AI usage
I used Claude to identify the N+1 query pattern and propose the batching approach and reviewed the generated code for correctness specifically verifying UUID type consistency between `ContentNode` and `ContentSummaryLog`, and the empty-set guard, and confirmed the change produces identical output across all existing test cases before accepting it.