### PR TITLE
Create content download requests and removal requests  for courses descendants

### DIFF
--- a/kolibri/core/content/public_api.py
+++ b/kolibri/core/content/public_api.py
@@ -49,18 +49,6 @@ class ImportMetadataViewset(GenericViewSet):
             )
         return error
 
-    def _validate_depth(self, depth):
-        if depth is not None:
-            try:
-                depth = int(depth)
-                if depth < 0:
-                    raise ValueError
-            except ValueError:
-                raise ValidationError(
-                    {"error": "Depth parameter must be a non-negative integer."}
-                )
-        return depth
-
     def _validate_content_schema(self, content_schema):
         try:
             if int(content_schema) > int(self.default_content_schema):
@@ -79,13 +67,14 @@ class ImportMetadataViewset(GenericViewSet):
 
     def _get_retrieve_queryset(self):
         pk = self.kwargs.get("pk")
-        depth = self.request.query_params.get("depth", None)
+        descendants = self.request.query_params.get("descendants", None)
         node = get_object_or_404(models.ContentNode.objects.all(), pk=pk)
-        if depth is not None:
-            depth = self._validate_depth(depth)
-            queryset = node.get_descendants(include_self=True).filter(
-                level__lte=node.level + depth
-            )
+        if descendants:
+            # Return ancestors first, then descendants (excluding self to avoid duplication).
+            # Ordering by lft puts ancestors (lower lft) before descendants (higher lft).
+            ancestors = node.get_ancestors(include_self=True)
+            node_descendants = node.get_descendants(include_self=False)
+            queryset = (ancestors | node_descendants).order_by("lft")
         else:
             queryset = node.get_ancestors(include_self=True)
 

--- a/kolibri/core/content/test/test_public_api.py
+++ b/kolibri/core/content/test/test_public_api.py
@@ -121,59 +121,50 @@ class ImportMetadataTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_import_metadata_with_depth_zero(self):
-        """Test that depth=0 returns only the node itself."""
+    def test_import_metadata_with_descendants_returns_ancestors_and_descendants(self):
+        """Test that descendants=true returns both ancestors and descendants (ancestors first)."""
         response = self.client.get(
             reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=0"
+            + "?descendants=true"
         )
         self.assertEqual(response.status_code, 200)
-        # With depth=0, should return only the root node itself
-        nodes_data = response.data[content.ContentNode._meta.db_table]
-        self.assertEqual(len(nodes_data), 1)
-        self.assertEqual(nodes_data[0]["id"], self.root.id)
-
-    def test_import_metadata_with_depth(self):
-        """Test that depth parameter returns descendants instead of ancestors."""
-        response = self.client.get(
-            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=1"
-        )
-        self.assertEqual(response.status_code, 200)
-        # With depth=1, should return the root and its direct children
-        expected_nodes = self.root.get_descendants(include_self=True).filter(
-            level__lte=self.root.level + 1
-        )
+        # For the root node, ancestors (include_self) == [root] and descendants (exclude_self)
+        # == all other nodes, so the combined set equals get_descendants(include_self=True).
+        expected_nodes = self.root.get_descendants(include_self=True)
         nodes_data = response.data[content.ContentNode._meta.db_table]
         self.assertEqual(len(nodes_data), expected_nodes.count())
 
-    def test_import_metadata_with_depth_negative(self):
-        """Test that negative depth returns 400."""
+    def test_import_metadata_with_descendants_includes_ancestors_for_non_root_node(
+        self,
+    ):
+        """Test that descendants=true on a non-root node includes the node's ancestors."""
         response = self.client.get(
-            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=-1"
+            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.node.id})
+            + "?descendants=true"
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.data["error"], "Depth parameter must be a non-negative integer."
-        )
-
-    def test_import_metadata_with_depth_invalid(self):
-        """Test that non-integer depth returns 400."""
-        response = self.client.get(
-            reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=abc"
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.data["error"], "Depth parameter must be a non-negative integer."
-        )
+        self.assertEqual(response.status_code, 200)
+        ancestors = self.node.get_ancestors(include_self=True)
+        node_descendants = self.node.get_descendants(include_self=False)
+        expected_count = ancestors.count() + node_descendants.count()
+        nodes_data = response.data[content.ContentNode._meta.db_table]
+        self.assertEqual(len(nodes_data), expected_count)
+        # Ancestors must appear before descendants — verify ordering by lft.
+        returned_ids = [n["id"] for n in nodes_data]
+        ancestor_positions = [
+            returned_ids.index(str(n.id).replace("-", "")) for n in ancestors
+        ]
+        descendant_ids = {str(n.id).replace("-", "") for n in node_descendants}
+        descendant_positions = [
+            i for i, nid in enumerate(returned_ids) if nid in descendant_ids
+        ]
+        if descendant_positions:
+            self.assertLess(max(ancestor_positions), min(descendant_positions))
 
     def test_import_metadata_with_pagination(self):
         """Test that max_results enables pagination."""
         response = self.client.get(
             reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=10&max_results=2"
+            + "?descendants=true&max_results=2"
         )
         self.assertEqual(response.status_code, 200)
         # Paginated response should have 'more' and 'results' keys
@@ -187,7 +178,7 @@ class ImportMetadataTestCase(APITestCase):
         max_results = 2
         response = self.client.get(
             reverse("kolibri:core:importmetadata-detail", kwargs={"pk": self.root.id})
-            + "?depth=10&max_results={}".format(max_results)
+            + "?descendants=true&max_results={}".format(max_results)
         )
         self.assertEqual(response.status_code, 200)
         nodes_data = response.data["results"][content.ContentNode._meta.db_table]

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -7,7 +7,6 @@ import mock
 from django.test import LiveServerTestCase
 from django.test import TestCase
 from django.utils import timezone
-from le_utils.constants import modalities
 from morango.models.core import SyncSession
 
 from kolibri.core.auth.models import Facility
@@ -22,15 +21,16 @@ from kolibri.core.content.models import File
 from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.test.helpers import ChannelBuilder
+from kolibri.core.content.utils.assignment import ContentAssignment
+from kolibri.core.content.utils.assignment import DeletedAssignment
 from kolibri.core.content.utils.content_request import _get_descendants_import_metadata
 from kolibri.core.content.utils.content_request import _get_import_metadata
-from kolibri.core.content.utils.content_request import _import_descendants_depth
 from kolibri.core.content.utils.content_request import _merge_import_metadata
 from kolibri.core.content.utils.content_request import _process_content_requests
 from kolibri.core.content.utils.content_request import _process_download
 from kolibri.core.content.utils.content_request import _total_size
 from kolibri.core.content.utils.content_request import completed_downloads_queryset
-from kolibri.core.content.utils.content_request import COURSES_DESCENDANTS_DEPTH
+from kolibri.core.content.utils.content_request import create_content_removal_requests
 from kolibri.core.content.utils.content_request import incomplete_downloads_queryset
 from kolibri.core.content.utils.content_request import incomplete_removals_queryset
 from kolibri.core.content.utils.content_request import InsufficientStorage
@@ -38,10 +38,12 @@ from kolibri.core.content.utils.content_request import MAX_NODES_PER_REQUEST
 from kolibri.core.content.utils.content_request import PreferredDevices
 from kolibri.core.content.utils.content_request import PreferredDevicesWithClient
 from kolibri.core.content.utils.content_request import process_content_removal_requests
+from kolibri.core.content.utils.content_request import process_content_requests
 from kolibri.core.content.utils.content_request import process_download_request
 from kolibri.core.content.utils.content_request import process_metadata_import
 from kolibri.core.content.utils.content_request import synchronize_content_requests
 from kolibri.core.content.utils.file_availability import LocationError
+from kolibri.core.courses.models import COURSES_DESCENDANTS_DEPTH
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
@@ -217,9 +219,12 @@ class ProcessMetadataImportTestCase(BaseTestCase):
         )
         return (request, peer)
 
-    def _mock_import_metadata(self, client, contentnode_ids):
-        # manually track the calls to import_metadata, so we can resolve `contentnode_ids` to a list
-        self.mock_import_metadata_calls.append((client, list(contentnode_ids)))
+    def _mock_import_metadata(self, client, incomplete_downloads):
+        # manually track the calls to import_metadata, resolving the queryset to a list of IDs
+        contentnode_ids = list(
+            incomplete_downloads.values_list("contentnode_id", flat=True)
+        )
+        self.mock_import_metadata_calls.append((client, contentnode_ids))
         for contentnode_id in contentnode_ids:
             # pretend we imported this metadata
             if contentnode_id not in self.mock_import_failed_contentnode_ids:
@@ -759,7 +764,7 @@ class PreferredDevicesWithClientTestCase(BaseTestCase):
         self.assertEqual(len(self.mock_capture_errors), 1)
 
 
-class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
+class InternalProcessContentRequestsTestCase(BaseQuerysetTestCase):
     def setUp(self):
         super().setUp()
         self.request = ContentDownloadRequest.build_for_user(self.learner)
@@ -1200,62 +1205,6 @@ class MergeImportMetadataTestCase(TestCase):
         self.assertEqual(result["some_int"], 42)
 
 
-class ImportDescendantsDepthTestCase(TestCase):
-    """Tests for _import_descendants_depth function"""
-
-    def test_non_course_node_returns_zero(self):
-        import_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": "node1", "options": "{}"},
-            ]
-        }
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, 0)
-
-    def test_course_node_returns_depth(self):
-        options = '{"modality": "' + modalities.COURSE + '"}'
-        import_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": "node1", "options": options},
-            ]
-        }
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, COURSES_DESCENDANTS_DEPTH)
-
-    def test_node_not_found_returns_zero(self):
-        options = '{"modality": "' + modalities.COURSE + '"}'
-        import_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": "other_node", "options": options},
-            ]
-        }
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, 0)
-
-    def test_invalid_options_json_returns_zero(self):
-        import_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": "node1", "options": "invalid json"},
-            ]
-        }
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, 0)
-
-    def test_empty_metadata_returns_zero(self):
-        import_metadata = {ContentNode._meta.db_table: []}
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, 0)
-
-    def test_missing_options_returns_zero(self):
-        import_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": "node1"},
-            ]
-        }
-        result = _import_descendants_depth(import_metadata, "node1")
-        self.assertEqual(result, 0)
-
-
 @mock.patch(_module + "reverse_path")
 class GetDescendantsImportMetadataTestCase(TestCase):
     """Tests for _get_descendants_import_metadata function"""
@@ -1413,14 +1362,16 @@ class GetImportMetadataTestCase(TestCase):
     def setUp(self):
         self.mock_client = mock.MagicMock()
         self.contentnode_id = uuid.uuid4().hex
+        self.mock_download = mock.MagicMock()
+        self.mock_download.contentnode_id = self.contentnode_id
+        self.mock_download.metadata = None
 
-    def _create_basic_metadata(self, contentnode_id, options="{}"):
+    def _create_basic_metadata(self, contentnode_id):
         return {
             ContentNode._meta.db_table: [
                 {
                     "id": contentnode_id,
                     "title": "Test Node",
-                    "options": options,
                 }
             ],
             File._meta.db_table: [{"id": "file1"}],
@@ -1434,16 +1385,18 @@ class GetImportMetadataTestCase(TestCase):
         metadata = self._create_basic_metadata(self.contentnode_id)
         self.mock_client.get.return_value.json.return_value = metadata
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         self.assertEqual(result, metadata)
         self.mock_client.get.assert_called_once()
 
     @mock.patch(_module + "_get_descendants_import_metadata")
-    def test_course_node_fetches_descendants(self, mock_get_descendants):
-        """Test that COURSE nodes trigger descendants fetching"""
-        options = '{"modality": "' + modalities.COURSE + '"}'
-        metadata = self._create_basic_metadata(self.contentnode_id, options=options)
+    def test_descendants_depth_in_metadata_fetches_descendants(
+        self, mock_get_descendants
+    ):
+        """Test that a download with descendants_depth in its metadata triggers descendants fetching"""
+        self.mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
+        metadata = self._create_basic_metadata(self.contentnode_id)
         descendants_metadata = {
             ContentNode._meta.db_table: [{"id": "child1"}, {"id": "child2"}],
             File._meta.db_table: [{"id": "child_file1"}],
@@ -1451,7 +1404,7 @@ class GetImportMetadataTestCase(TestCase):
         self.mock_client.get.return_value.json.return_value = metadata
         mock_get_descendants.return_value = [descendants_metadata]
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         mock_get_descendants.assert_called_once_with(
             self.mock_client, self.contentnode_id, COURSES_DESCENDANTS_DEPTH
@@ -1461,12 +1414,14 @@ class GetImportMetadataTestCase(TestCase):
         self.assertEqual(len(result[File._meta.db_table]), 2)
 
     @mock.patch(_module + "_get_descendants_import_metadata")
-    def test_non_course_node_does_not_fetch_descendants(self, mock_get_descendants):
-        """Test that non-COURSE nodes don't trigger descendants fetching"""
+    def test_no_descendants_depth_does_not_fetch_descendants(
+        self, mock_get_descendants
+    ):
+        """Test that downloads without descendants_depth in metadata don't trigger descendants fetching"""
         metadata = self._create_basic_metadata(self.contentnode_id)
         self.mock_client.get.return_value.json.return_value = metadata
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         mock_get_descendants.assert_not_called()
         self.assertEqual(result, metadata)
@@ -1478,7 +1433,7 @@ class GetImportMetadataTestCase(TestCase):
         error = NetworkLocationResponseFailure(response=mock_response)
         self.mock_client.get.side_effect = error
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         self.assertIsNone(result)
 
@@ -1489,7 +1444,7 @@ class GetImportMetadataTestCase(TestCase):
         error = NetworkLocationResponseFailure(response=mock_response)
         self.mock_client.get.side_effect = error
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         self.assertIsNone(result)
 
@@ -1501,15 +1456,15 @@ class GetImportMetadataTestCase(TestCase):
         self.mock_client.get.side_effect = error
 
         with self.assertRaises(NetworkLocationResponseFailure):
-            _get_import_metadata(self.mock_client, self.contentnode_id)
+            _get_import_metadata(self.mock_client, self.mock_download)
 
     @mock.patch(_module + "_get_descendants_import_metadata")
     def test_merges_ancestor_and_descendant_metadata(self, mock_get_descendants):
-        """Test that ancestor and descendant metadata are properly merged"""
-        options = '{"modality": "' + modalities.COURSE + '"}'
+        """Test that ancestor and descendant metadata are properly merged across pages"""
+        self.mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
         ancestor_metadata = {
             ContentNode._meta.db_table: [
-                {"id": self.contentnode_id, "options": options},
+                {"id": self.contentnode_id},
                 {"id": "parent1"},
             ],
             File._meta.db_table: [{"id": "ancestor_file"}],
@@ -1527,7 +1482,7 @@ class GetImportMetadataTestCase(TestCase):
         self.mock_client.get.return_value.json.return_value = ancestor_metadata
         mock_get_descendants.return_value = [page1_descendants, page2_descendants]
 
-        result = _get_import_metadata(self.mock_client, self.contentnode_id)
+        result = _get_import_metadata(self.mock_client, self.mock_download)
 
         # Should have: ancestor node + parent + child1 + child2 = 4 nodes
         self.assertEqual(len(result[ContentNode._meta.db_table]), 4)
@@ -1565,8 +1520,8 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
 
     def test_non_course_node_returns_ancestor_metadata_only(self):
         """
-        A non-course node returns the metadata for itself and its ancestors,
-        without fetching any descendants.
+        A download without descendants_depth returns metadata for the node and its
+        ancestors only, without fetching any descendants.
         """
         # Use a level-1 topic node that has both ancestors (root) and many descendants
         topic_node = ContentNode.objects.filter(
@@ -1574,7 +1529,11 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
             level=1,
         ).first()
 
-        result = _get_import_metadata(self.network_client, topic_node.id)
+        mock_download = mock.MagicMock()
+        mock_download.contentnode_id = topic_node.id
+        mock_download.metadata = None
+
+        result = _get_import_metadata(self.network_client, mock_download)
 
         self.assertIsNotNone(result)
         returned_node_ids = {n["id"] for n in result[ContentNode._meta.db_table]}
@@ -1591,10 +1550,10 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
 
     def test_course_node_returns_merged_ancestor_and_descendant_metadata(self):
         """
-        A course node triggers paginated descendant fetching via
-        _get_descendants_import_metadata. The final result contains nodes from
-        the ancestors call merged with all descendants up to
-        COURSES_DESCENDANTS_DEPTH levels deep.
+        A download with descendants_depth in its metadata triggers paginated descendant
+        fetching via _get_descendants_import_metadata. The final result contains nodes
+        from the ancestors call merged with all descendants up to descendants_depth
+        levels deep.
 
         The default ChannelBuilder tree has enough nodes to exceed
         MAX_NODES_PER_REQUEST, so this exercises the pagination code path
@@ -1605,10 +1564,12 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
             channel_id=self.root.channel_id,
             level=1,
         ).first()
-        topic_node.options = {"modality": modalities.COURSE}
-        topic_node.save()
 
-        result = _get_import_metadata(self.network_client, topic_node.id)
+        mock_download = mock.MagicMock()
+        mock_download.contentnode_id = topic_node.id
+        mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
+
+        result = _get_import_metadata(self.network_client, mock_download)
 
         self.assertIsNotNone(result)
         returned_node_ids = {n["id"] for n in result[ContentNode._meta.db_table]}
@@ -1623,3 +1584,418 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
         )
         expected_node_ids = expected_ancestor_ids.union(expected_descendant_ids)
         self.assertEqual(returned_node_ids, expected_node_ids)
+
+
+@mock.patch(_module + "get_device_setting", return_value=True)
+class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
+    """
+    Tests for process_content_requests().
+
+    Covers the three-phase flow end-to-end:
+        1. Metadata import — triggered for downloads whose ContentNode is absent.
+        2. Descendant request creation — extra download requests are created for
+            descendants of nodes that carry ``descendants_depth`` in their metadata.
+        3. Content download — _process_download is dispatched for every pending
+            download that now has metadata.
+
+    ``process_metadata_import`` is mocked to simulate the network import by
+    creating ContentNode entries as a side effect (including children when
+    ``descendants_depth`` is set).  ``_process_download`` and ``PreferredDevices``
+    are mocked to avoid real file-transfer and peer-discovery logic.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # Simulate metadata import from a remote peer: creates ContentNode entries
+        # for each requested node, plus children when descendants_depth is set.
+        process_metadata_import_patcher = mock.patch(
+            _module + "process_metadata_import"
+        )
+        self.mock_process_metadata_import = process_metadata_import_patcher.start()
+        self.mock_process_metadata_import.side_effect = (
+            self._mock_process_metadata_import
+        )
+        self.addCleanup(process_metadata_import_patcher.stop)
+
+        # Skip actual file transfer; treat every download attempt as a success.
+        process_download_patcher = mock.patch(_module + "_process_download")
+        self.mock_process_download = process_download_patcher.start()
+        self.mock_process_download.return_value = True
+        self.addCleanup(process_download_patcher.stop)
+
+        # Provide a fake peer so process_download_request can proceed.
+        preferred_devices_patcher = mock.patch(_module + "PreferredDevices")
+        self.mock_preferred_devices = preferred_devices_patcher.start()
+        mock_peer = mock.MagicMock()
+        self.mock_preferred_devices.return_value.__iter__.return_value = [mock_peer]
+        self.mock_preferred_devices.build_from_sync_sessions.return_value.__iter__.return_value = [
+            mock_peer
+        ]
+        self.addCleanup(preferred_devices_patcher.stop)
+
+        # Return abundant free space so no download is blocked by storage checks.
+        free_space_patcher = mock.patch(_module + "get_free_space_for_downloads")
+        self.mock_free_space = free_space_patcher.start()
+        self.mock_free_space.return_value = 10 ** 9
+        self.addCleanup(free_space_patcher.stop)
+
+        # Suppress device-status side effects (InsufficientStorage signals, etc.)
+        learner_status_patcher = mock.patch(_module + "LearnerDeviceStatus")
+        learner_status_patcher.start()
+        self.addCleanup(learner_status_patcher.stop)
+
+    def _mock_process_metadata_import(self, incomplete_downloads_without_metadata):
+        """
+        Simulates what ``import_channel_from_data`` would do after a real network
+        fetch: writes ContentNode rows for every requested node.  When a download
+        carries ``descendants_depth``, two child ContentNodes are also created so
+        that ``_create_related_download_requests_if_needed`` can traverse the tree.
+        """
+        channel_id = uuid.uuid4().hex
+        for download in incomplete_downloads_without_metadata:
+            if ContentNode.objects.filter(id=download.contentnode_id).exists():
+                continue
+            parent = ContentNode.objects.create(
+                id=download.contentnode_id,
+                title="imported node",
+                kind="topic",
+                channel_id=channel_id,
+                content_id=uuid.uuid4().hex,
+            )
+            depth = (download.metadata or {}).get("descendants_depth", 0)
+            if depth > 0:
+                for i in range(2):
+                    ContentNode.objects.create(
+                        id=uuid.uuid4().hex,
+                        title="child {}".format(i),
+                        kind="video",
+                        parent=parent,
+                        channel_id=channel_id,
+                        content_id=uuid.uuid4().hex,
+                    )
+
+    def _create_download(self, contentnode_id=None, metadata=None):
+        download = ContentDownloadRequest.build_for_user(self.admin)
+        download.contentnode_id = contentnode_id or uuid.uuid4().hex
+        download.metadata = metadata
+        download.save()
+        return download
+
+    # ------------------------------------------------------------------ #
+    # Phase 1: metadata import                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_metadata_import_triggered_when_contentnode_missing(self, _mock_setting):
+        """process_metadata_import is called when a download has no ContentNode yet."""
+        download = self._create_download()
+
+        process_content_requests()
+
+        self.mock_process_metadata_import.assert_called_once()
+        self.assertTrue(ContentNode.objects.filter(id=download.contentnode_id).exists())
+
+    def test_metadata_import_skipped_when_contentnode_already_present(
+        self, _mock_setting
+    ):
+        """process_metadata_import is NOT called when all downloads already have a ContentNode."""
+        node_id = uuid.uuid4().hex
+        ContentNode.objects.create(
+            id=node_id,
+            title="pre-existing",
+            kind="video",
+            channel_id=uuid.uuid4().hex,
+            content_id=uuid.uuid4().hex,
+        )
+        self._create_download(contentnode_id=node_id)
+
+        process_content_requests()
+
+        self.mock_process_metadata_import.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Phase 2: descendant request creation                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_no_descendant_requests_created_without_descendants_depth(
+        self, _mock_setting
+    ):
+        """A simple download (no descendants_depth) produces exactly one download request."""
+        self._create_download(metadata=None)
+
+        process_content_requests()
+
+        self.assertEqual(ContentDownloadRequest.objects.count(), 1)
+
+    def test_descendant_requests_created_when_descendants_depth_set(
+        self, _mock_setting
+    ):
+        """
+        When a download carries descendants_depth, after metadata import the mock
+        creates child ContentNodes.  process_content_requests must then create one
+        ContentDownloadRequest per child.
+        """
+        download = self._create_download(metadata={"descendants_depth": 1})
+
+        process_content_requests()
+
+        # The mock creates 2 children; there should be 3 requests total (parent + 2).
+        self.assertEqual(ContentDownloadRequest.objects.count(), 3)
+        parent_node = ContentNode.objects.get(id=download.contentnode_id)
+        child_ids = list(parent_node.get_descendants().values_list("id", flat=True))
+        self.assertEqual(len(child_ids), 2)
+        for child_id in child_ids:
+            self.assertTrue(
+                ContentDownloadRequest.objects.filter(contentnode_id=child_id).exists()
+            )
+
+    def test_descendant_requests_inherit_source_and_omit_descendants_depth(
+        self, _mock_setting
+    ):
+        """
+        Requests created for descendants share source_model/source_id with the
+        parent request and do not carry descendants_depth in their own metadata.
+        """
+        download = self._create_download(
+            metadata={"descendants_depth": 1, "extra": "value"}
+        )
+
+        process_content_requests()
+
+        parent_node = ContentNode.objects.get(id=download.contentnode_id)
+        for child_node in parent_node.get_descendants():
+            child_req = ContentDownloadRequest.objects.get(contentnode_id=child_node.id)
+            self.assertEqual(child_req.source_model, download.source_model)
+            self.assertEqual(child_req.source_id, download.source_id)
+            self.assertNotIn("descendants_depth", child_req.metadata)
+            self.assertEqual(child_req.metadata.get("extra"), "value")
+
+    # ------------------------------------------------------------------ #
+    # Phase 3: content download dispatch                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_process_download_called_for_simple_download(self, _mock_setting):
+        """_process_download is called once for a single download after metadata import."""
+        self._create_download()
+
+        process_content_requests()
+
+        self.assertEqual(self.mock_process_download.call_count, 1)
+
+    def test_process_download_called_for_parent_and_all_descendants(
+        self, _mock_setting
+    ):
+        """
+        _process_download is called for the parent node and every descendant
+        whose download request was created during the descendants phase.
+        """
+        self._create_download(metadata={"descendants_depth": 1})
+
+        process_content_requests()
+
+        # parent + 2 children = 3 download attempts
+        self.assertEqual(self.mock_process_download.call_count, 3)
+
+    def test_download_requests_marked_completed_after_successful_download(
+        self, _mock_setting
+    ):
+        """All download requests end up Completed when _process_download returns True."""
+        self._create_download(metadata={"descendants_depth": 1})
+
+        process_content_requests()
+
+        completed = ContentDownloadRequest.objects.filter(
+            status=ContentRequestStatus.Completed
+        )
+        # parent + 2 children = 3 completed
+        self.assertEqual(completed.count(), 3)
+
+
+class CreateContentRemovalRequestsTestCase(BaseQuerysetTestCase):
+    """
+    Tests for create_content_removal_requests().
+
+    Covers both assignment types:
+      - ContentAssignment: has contentnode_id and metadata; descendants are
+        resolved via metadata["descendants_depth"] when present.
+      - DeletedAssignment: has no contentnode_id or metadata; removal targets
+        are derived from the existing SyncInitiated downloads for that source.
+    """
+
+    def _make_content_assignment(
+        self, contentnode_id=None, source_id=None, metadata=None
+    ):
+        return ContentAssignment(
+            contentnode_id=contentnode_id or uuid.uuid4().hex,
+            source_model="test_model",
+            source_id=source_id or uuid.uuid4().hex,
+            metadata=metadata,
+        )
+
+    def _make_deleted_assignment(self, source_id=None):
+        return DeletedAssignment(
+            source_model="test_model",
+            source_id=source_id or uuid.uuid4().hex,
+        )
+
+    def _create_sync_download(self, source_model, source_id, contentnode_id=None):
+        """Creates a SyncInitiated ContentDownloadRequest (the kind that gets deleted)."""
+        download = ContentDownloadRequest(
+            facility=self.facility,
+            source_model=source_model,
+            source_id=source_id,
+            contentnode_id=contentnode_id or uuid.uuid4().hex,
+            reason=ContentRequestReason.SyncInitiated,
+            status=ContentRequestStatus.Pending,
+        )
+        download.save()
+        return download
+
+    def _create_node_tree(self):
+        """Creates a root -> parent -> child1, child2 MPTT tree."""
+        channel_id = uuid.uuid4().hex
+        root = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            title="root",
+            kind="topic",
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+        )
+        parent = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            title="parent",
+            kind="topic",
+            parent=root,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+        )
+        child1 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            title="child1",
+            kind="video",
+            parent=parent,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+        )
+        child2 = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            title="child2",
+            kind="video",
+            parent=parent,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+        )
+        parent.refresh_from_db()
+        return parent, child1, child2
+
+    def test_content_assignment_creates_removal_request(self):
+        """A ContentAssignment produces a removal request for its own contentnode_id."""
+        assignment = self._make_content_assignment()
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        self.assertTrue(
+            ContentRemovalRequest.objects.filter(
+                contentnode_id=assignment.contentnode_id,
+                source_model=assignment.source_model,
+                source_id=assignment.source_id,
+            ).exists()
+        )
+
+    def test_content_assignment_without_descendants_depth_creates_only_one_removal_request(
+        self,
+    ):
+        """ContentAssignment with no descendants_depth creates exactly one removal request."""
+        parent, child1, child2 = self._create_node_tree()
+        assignment = self._make_content_assignment(
+            contentnode_id=parent.id, metadata=None
+        )
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        created_ids = set(
+            ContentRemovalRequest.objects.values_list("contentnode_id", flat=True)
+        )
+        self.assertIn(parent.id, created_ids)
+        self.assertNotIn(child1.id, created_ids)
+        self.assertNotIn(child2.id, created_ids)
+
+    def test_content_assignment_with_descendants_depth_creates_removal_requests_for_descendants(
+        self,
+    ):
+        """ContentAssignment with descendants_depth creates removal requests for the node and all
+        descendants up to the given depth."""
+        parent, child1, child2 = self._create_node_tree()
+        assignment = self._make_content_assignment(
+            contentnode_id=parent.id,
+            metadata={"descendants_depth": 1},
+        )
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        created_ids = set(
+            ContentRemovalRequest.objects.values_list("contentnode_id", flat=True)
+        )
+        self.assertIn(parent.id, created_ids)
+        self.assertIn(child1.id, created_ids)
+        self.assertIn(child2.id, created_ids)
+
+    def test_content_assignment_deletes_related_sync_downloads(self):
+        """Sync-initiated downloads matching source_model/source_id are deleted."""
+        source_id = uuid.uuid4().hex
+        download = self._create_sync_download("test_model", source_id)
+        assignment = self._make_content_assignment(source_id=source_id)
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        self.assertFalse(ContentDownloadRequest.objects.filter(id=download.id).exists())
+
+    def test_content_assignment_removal_request_is_idempotent(self):
+        """Calling create_content_removal_requests twice does not create duplicate requests."""
+        assignment = self._make_content_assignment()
+
+        create_content_removal_requests(self.facility, [assignment])
+        create_content_removal_requests(self.facility, [assignment])
+
+        self.assertEqual(
+            ContentRemovalRequest.objects.filter(
+                contentnode_id=assignment.contentnode_id
+            ).count(),
+            1,
+        )
+
+    def test_deleted_assignment_creates_removal_requests_from_related_downloads(self):
+        """DeletedAssignment derives removal targets from the contentnode_ids of
+        its existing SyncInitiated download requests."""
+        source_id = uuid.uuid4().hex
+        download1 = self._create_sync_download("test_model", source_id)
+        download2 = self._create_sync_download("test_model", source_id)
+        assignment = self._make_deleted_assignment(source_id=source_id)
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        created_ids = set(
+            ContentRemovalRequest.objects.values_list("contentnode_id", flat=True)
+        )
+        self.assertIn(download1.contentnode_id, created_ids)
+        self.assertIn(download2.contentnode_id, created_ids)
+
+    def test_deleted_assignment_with_no_related_downloads_creates_no_removal_requests(
+        self,
+    ):
+        """DeletedAssignment with no matching downloads produces no removal requests."""
+        assignment = self._make_deleted_assignment()
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        self.assertEqual(ContentRemovalRequest.objects.count(), 0)
+
+    def test_deleted_assignment_deletes_related_sync_downloads(self):
+        """Sync-initiated downloads are deleted when processing a DeletedAssignment."""
+        source_id = uuid.uuid4().hex
+        download = self._create_sync_download("test_model", source_id)
+        assignment = self._make_deleted_assignment(source_id=source_id)
+
+        create_content_removal_requests(self.facility, [assignment])
+
+        self.assertFalse(ContentDownloadRequest.objects.filter(id=download.id).exists())

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -23,7 +23,6 @@ from kolibri.core.content.models import LocalFile
 from kolibri.core.content.test.helpers import ChannelBuilder
 from kolibri.core.content.utils.assignment import ContentAssignment
 from kolibri.core.content.utils.assignment import DeletedAssignment
-from kolibri.core.content.utils.content_request import _get_descendants_import_metadata
 from kolibri.core.content.utils.content_request import _get_import_metadata
 from kolibri.core.content.utils.content_request import _merge_import_metadata
 from kolibri.core.content.utils.content_request import _process_content_requests
@@ -43,7 +42,6 @@ from kolibri.core.content.utils.content_request import process_download_request
 from kolibri.core.content.utils.content_request import process_metadata_import
 from kolibri.core.content.utils.content_request import synchronize_content_requests
 from kolibri.core.content.utils.file_availability import LocationError
-from kolibri.core.courses.models import COURSES_DESCENDANTS_DEPTH
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
@@ -1205,157 +1203,6 @@ class MergeImportMetadataTestCase(TestCase):
         self.assertEqual(result["some_int"], 42)
 
 
-@mock.patch(_module + "reverse_path")
-class GetDescendantsImportMetadataTestCase(TestCase):
-    """Tests for _get_descendants_import_metadata function"""
-
-    def setUp(self):
-        self.mock_client = mock.MagicMock()
-        self.contentnode_id = uuid.uuid4().hex
-
-    def test_single_page_response(self, mock_reverse_path):
-        """Test when response has no pagination (no 'more' key)"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        response_data = {
-            "results": {
-                ContentNode._meta.db_table: [{"id": "child1"}],
-                File._meta.db_table: [{"id": "file1"}],
-                "schema_version": "5",
-            }
-        }
-        self.mock_client.get.return_value.json.return_value = response_data
-
-        result = _get_descendants_import_metadata(
-            self.mock_client, self.contentnode_id, depth=1
-        )
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0][ContentNode._meta.db_table], [{"id": "child1"}])
-        self.mock_client.get.assert_called_once()
-
-    def test_paginated_response(self, mock_reverse_path):
-        """Test when response has multiple pages with 'more' cursor"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        page1_response = {
-            "more": {
-                "schema_version": "5",
-                "depth": "1",
-                "max_results": "1",
-                "cursor": "cD00MQ==",
-            },
-            "results": {
-                ContentNode._meta.db_table: [{"id": "child1"}],
-                "schema_version": "5",
-            },
-        }
-        page2_response = {
-            "results": {
-                ContentNode._meta.db_table: [{"id": "child2"}],
-                "schema_version": "5",
-            }
-        }
-        self.mock_client.get.return_value.json.side_effect = [
-            page1_response,
-            page2_response,
-        ]
-
-        result = _get_descendants_import_metadata(
-            self.mock_client, self.contentnode_id, depth=1
-        )
-
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0][ContentNode._meta.db_table], [{"id": "child1"}])
-        self.assertEqual(result[1][ContentNode._meta.db_table], [{"id": "child2"}])
-        self.assertEqual(self.mock_client.get.call_count, 2)
-
-    def test_500_error_raises(self, mock_reverse_path):
-        """Test that 500 errors are re-raised"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        mock_response = mock.MagicMock()
-        mock_response.status_code = 500
-        error = NetworkLocationResponseFailure(response=mock_response)
-        self.mock_client.get.side_effect = error
-
-        with self.assertRaises(NetworkLocationResponseFailure):
-            _get_descendants_import_metadata(
-                self.mock_client, self.contentnode_id, depth=1
-            )
-
-    def test_initial_request_has_depth_and_max_results(self, mock_reverse_path):
-        """Test that the initial request includes depth and max_results params"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        response_data = {
-            "results": {
-                ContentNode._meta.db_table: [],
-                "schema_version": "5",
-            }
-        }
-        self.mock_client.get.return_value.json.return_value = response_data
-
-        _get_descendants_import_metadata(
-            self.mock_client, self.contentnode_id, depth=COURSES_DESCENDANTS_DEPTH
-        )
-
-        call_args = self.mock_client.get.call_args[0][0]
-        self.assertIn("depth={}".format(COURSES_DESCENDANTS_DEPTH), call_args)
-        self.assertIn("max_results={}".format(MAX_NODES_PER_REQUEST), call_args)
-
-    def test_empty_results(self, mock_reverse_path):
-        """Test handling of empty results"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        response_data = {"results": {}}
-        self.mock_client.get.return_value.json.return_value = response_data
-
-        result = _get_descendants_import_metadata(
-            self.mock_client, self.contentnode_id, depth=1
-        )
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], {})
-
-    def test_subsequent_requests_use_cursor(self, mock_reverse_path):
-        """Test that subsequent requests use the cursor from 'more'"""
-        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
-            self.contentnode_id
-        )
-        page1_response = {
-            "more": {
-                "schema_version": "5",
-                "depth": "1",
-                "max_results": "10",
-                "cursor": "cD00MQ==",
-            },
-            "results": {
-                ContentNode._meta.db_table: [{"id": "child1"}],
-            },
-        }
-        page2_response = {
-            "results": {
-                ContentNode._meta.db_table: [{"id": "child2"}],
-            }
-        }
-        self.mock_client.get.return_value.json.side_effect = [
-            page1_response,
-            page2_response,
-        ]
-
-        _get_descendants_import_metadata(self.mock_client, self.contentnode_id, depth=1)
-
-        # Check second call uses cursor params
-        second_call_url = self.mock_client.get.call_args_list[1][0][0]
-        self.assertIn("cursor=cD00MQ%3D%3D", second_call_url)
-
-
 class GetImportMetadataTestCase(TestCase):
     """Tests for _get_import_metadata function"""
 
@@ -1380,50 +1227,61 @@ class GetImportMetadataTestCase(TestCase):
             "schema_version": "5",
         }
 
-    def test_basic_metadata_retrieval(self):
+    @mock.patch(_module + "reverse_path")
+    def test_basic_metadata_retrieval(self, mock_reverse_path):
         """Test basic metadata retrieval without descendants"""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
         metadata = self._create_basic_metadata(self.contentnode_id)
-        self.mock_client.get.return_value.json.return_value = metadata
+        self.mock_client.get.return_value.json.return_value = {"results": metadata}
 
         result = _get_import_metadata(self.mock_client, self.mock_download)
 
         self.assertEqual(result, metadata)
         self.mock_client.get.assert_called_once()
 
-    @mock.patch(_module + "_get_descendants_import_metadata")
-    def test_descendants_depth_in_metadata_fetches_descendants(
-        self, mock_get_descendants
-    ):
-        """Test that a download with descendants_depth in its metadata triggers descendants fetching"""
-        self.mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
-        metadata = self._create_basic_metadata(self.contentnode_id)
-        descendants_metadata = {
-            ContentNode._meta.db_table: [{"id": "child1"}, {"id": "child2"}],
-            File._meta.db_table: [{"id": "child_file1"}],
+    @mock.patch(_module + "reverse_path")
+    def test_import_descendants_adds_descendants_flag_to_url(self, mock_reverse_path):
+        """Test that import_descendants=True adds descendants=true to the API request URL."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_download.metadata = {"import_descendants": True}
+        combined_metadata = {
+            ContentNode._meta.db_table: [
+                {"id": self.contentnode_id},
+                {"id": "child1"},
+                {"id": "child2"},
+            ],
+            File._meta.db_table: [{"id": "ancestor_file"}, {"id": "child_file1"}],
         }
-        self.mock_client.get.return_value.json.return_value = metadata
-        mock_get_descendants.return_value = [descendants_metadata]
+        self.mock_client.get.return_value.json.return_value = {
+            "results": combined_metadata
+        }
 
         result = _get_import_metadata(self.mock_client, self.mock_download)
 
-        mock_get_descendants.assert_called_once_with(
-            self.mock_client, self.contentnode_id, COURSES_DESCENDANTS_DEPTH
-        )
-        # Check merged results
+        call_url = self.mock_client.get.call_args[0][0]
+        self.assertIn("descendants=true", call_url)
         self.assertEqual(len(result[ContentNode._meta.db_table]), 3)
         self.assertEqual(len(result[File._meta.db_table]), 2)
 
-    @mock.patch(_module + "_get_descendants_import_metadata")
-    def test_no_descendants_depth_does_not_fetch_descendants(
-        self, mock_get_descendants
+    @mock.patch(_module + "reverse_path")
+    def test_no_import_descendants_does_not_add_descendants_flag(
+        self, mock_reverse_path
     ):
-        """Test that downloads without descendants_depth in metadata don't trigger descendants fetching"""
+        """Test that requests without import_descendants do not include descendants=true."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
         metadata = self._create_basic_metadata(self.contentnode_id)
-        self.mock_client.get.return_value.json.return_value = metadata
+        self.mock_client.get.return_value.json.return_value = {"results": metadata}
 
         result = _get_import_metadata(self.mock_client, self.mock_download)
 
-        mock_get_descendants.assert_not_called()
+        call_url = self.mock_client.get.call_args[0][0]
+        self.assertNotIn("descendants", call_url)
         self.assertEqual(result, metadata)
 
     def test_404_returns_none(self):
@@ -1458,53 +1316,141 @@ class GetImportMetadataTestCase(TestCase):
         with self.assertRaises(NetworkLocationResponseFailure):
             _get_import_metadata(self.mock_client, self.mock_download)
 
-    @mock.patch(_module + "_get_descendants_import_metadata")
-    def test_merges_ancestor_and_descendant_metadata(self, mock_get_descendants):
-        """Test that ancestor and descendant metadata are properly merged across pages"""
-        self.mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
-        ancestor_metadata = {
-            ContentNode._meta.db_table: [
-                {"id": self.contentnode_id},
-                {"id": "parent1"},
-            ],
-            File._meta.db_table: [{"id": "ancestor_file"}],
-            Language._meta.db_table: [{"id": "en"}],
-            "schema_version": "5",
+    @mock.patch(_module + "reverse_path")
+    def test_merges_paginated_metadata(self, mock_reverse_path):
+        """Test that paginated pages from the combined endpoint are properly merged."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_download.metadata = {"import_descendants": True}
+        # Page 1 contains the node itself, its parent, and the first child.
+        page1_response = {
+            "more": {"descendants": "true", "max_results": "10", "cursor": "abc"},
+            "results": {
+                ContentNode._meta.db_table: [
+                    {"id": self.contentnode_id},
+                    {"id": "parent1"},
+                    {"id": "child1"},
+                ],
+                File._meta.db_table: [{"id": "ancestor_file"}, {"id": "child_file1"}],
+                Language._meta.db_table: [{"id": "en"}],
+                "schema_version": "5",
+            },
         }
-        page1_descendants = {
-            ContentNode._meta.db_table: [{"id": "child1"}],
-            File._meta.db_table: [{"id": "child_file1"}],
+        # Page 2 contains the second child.
+        page2_response = {
+            "results": {
+                ContentNode._meta.db_table: [{"id": "child2"}],
+                File._meta.db_table: [{"id": "child_file2"}],
+            }
         }
-        page2_descendants = {
-            ContentNode._meta.db_table: [{"id": "child2"}],
-            File._meta.db_table: [{"id": "child_file2"}],
-        }
-        self.mock_client.get.return_value.json.return_value = ancestor_metadata
-        mock_get_descendants.return_value = [page1_descendants, page2_descendants]
+        self.mock_client.get.return_value.json.side_effect = [
+            page1_response,
+            page2_response,
+        ]
 
         result = _get_import_metadata(self.mock_client, self.mock_download)
 
-        # Should have: ancestor node + parent + child1 + child2 = 4 nodes
+        self.assertEqual(self.mock_client.get.call_count, 2)
+        # Should have: node + parent1 + child1 + child2 = 4 nodes
         self.assertEqual(len(result[ContentNode._meta.db_table]), 4)
         # Should have: ancestor_file + child_file1 + child_file2 = 3 files
         self.assertEqual(len(result[File._meta.db_table]), 3)
-        # Language should be preserved
+        # Language and schema_version from page 1 should be preserved
         self.assertEqual(result[Language._meta.db_table], [{"id": "en"}])
         self.assertEqual(result["schema_version"], "5")
+
+    @mock.patch(_module + "reverse_path")
+    def test_initial_request_always_includes_max_results(self, mock_reverse_path):
+        """Test that every first request includes max_results regardless of import_descendants."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_client.get.return_value.json.return_value = {
+            "results": {ContentNode._meta.db_table: []}
+        }
+
+        _get_import_metadata(self.mock_client, self.mock_download)
+
+        call_url = self.mock_client.get.call_args[0][0]
+        self.assertIn("max_results={}".format(MAX_NODES_PER_REQUEST), call_url)
+
+    @mock.patch(_module + "reverse_path")
+    def test_initial_request_with_descendants_includes_both_flags(
+        self, mock_reverse_path
+    ):
+        """Test that the initial request with import_descendants includes both
+        descendants=true and max_results."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_download.metadata = {"import_descendants": True}
+        self.mock_client.get.return_value.json.return_value = {
+            "results": {ContentNode._meta.db_table: []}
+        }
+
+        _get_import_metadata(self.mock_client, self.mock_download)
+
+        call_url = self.mock_client.get.call_args[0][0]
+        self.assertIn("descendants=true", call_url)
+        self.assertIn("max_results={}".format(MAX_NODES_PER_REQUEST), call_url)
+
+    @mock.patch(_module + "reverse_path")
+    def test_subsequent_requests_use_cursor(self, mock_reverse_path):
+        """Test that follow-up requests use the cursor from the 'more' field."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_download.metadata = {"import_descendants": True}
+        page1_response = {
+            "more": {
+                "descendants": "true",
+                "max_results": "10",
+                "cursor": "cD00MQ==",
+            },
+            "results": {ContentNode._meta.db_table: [{"id": "child1"}]},
+        }
+        page2_response = {"results": {ContentNode._meta.db_table: [{"id": "child2"}]}}
+        self.mock_client.get.return_value.json.side_effect = [
+            page1_response,
+            page2_response,
+        ]
+
+        _get_import_metadata(self.mock_client, self.mock_download)
+
+        second_call_url = self.mock_client.get.call_args_list[1][0][0]
+        self.assertIn("cursor=cD00MQ%3D%3D", second_call_url)
+
+    @mock.patch(_module + "reverse_path")
+    def test_import_descendants_404_returns_none(self, mock_reverse_path):
+        """Test that a 404 during a descendants fetch returns None."""
+        mock_reverse_path.return_value = "/api/public/v2/importmetadata/{}/".format(
+            self.contentnode_id
+        )
+        self.mock_download.metadata = {"import_descendants": True}
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        self.mock_client.get.side_effect = NetworkLocationResponseFailure(
+            response=mock_response
+        )
+
+        result = _get_import_metadata(self.mock_client, self.mock_download)
+
+        self.assertIsNone(result)
 
 
 class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
     """
     Integration tests for _get_import_metadata against a live server.
 
-    Unlike the unit tests in GetDescendantsImportMetadataTestCase and
-    GetImportMetadataTestCase, these tests use a real NetworkClient making
-    actual HTTP requests to a live Django server, verifying the end-to-end
-    data flow including the correct format of data returned by the endpoint.
+    Unlike the unit tests in GetImportMetadataTestCase, these tests use a real
+    NetworkClient making actual HTTP requests to a live Django server, verifying
+    the end-to-end data flow including the correct format of data returned by
+    the endpoint.
 
     Two cases are covered:
     - Non-course node: only ancestor metadata is returned
-    - Course node: ancestors are merged with paginated descendant metadata
+    - Course node: ancestors and paginated descendant metadata are returned together
     """
 
     databases = "__all__"
@@ -1520,7 +1466,7 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
 
     def test_non_course_node_returns_ancestor_metadata_only(self):
         """
-        A download without descendants_depth returns metadata for the node and its
+        A download without import_descendants returns metadata for the node and its
         ancestors only, without fetching any descendants.
         """
         # Use a level-1 topic node that has both ancestors (root) and many descendants
@@ -1550,10 +1496,9 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
 
     def test_course_node_returns_merged_ancestor_and_descendant_metadata(self):
         """
-        A download with descendants_depth in its metadata triggers paginated descendant
-        fetching via _get_descendants_import_metadata. The final result contains nodes
-        from the ancestors call merged with all descendants up to descendants_depth
-        levels deep.
+        A download with import_descendants in its metadata adds descendants=true to the
+        request, triggering paginated fetching of ancestors and descendants together.
+        The final result contains all ancestor and descendant nodes merged.
 
         The default ChannelBuilder tree has enough nodes to exceed
         MAX_NODES_PER_REQUEST, so this exercises the pagination code path
@@ -1567,7 +1512,7 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
 
         mock_download = mock.MagicMock()
         mock_download.contentnode_id = topic_node.id
-        mock_download.metadata = {"descendants_depth": COURSES_DESCENDANTS_DEPTH}
+        mock_download.metadata = {"import_descendants": True}
 
         result = _get_import_metadata(self.network_client, mock_download)
 
@@ -1578,9 +1523,7 @@ class GetImportMetadataLiveServerTestCase(LiveServerTestCase):
             topic_node.get_ancestors(include_self=True).values_list("id", flat=True)
         )
         expected_descendant_ids = set(
-            topic_node.get_descendants(include_self=True)
-            .filter(level__lte=topic_node.level + COURSES_DESCENDANTS_DEPTH)
-            .values_list("id", flat=True)
+            topic_node.get_descendants(include_self=True).values_list("id", flat=True)
         )
         expected_node_ids = expected_ancestor_ids.union(expected_descendant_ids)
         self.assertEqual(returned_node_ids, expected_node_ids)
@@ -1594,13 +1537,13 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
     Covers the three-phase flow end-to-end:
         1. Metadata import — triggered for downloads whose ContentNode is absent.
         2. Descendant request creation — extra download requests are created for
-            descendants of nodes that carry ``descendants_depth`` in their metadata.
+            descendants of nodes that carry ``import_descendants`` in their metadata.
         3. Content download — _process_download is dispatched for every pending
             download that now has metadata.
 
     ``process_metadata_import`` is mocked to simulate the network import by
     creating ContentNode entries as a side effect (including children when
-    ``descendants_depth`` is set).  ``_process_download`` and ``PreferredDevices``
+    ``import_descendants`` is set).  ``_process_download`` and ``PreferredDevices``
     are mocked to avoid real file-transfer and peer-discovery logic.
     """
 
@@ -1608,7 +1551,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
         super().setUp()
 
         # Simulate metadata import from a remote peer: creates ContentNode entries
-        # for each requested node, plus children when descendants_depth is set.
+        # for each requested node, plus children when import_descendants is set.
         process_metadata_import_patcher = mock.patch(
             _module + "process_metadata_import"
         )
@@ -1649,7 +1592,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
         """
         Simulates what ``import_channel_from_data`` would do after a real network
         fetch: writes ContentNode rows for every requested node.  When a download
-        carries ``descendants_depth``, two child ContentNodes are also created so
+        carries ``import_descendants``, two child ContentNodes are also created so
         that ``_create_related_download_requests_if_needed`` can traverse the tree.
         """
         channel_id = uuid.uuid4().hex
@@ -1663,8 +1606,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
                 channel_id=channel_id,
                 content_id=uuid.uuid4().hex,
             )
-            depth = (download.metadata or {}).get("descendants_depth", 0)
-            if depth > 0:
+            if (download.metadata or {}).get("import_descendants", False):
                 for i in range(2):
                     ContentNode.objects.create(
                         id=uuid.uuid4().hex,
@@ -1717,25 +1659,25 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
     # Phase 2: descendant request creation                                 #
     # ------------------------------------------------------------------ #
 
-    def test_no_descendant_requests_created_without_descendants_depth(
+    def test_no_descendant_requests_created_without_import_descendants(
         self, _mock_setting
     ):
-        """A simple download (no descendants_depth) produces exactly one download request."""
+        """A simple download (no import_descendants) produces exactly one download request."""
         self._create_download(metadata=None)
 
         process_content_requests()
 
         self.assertEqual(ContentDownloadRequest.objects.count(), 1)
 
-    def test_descendant_requests_created_when_descendants_depth_set(
+    def test_descendant_requests_created_when_import_descendants_set(
         self, _mock_setting
     ):
         """
-        When a download carries descendants_depth, after metadata import the mock
+        When a download carries import_descendants, after metadata import the mock
         creates child ContentNodes.  process_content_requests must then create one
         ContentDownloadRequest per child.
         """
-        download = self._create_download(metadata={"descendants_depth": 1})
+        download = self._create_download(metadata={"import_descendants": True})
 
         process_content_requests()
 
@@ -1749,15 +1691,15 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
                 ContentDownloadRequest.objects.filter(contentnode_id=child_id).exists()
             )
 
-    def test_descendant_requests_inherit_source_and_omit_descendants_depth(
+    def test_descendant_requests_inherit_source_and_omit_import_descendants(
         self, _mock_setting
     ):
         """
         Requests created for descendants share source_model/source_id with the
-        parent request and do not carry descendants_depth in their own metadata.
+        parent request and do not carry import_descendants in their own metadata.
         """
         download = self._create_download(
-            metadata={"descendants_depth": 1, "extra": "value"}
+            metadata={"import_descendants": True, "extra": "value"}
         )
 
         process_content_requests()
@@ -1767,7 +1709,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
             child_req = ContentDownloadRequest.objects.get(contentnode_id=child_node.id)
             self.assertEqual(child_req.source_model, download.source_model)
             self.assertEqual(child_req.source_id, download.source_id)
-            self.assertNotIn("descendants_depth", child_req.metadata)
+            self.assertNotIn("import_descendants", child_req.metadata)
             self.assertEqual(child_req.metadata.get("extra"), "value")
 
     # ------------------------------------------------------------------ #
@@ -1789,7 +1731,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
         _process_download is called for the parent node and every descendant
         whose download request was created during the descendants phase.
         """
-        self._create_download(metadata={"descendants_depth": 1})
+        self._create_download(metadata={"import_descendants": True})
 
         process_content_requests()
 
@@ -1800,7 +1742,7 @@ class ProcessContentRequestsTestCase(BaseQuerysetTestCase):
         self, _mock_setting
     ):
         """All download requests end up Completed when _process_download returns True."""
-        self._create_download(metadata={"descendants_depth": 1})
+        self._create_download(metadata={"import_descendants": True})
 
         process_content_requests()
 
@@ -1817,7 +1759,7 @@ class CreateContentRemovalRequestsTestCase(BaseQuerysetTestCase):
 
     Covers both assignment types:
       - ContentAssignment: has contentnode_id and metadata; descendants are
-        resolved via metadata["descendants_depth"] when present.
+        resolved via metadata["import_descendants"] when present.
       - DeletedAssignment: has no contentnode_id or metadata; removal targets
         are derived from the existing SyncInitiated downloads for that source.
     """
@@ -1902,10 +1844,10 @@ class CreateContentRemovalRequestsTestCase(BaseQuerysetTestCase):
             ).exists()
         )
 
-    def test_content_assignment_without_descendants_depth_creates_only_one_removal_request(
+    def test_content_assignment_without_import_descendants_creates_only_one_removal_request(
         self,
     ):
-        """ContentAssignment with no descendants_depth creates exactly one removal request."""
+        """ContentAssignment with no import_descendants creates exactly one removal request."""
         parent, child1, child2 = self._create_node_tree()
         assignment = self._make_content_assignment(
             contentnode_id=parent.id, metadata=None
@@ -1920,15 +1862,15 @@ class CreateContentRemovalRequestsTestCase(BaseQuerysetTestCase):
         self.assertNotIn(child1.id, created_ids)
         self.assertNotIn(child2.id, created_ids)
 
-    def test_content_assignment_with_descendants_depth_creates_removal_requests_for_descendants(
+    def test_content_assignment_with_import_descendants_creates_removal_requests_for_descendants(
         self,
     ):
-        """ContentAssignment with descendants_depth creates removal requests for the node and all
-        descendants up to the given depth."""
+        """ContentAssignment with import_descendants creates removal requests for the node and all
+        its descendants."""
         parent, child1, child2 = self._create_node_tree()
         assignment = self._make_content_assignment(
             contentnode_id=parent.id,
-            metadata={"descendants_depth": 1},
+            metadata={"import_descendants": True},
         )
 
         create_content_removal_requests(self.facility, [assignment])

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import uuid
 from itertools import chain
@@ -10,14 +9,12 @@ from django.db.models import Case
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django.db.models import Q
-from django.db.models import QuerySet
 from django.db.models import Subquery
 from django.db.models import Sum
 from django.db.models import Value
 from django.db.models import When
 from django.db.models.expressions import CombinedExpression
 from django.db.models.functions import Coalesce
-from le_utils.constants import modalities
 from morango.models.core import SyncSession
 
 from kolibri.core.auth.models import Facility
@@ -29,6 +26,7 @@ from kolibri.core.content.models import ContentRequest
 from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import File
+from kolibri.core.content.utils.assignment import ContentAssignment
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.content.utils.assignment import DeletedAssignment
 from kolibri.core.content.utils.channel_import import import_channel_from_data
@@ -51,7 +49,6 @@ from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.data import bytes_for_humans
 from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
-
 
 logger = logging.getLogger(__name__)
 
@@ -93,11 +90,36 @@ def create_content_download_requests(facility, assignments, source_instance_id=N
                 reason=ContentRequestReason.SyncInitiated,
                 status=ContentRequestStatus.Pending,
                 source_instance_id=source_instance_id,
+                metadata=assignment.metadata,
             ),
             source_model=assignment.source_model,
             source_id=assignment.source_id,
             contentnode_id=assignment.contentnode_id,
         )
+
+
+def _get_related_contentnode_ids_for_removal(assignment):
+    """
+    Returns IDs of descendant content nodes that should also be removed when an assignment
+    is removed, based on the ``descendants_depth`` value stored in the assignment's metadata.
+
+    :param assignment: A ContentAssignment or DeletedAssignment instance
+    :return: A list of content node IDs for the descendants that should be removed,
+            or an empty list if the assignment has no descendants depth or no matching node
+    :rtype: list[str]
+    """
+    metadata = getattr(assignment, "metadata", None)
+    descendants_depth = metadata.get("descendants_depth", 0) if metadata else 0
+    if descendants_depth > 0:
+        contentnode = ContentNode.objects.filter(id=assignment.contentnode_id).first()
+        if contentnode:
+            contentnode_ids = list(
+                contentnode.get_descendants()
+                .filter(level__lte=contentnode.level + descendants_depth)
+                .values_list("id", flat=True)
+            )
+            return contentnode_ids
+    return []
 
 
 def create_content_removal_requests(facility, removable_assignments):
@@ -117,11 +139,15 @@ def create_content_removal_requests(facility, removable_assignments):
         )
         if isinstance(assignment, DeletedAssignment):
             # for completed downloads, we'll go through contentnode_ids and add removals
-            removed_contentnode_ids = related_downloads.values_list(
-                "contentnode_id", flat=True
-            ).distinct()
+            removed_contentnode_ids = list(
+                related_downloads.values_list("contentnode_id", flat=True).distinct()
+            )
         else:
             removed_contentnode_ids = [assignment.contentnode_id]
+
+        removed_contentnode_ids.extend(
+            _get_related_contentnode_ids_for_removal(assignment)
+        )
 
         for contentnode_id in removed_contentnode_ids:
             logger.debug(
@@ -483,6 +509,61 @@ class AlreadyAvailable(Exception):
     pass
 
 
+def _create_related_download_requests_if_needed(incomplete_downloads):
+    """
+    Creates download requests for the descendants of any incomplete download whose metadata
+    specifies a ``descendants_depth`` greater than zero (e.g. course nodes).
+
+    After metadata has been imported, the local ``ContentNode`` tree is available, so we
+    can resolve the actual descendant IDs and create individual `ContentDownloadRequest` entries
+    for each one.
+
+    :param incomplete_downloads: A queryset of pending `ContentDownloadRequest` instances
+    :type incomplete_downloads: django.db.models.QuerySet
+    """
+    contentnodes_map = {}
+    for contentnode in ContentNode.objects.filter(
+        id__in=incomplete_downloads.values_list("contentnode_id", flat=True)
+    ):
+        contentnodes_map[contentnode.id] = contentnode
+
+    for download_request in incomplete_downloads:
+        contentnode = contentnodes_map.get(download_request.contentnode_id, None)
+        if not contentnode:
+            continue
+
+        descendants_depth = (
+            download_request.metadata.get("descendants_depth", 0)
+            if download_request.metadata
+            else 0
+        )
+        if descendants_depth > 0:
+            course_descendants = contentnode.get_descendants().filter(
+                level__lte=contentnode.level + descendants_depth
+            )
+            derived_assignments = [
+                ContentAssignment(
+                    contentnode_id=descendant.id,
+                    source_model=download_request.source_model,
+                    source_id=download_request.source_id,
+                    # Include everything but descendants_depth in the metadata, since that's only
+                    # relevant for the original request
+                    metadata={
+                        key: value
+                        for key, value in (download_request.metadata or {}).items()
+                        if key != "descendants_depth"
+                    },
+                )
+                for descendant in course_descendants
+            ]
+
+            create_content_download_requests(
+                download_request.facility,
+                derived_assignments,
+                source_instance_id=download_request.source_instance_id,
+            )
+
+
 def process_content_requests():
     """
     Wrapper around the processing of content requests to capture errors
@@ -497,6 +578,8 @@ def process_content_requests():
     if incomplete_downloads_without_metadata.exists():
         logger.debug("Attempting to import missing metadata before content import")
         process_metadata_import(incomplete_downloads_without_metadata)
+
+    _create_related_download_requests_if_needed(incomplete_downloads)
 
     try:
         logger.debug("Starting automated import of content")
@@ -542,7 +625,6 @@ def _merge_import_metadata(metadata_list):
 
 
 MAX_NODES_PER_REQUEST = 10
-COURSES_DESCENDANTS_DEPTH = 3
 
 
 def _get_descendants_import_metadata(client, contentnode_id, depth):
@@ -594,46 +676,22 @@ def _get_descendants_import_metadata(client, contentnode_id, depth):
     return metadata_list
 
 
-def _import_descendants_depth(import_metadata, contentnode_id):
+def _get_import_metadata(client, download):
     """
-    Determines whether we should import the descendants of the content node being imported,
-    based on the import metadata.
+    Fetches import metadata for a single content node from a remote peer. If the download
+    request carries a ``descendants_depth`` in its metadata, also fetches metadata for
+    all descendants up to that depth and merges everything into one dict.
 
-    :param import_metadata: The metadata result from the import metadata request for the
-                            content node
-    :type import_metadata: dict
-    :param contentnode_id: The ID of the content node being imported
-    :type contentnode_id: str
-    :return: A number representing the depth of the content node being imported, if 0
-            it means we should not import descendants
-    """
-    contentnodes_metadata = import_metadata.get(ContentNode._meta.db_table, [])
+    Returns ``None`` when the remote peer responds with a 4xx error (e.g. 404 — node not
+    found on that peer). Other network errors are re-raised.
 
-    node_being_imported = next(
-        (
-            node_metadata
-            for node_metadata in contentnodes_metadata
-            if node_metadata["id"] == contentnode_id
-        ),
-        None,
-    )
-
-    try:
-        options_str = node_being_imported.get("options", "{}")
-        options = json.loads(options_str)
-        if options.get("modality") == modalities.COURSE:
-            return COURSES_DESCENDANTS_DEPTH
-        return 0
-    except (json.JSONDecodeError, AttributeError):
-        return 0
-
-
-def _get_import_metadata(client, contentnode_id):
-    """
+    :param client: An active network client pointed at the remote peer
     :type client: NetworkClient
-    :type contentnode_id: str
+    :param download: The pending download request whose metadata should be imported
+    :type download: ContentDownloadRequest
     :rtype: None|dict
     """
+    contentnode_id = download.contentnode_id
     url_path = reverse_path(
         "kolibri:core:importmetadata-detail", kwargs={"pk": contentnode_id}
     )
@@ -641,9 +699,8 @@ def _get_import_metadata(client, contentnode_id):
         response = client.get(url_path)
         import_metadata = response.json()
 
-        # Should we import contentnode's descendants? How far down the tree should we go?
-        descendants_depth_to_import = _import_descendants_depth(
-            import_metadata, contentnode_id
+        descendants_depth_to_import = (
+            download.metadata.get("descendants_depth", 0) if download.metadata else 0
         )
         if descendants_depth_to_import > 0:
             descendants_import_metadata = _get_descendants_import_metadata(
@@ -666,26 +723,23 @@ def _get_import_metadata(client, contentnode_id):
         raise e
 
 
-def _import_metadata(client, contentnode_ids):
+def _import_metadata(client, incomplete_downloads_without_metadata):
     """
     :type client: NetworkClient
-    :param contentnode_ids: a values_list QuerySet of content node ids or list of them
-    :type contentnode_ids: QuerySet or list
+    :param incomplete_downloads_without_metadata: a ContentDownloadRequest queryset
+    :type incomplete_downloads_without_metadata: django.db.models.QuerySet
     :return: A boolean indicating whether all metadata was imported successfully
     """
-    total_count = (
-        contentnode_ids.count()
-        if isinstance(contentnode_ids, QuerySet)
-        else len(contentnode_ids)
-    )
+    total_count = incomplete_downloads_without_metadata.count()
+
     # quick exit, without log noise, if nothing to do
     if not total_count:
         logging.debug("No content metadata to import")
         return
     processed_count = 0
     logger.info("Importing content metadata for {} nodes".format(total_count))
-    for contentnode_id in contentnode_ids:
-        import_metadata = _get_import_metadata(client, contentnode_id)
+    for download in incomplete_downloads_without_metadata:
+        import_metadata = _get_import_metadata(client, download)
         # if the request 404'd, then we wouldn't have this data
         if import_metadata:
             processed_count += 1
@@ -698,7 +752,9 @@ def _import_metadata(client, contentnode_ids):
                 )
         else:
             logger.warning(
-                "Failed to import content metadata for {}".format(contentnode_id)
+                "Failed to import content metadata for {}".format(
+                    download.contentnode_id
+                )
             )
     logger.info("Imported content metadata for {} nodes".format(processed_count))
     return total_count == processed_count
@@ -729,7 +785,7 @@ def process_metadata_import(incomplete_downloads_without_metadata):
             client,
             incomplete_downloads_without_metadata.filter(
                 source_instance_id=_uuid_to_hex(peer.instance_id),
-            ).values_list("contentnode_id", flat=True),
+            ),
         )
 
     # if we've completed the import, then we can stop
@@ -746,7 +802,7 @@ def process_metadata_import(incomplete_downloads_without_metadata):
             client,
             incomplete_downloads_without_metadata.exclude(
                 source_instance_id=_uuid_to_hex(peer.instance_id)
-            ).values_list("contentnode_id", flat=True),
+            ),
         )
         # if we've completed the import, then we can stop
         if is_complete:

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -101,24 +101,21 @@ def create_content_download_requests(facility, assignments, source_instance_id=N
 def _get_related_contentnode_ids_for_removal(assignment):
     """
     Returns IDs of descendant content nodes that should also be removed when an assignment
-    is removed, based on the ``descendants_depth`` value stored in the assignment's metadata.
+    is removed, based on the ``import_descendants`` flag stored in the assignment's metadata.
 
     :param assignment: A ContentAssignment or DeletedAssignment instance
     :return: A list of content node IDs for the descendants that should be removed,
-            or an empty list if the assignment has no descendants depth or no matching node
+            or an empty list if the assignment has no import_descendants flag or no matching node
     :rtype: list[str]
     """
     metadata = getattr(assignment, "metadata", None)
-    descendants_depth = metadata.get("descendants_depth", 0) if metadata else 0
-    if descendants_depth > 0:
+    import_descendants = (
+        metadata.get("import_descendants", False) if metadata else False
+    )
+    if import_descendants:
         contentnode = ContentNode.objects.filter(id=assignment.contentnode_id).first()
         if contentnode:
-            contentnode_ids = list(
-                contentnode.get_descendants()
-                .filter(level__lte=contentnode.level + descendants_depth)
-                .values_list("id", flat=True)
-            )
-            return contentnode_ids
+            return list(contentnode.get_descendants().values_list("id", flat=True))
     return []
 
 
@@ -512,7 +509,7 @@ class AlreadyAvailable(Exception):
 def _create_related_download_requests_if_needed(incomplete_downloads):
     """
     Creates download requests for the descendants of any incomplete download whose metadata
-    specifies a ``descendants_depth`` greater than zero (e.g. course nodes).
+    has ``import_descendants`` set to True (e.g. course nodes).
 
     After metadata has been imported, the local ``ContentNode`` tree is available, so we
     can resolve the actual descendant IDs and create individual `ContentDownloadRequest` entries
@@ -532,26 +529,24 @@ def _create_related_download_requests_if_needed(incomplete_downloads):
         if not contentnode:
             continue
 
-        descendants_depth = (
-            download_request.metadata.get("descendants_depth", 0)
+        import_descendants = (
+            download_request.metadata.get("import_descendants", False)
             if download_request.metadata
-            else 0
+            else False
         )
-        if descendants_depth > 0:
-            course_descendants = contentnode.get_descendants().filter(
-                level__lte=contentnode.level + descendants_depth
-            )
+        if import_descendants:
+            course_descendants = contentnode.get_descendants()
             derived_assignments = [
                 ContentAssignment(
                     contentnode_id=descendant.id,
                     source_model=download_request.source_model,
                     source_id=download_request.source_id,
-                    # Include everything but descendants_depth in the metadata, since that's only
+                    # Include everything but import_descendants in the metadata, since that's only
                     # relevant for the original request
                     metadata={
                         key: value
                         for key, value in (download_request.metadata or {}).items()
-                        if key != "descendants_depth"
+                        if key != "import_descendants"
                     },
                 )
                 for descendant in course_descendants
@@ -627,43 +622,55 @@ def _merge_import_metadata(metadata_list):
 MAX_NODES_PER_REQUEST = 10
 
 
-def _get_descendants_import_metadata(client, contentnode_id, depth):
+def _get_import_metadata(client, download):
     """
+    Fetches import metadata for a single content node from a remote peer.
+
+    When the download carries ``import_descendants`` in its metadata, the
+    ``descendants=true`` filter is added to the request.  The endpoint then
+    returns both ancestors and descendants together and may paginate the
+    response; this function follows pagination until all pages are collected
+    and merges them into a single dict.
+
+    Returns ``None`` when the remote peer responds with a 4xx error (e.g. 404
+    — node not found on that peer).  Other network errors are re-raised.
+
+    :param client: An active network client pointed at the remote peer
     :type client: NetworkClient
-    :type contentnode_id: str
-    :type depth: int
-    :rtype: list[dict]
+    :param download: The pending download request whose metadata should be imported
+    :type download: ContentDownloadRequest
+    :rtype: None|dict
     """
+    contentnode_id = download.contentnode_id
+    import_descendants = (
+        download.metadata.get("import_descendants", False)
+        if download.metadata
+        else False
+    )
+
+    base_url = reverse_path(
+        "kolibri:core:importmetadata-detail", kwargs={"pk": contentnode_id}
+    )
+
     has_more = True
     more = None
     metadata_list = []
 
     while has_more:
-        url_path = reverse_path(
-            "kolibri:core:importmetadata-detail",
-            kwargs={"pk": contentnode_id},
-        )
         if more:
-            url_path += "?" + urlencode(more)
+            url_path = base_url + "?" + urlencode(more)
         else:
-            url_path += "?" + urlencode(
-                {
-                    "depth": depth,
-                    "max_results": MAX_NODES_PER_REQUEST,
-                }
-            )
+            params = {"max_results": MAX_NODES_PER_REQUEST}
+            if import_descendants:
+                params["descendants"] = "true"
+            url_path = base_url + "?" + urlencode(params)
 
         try:
-            response = client.get(url_path)
-            json_response = response.json()
-            import_metadata = json_response.get("results", {})
-            metadata_list.append(import_metadata)
-
+            json_response = client.get(url_path).json()
+            metadata_list.append(json_response.get("results", {}))
             more = json_response.get("more", None)
             has_more = more is not None
-
         except NetworkLocationResponseFailure as e:
-            # 400 level errors, like 404, are ignored
             if e.response is not None and 400 <= e.response.status_code < 500:
                 logger.debug(
                     "Metadata request failure: GET {} {}".format(
@@ -673,54 +680,7 @@ def _get_descendants_import_metadata(client, contentnode_id, depth):
                 break
             raise e
 
-    return metadata_list
-
-
-def _get_import_metadata(client, download):
-    """
-    Fetches import metadata for a single content node from a remote peer. If the download
-    request carries a ``descendants_depth`` in its metadata, also fetches metadata for
-    all descendants up to that depth and merges everything into one dict.
-
-    Returns ``None`` when the remote peer responds with a 4xx error (e.g. 404 — node not
-    found on that peer). Other network errors are re-raised.
-
-    :param client: An active network client pointed at the remote peer
-    :type client: NetworkClient
-    :param download: The pending download request whose metadata should be imported
-    :type download: ContentDownloadRequest
-    :rtype: None|dict
-    """
-    contentnode_id = download.contentnode_id
-    url_path = reverse_path(
-        "kolibri:core:importmetadata-detail", kwargs={"pk": contentnode_id}
-    )
-    try:
-        response = client.get(url_path)
-        import_metadata = response.json()
-
-        descendants_depth_to_import = (
-            download.metadata.get("descendants_depth", 0) if download.metadata else 0
-        )
-        if descendants_depth_to_import > 0:
-            descendants_import_metadata = _get_descendants_import_metadata(
-                client, contentnode_id, descendants_depth_to_import
-            )
-            return _merge_import_metadata(
-                [import_metadata, *descendants_import_metadata]
-            )
-        else:
-            return import_metadata
-    except NetworkLocationResponseFailure as e:
-        # 400 level errors, like 404, are ignored
-        if e.response is not None and 400 <= e.response.status_code < 500:
-            logger.debug(
-                "Metadata request failure: GET {} {}".format(
-                    url_path, e.response.status_code
-                )
-            )
-            return None
-        raise e
+    return _merge_import_metadata(metadata_list) or None
 
 
 def _import_metadata(client, incomplete_downloads_without_metadata):

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -15,8 +15,6 @@ from kolibri.core.fields import DateTimeTzField
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
 
-COURSES_DESCENDANTS_DEPTH = 3
-
 
 def course_assignment_lookup(course_id):
     """
@@ -24,7 +22,7 @@ def course_assignment_lookup(course_id):
     :param course_id: a UUID of a course ContentNode
     :return: a tuple of contentnode_id and metadata
     """
-    return (course_id, {"descendants_depth": COURSES_DESCENDANTS_DEPTH})
+    return (course_id, {"import_descendants": True})
 
 
 class TestType(ChoicesEnum):

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -10,9 +10,21 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.utils.sync import ClassroomPartitionFactory
+from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.fields import DateTimeTzField
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
+
+COURSES_DESCENDANTS_DEPTH = 3
+
+
+def course_assignment_lookup(course_id):
+    """
+    Lookup function for the ContentAssignmentManager
+    :param course_id: a UUID of a course ContentNode
+    :return: a tuple of contentnode_id and metadata
+    """
+    return (course_id, {"descendants_depth": COURSES_DESCENDANTS_DEPTH})
 
 
 class TestType(ChoicesEnum):
@@ -68,6 +80,15 @@ class CourseSession(AbstractFacilityDataModel):
     date_created = DateTimeTzField(default=local_now, editable=False)
 
     morango_model_name = "coursesession"
+
+    content_assignments = ContentAssignmentManager(
+        # This manager will assign just the course ContentNode, further course nodes
+        # will be requested later
+        one_to_many=False,
+        filters=dict(is_active=True),
+        lookup_field="course",
+        lookup_func=course_assignment_lookup,
+    )
 
     def __str__(self):
         return "CourseSession {} for Classroom {}".format(


### PR DESCRIPTION
## Summary
* Creates content download requests and removal requests for course descendants.
* Adds a `descendants_depth` attribute to metadata related to the contentnode ids on the assignment manager lookup field. This field would now be responsible for requesting additional descendants for a given content node.
* Creates additional content download requests on `process_content_requests` after metadata import, depending on the `descendants_depth` field.
* When processing updated/removed assignments, create content removal requests for descendants of a given assignment if it has a `descendants_depth` metadata.
* Creates a general test case for the `process_content_requests` and `create_content_removal_requests` methods.

## References

Closes #14284.

## Reviewer guidance

* Go to coach > courses.
* Create/Assign a new course to an LOD device.
* Activate the new course.
* On the LOD device, check that the course is imported after activating the course.
* Check that you can access the resources in the course.
* As a coach, deactivate the course.
* Check that the learner cannot see the course anymore.
* Check that `ContentRemovalRequest`'s have been created for all descendant nodes of the course (and the course node itself).


<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude Sonnet to generate unit tests for functions that had missing tests, and then updated them to include the new expectations. Also used Claude to generate some of the docstrings for new/updated methods.