### PR TITLE
Add picture password API endpoint with role-based access

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -71,7 +71,6 @@ from .serializers import FacilitySerializer
 from .serializers import FacilityUserSerializer
 from .serializers import LearnerGroupSerializer
 from .serializers import MembershipSerializer
-from .serializers import PicturePasswordSerializer
 from .serializers import PublicFacilitySerializer
 from .serializers import RoleSerializer
 from kolibri.core import error_constants
@@ -573,6 +572,7 @@ class FacilityUserViewSet(FacilityUserConsolidateMixin, ValuesViewset, BulkDelet
         "birth_year",
         "extra_demographics",
         "date_joined",
+        "picture_password",
     )
 
     ordering_fields = (
@@ -614,24 +614,6 @@ class FacilityUserViewSet(FacilityUserConsolidateMixin, ValuesViewset, BulkDelet
         # if the user is updating their own password, ensure they don't get logged out
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
-
-    @decorators.action(detail=False, methods=["get"], url_path="picture-password")
-    def picture_password(self, request):
-        queryset = (
-            self.filter_queryset(self.get_queryset())
-            .filter(roles__isnull=True)
-            .filter(
-                Q(devicepermissions__is_superuser=False)
-                | Q(devicepermissions__isnull=True)
-            )
-            .distinct()
-        )
-        return Response(PicturePasswordSerializer(queryset, many=True).data)
-
-    @decorators.action(detail=True, methods=["get"], url_path="picture-password")
-    def picture_password_detail(self, request, pk=None):
-        instance = self.get_object()
-        return Response(PicturePasswordSerializer(instance).data)
 
 
 class DeletedFacilityUserViewSet(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -71,6 +71,7 @@ from .serializers import FacilitySerializer
 from .serializers import FacilityUserSerializer
 from .serializers import LearnerGroupSerializer
 from .serializers import MembershipSerializer
+from .serializers import PicturePasswordSerializer
 from .serializers import PublicFacilitySerializer
 from .serializers import RoleSerializer
 from kolibri.core import error_constants
@@ -613,6 +614,63 @@ class FacilityUserViewSet(FacilityUserConsolidateMixin, ValuesViewset, BulkDelet
         # if the user is updating their own password, ensure they don't get logged out
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
+
+    @decorators.action(
+        detail=False,
+        methods=["get"],
+        url_path="picture-password",
+        permission_classes=[IsAuthenticated],
+    )
+    def picture_password(self, request):
+        user = request.user
+        is_admin = user.is_superuser or _user_is_admin_for_own_facility(user)
+        is_coach = (
+            not is_admin
+            and user.roles.filter(
+                kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH]
+            ).exists()
+        )
+
+        if is_admin or is_coach:
+            queryset = (
+                FacilityUser.objects.filter(
+                    facility=user.facility,
+                    roles__isnull=True,
+                )
+                .filter(
+                    Q(devicepermissions__is_superuser=False)
+                    | Q(devicepermissions__isnull=True)
+                )
+                .distinct()
+            )
+
+            class_id = request.query_params.get("classId")
+            if is_coach and not class_id:
+                return Response(
+                    {"detail": "classId is required for coaches"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if class_id:
+                queryset = queryset.filter(memberships__collection_id=class_id)
+
+            learner_id = request.query_params.get("learnerId")
+            if learner_id:
+                queryset = queryset.filter(id=learner_id)
+
+            return Response(PicturePasswordSerializer(queryset, many=True).data)
+
+        # Learner: only their own record
+        learner_id = request.query_params.get("learnerId")
+        if learner_id:
+            try:
+                normalized = UUID(learner_id).hex
+            except (ValueError, AttributeError):
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+            if normalized != user.id:
+                return Response(status=status.HTTP_403_FORBIDDEN)
+
+        return Response(PicturePasswordSerializer(user).data)
 
 
 class DeletedFacilityUserViewSet(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -615,62 +615,23 @@ class FacilityUserViewSet(FacilityUserConsolidateMixin, ValuesViewset, BulkDelet
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
 
-    @decorators.action(
-        detail=False,
-        methods=["get"],
-        url_path="picture-password",
-        permission_classes=[IsAuthenticated],
-    )
+    @decorators.action(detail=False, methods=["get"], url_path="picture-password")
     def picture_password(self, request):
-        user = request.user
-        is_admin = user.is_superuser or _user_is_admin_for_own_facility(user)
-        is_coach = (
-            not is_admin
-            and user.roles.filter(
-                kind__in=[role_kinds.COACH, role_kinds.ASSIGNABLE_COACH]
-            ).exists()
-        )
-
-        if is_admin or is_coach:
-            queryset = (
-                FacilityUser.objects.filter(
-                    facility=user.facility,
-                    roles__isnull=True,
-                )
-                .filter(
-                    Q(devicepermissions__is_superuser=False)
-                    | Q(devicepermissions__isnull=True)
-                )
-                .distinct()
+        queryset = (
+            self.filter_queryset(self.get_queryset())
+            .filter(roles__isnull=True)
+            .filter(
+                Q(devicepermissions__is_superuser=False)
+                | Q(devicepermissions__isnull=True)
             )
+            .distinct()
+        )
+        return Response(PicturePasswordSerializer(queryset, many=True).data)
 
-            class_id = request.query_params.get("classId")
-            if is_coach and not class_id:
-                return Response(
-                    {"detail": "classId is required for coaches"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            if class_id:
-                queryset = queryset.filter(memberships__collection_id=class_id)
-
-            learner_id = request.query_params.get("learnerId")
-            if learner_id:
-                queryset = queryset.filter(id=learner_id)
-
-            return Response(PicturePasswordSerializer(queryset, many=True).data)
-
-        # Learner: only their own record
-        learner_id = request.query_params.get("learnerId")
-        if learner_id:
-            try:
-                normalized = UUID(learner_id).hex
-            except (ValueError, AttributeError):
-                return Response(status=status.HTTP_400_BAD_REQUEST)
-            if normalized != user.id:
-                return Response(status=status.HTTP_403_FORBIDDEN)
-
-        return Response(PicturePasswordSerializer(user).data)
+    @decorators.action(detail=True, methods=["get"], url_path="picture-password")
+    def picture_password_detail(self, request, pk=None):
+        instance = self.get_object()
+        return Response(PicturePasswordSerializer(instance).data)
 
 
 class DeletedFacilityUserViewSet(

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -323,6 +323,13 @@ def validate_pin_code(value):
         raise serializers.ValidationError("A Pin must be number")
 
 
+class PicturePasswordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FacilityUser
+        fields = ("id", "full_name", "username", "picture_password")
+        read_only_fields = ("id", "full_name", "username", "picture_password")
+
+
 class ExtraFieldsSerializer(serializers.Serializer):
     facility = serializers.JSONField(required=False)
     pin_code = serializers.CharField(

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -75,8 +75,9 @@ class FacilityUserSerializer(serializers.ModelSerializer):
             "gender",
             "birth_year",
             "extra_demographics",
+            "picture_password",
         )
-        read_only_fields = ("is_superuser",)
+        read_only_fields = ("is_superuser", "picture_password")
 
     def save(self, **kwargs):
         instance = super().save(**kwargs)
@@ -321,13 +322,6 @@ class LearnerGroupSerializer(serializers.ModelSerializer):
 def validate_pin_code(value):
     if not value.isdigit():
         raise serializers.ValidationError("A Pin must be number")
-
-
-class PicturePasswordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = FacilityUser
-        fields = ("id", "full_name", "username", "picture_password")
-        read_only_fields = ("id", "full_name", "username", "picture_password")
 
 
 class ExtraFieldsSerializer(serializers.Serializer):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2919,9 +2919,6 @@ class PicturePasswordViewSetTestCase(APITestCase):
         cls.learner_outside_class.picture_password = "4.5.6"
         cls.learner_outside_class.save()
 
-    def get_url(self):
-        return reverse("kolibri:core:facilityuser-picture-password")
-
     def login(self, user):
         self.client.login(
             username=user.username,
@@ -2929,32 +2926,28 @@ class PicturePasswordViewSetTestCase(APITestCase):
             facility=self.facility,
         )
 
-    # --- Coach and admin access ---
-    def test_coach_without_class_id_returns_400(self):
-        self.login(self.coach)
-        response = self.client.get(self.get_url())
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    def list_url(self):
+        return reverse("kolibri:core:facilityuser-picture-password")
 
-    def test_coach_with_class_id_returns_class_learners_only(self):
-        self.login(self.coach)
-        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_ids = {u["id"] for u in response.data}
-        self.assertIn(self.learner_with_password.id, returned_ids)
-        self.assertIn(self.learner_no_password.id, returned_ids)
-        self.assertNotIn(self.learner_outside_class.id, returned_ids)
+    def detail_url(self, pk):
+        return reverse(
+            "kolibri:core:facilityuser-picture-password-detail", kwargs={"pk": pk}
+        )
 
-    def test_coach_and_admin_users_excluded_from_results(self):
-        self.login(self.coach)
-        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+    # --- List action ---
+
+    def test_list_returns_only_learners_not_coaches_or_admins(self):
+        self.login(self.admin)
+        response = self.client.get(self.list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {u["id"] for u in response.data}
         self.assertNotIn(self.coach.id, returned_ids)
         self.assertNotIn(self.admin.id, returned_ids)
+        self.assertIn(self.learner_with_password.id, returned_ids)
 
-    def test_response_includes_full_name_username_and_picture_password(self):
-        self.login(self.coach)
-        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+    def test_list_response_includes_required_fields(self):
+        self.login(self.admin)
+        response = self.client.get(self.list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data), 0)
         for user_data in response.data:
@@ -2962,9 +2955,9 @@ class PicturePasswordViewSetTestCase(APITestCase):
             self.assertIn("username", user_data)
             self.assertIn("picture_password", user_data)
 
-    def test_learners_with_null_picture_password_included_in_response(self):
+    def test_list_includes_learners_with_null_picture_password(self):
         self.login(self.admin)
-        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        response = self.client.get(self.list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {u["id"] for u in response.data}
         self.assertIn(self.learner_no_password.id, returned_ids)
@@ -2973,38 +2966,28 @@ class PicturePasswordViewSetTestCase(APITestCase):
         )
         self.assertIsNone(null_entry["picture_password"])
 
-    def test_admin_can_omit_class_id_to_get_all_facility_learners(self):
+    def test_list_filtered_by_member_of_returns_collection_learners_only(self):
         self.login(self.admin)
-        response = self.client.get(self.get_url())
+        response = self.client.get(self.list_url(), {"member_of": self.classroom.id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {u["id"] for u in response.data}
         self.assertIn(self.learner_with_password.id, returned_ids)
         self.assertIn(self.learner_no_password.id, returned_ids)
-        self.assertIn(self.learner_outside_class.id, returned_ids)
-        self.assertNotIn(self.admin.id, returned_ids)
-        self.assertNotIn(self.coach.id, returned_ids)
+        self.assertNotIn(self.learner_outside_class.id, returned_ids)
 
-    def test_admin_with_class_id_returns_only_class_learners(self):
-        self.login(self.admin)
-        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+    def test_list_coach_scoped_to_coached_collections(self):
+        self.login(self.coach)
+        response = self.client.get(self.list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = {u["id"] for u in response.data}
         self.assertIn(self.learner_with_password.id, returned_ids)
         self.assertNotIn(self.learner_outside_class.id, returned_ids)
 
-    def test_admin_with_learner_id_returns_single_learner(self):
-        self.login(self.admin)
-        response = self.client.get(
-            self.get_url(), {"learnerId": self.learner_with_password.id}
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["id"], self.learner_with_password.id)
+    # --- Detail action ---
 
-    # --- Learner self-access ---
-    def test_learner_retrieves_own_record(self):
+    def test_detail_returns_learners_own_record(self):
         self.login(self.learner_with_password)
-        response = self.client.get(self.get_url())
+        response = self.client.get(self.detail_url(self.learner_with_password.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["id"], self.learner_with_password.id)
         self.assertEqual(
@@ -3012,27 +2995,13 @@ class PicturePasswordViewSetTestCase(APITestCase):
             self.learner_with_password.picture_password,
         )
 
-    def test_learner_own_record_has_null_picture_password_when_unassigned(self):
+    def test_detail_returns_null_picture_password_when_unassigned(self):
         self.login(self.learner_no_password)
-        response = self.client.get(self.get_url())
+        response = self.client.get(self.detail_url(self.learner_no_password.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data["picture_password"])
 
-    def test_learner_with_learner_id_matching_self_returns_own_record(self):
+    def test_detail_learner_cannot_access_another_users_record(self):
         self.login(self.learner_with_password)
-        response = self.client.get(
-            self.get_url(), {"learnerId": self.learner_with_password.id}
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["id"], self.learner_with_password.id)
-
-    def test_learner_with_other_learner_id_returns_403(self):
-        self.login(self.learner_with_password)
-        response = self.client.get(
-            self.get_url(), {"learnerId": self.learner_no_password.id}
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_unauthenticated_request_returns_403(self):
-        response = self.client.get(self.get_url())
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        response = self.client.get(self.detail_url(self.learner_no_password.id))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2888,7 +2888,7 @@ class KolibriDataPortalViewSetTestCase(APITestCase):
         mock_enqueue_sync.assert_called_once_with(self.facility)
 
 
-class PicturePasswordViewSetTestCase(APITestCase):
+class PicturePasswordSerializerTestCase(APITestCase):
     databases = "__all__"
 
     @classmethod
@@ -2896,28 +2896,10 @@ class PicturePasswordViewSetTestCase(APITestCase):
         provision_device()
         cls.facility = FacilityFactory.create()
         cls.superuser = create_superuser(cls.facility)
-
-        cls.classroom = models.Classroom.objects.create(
-            parent=cls.facility, name="Test Class"
-        )
-
-        cls.admin = FacilityUserFactory.create(facility=cls.facility)
-        cls.facility.add_admin(cls.admin)
-
-        cls.coach = FacilityUserFactory.create(facility=cls.facility)
-        cls.classroom.add_coach(cls.coach)
-
         cls.learner_with_password = FacilityUserFactory.create(facility=cls.facility)
         cls.learner_with_password.picture_password = "1.2.3"
         cls.learner_with_password.save()
-        cls.classroom.add_member(cls.learner_with_password)
-
         cls.learner_no_password = FacilityUserFactory.create(facility=cls.facility)
-        cls.classroom.add_member(cls.learner_no_password)
-
-        cls.learner_outside_class = FacilityUserFactory.create(facility=cls.facility)
-        cls.learner_outside_class.picture_password = "4.5.6"
-        cls.learner_outside_class.save()
 
     def login(self, user):
         self.client.login(
@@ -2926,83 +2908,19 @@ class PicturePasswordViewSetTestCase(APITestCase):
             facility=self.facility,
         )
 
-    def list_url(self):
-        return reverse("kolibri:core:facilityuser-picture-password")
-
     def detail_url(self, pk):
-        return reverse(
-            "kolibri:core:facilityuser-picture-password-detail", kwargs={"pk": pk}
-        )
+        return reverse("kolibri:core:facilityuser-detail", kwargs={"pk": pk})
 
-    # --- List action ---
-
-    def test_list_returns_only_learners_not_coaches_or_admins(self):
-        self.login(self.admin)
-        response = self.client.get(self.list_url())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_ids = {u["id"] for u in response.data}
-        self.assertNotIn(self.coach.id, returned_ids)
-        self.assertNotIn(self.admin.id, returned_ids)
-        self.assertNotIn(self.superuser.id, returned_ids)
-        self.assertIn(self.learner_with_password.id, returned_ids)
-
-    def test_list_response_includes_required_fields(self):
-        self.login(self.admin)
-        response = self.client.get(self.list_url())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data), 0)
-        for user_data in response.data:
-            self.assertIn("full_name", user_data)
-            self.assertIn("username", user_data)
-            self.assertIn("picture_password", user_data)
-
-    def test_list_includes_learners_with_null_picture_password(self):
-        self.login(self.admin)
-        response = self.client.get(self.list_url())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_ids = {u["id"] for u in response.data}
-        self.assertIn(self.learner_no_password.id, returned_ids)
-        null_entry = next(
-            u for u in response.data if u["id"] == self.learner_no_password.id
-        )
-        self.assertIsNone(null_entry["picture_password"])
-
-    def test_list_filtered_by_member_of_returns_collection_learners_only(self):
-        self.login(self.admin)
-        response = self.client.get(self.list_url(), {"member_of": self.classroom.id})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_ids = {u["id"] for u in response.data}
-        self.assertIn(self.learner_with_password.id, returned_ids)
-        self.assertIn(self.learner_no_password.id, returned_ids)
-        self.assertNotIn(self.learner_outside_class.id, returned_ids)
-
-    def test_list_coach_scoped_to_coached_collections(self):
-        self.login(self.coach)
-        response = self.client.get(self.list_url())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_ids = {u["id"] for u in response.data}
-        self.assertIn(self.learner_with_password.id, returned_ids)
-        self.assertNotIn(self.learner_outside_class.id, returned_ids)
-
-    # --- Detail action ---
-
-    def test_detail_returns_learners_own_record(self):
-        self.login(self.learner_with_password)
+    def test_serializer_includes_picture_password_in_output(self):
+        self.login(self.superuser)
         response = self.client.get(self.detail_url(self.learner_with_password.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["id"], self.learner_with_password.id)
-        self.assertEqual(
-            response.data["picture_password"],
-            self.learner_with_password.picture_password,
-        )
+        self.assertIn("picture_password", response.data)
+        self.assertEqual(response.data["picture_password"], "1.2.3")
 
-    def test_detail_returns_null_picture_password_when_unassigned(self):
-        self.login(self.learner_no_password)
+    def test_picture_password_is_null_when_unassigned(self):
+        self.login(self.superuser)
         response = self.client.get(self.detail_url(self.learner_no_password.id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("picture_password", response.data)
         self.assertIsNone(response.data["picture_password"])
-
-    def test_detail_learner_cannot_access_another_users_record(self):
-        self.login(self.learner_with_password)
-        response = self.client.get(self.detail_url(self.learner_no_password.id))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2886,3 +2886,153 @@ class KolibriDataPortalViewSetTestCase(APITestCase):
             format="json",
         )
         mock_enqueue_sync.assert_called_once_with(self.facility)
+
+
+class PicturePasswordViewSetTestCase(APITestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+        cls.classroom = models.Classroom.objects.create(
+            parent=cls.facility, name="Test Class"
+        )
+
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
+
+        cls.coach = FacilityUserFactory.create(facility=cls.facility)
+        cls.classroom.add_coach(cls.coach)
+
+        cls.learner_with_password = FacilityUserFactory.create(facility=cls.facility)
+        cls.learner_with_password.picture_password = "1.2.3"
+        cls.learner_with_password.save()
+        cls.classroom.add_member(cls.learner_with_password)
+
+        cls.learner_no_password = FacilityUserFactory.create(facility=cls.facility)
+        cls.classroom.add_member(cls.learner_no_password)
+
+        cls.learner_outside_class = FacilityUserFactory.create(facility=cls.facility)
+        cls.learner_outside_class.picture_password = "4.5.6"
+        cls.learner_outside_class.save()
+
+    def get_url(self):
+        return reverse("kolibri:core:facilityuser-picture-password")
+
+    def login(self, user):
+        self.client.login(
+            username=user.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    # --- Coach and admin access ---
+    def test_coach_without_class_id_returns_400(self):
+        self.login(self.coach)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_coach_with_class_id_returns_class_learners_only(self):
+        self.login(self.coach)
+        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {u["id"] for u in response.data}
+        self.assertIn(self.learner_with_password.id, returned_ids)
+        self.assertIn(self.learner_no_password.id, returned_ids)
+        self.assertNotIn(self.learner_outside_class.id, returned_ids)
+
+    def test_coach_and_admin_users_excluded_from_results(self):
+        self.login(self.coach)
+        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {u["id"] for u in response.data}
+        self.assertNotIn(self.coach.id, returned_ids)
+        self.assertNotIn(self.admin.id, returned_ids)
+
+    def test_response_includes_full_name_username_and_picture_password(self):
+        self.login(self.coach)
+        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data), 0)
+        for user_data in response.data:
+            self.assertIn("full_name", user_data)
+            self.assertIn("username", user_data)
+            self.assertIn("picture_password", user_data)
+
+    def test_learners_with_null_picture_password_included_in_response(self):
+        self.login(self.admin)
+        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {u["id"] for u in response.data}
+        self.assertIn(self.learner_no_password.id, returned_ids)
+        null_entry = next(
+            u for u in response.data if u["id"] == self.learner_no_password.id
+        )
+        self.assertIsNone(null_entry["picture_password"])
+
+    def test_admin_can_omit_class_id_to_get_all_facility_learners(self):
+        self.login(self.admin)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {u["id"] for u in response.data}
+        self.assertIn(self.learner_with_password.id, returned_ids)
+        self.assertIn(self.learner_no_password.id, returned_ids)
+        self.assertIn(self.learner_outside_class.id, returned_ids)
+        self.assertNotIn(self.admin.id, returned_ids)
+        self.assertNotIn(self.coach.id, returned_ids)
+
+    def test_admin_with_class_id_returns_only_class_learners(self):
+        self.login(self.admin)
+        response = self.client.get(self.get_url(), {"classId": self.classroom.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {u["id"] for u in response.data}
+        self.assertIn(self.learner_with_password.id, returned_ids)
+        self.assertNotIn(self.learner_outside_class.id, returned_ids)
+
+    def test_admin_with_learner_id_returns_single_learner(self):
+        self.login(self.admin)
+        response = self.client.get(
+            self.get_url(), {"learnerId": self.learner_with_password.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.learner_with_password.id)
+
+    # --- Learner self-access ---
+    def test_learner_retrieves_own_record(self):
+        self.login(self.learner_with_password)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.learner_with_password.id)
+        self.assertEqual(
+            response.data["picture_password"],
+            self.learner_with_password.picture_password,
+        )
+
+    def test_learner_own_record_has_null_picture_password_when_unassigned(self):
+        self.login(self.learner_no_password)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["picture_password"])
+
+    def test_learner_with_learner_id_matching_self_returns_own_record(self):
+        self.login(self.learner_with_password)
+        response = self.client.get(
+            self.get_url(), {"learnerId": self.learner_with_password.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.learner_with_password.id)
+
+    def test_learner_with_other_learner_id_returns_403(self):
+        self.login(self.learner_with_password)
+        response = self.client.get(
+            self.get_url(), {"learnerId": self.learner_no_password.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_request_returns_403(self):
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2943,6 +2943,7 @@ class PicturePasswordViewSetTestCase(APITestCase):
         returned_ids = {u["id"] for u in response.data}
         self.assertNotIn(self.coach.id, returned_ids)
         self.assertNotIn(self.admin.id, returned_ids)
+        self.assertNotIn(self.superuser.id, returned_ids)
         self.assertIn(self.learner_with_password.id, returned_ids)
 
     def test_list_response_includes_required_fields(self):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1337,6 +1337,7 @@ class UserRetrieveTestCase(APITestCase):
             "birth_year": user.birth_year,
             "is_superuser": user.is_superuser,
             "extra_demographics": None,
+            "picture_password": user.picture_password,
         }
         roles = []
         user_roles = user.roles.all()

--- a/packages/kolibri-common/apiResources/FacilityUserResource.js
+++ b/packages/kolibri-common/apiResources/FacilityUserResource.js
@@ -4,12 +4,6 @@ import client from 'kolibri/client';
 
 export default new Resource({
   name: 'facilityuser',
-  fetchPicturePasswords(params) {
-    return client({
-      url: urls['kolibri:core:facilityuser-picture-password'](),
-      params,
-    });
-  },
   removeImportedUser(user_id) {
     return client({
       url: urls['kolibri:core:deleteimporteduser'](user_id),

--- a/packages/kolibri-common/apiResources/FacilityUserResource.js
+++ b/packages/kolibri-common/apiResources/FacilityUserResource.js
@@ -4,6 +4,12 @@ import client from 'kolibri/client';
 
 export default new Resource({
   name: 'facilityuser',
+  fetchPicturePasswords(params) {
+    return client({
+      url: urls['kolibri:core:facilityuser-picture-password'](),
+      params,
+    });
+  },
   removeImportedUser(user_id) {
     return client({
       url: urls['kolibri:core:deleteimporteduser'](user_id),


### PR DESCRIPTION
## Summary

Implements learningequality/kolibri#14369.

- Adds `picture_password` to `FacilityUserSerializer`'s `fields` and `read_only_fields` tuples so it is returned by the existing list and detail endpoints
- Adds `picture_password` to `FacilityUserViewSet.values` so the field is included in queryset projection
- `picture_password` is read-only; it returns `null` for users with no sequence assigned

## References

Closes learningequality/kolibri#14369

## Reviewer guidance

- **`read_only_fields`** (`serializers.py`): at present `read_only_fields` on a `ValuesViewset`-backed serializer is a no-op for enforcement, but is correct for documentation purposes and will become load-bearing once the open PR that makes `ValuesViewset` use the serializer as the source of truth for writable fields lands
- **`picture_password` in `values`** (`api.py`): without this addition the field would be absent from all viewset responses even after being added to the serializer, since `ValuesViewset` drives its queryset projection from the `values` tuple

## AI usage

I used Claude Code (claude-sonnet-4-6) to support implementation of this PR. I reviewed the generated code, made edits, verified test correctness, and confirmed the implementation matches the issue specification.