### PR TITLE
Remove duplicate page name definitions which was causing errors

### DIFF
--- a/kolibri/plugins/coach/frontend/views/home/HomePage/LessonsBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/LessonsBlock.vue
@@ -39,7 +39,6 @@
   import orderBy from 'lodash/orderBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
-  import { PageNames } from '../../../constants';
   import Block from './Block';
   import BlockItem from './BlockItem';
   import ItemProgressDisplay from './ItemProgressDisplay';
@@ -54,11 +53,6 @@
       BlockItem,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
-      return {
-        PageNames,
-      };
-    },
     computed: {
       table() {
         const recent = orderBy(this.lessons, this.lastActivity, ['desc']).slice(0, MAX_LESSONS);

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/QuizzesBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/QuizzesBlock.vue
@@ -38,7 +38,6 @@
   import orderBy from 'lodash/orderBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
-  import { PageNames } from '../../../constants';
   import Block from './Block';
   import BlockItem from './BlockItem';
   import ItemProgressDisplay from './ItemProgressDisplay';
@@ -53,11 +52,6 @@
       BlockItem,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
-      return {
-        PageNames,
-      };
-    },
     computed: {
       table() {
         const recent = orderBy(this.exams, this.lastActivity, ['desc']).slice(0, MAX_QUIZZES);


### PR DESCRIPTION
## Summary

<img width="1506" height="773" alt="Screenshot 2026-03-27 at 11 45 24 AM" src="https://github.com/user-attachments/assets/9b340849-8888-44e4-966a-3132f1cc1328" />

This happens on the coach class home page and is so annoying. `PageNames` are already available (via `commonCoach`)

## Reviewer Guidance

Confirm page still works as expected

## AI usage

I had claude fix while i was doing other things