### PR TITLE
Improve wording and readability in LFS pre-commit hook

### DIFF
--- a/.pre-commit-hooks/check_lfs_pointers.py
+++ b/.pre-commit-hooks/check_lfs_pointers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-"Pre-commit hook to ensure that files designated for Git LFS are actually LFS pointers."
+Pre-commit hook to ensure that files designated for Git LFS are actually LFS pointers.
 
 This prevents accidentally committing binary files that should be managed by Git LFS.
 See: https://github.com/learningequality/kolibri/issues/7099

--- a/.pre-commit-hooks/check_lfs_pointers.py
+++ b/.pre-commit-hooks/check_lfs_pointers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Pre-commit hook to ensure files designated for Git LFS are actually LFS pointers.
+"Pre-commit hook to ensure that files designated for Git LFS are actually LFS pointers."
 
 This prevents accidentally committing binary files that should be managed by Git LFS.
 See: https://github.com/learningequality/kolibri/issues/7099
@@ -58,7 +58,7 @@ def is_lfs_pointer(filepath):
             capture_output=True,
             check=True,
         )
-        first_line = result.stdout.split(b"\n")[0].strip()
+        first_line = result.stdout.splitlines()[0].strip()
         return first_line.startswith(LFS_POINTER_HEADER)
     except subprocess.CalledProcessError:
         return False
@@ -91,7 +91,7 @@ def main(filenames):
         logger.error("=" * 80)
         logger.error("")
         logger.error(
-            "The following files should be LFS pointers but contain binary data:"
+            "The following files should be LFS pointers but appear to contain binary data:"
         )
         logger.error("")
 


### PR DESCRIPTION
## Summary

- Added "that" in the docstring for smoother grammer.
- Clarified the error message wording ("appear to contain binary data").
-  Replaced `.split(n"/n")` with `.splitlines()` for cleaner Python code.

Changes were verified manually by reviewing the code; no functional changes were made.

## Review giudance

- Reviewer can verify the changes only affect comments and the LFS pointer check string handling
- No functional behavior was changed, so testing the pre-commit hook is not required for this PR

## AI usage
I used Claude Ai only to help suggest the replacement of `.split(b"\n")` with `.splitlines()` for readability. 
All other changes, including docstring and error message improvements, were done manually. 
The AI suggestion was reviewed and verified to ensure no functional changes occur.