### PR TITLE
Remove remaining duplicate PageNames definitions in coach plugin

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/ReportsResourceHeader.vue
+++ b/kolibri/plugins/coach/frontend/views/common/ReportsResourceHeader.vue
@@ -147,7 +147,6 @@
   import markdownIt from 'markdown-it';
   import HeaderWithOptions from '../common/HeaderWithOptions';
   import commonCoach from '../common';
-  import { PageNames } from '../../constants';
 
   export default {
     name: 'ReportsResourceHeader',
@@ -163,11 +162,6 @@
         type: Object,
         required: true,
       },
-    },
-    data() {
-      return {
-        PageNames,
-      };
     },
     computed: {
       practiceQuiz() {

--- a/kolibri/plugins/coach/frontend/views/groups/GroupEnrollPage.vue
+++ b/kolibri/plugins/coach/frontend/views/groups/GroupEnrollPage.vue
@@ -86,7 +86,7 @@
   import filterUsersByNames from 'kolibri-common/utils/filterUsersByNames';
   import UserTable from 'kolibri-common/components/UserTable';
   import commonCoach from '../common';
-  import { PageNames } from '../../constants';
+
   import CoachImmersivePage from '../CoachImmersivePage';
 
   export default {
@@ -99,7 +99,6 @@
     mixins: [commonCoach, commonCoreStrings],
     data() {
       return {
-        PageNames,
         filterInput: '',
         perPage: 10,
         pageNum: 1,
@@ -173,7 +172,7 @@
           groupId: this.currentGroup.id,
           userIds: this.selectedUsers,
         }).then(() => {
-          this.$router.push(this.$router.getRoute(PageNames.GROUP_SUMMARY), () => {
+          this.$router.push(this.$router.getRoute(this.PageNames.GROUP_SUMMARY), () => {
             this.showSnackbarNotification('learnersEnrolledNoCount', {
               count: this.selectedUsers.length,
             });

--- a/kolibri/plugins/coach/frontend/views/groups/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/frontend/views/groups/GroupMembersPage/index.vue
@@ -126,7 +126,7 @@
   import CoreTable from 'kolibri/components/CoreTable';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import commonCoach from '../../common';
-  import { GroupModals, PageNames } from '../../../constants';
+  import { GroupModals } from '../../../constants';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import RenameGroupModal from '../GroupsRootPage/RenameGroupModal';
   import DeleteGroupModal from '../GroupsRootPage/DeleteGroupModal';
@@ -144,7 +144,6 @@
     mixins: [commonCoreStrings, commonCoach],
     data() {
       return {
-        PageNames,
         userForRemoval: null,
       };
     },
@@ -182,7 +181,7 @@
       handleSuccessDeleteGroup() {
         this.showSnackbarNotification('groupDeleted');
         this.displayModal(false);
-        this.$router.push(this.classRoute(PageNames.GROUPS_ROOT));
+        this.$router.push(this.classRoute(this.PageNames.GROUPS_ROOT));
       },
       handleOptionSelect(value) {
         switch (value) {

--- a/kolibri/plugins/coach/frontend/views/learners/reports/LearnerLessonPage.vue
+++ b/kolibri/plugins/coach/frontend/views/learners/reports/LearnerLessonPage.vue
@@ -98,7 +98,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import { PageNames } from '../../../constants';
+
   import commonCoach from '../../common';
   import CoachAppBarPage from '../../CoachAppBarPage';
   import CSVExporter from '../../../csv/exporter';
@@ -112,11 +112,6 @@
       ReportsControls,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
-      return {
-        PageNames,
-      };
-    },
     computed: {
       emptyMessage() {
         return this.coachString('noResourcesInLessonLabel');
@@ -135,7 +130,7 @@
           }
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
-            link: this.classRoute(PageNames.LESSON_LEARNER_EXERCISE_PAGE_ROOT, {
+            link: this.classRoute(this.PageNames.LESSON_LEARNER_EXERCISE_PAGE_ROOT, {
               exerciseId: content.content_id,
               learnerId: this.learner.id,
             }),

--- a/kolibri/plugins/coach/frontend/views/lessons/reports/LessonLearnerPage.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/reports/LessonLearnerPage.vue
@@ -87,7 +87,7 @@
   import CoachAppBarPage from '../../CoachAppBarPage';
   import CSVExporter from '../../../csv/exporter';
   import * as csvFields from '../../../csv/fields';
-  import { PageNames } from '../../../constants';
+
   import ReportsControls from '../../common/ReportsControls';
   import ReportsResourcesStats from '../../common/tables/ReportsResourcesStats';
 
@@ -100,11 +100,6 @@
       ReportsResourcesStats,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
-      return {
-        PageNames,
-      };
-    },
     computed: {
       lesson() {
         return this.lessonMap[this.$route.params.lessonId];
@@ -131,7 +126,7 @@
     },
     methods: {
       exerciseLink(exerciseId) {
-        return this.classRoute(PageNames.LESSON_LEARNER_EXERCISE_PAGE_ROOT, { exerciseId });
+        return this.classRoute(this.PageNames.LESSON_LEARNER_EXERCISE_PAGE_ROOT, { exerciseId });
       },
       showLink(tableRow) {
         return (


### PR DESCRIPTION
## Summary

Follow-up to #14463 — remove the remaining duplicate `PageNames` definitions in 5 more coach plugin files, as identified by @AlexVelezLl in [this comment](https://github.com/learningequality/kolibri/pull/14463#issuecomment-4144388064). `PageNames` is already provided by the `commonCoach` mixin.

## References

Follows up on #14463 (comment: https://github.com/learningequality/kolibri/pull/14463#issuecomment-4144388064)

## Reviewer guidance

Verify that pages using `PageNames` still route correctly: GroupMembersPage, ReportsResourceHeader, GroupEnrollPage, LearnerLessonPage, LessonLearnerPage.

Manually verified against devserver that the Groups page, Lessons list, lesson detail (Resources and Learners tabs), learner detail page, and LearnerLessonPage all load and render correctly with no console errors. Exercise links using `PageNames` route references render as expected.

## AI usage

Used Claude Code to find and remove the duplicate `PageNames` definitions across the 5 files identified in Alex's comment. Verified linting passes and manually verified affected pages in the browser.