### PR TITLE
Add minReleaseAge to pnpm settings to reduce likelihood of supply chain compromises

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "browserslist": [
     "extends browserslist-config-kolibri"
   ],
-  "packageManager": "pnpm@10.4.1",
+  "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8",
   "volta": {
     "node": "20.19.3",
     "pnpm": "10.4.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+# minimum number of minutes
+minimumReleaseAge: 10080
+
 packages:
   - packages/*
   - kolibri/core


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Using [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) should reduce likelihood of supply chain compromises
- Sets the `minimumReleaseAge` to 1 week to match dependabot
- Upgrades `pnpm` since the feature needs [at least 10.16.0](https://pnpm.io/blog/releases/10.16)

### Notes
- Initially I tried upgrading to pnpm `10.33` but the build was complaining about `mathquill` not being in the approved-builds. The error would not reproduce locally

## References
<!--
 * references to related issues and PRs
-->
https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Can you run `pnpm install`?
