### PR TITLE
Add excludes for dep cool downs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+      exclude:
+        - kolibri-constants
+        - kolibri-design-system
     groups:
       babel:
         patterns:

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -87,7 +87,7 @@
     "intl": "^1.2.4",
     "kolibri-constants": "catalog:",
     "kolibri-design-system": "catalog:",
-    "kolibri-logging": "^1.0.0",
+    "kolibri-logging": "workspace:*",
     "lockr": "0.8.5",
     "lodash": "catalog:",
     "path-to-regexp": "1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,8 +1001,8 @@ importers:
         specifier: 'catalog:'
         version: 5.5.2
       kolibri-logging:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../kolibri-logging
       lockr:
         specifier: 0.8.5
         version: 0.8.5
@@ -3429,41 +3429,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6397,9 +6405,6 @@ packages:
 
   kolibri-design-system@5.5.2:
     resolution: {integrity: sha512-Fh1re4glwEFJGBQoe3CQ5Qz97Wkj90gOtzglBB1KBuF38kauO/xGaD3AnRsOvYKe+vOgYCgccr+ODyLafMm4oA==}
-
-  kolibri-logging@1.0.0:
-    resolution: {integrity: sha512-XsP2JzrzZWwnN5bbCZ12hYTrOuuREyFqOU3EZZP8tlVI2p4jO7/bvBo7xRs1gdAmU/8DSFY6tU1NRNRsBBu4aA==}
 
   launch-editor-middleware@2.12.0:
     resolution: {integrity: sha512-SgU5QWoR+Grq1sQedvS/RlfoyO6bdvrztpP+2RRg8UzE7Jz2Yup5J4jiFfm2J9dYBCQYD26AbJVbjnvgwdL6Pw==}
@@ -14780,11 +14785,6 @@ snapshots:
       vue-intl: 3.1.0(vue@2.7.16)
       vue2-teleport: 1.1.4
       xstate: 4.38.3
-
-  kolibri-logging@1.0.0:
-    dependencies:
-      chalk: 4.1.2
-      loglevel: 1.9.2
 
   launch-editor-middleware@2.12.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 # minimum number of minutes
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - kolibri-constants
+  - kolibri-design-system
 
 packages:
   - packages/*


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Follows up  to add excludes to for cool downs

## References
<!--
 * references to related issues and PRs
-->
follow up from https://github.com/learningequality/kolibri/pull/14475

## AI Usage
My assumption was that workspace packages aren't included in the release age check, since they're local. I asked AI about it and it concurred, because local packages wouldn't have a published date. The only ones I listed as excluded are packages that are used with a specific version, instead of `workspace:`
