### PR TITLE
Ensure Attendance Tracking confirmation snackbar is displayed

### DIFF
--- a/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
+++ b/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
@@ -121,8 +121,11 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
     showMarkAllModal.value = false;
   }
 
-  function navigateBack() {
-    router.push(backRoute.value);
+  function navigateBack(query = {}) {
+    router.push({
+      ...backRoute.value,
+      query,
+    });
   }
 
   // Unsaved changes guard

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
@@ -181,7 +181,7 @@
           originalAttendanceMap.value = { ...currentMap };
           form.setPreviouslyEnrolled(removedRecords);
         } catch (_err) {
-          form.navigateBack({ snackbar: submitErrorMessage$() });
+          form.navigateBack({ snackbar: coreString('defaultErrorMessage') });
         } finally {
           loading.value = false;
         }

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceEditPage.vue
@@ -140,8 +140,7 @@
         try {
           await bulkUpdateRecords(attendanceId.value, changedRecords.value);
           originalAttendanceMap.value = { ...form.attendanceMap.value };
-          form.navigateBack();
-          createSnackbar(updateSuccessMessage$());
+          form.navigateBack({ snackbar: updateSuccessMessage$() });
         } catch (_err) {
           createSnackbar(submitErrorMessage$());
         } finally {
@@ -182,8 +181,7 @@
           originalAttendanceMap.value = { ...currentMap };
           form.setPreviouslyEnrolled(removedRecords);
         } catch (_err) {
-          createSnackbar(submitErrorMessage$());
-          form.navigateBack();
+          form.navigateBack({ snackbar: submitErrorMessage$() });
         } finally {
           loading.value = false;
         }

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceHistoryPage.vue
@@ -90,7 +90,9 @@
 
 <script>
 
-  import { ref, computed, watch } from 'vue';
+  import { ref, computed, watch, onMounted } from 'vue';
+  import { useRoute, useRouter } from 'vue-router/composables';
+  import useSnackbar from 'kolibri/composables/useSnackbar';
   import { coreString } from 'kolibri/uiText/commonCoreStrings';
   import { attendanceStrings } from 'kolibri-common/strings/attendanceStrings';
   import AttendanceSessionResource from 'kolibri-common/apiResources/AttendanceSessionResource';
@@ -125,6 +127,9 @@
       ReportsControls,
     },
     setup() {
+      const route = useRoute();
+      const router = useRouter();
+      const { createSnackbar } = useSnackbar();
       const { classId, className } = useCoreCoach();
 
       const { attendanceLoading, sessions, totalPages, sessionCount, fetchSessions } =
@@ -188,6 +193,18 @@
       const selectedDateRange = ref(
         baseOptions.find(o => o.value === DateRangeFilters.LAST_30_DAYS),
       );
+
+      onMounted(() => {
+        const { snackbar, ...query } = route.query;
+        if (snackbar) {
+          createSnackbar(snackbar);
+          router.replace({
+            name: route.name,
+            params: route.params,
+            query,
+          });
+        }
+      });
 
       function getDateRange(filterValue) {
         if (filterValue === DateRangeFilters.CUSTOM_APPLIED) {

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceNewPage.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceNewPage.vue
@@ -82,8 +82,7 @@
             attendance_records: form.buildRecords(),
           });
           isDirty.value = false;
-          form.navigateBack();
-          createSnackbar(submitSuccessMessage$());
+          form.navigateBack({ snackbar: submitSuccessMessage$() });
         } catch (_err) {
           createSnackbar(submitErrorMessage$());
         } finally {

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendanceHistoryPage.spec.js
@@ -2,6 +2,8 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import { ref } from 'vue';
 import store from 'kolibri/store';
+// eslint-disable-next-line import/named
+import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar';
 import { DateRangeFilters } from 'kolibri-common/constants/DateRangeFilters';
 import AttendanceSessionResource from 'kolibri-common/apiResources/AttendanceSessionResource';
 import makeStore from '../../../__tests__/utils/makeStore';
@@ -11,6 +13,7 @@ import CSVExporter from '../../../csv/exporter';
 import AttendanceHistoryPage from '../AttendanceHistoryPage.vue';
 
 jest.mock('../../../composables/useAttendance');
+jest.mock('kolibri/composables/useSnackbar');
 jest.mock('kolibri-common/apiResources/AttendanceSessionResource');
 jest.mock('../../../csv/exporter', () => {
   const MockCSVExporter = jest.fn(() => ({ export: jest.fn(), addNames: jest.fn() }));
@@ -48,6 +51,11 @@ const router = new VueRouter({
   routes: [
     { path: '/', name: 'HomePage', component: { template: '<div />' } },
     { path: '/attendance/new', name: 'ATTENDANCE_NEW', component: { template: '<div />' } },
+    {
+      path: '/attendance/history',
+      name: 'ATTENDANCE_HISTORY',
+      component: { template: '<div />' },
+    },
     {
       path: '/attendance/:attendanceId',
       name: 'ATTENDANCE_EDIT',
@@ -121,6 +129,7 @@ function makeWrapper({
   sessionCount = null,
   loading = false,
   className = 'Test Class',
+  route = null,
 } = {}) {
   const mockValues = useAttendanceMock({
     sessions: ref(sessions),
@@ -135,6 +144,13 @@ function makeWrapper({
   testStore.state.classSummary.name = className;
   store.replaceState(testStore.state);
 
+  const createSnackbar = jest.fn();
+  useSnackbar.mockImplementation(() => useSnackbarMock({ createSnackbar }));
+
+  if (route) {
+    router.push(route);
+  }
+
   const wrapper = mount(AttendanceHistoryPage, {
     store: testStore,
     localVue,
@@ -142,7 +158,7 @@ function makeWrapper({
     stubs: STUBS,
   });
 
-  return { wrapper, mock: mockValues };
+  return { wrapper, mock: mockValues, createSnackbar };
 }
 
 describe('AttendanceHistoryPage', () => {
@@ -152,6 +168,7 @@ describe('AttendanceHistoryPage', () => {
     jest.clearAllMocks();
     jest.spyOn(store, 'dispatch').mockImplementation(jest.fn());
     useAttendance.mockImplementation(() => useAttendanceMock());
+    useSnackbar.mockImplementation(() => useSnackbarMock());
   });
 
   afterEach(() => {
@@ -177,6 +194,20 @@ describe('AttendanceHistoryPage', () => {
     it('renders ReportsControls', () => {
       const { wrapper } = makeWrapper({ sessions: MOCK_SESSIONS });
       expect(wrapper.findComponent({ name: 'ReportsControls' }).exists()).toBe(true);
+    });
+
+    it('shows the snackbar from the route query and clears it', async () => {
+      const { wrapper, createSnackbar } = makeWrapper({
+        route: {
+          name: 'ATTENDANCE_HISTORY',
+          query: { snackbar: 'Attendance submitted' },
+        },
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(createSnackbar).toHaveBeenCalledWith('Attendance submitted');
+      expect(router.currentRoute.query.snackbar).toBeUndefined();
     });
 
     it('includes class name and export date in CSV filename', async () => {

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
@@ -319,7 +319,7 @@ describe('AttendanceNewPage', () => {
     });
   });
 
-  it('calls createSession and shows success snackbar on submit', async () => {
+  it('calls createSession and redirects with a success snackbar query on submit', async () => {
     const { createSession, createSnackbar } = renderNewPage();
     await waitFor(() => {
       expect(screen.getByText('Alice')).toBeInTheDocument();
@@ -335,7 +335,9 @@ describe('AttendanceNewPage', () => {
         attendance_records: expect.arrayContaining([expect.objectContaining({ present: true })]),
       }),
     );
-    expect(createSnackbar).toHaveBeenCalled();
+    expect(createSnackbar).not.toHaveBeenCalled();
+    expect(window.location.hash).toContain('/class/test-class/attendance/history');
+    expect(window.location.hash).toContain('snackbar=');
   });
 
   it('shows error snackbar and stays on page when submit fails', async () => {
@@ -459,7 +461,7 @@ describe('AttendanceEditPage', () => {
     });
   });
 
-  it('calls bulkUpdateRecords with only changed records on confirmed save', async () => {
+  it('calls bulkUpdateRecords and redirects with a success snackbar query on confirmed save', async () => {
     const { bulkUpdateRecords, createSnackbar } = renderEditPage();
     await global.flushPromises();
 
@@ -485,7 +487,9 @@ describe('AttendanceEditPage', () => {
     expect(bulkUpdateRecords).toHaveBeenCalledWith('session-1', [
       { user: 'learner-b', present: true },
     ]);
-    expect(createSnackbar).toHaveBeenCalled();
+    expect(createSnackbar).not.toHaveBeenCalled();
+    expect(window.location.hash).toContain('/class/test-class/attendance/history');
+    expect(window.location.hash).toContain('snackbar=');
   });
 
   it('shows error snackbar and stays on page when save fails', async () => {


### PR DESCRIPTION

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

This pull request shows the attendance success snackbar on `AttendanceHistoryPage` after redirect, instead of on the page being left. The attendance flow has been updated so `AttendanceNewPage` and `AttendanceEditPage` pass the snackbar message through navigation, and `AttendanceHistoryPage` displays it once on load, then clears it from the URL.

Before:

https://github.com/user-attachments/assets/99ecc562-c064-4f43-a3f7-e36066596ba7



After:

https://github.com/user-attachments/assets/b2bab13f-a71c-4862-9ca3-fbafb00668c8


## References
<!--
 * references to related issues and PRs
-->
Fixes #14417 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go to Coach > Class home > class > Mark attendance
2. Edit or create a new attendance session and confirm the success snackbar appears on the attendance history page
3. Confirm that the snackbar only appears once and does not reappear on refresh

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Codex to help implement the route-based snackbar handling and update the related tests. I reviewed and refined the changes, checked that the flow stayed consistent with existing coach patterns, and verified the Jest tests pass.