### PR TITLE
Add dynamic RTL CSS loading support for webpack bundles

### DIFF
--- a/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
@@ -249,10 +249,11 @@
     name: 'PerseusRendererIndex',
     setup(props, context) {
       const { windowBreakpoint } = useKResponsiveWindow();
-      const { defaultFile } = useContentViewer(props, context);
+      const { defaultFile, contentDirection } = useContentViewer(props, context);
       return {
         windowBreakpoint,
         defaultFile,
+        contentDirection,
       };
     },
     props: contentViewerProps,

--- a/packages/kolibri-build/src/__tests__/webpackRtlPlugin.spec.js
+++ b/packages/kolibri-build/src/__tests__/webpackRtlPlugin.spec.js
@@ -1,0 +1,430 @@
+const path = require('path');
+const webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const WebpackRTLPlugin = require('../webpackRtlPlugin');
+const { createCssInsert } = require('../createCssInsert');
+const fs = require('fs');
+const os = require('os');
+
+// Polyfill setImmediate for Jest environment (webpack requires it)
+if (typeof setImmediate === 'undefined') {
+  global.setImmediate = (fn, ...args) => setTimeout(fn, 0, ...args);
+  global.clearImmediate = (id) => clearTimeout(id);
+}
+
+/**
+ * Helper to compile a webpack bundle and return the output
+ */
+function compileBundle(config) {
+  return new Promise((resolve, reject) => {
+    const compiler = webpack(config);
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      if (stats.hasErrors()) {
+        reject(new Error(stats.toString()));
+        return;
+      }
+      resolve({ compiler, stats });
+    });
+  });
+}
+
+/**
+ * Helper to create test files for webpack compilation
+ */
+function createTestFiles(tempDir) {
+  const entryFile = path.join(tempDir, 'entry.js');
+  const cssFile = path.join(tempDir, 'styles.css');
+  const asyncModuleFile = path.join(tempDir, 'asyncModule.js');
+
+  fs.writeFileSync(cssFile, '.test { direction: ltr; margin-left: 10px; }');
+  fs.writeFileSync(asyncModuleFile, `import './styles.css'; export default 'async';`);
+  fs.writeFileSync(entryFile, `import('./asyncModule.js');`);
+
+  return { entryFile, cssFile, asyncModuleFile };
+}
+
+describe('WebpackRTLPlugin', () => {
+  let tempDir;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rtl-test-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('RTL CSS file generation', () => {
+    it('should generate .rtl.css files with RTL-transformed styles', async () => {
+      const testDir = path.join(tempDir, 'rtl-generation');
+      fs.mkdirSync(testDir, { recursive: true });
+      const { entryFile } = createTestFiles(testDir);
+      const outputDir = path.join(testDir, 'dist');
+
+      await compileBundle({
+        mode: 'development',
+        entry: entryFile,
+        output: { path: outputDir, filename: 'bundle.js' },
+        module: {
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')] }],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      const files = fs.readdirSync(outputDir);
+      const cssFiles = files.filter((f) => f.endsWith('.css') && !f.endsWith('.rtl.css'));
+      const rtlCssFiles = files.filter((f) => f.endsWith('.rtl.css'));
+
+      expect(cssFiles.length).toBeGreaterThan(0);
+      expect(rtlCssFiles.length).toBeGreaterThan(0);
+
+      // Verify RTL transformation actually happened (margin-left -> margin-right)
+      const rtlCssContent = fs.readFileSync(path.join(outputDir, rtlCssFiles[0]), 'utf-8');
+      expect(rtlCssContent).toContain('margin-right');
+      expect(rtlCssContent).not.toContain('margin-left');
+    });
+  });
+
+  describe('runtime module ordering', () => {
+    it('should order RTLCSSRuntimeModule to run after GetChunkFilenameRuntimeModule', async () => {
+      const testDir = path.join(tempDir, 'ordering');
+      fs.mkdirSync(testDir, { recursive: true });
+      const { entryFile } = createTestFiles(testDir);
+      const outputDir = path.join(testDir, 'dist');
+
+      let foundBothModules = false;
+      let orderingCorrect = false;
+
+      const compiler = webpack({
+        mode: 'development',
+        entry: entryFile,
+        output: { path: outputDir, filename: 'bundle.js' },
+        module: {
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')] }],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+        compilation.hooks.afterProcessAssets.tap('TestPlugin', () => {
+          for (const chunk of compilation.chunks) {
+            const runtimeModules = [...compilation.chunkGraph.getChunkRuntimeModulesInOrder(chunk)];
+            let miniCssIndex = -1;
+            let rtlIndex = -1;
+
+            runtimeModules.forEach((module, index) => {
+              if (module.name && module.name.includes('mini-css')) miniCssIndex = index;
+              if (module.name === 'RTL CSS Loading') rtlIndex = index;
+            });
+
+            if (miniCssIndex !== -1 && rtlIndex !== -1) {
+              foundBothModules = true;
+              orderingCorrect = rtlIndex > miniCssIndex;
+            }
+          }
+        });
+      });
+
+      await new Promise((resolve, reject) => {
+        compiler.run((err, stats) => {
+          if (err) reject(err);
+          else if (stats.hasErrors()) reject(new Error(stats.toString()));
+          else resolve();
+        });
+      });
+
+      expect(foundBothModules).toBe(true);
+      expect(orderingCorrect).toBe(true);
+    });
+  });
+
+  describe('runtime code generation', () => {
+    let bundleContent;
+    let testDir;
+
+    beforeAll(async () => {
+      testDir = path.join(tempDir, 'runtime-code');
+      fs.mkdirSync(testDir, { recursive: true });
+      const { entryFile } = createTestFiles(testDir);
+      const outputDir = path.join(testDir, 'dist');
+
+      await compileBundle({
+        name: 'test-bundle-name',
+        mode: 'development',
+        entry: entryFile,
+        output: { path: outputDir, filename: 'bundle.js' },
+        module: {
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')] }],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      bundleContent = fs.readFileSync(path.join(outputDir, 'bundle.js'), 'utf-8');
+    });
+
+    it('should include bundle ID in generated code', () => {
+      expect(bundleContent).toContain('test-bundle-name');
+    });
+
+    it('should intercept miniCssF', () => {
+      expect(bundleContent).toContain('originalMiniCssF');
+      expect(bundleContent).toMatch(/__webpack_require__\.miniCssF\s*=\s*function/);
+    });
+
+    it('should use lazy initialization for bundleAPI', () => {
+      expect(bundleContent).toContain('bundleAPI');
+      expect(bundleContent).toContain('if (!bundleAPI)');
+    });
+
+    it('should register bundle with rtlManager', () => {
+      expect(bundleContent).toContain('registerBundle');
+    });
+
+    it('should use __webpack_require__ for core bundle rtlcss access', () => {
+      // Core bundles use __webpack_require__ with the resolved module ID,
+      // not the import specifier "kolibri/rtlcss"
+      expect(bundleContent).toContain('__webpack_require__');
+      expect(bundleContent).not.toContain('__webpack_require__("kolibri/rtlcss")');
+    });
+  });
+
+  describe('plugin bundle code generation', () => {
+    let bundleContent;
+
+    beforeAll(async () => {
+      const testDir = path.join(tempDir, 'plugin-bundle');
+      fs.mkdirSync(testDir, { recursive: true });
+      const { entryFile } = createTestFiles(testDir);
+      const outputDir = path.join(testDir, 'dist');
+
+      await compileBundle({
+        name: 'plugin-bundle-name',
+        mode: 'development',
+        entry: entryFile,
+        output: { path: outputDir, filename: 'bundle.js' },
+        module: {
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')] }],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
+          new WebpackRTLPlugin({ isCoreBundle: false }), // Plugin bundle, not core
+        ],
+      });
+
+      bundleContent = fs.readFileSync(path.join(outputDir, 'bundle.js'), 'utf-8');
+    });
+
+    it('should use window global for plugin bundle rtlcss access', () => {
+      // Plugin bundles access rtlcss via window.kolibriCoreAppGlobal
+      expect(bundleContent).toContain('window.kolibriCoreAppGlobal');
+      expect(bundleContent).toContain('kolibri/rtlcss');
+    });
+
+    it('should include plugin bundle ID', () => {
+      expect(bundleContent).toContain('plugin-bundle-name');
+    });
+  });
+
+  describe('integration with MiniCssExtractPlugin', () => {
+    let entryFile;
+    let cssFile;
+    let integrationDir;
+
+    beforeAll(() => {
+      integrationDir = path.join(tempDir, 'integration');
+      fs.mkdirSync(integrationDir, { recursive: true });
+      entryFile = path.join(integrationDir, 'entry.js');
+      cssFile = path.join(integrationDir, 'styles.css');
+      const asyncModuleFile = path.join(integrationDir, 'asyncModule.js');
+
+      fs.writeFileSync(cssFile, '.test { direction: ltr; }');
+      fs.writeFileSync(asyncModuleFile, `import './styles.css'; export default 'async';`);
+      fs.writeFileSync(entryFile, `import('./asyncModule.js');`);
+    });
+
+    it('should generate RTL CSS files', (done) => {
+      const outputDir = path.join(tempDir, 'dist2');
+
+      const compiler = webpack({
+        mode: 'development',
+        entry: entryFile,
+        output: {
+          path: outputDir,
+          filename: 'bundle.js',
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')],
+            },
+          ],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({
+            filename: '[name].css',
+          }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      compiler.run((err, stats) => {
+        if (err) {
+          done(err);
+          return;
+        }
+        if (stats.hasErrors()) {
+          done(new Error(stats.toString()));
+          return;
+        }
+
+        // Verify that both LTR and RTL CSS files were generated
+        const files = fs.readdirSync(outputDir);
+        // With dynamic imports, CSS ends up in a chunk file not main.css
+        const cssFiles = files.filter((f) => f.endsWith('.css'));
+        const rtlCssFiles = cssFiles.filter((f) => f.endsWith('.rtl.css'));
+        const ltrCssFiles = cssFiles.filter((f) => !f.endsWith('.rtl.css'));
+        expect(ltrCssFiles.length).toBeGreaterThan(0);
+        expect(rtlCssFiles.length).toBeGreaterThan(0);
+        done();
+      });
+    });
+
+    it('should have miniCssF intercept code in the generated bundle', (done) => {
+      const outputDir = path.join(tempDir, 'dist3');
+
+      const compiler = webpack({
+        mode: 'development',
+        entry: entryFile,
+        output: {
+          path: outputDir,
+          filename: 'bundle.js',
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')],
+            },
+          ],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({
+            filename: '[name].css',
+          }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      compiler.run((err, stats) => {
+        if (err) {
+          done(err);
+          return;
+        }
+        if (stats.hasErrors()) {
+          done(new Error(stats.toString()));
+          return;
+        }
+
+        // Read the generated bundle and verify the intercept pattern
+        const bundleContent = fs.readFileSync(
+          path.join(outputDir, 'bundle.js'),
+          'utf-8'
+        );
+
+        // The bundle should contain the miniCssF definition (from MiniCssExtractPlugin)
+        expect(bundleContent).toContain('miniCssF');
+
+        // Verify the intercept overwrites miniCssF
+        expect(bundleContent).toContain('originalMiniCssF');
+
+        // Verify it registers with rtlManager
+        expect(bundleContent).toContain('registerBundle');
+
+        done();
+      });
+    });
+  });
+
+  describe('createCssInsert', () => {
+    it('should return a function', () => {
+      const insert = createCssInsert('test-bundle');
+      expect(typeof insert).toBe('function');
+    });
+
+    it('should serialize with bundleId as literal string, not variable reference', () => {
+      // MiniCssExtractPlugin serializes insert functions with .toString()
+      // If bundleId were a closure variable, it would be lost during serialization
+      const insert = createCssInsert('my-bundle-id');
+      const serialized = insert.toString();
+
+      // The serialized function must contain the bundleId as a literal string
+      expect(serialized).toContain('"my-bundle-id"');
+      // And must NOT reference bundleId as a variable
+      expect(serialized).not.toMatch(/[^"']bundleId[^"']/);
+    });
+
+    it('should tag link element with data-webpack-bundle attribute', () => {
+      const insert = createCssInsert('my-bundle-id');
+
+      // Create a real link element for JSDOM
+      const linkElement = document.createElement('link');
+      linkElement.rel = 'stylesheet';
+      linkElement.href = 'test.css';
+
+      insert(linkElement);
+
+      expect(linkElement.getAttribute('data-webpack-bundle')).toBe('my-bundle-id');
+      expect(document.head.contains(linkElement)).toBe(true);
+
+      // Clean up
+      linkElement.remove();
+    });
+
+    it('should work with MiniCssExtractPlugin insert option', async () => {
+      const testDir = path.join(tempDir, 'css-insert-test');
+      fs.mkdirSync(testDir, { recursive: true });
+      const { entryFile } = createTestFiles(testDir);
+      const outputDir = path.join(testDir, 'dist');
+
+      const bundleName = 'insert-test-bundle';
+
+      await compileBundle({
+        name: bundleName,
+        mode: 'development',
+        entry: entryFile,
+        output: { path: outputDir, filename: 'bundle.js' },
+        module: {
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')] }],
+        },
+        plugins: [
+          new MiniCssExtractPlugin({
+            filename: '[name].css',
+            insert: createCssInsert(bundleName),
+          }),
+          new WebpackRTLPlugin({ isCoreBundle: true }),
+        ],
+      });
+
+      // Read the generated bundle and verify the insert function is included
+      const bundleContent = fs.readFileSync(path.join(outputDir, 'bundle.js'), 'utf-8');
+
+      // The bundle should contain the insert function with bundle ID
+      expect(bundleContent).toContain('data-webpack-bundle');
+      expect(bundleContent).toContain(bundleName);
+    });
+  });
+});

--- a/packages/kolibri-build/src/createCssInsert.js
+++ b/packages/kolibri-build/src/createCssInsert.js
@@ -1,0 +1,18 @@
+/**
+ * Generate a CSS insert function for MiniCssExtractPlugin that tags
+ * link elements with their bundle ID for RTL CSS management.
+ *
+ * @param {string} bundleId - The webpack bundle identifier
+ * @returns {function} Insert function that tags links and appends to head
+ */
+function createCssInsert(bundleId) {
+  // MiniCssExtractPlugin serializes functions with .toString(), losing closures.
+  // Use new Function to bake the bundleId into the function's source code.
+  return new Function(
+    'linkTag',
+    `linkTag.setAttribute("data-webpack-bundle", ${JSON.stringify(bundleId)});
+    document.head.appendChild(linkTag);`
+  );
+}
+
+module.exports = { createCssInsert };

--- a/packages/kolibri-build/src/webpack.config.plugin.js
+++ b/packages/kolibri-build/src/webpack.config.plugin.js
@@ -19,6 +19,7 @@ const WebpackRTLPlugin = require('./webpackRtlPlugin');
 const { kolibriName } = require('./kolibriName');
 const WebpackMessages = require('./webpackMessages');
 const MessageRegistrationPlugin = require('./webpackMessageRegistrationPlugin');
+const { createCssInsert } = require('./createCssInsert');
 
 /**
  * Turn an object containing the vital information for a frontend plugin and return a bundle
@@ -136,9 +137,11 @@ module.exports = (
       new MiniCssExtractPlugin({
         filename: '[name]' + data.version + '.css',
         chunkFilename: '[name]' + data.version + '[id].css',
+        insert: createCssInsert(data.name),
       }),
       new WebpackRTLPlugin({
         minify: false,
+        isCoreBundle,
       }),
       // BundleTracker creates stats about our built files which we can then pass to Django to
       // allow our template tags to load the correct frontend files.

--- a/packages/kolibri-build/src/webpackRtlPlugin.js
+++ b/packages/kolibri-build/src/webpackRtlPlugin.js
@@ -13,49 +13,147 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // Vendored and simplified from https://github.com/romainberger/webpack-rtl-plugin/blob/master/src/index.js
-const path = require('node:path');
+
 const rtlcss = require('rtlcss');
 const webpack = require('webpack');
+const { kolibriName } = require('./kolibriName');
 
 const pluginName = 'WebpackRTLPlugin';
+const RuntimeModule = webpack.RuntimeModule;
+const STAGE_ATTACH = 10;
 
+/**
+ * Generate the runtime code for RTL CSS dynamic loading.
+ *
+ * @param {string} bundleId - The webpack bundle identifier
+ * @param {string} rtlManagerAccess - JS expression that evaluates to the rtlcss module
+ * @returns {string} The runtime JavaScript code
+ */
+function generateRuntimeCode(bundleId, rtlManagerAccess) {
+  // Lazy initialization is required because runtime code executes before modules.
+  // By the time miniCssF is called (during dynamic CSS loading), modules are ready.
+  return `
+var bundleAPI;
+var originalMiniCssF = __webpack_require__.miniCssF;
+__webpack_require__.miniCssF = function(chunkId) {
+  if (!bundleAPI) {
+    bundleAPI = ${rtlManagerAccess}.rtlManager.registerBundle(${JSON.stringify(bundleId)});
+  }
+  return bundleAPI.miniCssF(originalMiniCssF(chunkId));
+};
+`.trim();
+}
+
+/**
+ * Runtime module that injects RTL CSS loading support into webpack bundles.
+ */
+class RTLCSSRuntimeModule extends RuntimeModule {
+  constructor(bundleId, isCoreBundle) {
+    // Use STAGE_ATTACH (10) to ensure this runs AFTER GetChunkFilenameRuntimeModule
+    // which defines miniCssF at STAGE_NORMAL (0). Runtime modules are sorted by
+    // stage first, then by identifier. Without this, "RTL CSS Loading" sorts before
+    // "get mini-css chunk filename" alphabetically and the miniCssF intercept fails.
+    super('RTL CSS Loading', STAGE_ATTACH);
+    this.bundleId = bundleId;
+    this.isCoreBundle = isCoreBundle;
+  }
+
+  generate() {
+    let rtlManagerAccess;
+    if (this.isCoreBundle) {
+      // Core bundle uses __webpack_require__ directly with the real module ID.
+      // We resolve it here (during code generation, after IDs are assigned) because
+      // webpack's module IDs are based on resolved paths, not import specifiers.
+      const moduleId = this._findRtlModuleId();
+      rtlManagerAccess = `__webpack_require__(${JSON.stringify(moduleId)})`;
+    } else {
+      // Plugin bundles access rtlcss via the core bundle's window global (externals).
+      rtlManagerAccess = `window.${kolibriName}["kolibri/rtlcss"]`;
+    }
+    return generateRuntimeCode(this.bundleId, rtlManagerAccess);
+  }
+
+  /**
+   * Find the webpack-assigned module ID for kolibri/rtlcss.
+   * Called during generate(), which runs after module ID optimization.
+   */
+  _findRtlModuleId() {
+    for (const module of this.compilation.modules) {
+      if (module.rawRequest === 'kolibri/rtlcss') {
+        return this.compilation.chunkGraph.getModuleId(module);
+      }
+    }
+    const msg =
+      `${pluginName}: could not find 'kolibri/rtlcss' module in compilation '${this.compilation.name}'. ` +
+      'Ensure the core bundle imports kolibri/rtlcss (it should be listed in apiSpec.js).';
+    this.compilation.warnings.push(new webpack.WebpackError(msg));
+    return null;
+  }
+}
+
+/**
+ * Webpack plugin that:
+ * 1. Generates RTL variants of all CSS files using rtlcss
+ * 2. Injects runtime code to dynamically load RTL CSS based on language direction
+ */
 class WebpackRTLPlugin {
-  constructor(options) {
+  constructor(options = {}) {
     this.options = {
-      filename: false,
-      options: {},
-      plugins: [],
+      rtlcssOptions: {},
+      rtlcssPlugins: [],
+      isCoreBundle: false,
       ...options,
     };
   }
 
   apply(compiler) {
     compiler.hooks.compilation.tap(pluginName, compilation => {
-      compilation.hooks.processAssets.tap(
-        {
-          name: pluginName,
-          stage: compilation.PROCESS_ASSETS_STAGE_DERIVED,
-          additionalAssets: true,
-        },
-        assets => {
-          for (const asset in assets) {
-            if (asset.endsWith('.css') && !asset.endsWith('.rtl.css')) {
-              const baseSource = assets[asset].source();
-              const rtlSource = rtlcss.process(
-                baseSource,
-                this.options.options,
-                this.options.plugins,
-              );
-
-              const newFilename = `${path.basename(asset, '.css')}.rtl`;
-              const filename = asset.replace(path.basename(asset, '.css'), newFilename);
-
-              compilation.emitAsset(filename, new webpack.sources.RawSource(rtlSource));
-            }
-          }
-        },
-      );
+      this._setupRTLCSSGeneration(compilation);
+      this._setupRuntimeModule(compilation);
     });
+  }
+
+  /**
+   * Generate .rtl.css files for all CSS assets
+   */
+  _setupRTLCSSGeneration(compilation) {
+    compilation.hooks.processAssets.tap(
+      {
+        name: pluginName,
+        stage: compilation.PROCESS_ASSETS_STAGE_DERIVED,
+        additionalAssets: true,
+      },
+      assets => {
+        for (const assetName in assets) {
+          if (assetName.endsWith('.css') && !assetName.endsWith('.rtl.css')) {
+            const rtlAssetName = assetName.replace(/\.css$/, '.rtl.css');
+            const originalCSS = assets[assetName].source();
+            const rtlCSS = rtlcss.process(
+              originalCSS,
+              this.options.rtlcssOptions,
+              this.options.rtlcssPlugins,
+            );
+            compilation.emitAsset(rtlAssetName, new webpack.sources.RawSource(rtlCSS));
+          }
+        }
+      },
+    );
+  }
+
+  /**
+   * Inject runtime module for dynamic RTL CSS loading
+   */
+  _setupRuntimeModule(compilation) {
+    const { isCoreBundle } = this.options;
+
+    // Only add to chunks that need dynamic chunk loading (same hook as MiniCssExtractPlugin).
+    // This guarantees miniCssF will be defined when our code runs.
+    compilation.hooks.runtimeRequirementInTree
+      .for(webpack.RuntimeGlobals.ensureChunkHandlers)
+      .tap(pluginName, chunk => {
+        const bundleId = compilation.name || 'unknown';
+        compilation.addRuntimeModule(chunk, new RTLCSSRuntimeModule(bundleId, isCoreBundle));
+      });
   }
 }
 

--- a/packages/kolibri/__tests__/rtlcss.spec.js
+++ b/packages/kolibri/__tests__/rtlcss.spec.js
@@ -1,0 +1,171 @@
+import { languageDirections } from 'kolibri/utils/i18n';
+
+// Use a variable to control the mocked languageDirection value
+let mockLanguageDirection = languageDirections.LTR;
+
+jest.mock('kolibri/utils/i18n', () => {
+  const actual = jest.requireActual('kolibri/utils/i18n');
+  return {
+    ...actual,
+    get languageDirection() {
+      return mockLanguageDirection;
+    },
+  };
+});
+
+// Re-import after mock setup so each test gets a fresh RTLManager
+let rtlManager;
+
+beforeEach(() => {
+  // Reset mock direction to LTR
+  mockLanguageDirection = languageDirections.LTR;
+  // Clear any link elements from previous tests
+  document.querySelectorAll('link[data-webpack-bundle]').forEach(el => el.remove());
+  // Fresh RTLManager for each test
+  jest.resetModules();
+  return import('../rtlcss.js').then(mod => {
+    rtlManager = mod.rtlManager;
+  });
+});
+
+describe('RTLManager', () => {
+  describe('registerBundleCSS and loadRegisteredBundleCSS', () => {
+    it('creates tagged link elements for LTR CSS when direction is LTR', () => {
+      mockLanguageDirection = languageDirections.LTR;
+
+      rtlManager.registerBundleCSS('test-viewer', ['/static/viewer.css', '/static/viewer.rtl.css']);
+      rtlManager.loadRegisteredBundleCSS('test-viewer');
+
+      const links = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toContain('/static/viewer.css');
+      expect(links[0].href).not.toContain('.rtl.css');
+    });
+
+    it('creates tagged link elements for RTL CSS when direction is RTL', () => {
+      mockLanguageDirection = languageDirections.RTL;
+
+      rtlManager.registerBundleCSS('test-viewer', ['/static/viewer.css', '/static/viewer.rtl.css']);
+      rtlManager.loadRegisteredBundleCSS('test-viewer');
+
+      const links = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toContain('.rtl.css');
+    });
+
+    it('stores only LTR URLs from the registered set', () => {
+      rtlManager.registerBundleCSS('test-viewer', [
+        '/static/chunk1.css',
+        '/static/chunk1.rtl.css',
+        '/static/chunk2.css',
+        '/static/chunk2.rtl.css',
+      ]);
+
+      expect(rtlManager.bundleCSSUrls.get('test-viewer')).toEqual([
+        '/static/chunk1.css',
+        '/static/chunk2.css',
+      ]);
+    });
+
+    it('creates links for multiple CSS files', () => {
+      rtlManager.registerBundleCSS('multi-css', [
+        '/static/chunk1.css',
+        '/static/chunk1.rtl.css',
+        '/static/chunk2.css',
+        '/static/chunk2.rtl.css',
+      ]);
+      rtlManager.loadRegisteredBundleCSS('multi-css');
+
+      const links = document.querySelectorAll('link[data-webpack-bundle="multi-css"]');
+      expect(links).toHaveLength(2);
+    });
+  });
+
+  describe('enableRTL switches direction for registered bundle CSS', () => {
+    beforeEach(() => {
+      mockLanguageDirection = languageDirections.LTR;
+      rtlManager.registerBundleCSS('test-viewer', ['/static/viewer.css', '/static/viewer.rtl.css']);
+      rtlManager.loadRegisteredBundleCSS('test-viewer');
+
+      // Stub requestAnimationFrame for reloadBundleCSS swap path
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    });
+
+    afterEach(() => {
+      window.requestAnimationFrame.mockRestore();
+    });
+
+    it('swaps LTR link to RTL link', async () => {
+      await rtlManager.enableRTL('test-viewer');
+
+      const links = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      expect(links).toHaveLength(1);
+      expect(links[0].href).toContain('.rtl.css');
+    });
+
+    it('is a no-op when already RTL', async () => {
+      await rtlManager.enableRTL('test-viewer');
+      const linksAfterFirst = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      const href = linksAfterFirst[0].href;
+
+      await rtlManager.enableRTL('test-viewer');
+      const linksAfterSecond = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      expect(linksAfterSecond).toHaveLength(1);
+      expect(linksAfterSecond[0].href).toBe(href);
+    });
+  });
+
+  describe('disableRTL switches direction for registered bundle CSS', () => {
+    beforeEach(() => {
+      mockLanguageDirection = languageDirections.RTL;
+      rtlManager.registerBundleCSS('test-viewer', ['/static/viewer.css', '/static/viewer.rtl.css']);
+      rtlManager.loadRegisteredBundleCSS('test-viewer');
+
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    });
+
+    afterEach(() => {
+      window.requestAnimationFrame.mockRestore();
+    });
+
+    it('swaps RTL link to LTR link', async () => {
+      await rtlManager.disableRTL('test-viewer');
+
+      const links = document.querySelectorAll('link[data-webpack-bundle="test-viewer"]');
+      expect(links).toHaveLength(1);
+      expect(links[0].href).not.toContain('.rtl.css');
+    });
+  });
+
+  describe('reloadBundleCSS race condition', () => {
+    it('preserves old CSS link when new CSS fails to load', async () => {
+      mockLanguageDirection = languageDirections.LTR;
+      rtlManager.registerBundleCSS('fail-viewer', ['/static/viewer.css']);
+      rtlManager.loadRegisteredBundleCSS('fail-viewer');
+
+      // Collect rAF callbacks without executing them, so onerror can fire first
+      const rAFCallbacks = [];
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => rAFCallbacks.push(cb));
+
+      rtlManager.bundleStates.set('fail-viewer', true);
+      const reloadPromise = rtlManager.reloadBundleCSS('fail-viewer');
+
+      // Simulate onerror on the new link before rAF callbacks run
+      const newLink = document.querySelectorAll('link[data-webpack-bundle="fail-viewer"]')[1];
+      newLink.onerror();
+
+      // Now run the deferred rAF callbacks — the errored flag should prevent old link removal
+      rAFCallbacks.forEach(cb => cb());
+
+      await expect(reloadPromise).rejects.toThrow('Failed to load');
+
+      // Old link should still be in the DOM
+      const remainingLinks = document.querySelectorAll('link[data-webpack-bundle="fail-viewer"]');
+      expect(remainingLinks).toHaveLength(1);
+      expect(remainingLinks[0].href).toContain('/static/viewer.css');
+      expect(remainingLinks[0].href).not.toContain('.rtl.css');
+
+      window.requestAnimationFrame.mockRestore();
+    });
+  });
+});

--- a/packages/kolibri/internal/apiSpec.js
+++ b/packages/kolibri/internal/apiSpec.js
@@ -44,6 +44,7 @@ export default {
   'kolibri/constants': require('kolibri/constants'),
   'kolibri/heartbeat': require('kolibri/heartbeat'),
   'kolibri/router': require('kolibri/router'),
+  'kolibri/rtlcss': require('kolibri/rtlcss'),
   'kolibri/store': require('kolibri/store'),
   'kolibri/styles/themeConfig': require('kolibri/styles/themeConfig'),
   'kolibri/uiText/bytesForHumans': require('kolibri/uiText/bytesForHumans'),

--- a/packages/kolibri/internal/pluginMediator.js
+++ b/packages/kolibri/internal/pluginMediator.js
@@ -2,7 +2,8 @@ import Vue from 'vue';
 import logging from 'kolibri-logging';
 import scriptLoader from 'kolibri/utils/scriptLoader';
 import { VIEWER_SUFFIX } from 'kolibri/constants';
-import { languageDirection, languageDirections, currentLanguage } from 'kolibri/utils/i18n';
+import { languageDirections, currentLanguage } from 'kolibri/utils/i18n';
+import { rtlManager } from 'kolibri/rtlcss';
 import ContentViewerLoading from '../components/internal/ContentViewer/ContentViewerLoading';
 import ContentViewerError from '../components/internal/ContentViewer/ContentViewerError';
 
@@ -383,42 +384,21 @@ export default function pluginMediatorFactory(facade) {
         } else {
           // We have a content viewer for this, but it has not been loaded, so load it, and then
           // resolve the promise when it has been loaded.
-          const urls = this._contentViewerUrls[kolibriModuleName].filter(
-            url =>
-              // By default we load CSS for the particular direction that the user interface
-              // is set to so we filter CSS files that do not match the current language direction.
-              // LTR CSS files are just end with .css, whereas RTL files end with .rtl.css
-              (languageDirection === languageDirections.RTL &&
-                url.includes(languageDirections.RTL)) ||
-              (languageDirection === languageDirections.LTR &&
-                !url.includes(languageDirections.RTL)) ||
-              !url.endsWith('css'),
-          );
-          Promise.all(urls.map(scriptLoader))
-            // Load all the urls that we just filtered (all the javascript
-            // and css files that we think we want by default).
-            .then(scriptsArray => {
-              // If we want to dynamically switch css, e.g. we loaded RTL css and later decide we
-              // need LTR, we need to keep track of the script/link tags that we instantiated when
-              // we loaded the css so that we can remove them from the DOM, and prevent a styling
-              // collision from the two conflicting style sheets
-              const storeTags = module => {
-                // Function to keep track of the <link>/<script> tags for each URL.
-                module.urlTags = {};
-                urls.forEach((url, index) => {
-                  // Key by URL and then track the DOM node returned from the scriptLoader
-                  module.urlTags[url] = scriptsArray[index];
-                });
-              };
-              // Either store them immediately on the module, if it is loaded
+          const allUrls = this._contentViewerUrls[kolibriModuleName];
+          const cssUrls = allUrls.filter(url => url.endsWith('css'));
+          const jsUrls = allUrls.filter(url => !url.endsWith('css'));
+          // Register CSS URLs with rtlManager so it can create tagged link elements
+          // and switch direction later via the same loadDirectionalCSS code path.
+          rtlManager.registerBundleCSS(kolibriModuleName, cssUrls);
+          rtlManager.loadRegisteredBundleCSS(kolibriModuleName);
+          Promise.all(jsUrls.map(scriptLoader))
+            .then(() => {
               if (this._kolibriModuleRegistry[kolibriModuleName]) {
-                storeTags(this._kolibriModuleRegistry[kolibriModuleName]);
                 resolveComponent(this._kolibriModuleRegistry[kolibriModuleName]);
               } else {
-                // Or wait until the module has been registered
+                // Wait until the module has been registered
                 this.on('kolibri_register', moduleName => {
                   if (moduleName === kolibriModuleName) {
-                    storeTags(this._kolibriModuleRegistry[kolibriModuleName]);
                     resolveComponent(this._kolibriModuleRegistry[kolibriModuleName]);
                   }
                 });
@@ -439,46 +419,17 @@ export default function pluginMediatorFactory(facade) {
      * @return {Promise} Promise that resolves when new CSS has loaded
      */
     loadDirectionalCSS(contentViewerModule, direction) {
-      return new Promise((resolve, reject) => {
-        if (!contentViewerModule.urlTags) {
-          reject(`${contentViewerModule.name} has not already loaded - improper method call`);
-        }
-        const urls = this._contentViewerUrls[contentViewerModule.name];
-        // Find the URL for the specified direction
-        // Note that this will only work if we have one CSS file per module - which is
-        // currently the case
-        const cssUrl = urls.find(
-          url =>
-            (direction === languageDirections.RTL && url.includes(languageDirections.RTL)) ||
-            (direction === languageDirections.LTR &&
-              !url.includes(languageDirections.RTL) &&
-              url.endsWith('css')),
-        );
-        // Find the URL for the direction not specified
-        const otherCssUrl = urls.find(
-          url =>
-            (direction !== languageDirections.RTL && url.includes(languageDirections.RTL)) ||
-            (direction !== languageDirections.LTR &&
-              !url.includes(languageDirections.RTL) &&
-              url.endsWith('css')),
-        );
-        if (!cssUrl || contentViewerModule.urlTags[cssUrl]) {
-          // There is no css file to try to load or
-          // this css file is already loaded and in the DOM, nothing to do.
-          resolve();
-        } else {
-          // First unload the other direction CSS from the DOM
-          if (contentViewerModule.urlTags[otherCssUrl]) {
-            contentViewerModule.urlTags[otherCssUrl].remove();
-            delete contentViewerModule.urlTags[otherCssUrl];
-          }
-          // Now load the new CSS and keep track of it for future unloading.
-          scriptLoader(cssUrl).then(tag => {
-            contentViewerModule.urlTags[cssUrl] = tag;
-            resolve();
-          });
-        }
-      });
+      // Use the RTL manager to dynamically switch CSS direction for webpack bundles.
+      // The RTL manager handles all CSS files for the bundle, not just a single file.
+      const bundleName = contentViewerModule.name;
+
+      if (direction === languageDirections.RTL) {
+        return rtlManager.enableRTL(bundleName);
+      } else if (direction === languageDirections.LTR) {
+        return rtlManager.disableRTL(bundleName);
+      } else {
+        return Promise.reject(`Invalid direction: ${direction}`);
+      }
     },
   };
   publicMethods.forEach(method => {

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -51,6 +51,7 @@
     "./constants": "./constants",
     "./heartbeat": "./heartbeat",
     "./router": "./router",
+    "./rtlcss": "./rtlcss",
     "./store": "./store",
     "./styles/themeConfig": "./styles/themeConfig",
     "./uiText/bytesForHumans": "./uiText/bytesForHumans",

--- a/packages/kolibri/rtlcss.js
+++ b/packages/kolibri/rtlcss.js
@@ -1,0 +1,182 @@
+/**
+ * Core RTL (Right-to-Left) CSS management module.
+ * Provides per-bundle RTL CSS loading and switching capabilities.
+ *
+ * This module is exposed globally and accessed by webpack bundles to enable
+ * dynamic RTL/LTR CSS switching without page reloads.
+ */
+
+import { languageDirection, languageDirections } from 'kolibri/utils/i18n';
+
+class RTLManager {
+  constructor() {
+    // Map of bundleId -> RTL state (boolean)
+    this.bundleStates = new Map();
+    // Map of bundleId -> array of LTR CSS URLs (registered for bundles loaded via pluginMediator)
+    this.bundleCSSUrls = new Map();
+  }
+
+  /**
+   * Register a webpack bundle for RTL management.
+   * Called by webpack runtime code injected into each bundle.
+   *
+   * @param {string} bundleId - The webpack bundle identifier (compilation.name)
+   * @returns {Object} Bundle-scoped API with miniCssF method for URL transformation
+   */
+  registerBundle(bundleId) {
+    if (!this.bundleStates.has(bundleId)) {
+      const isRtl = languageDirection === languageDirections.RTL;
+      this.bundleStates.set(bundleId, isRtl);
+    }
+
+    return {
+      /**
+       * Transform CSS URL based on current RTL state.
+       * Called by webpack's miniCssF hook to transform chunk URLs.
+       *
+       * @param {string} originalPath - Original CSS file path
+       * @returns {string} Transformed path (.rtl.css if RTL enabled)
+       */
+      miniCssF: originalPath => {
+        if (!originalPath) return originalPath;
+        return this.bundleStates.get(bundleId)
+          ? originalPath.replace(/\.css($|\?)/, '.rtl.css$1')
+          : originalPath;
+      },
+    };
+  }
+
+  /**
+   * Register CSS URLs for a bundle so that enableRTL/disableRTL can
+   * create initial link elements or switch direction for them.
+   *
+   * @param {string} bundleId - Bundle identifier
+   * @param {string[]} cssUrls - All CSS URLs for the bundle (both LTR and RTL variants)
+   */
+  registerBundleCSS(bundleId, cssUrls) {
+    // Store LTR URLs as the canonical set — RTL URLs are derived by URL transformation.
+    const ltrUrls = cssUrls.filter(url => !url.includes('.rtl.css'));
+    this.bundleCSSUrls.set(bundleId, ltrUrls);
+  }
+
+  /**
+   * Load CSS for a bundle using its registered URLs and the current direction.
+   * Creates tagged link elements via reloadBundleCSS — the same code path
+   * used by enableRTL/disableRTL for subsequent direction switches.
+   *
+   * @param {string} bundleId - Bundle identifier (must have been registered via registerBundleCSS)
+   */
+  loadRegisteredBundleCSS(bundleId) {
+    const isRtl = languageDirection === languageDirections.RTL;
+    this.bundleStates.set(bundleId, isRtl);
+    this.reloadBundleCSS(bundleId);
+  }
+
+  /**
+   * Enable RTL mode for a bundle.
+   * If CSS links already exist in the DOM, swaps them to RTL.
+   * If no links exist but URLs are registered, creates them.
+   *
+   * @param {string} bundleId - Bundle identifier
+   * @returns {Promise<void>}
+   */
+  async enableRTL(bundleId) {
+    if (this.bundleStates.get(bundleId)) return;
+    this.bundleStates.set(bundleId, true);
+    await this.reloadBundleCSS(bundleId);
+  }
+
+  /**
+   * Disable RTL mode for a bundle.
+   * If CSS links already exist in the DOM, swaps them to LTR.
+   * If no links exist but URLs are registered, creates them.
+   *
+   * @param {string} bundleId - Bundle identifier
+   * @returns {Promise<void>}
+   */
+  async disableRTL(bundleId) {
+    if (!this.bundleStates.get(bundleId)) return;
+    this.bundleStates.set(bundleId, false);
+    await this.reloadBundleCSS(bundleId);
+  }
+
+  /**
+   * Reload all CSS for a bundle with the current direction.
+   * If tagged link elements exist in the DOM, swaps their URLs.
+   * If no tagged links exist but URLs were registered via registerBundleCSS,
+   * creates new tagged link elements for the current direction.
+   *
+   * @param {string} bundleId - Bundle identifier
+   * @returns {Promise<void>}
+   * @throws {Error} If CSS file fails to load
+   */
+  async reloadBundleCSS(bundleId) {
+    const bundleLinks = document.querySelectorAll(
+      `link[rel="stylesheet"][data-webpack-bundle="${bundleId}"]`,
+    );
+
+    if (bundleLinks.length === 0) {
+      // No existing links — create them from registered URLs
+      const ltrUrls = this.bundleCSSUrls.get(bundleId);
+      if (ltrUrls) {
+        const shouldBeRTL = this.bundleStates.get(bundleId);
+        for (const ltrUrl of ltrUrls) {
+          const href = shouldBeRTL ? ltrUrl.replace(/\.css($|\?)/, '.rtl.css$1') : ltrUrl;
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.type = 'text/css';
+          link.href = href;
+          link.setAttribute('data-webpack-bundle', bundleId);
+          document.head.appendChild(link);
+        }
+      }
+      return;
+    }
+
+    for (const link of bundleLinks) {
+      const href = link.href;
+      const isRTL = href.includes('.rtl.css');
+      const shouldBeRTL = this.bundleStates.get(bundleId);
+
+      // Only reload if direction needs to change
+      if (isRTL !== shouldBeRTL) {
+        const newHref = shouldBeRTL
+          ? href.replace(/\.css($|\?)/, '.rtl.css$1')
+          : href.replace(/\.rtl\.css($|\?)/, '.css$1');
+
+        const newLink = document.createElement('link');
+        newLink.rel = 'stylesheet';
+        newLink.href = newHref;
+        newLink.setAttribute('data-webpack-bundle', bundleId);
+
+        // Insert new link before removing old one to prevent FOUC
+        link.parentNode.insertBefore(newLink, link.nextSibling);
+
+        await new Promise((resolve, reject) => {
+          let errored = false;
+
+          // Handle load errors - keep old CSS if new one fails
+          newLink.onerror = () => {
+            errored = true;
+            newLink.remove();
+            reject(new Error(`Failed to load ${newHref}`));
+          };
+
+          // Use double requestAnimationFrame to ensure CSS is applied
+          // This is more reliable than onload for CSS link elements
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              if (!errored) {
+                link.remove();
+                resolve();
+              }
+            });
+          });
+        });
+      }
+    }
+  }
+}
+
+// Export singleton instance
+export const rtlManager = new RTLManager();


### PR DESCRIPTION
## Summary

Enable webpack CSS code splitting to work with RTL by replacing the manual `scriptLoader`-based CSS swapping with a webpack runtime integration. An `RTLManager` module exposed on the core app tracks per-bundle RTL state, and the RTL webpack plugin injects a `miniCssF` intercept into each bundle's runtime so dynamically loaded CSS chunks automatically resolve to `.rtl.css` variants when needed.

## References

Closes #13536

## Reviewer guidance

- Testing requires `pnpm devserver` (not `devserver-hot`) since HMR uses `style-loader` which bypasses MiniCssExtractPlugin. To verify CSS code splitting works, convert a route component to an async import. For example, in `kolibri/plugins/learn/frontend/routes/index.js`:
  ```diff
  -import BookmarkPage from '../views/BookmarkPage.vue';
  +const BookmarkPage = () => import('../views/BookmarkPage.vue');
  ```
  Then navigate to the bookmarks page and confirm the CSS chunk loads correctly.
- The `miniCssF` intercept in `webpackRtlPlugin.js` resolves the `kolibri/rtlcss` module ID differently for core vs plugin bundles — core looks up the real webpack module ID at code generation time, plugins use the window global. Worth verifying both paths in the generated output.
- `reloadBundleCSS` in `rtlcss.js` uses double `requestAnimationFrame` instead of `onload` for CSS swap timing — this only covers link elements tagged with `data-webpack-bundle`, which currently only applies to async CSS chunks loaded by MiniCssExtractPlugin's runtime.
- Content viewers that call `loadDirectionalCSS` must destructure `contentDirection` from `useContentViewer` in their `setup()`. Currently only Perseus and EPUB do this — Perseus was missing it and is fixed in this PR.

## AI usage

Implemented with Claude Code. Debugged the content viewer loading stall by driving a browser to reproduce, then tracing the promise chain to find the root cause.