### PR TITLE
Refactored facility settings page with picture password settings

### DIFF
--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -1,12 +1,11 @@
-import { computed } from 'vue';
-import { useRoute } from 'vue-router/composables';
+import { computed, ref } from 'vue';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import { useFacilityConfig, useFacilityConfigMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
-import store from 'kolibri/store';
+import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import useFacilityEditor from '../useFacilityEditor';
 
 jest.mock('kolibri-common/apiResources/FacilityResource');
@@ -15,25 +14,21 @@ jest.mock('kolibri/client');
 jest.mock('kolibri/urls');
 jest.mock('kolibri-common/composables/useFacilities');
 jest.mock('kolibri-common/composables/useFacility');
-jest.mock('vue-router/composables', () => ({
-  useRoute: jest.fn(),
-}));
 
-const defaultGetters = {
-  activeFacilityId: 'default-facility-id',
-};
-
-jest.mock('kolibri/store', () => ({
-  __esModule: true,
-  default: {
-    get getters() {
-      return this._getters || defaultGetters;
-    },
-    set getters(value) {
-      this._getters = value;
-    },
-  },
-}));
+function mockSignInOptions(facilityConfig) {
+  return computed(() => {
+    const options = [];
+    if (facilityConfig.value.picture_password_settings) {
+      options.push(OptionsForSignIn.PICTURE_PASSWORD);
+    }
+    if (facilityConfig.value.learner_can_login_with_no_password) {
+      options.push(OptionsForSignIn.USERNAME_ONLY);
+    } else {
+      options.push(OptionsForSignIn.USERNAME_PASSWORD);
+    }
+    return options;
+  });
+}
 
 describe('useFacilityEditor', () => {
   const mockFacilityId = 'test-facility-id';
@@ -52,23 +47,10 @@ describe('useFacilityEditor', () => {
     learner_can_sign_up: false,
     learner_can_login_with_no_password: false,
     show_download_button_in_learn: true,
-    extra_fields: { pin_code: '1234' },
+    extra_fields: { pin_code: '5678' },
   };
 
-  let mockRoute;
-
   beforeEach(() => {
-    mockRoute = {
-      params: {},
-    };
-
-    useRoute.mockReturnValue(mockRoute);
-
-    // Mock store getters with restoration via spy
-    jest.spyOn(store, 'getters', 'get').mockImplementation(() => ({
-      activeFacilityId: mockFacilityId,
-    }));
-
     // Mock useFacilities
     useFacilities.mockReturnValue(
       useFacilitiesMock({
@@ -81,7 +63,8 @@ describe('useFacilityEditor', () => {
     useFacilityConfig.mockReturnValue(
       useFacilityConfigMock({
         fetchFacilityConfig: jest.fn().mockResolvedValue(mockFacilityConfig),
-        facilityConfig: computed(() => mockFacilityConfig),
+        facilityConfig: ref(mockFacilityConfig),
+        signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
       }),
     );
 
@@ -94,7 +77,6 @@ describe('useFacilityEditor', () => {
   describe('initialization', () => {
     it('returns reactive state with correct initial values', () => {
       const {
-        facilityId,
         facilityDatasetId,
         facilityName,
         settings,
@@ -103,13 +85,43 @@ describe('useFacilityEditor', () => {
         facilityDataLoading,
       } = useFacilityEditor(mockFacilityId);
 
-      expect(facilityId).toBe(mockFacilityId);
       expect(facilityDatasetId.value).toBe('');
       expect(facilityName.value).toBe('');
-      expect(settings.value).toEqual({});
+      expect(settings.value).toEqual(mockFacilityConfig);
       expect(settingsCopy.value).toEqual({});
       expect(isFacilityPinValid.value).toBe(false);
       expect(facilityDataLoading.value).toBe(false);
+    });
+
+    it('returns computed properties with correct initial values', () => {
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig: ref({}),
+          signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
+        }),
+      );
+
+      const {
+        settingsHaveChanged,
+        isPinSet,
+        isAttendanceFeatureEnabled,
+        isPictureLoginFeatureEnabled,
+        signInOption,
+        signInOptions,
+        picturePasswordSettings,
+        picturePasswordStyle,
+        picturePasswordShowIconText,
+      } = useFacilityEditor(mockFacilityId);
+
+      expect(settingsHaveChanged.value).toBe(false);
+      expect(isPinSet.value).toBeNull();
+      expect(isAttendanceFeatureEnabled.value).toBeDefined();
+      expect(isPictureLoginFeatureEnabled.value).toBeDefined();
+      expect(signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
+      expect(signInOptions.value).toEqual([OptionsForSignIn.USERNAME_PASSWORD]);
+      expect(picturePasswordSettings.value).toBeNull();
+      expect(picturePasswordStyle.value).toBeUndefined();
+      expect(picturePasswordShowIconText.value).toBeUndefined();
     });
   });
 
@@ -179,7 +191,7 @@ describe('useFacilityEditor', () => {
       const mockError = new Error('Failed to fetch');
       useFacilityConfig.mockReturnValue({
         fetchFacilityConfig: jest.fn().mockRejectedValue(mockError),
-        facilityConfig: computed(() => ({})),
+        facilityConfig: ref({}),
       });
 
       const { fetchFacility, facilityName, settings, settingsCopy } =
@@ -225,22 +237,258 @@ describe('useFacilityEditor', () => {
     });
   });
 
-  describe('modifyAllSettings', () => {
-    it('updates multiple settings at once', () => {
-      const { settings, modifyAllSettings } = useFacilityEditor(mockFacilityId);
-      settings.value = { learner_can_edit_username: false, learner_can_edit_name: false };
+  describe('signInOption computed', () => {
+    it('returns PICTURE_PASSWORD when in signInOptions', () => {
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig: ref({
+            ...mockFacilityConfig,
+            picture_password_settings: { icon_style: 'colorful' },
+          }),
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+        }),
+      );
 
-      modifyAllSettings({
-        learner_can_edit_username: true,
-        learner_can_edit_name: true,
-        learner_can_sign_up: true,
+      const { signInOption } = useFacilityEditor(mockFacilityId);
+      expect(signInOption.value).toBe(OptionsForSignIn.PICTURE_PASSWORD);
+    });
+
+    it('returns first signInOption when PICTURE_PASSWORD is not available', () => {
+      const { signInOption } = useFacilityEditor(mockFacilityId);
+      expect(signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
+    });
+
+    it('sets signInOption via modifySignInOption', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        learner_can_login_with_no_password: false,
+        picture_password_settings: null,
+      });
+      const signInOptions = mockSignInOptions(facilityConfig);
+      const picturePasswordSettings = computed(() => {
+        if (signInOptions.value.includes(OptionsForSignIn.PICTURE_PASSWORD)) {
+          return facilityConfig.value.picture_password_settings;
+        }
+        return null;
       });
 
-      expect(settings.value).toEqual({
-        learner_can_edit_username: true,
-        learner_can_edit_name: true,
-        learner_can_sign_up: true,
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions,
+          picturePasswordSettings,
+        }),
+      );
+
+      const { signInOption, modifySignInOption, settings } = useFacilityEditor(mockFacilityId);
+      expect(signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
+      modifySignInOption(OptionsForSignIn.PICTURE_PASSWORD);
+      // modifySignInOption updates settings.value which is the same ref as facilityConfig
+      expect(settings.value.learner_can_login_with_no_password).toBe(true);
+      expect(settings.value.picture_password_settings).toBeDefined();
+      expect(signInOption.value).toBe(OptionsForSignIn.PICTURE_PASSWORD);
+    });
+  });
+
+  describe('picturePasswordStyle computed', () => {
+    it('returns icon_style from picture_password_settings', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: PicturePasswordIconStyle.STANDARD },
+        learner_can_login_with_no_password: true,
       });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { picturePasswordStyle } = useFacilityEditor(mockFacilityId);
+      expect(picturePasswordStyle.value).toBe(PicturePasswordIconStyle.STANDARD);
+    });
+
+    it('sets picturePasswordStyle via modifyPicturePasswordSetting', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: PicturePasswordIconStyle.COLORFUL },
+        learner_can_login_with_no_password: true,
+      });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { picturePasswordStyle, modifyPicturePasswordSetting } =
+        useFacilityEditor(mockFacilityId);
+      modifyPicturePasswordSetting('icon_style', PicturePasswordIconStyle.STANDARD);
+      expect(picturePasswordStyle.value).toBe(PicturePasswordIconStyle.STANDARD);
+    });
+  });
+
+  describe('picturePasswordShowIconText computed', () => {
+    it('returns show_icon_text from picture_password_settings', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        picture_password_settings: { show_icon_text: true },
+        learner_can_login_with_no_password: true,
+      });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { picturePasswordShowIconText } = useFacilityEditor(mockFacilityId);
+      expect(picturePasswordShowIconText.value).toBe(true);
+    });
+
+    it('sets picturePasswordShowIconText via modifyPicturePasswordSetting', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        picture_password_settings: { show_icon_text: false },
+        learner_can_login_with_no_password: true,
+      });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { picturePasswordShowIconText, modifyPicturePasswordSetting } =
+        useFacilityEditor(mockFacilityId);
+      modifyPicturePasswordSetting('show_icon_text', true);
+      expect(picturePasswordShowIconText.value).toBe(true);
+    });
+  });
+
+  describe('modifySignInOption', () => {
+    it('sets PICTURE_PASSWORD and default picture_password_settings', () => {
+      const facilityConfig = ref({
+        learner_can_login_with_no_password: false,
+        picture_password_settings: null,
+      });
+      const signInOptions = mockSignInOptions(facilityConfig);
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions,
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+
+      modifySignInOption(OptionsForSignIn.PICTURE_PASSWORD);
+
+      expect(settings.value.learner_can_login_with_no_password).toBe(true);
+      expect(settings.value.picture_password_settings).toEqual({
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: false,
+      });
+    });
+
+    it('sets USERNAME_ONLY and clears picture_password_settings', () => {
+      const facilityConfig = ref({
+        learner_can_login_with_no_password: false,
+        picture_password_settings: { icon_style: 'colorful' },
+      });
+      const signInOptions = mockSignInOptions(facilityConfig);
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions,
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+
+      modifySignInOption(OptionsForSignIn.USERNAME_ONLY);
+
+      expect(settings.value.learner_can_login_with_no_password).toBe(true);
+      expect(settings.value.picture_password_settings).toBeNull();
+    });
+
+    it('sets USERNAME_PASSWORD and clears picture_password_settings', () => {
+      const facilityConfig = ref({
+        learner_can_login_with_no_password: true,
+        picture_password_settings: { icon_style: 'colorful' },
+      });
+      const signInOptions = mockSignInOptions(facilityConfig);
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions,
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+
+      modifySignInOption(OptionsForSignIn.USERNAME_PASSWORD);
+
+      expect(settings.value.learner_can_login_with_no_password).toBe(false);
+      expect(settings.value.picture_password_settings).toBeNull();
+    });
+  });
+
+  describe('modifyPicturePasswordSetting', () => {
+    it('updates picture_password_settings when PICTURE_PASSWORD is enabled', () => {
+      const facilityConfig = ref({
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'colorful' },
+        learner_can_login_with_no_password: true,
+      });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+          signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
+          picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
+        }),
+      );
+
+      const { settings, modifyPicturePasswordSetting } = useFacilityEditor(mockFacilityId);
+
+      modifyPicturePasswordSetting('icon_style', PicturePasswordIconStyle.STANDARD);
+
+      expect(settings.value.picture_password_settings.icon_style).toBe(
+        PicturePasswordIconStyle.STANDARD,
+      );
+    });
+  });
+
+  describe('modifyExtraFields', () => {
+    it('updates extra_fields in settings', () => {
+      const facilityConfig = ref({ extra_fields: { pin_code: '1234' } });
+
+      useFacilityConfig.mockReturnValue(
+        useFacilityConfigMock({
+          facilityConfig,
+        }),
+      );
+
+      const { settings, modifyExtraFields } = useFacilityEditor(mockFacilityId);
+
+      modifyExtraFields({ pin_code: '5678' });
+
+      expect(settings.value.extra_fields).toEqual({ pin_code: '5678' });
     });
   });
 
@@ -292,7 +540,6 @@ describe('useFacilityEditor', () => {
 
       expect(facilityDatasetId.value).toBe('');
       expect(facilityName.value).toBe('');
-      expect(settings.value).toEqual({});
       expect(settingsCopy.value).toEqual({});
       expect(isFacilityPinValid.value).toBe(false);
       expect(facilityDataLoading.value).toBe(false);

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -5,6 +5,7 @@ import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDataset
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
 import useFacilities from 'kolibri-common/composables/useFacilities';
+import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import { useFacilityConfig } from 'kolibri-common/composables/useFacility';
 
 /**
@@ -12,12 +13,19 @@ import { useFacilityConfig } from 'kolibri-common/composables/useFacility';
  */
 export default function useFacilityEditor(facilityId) {
   const { fetchFacilities, getFacility } = useFacilities();
-  const { fetchFacilityConfig } = useFacilityConfig(facilityId);
+  const {
+    isAttendanceFeatureEnabled,
+    isPictureLoginFeatureEnabled,
+    signInOptions,
+    picturePasswordSettings,
+    // TODO: update this composable to use 'facilityConfig' naming instead
+    facilityConfig: settings,
+    fetchFacilityConfig,
+  } = useFacilityConfig(facilityId);
 
   // Reactive state
   const facilityDatasetId = ref('');
   const facilityName = ref('');
-  const settings = ref({});
   const settingsCopy = ref({});
   const isFacilityPinValid = ref(false);
   const facilityDataLoading = ref(false);
@@ -32,6 +40,37 @@ export default function useFacilityEditor(facilityId) {
     }
     return null;
   });
+  const signInOption = computed({
+    get() {
+      // the facility editor uses radio buttons, so it's simpler to have this computed value
+      // return a single value
+      if (signInOptions.value.includes(OptionsForSignIn.PICTURE_PASSWORD)) {
+        return OptionsForSignIn.PICTURE_PASSWORD;
+      }
+      return signInOptions.value[0];
+    },
+    set(value) {
+      modifySignInOption(value);
+    },
+  });
+  const picturePasswordStyle = computed({
+    get() {
+      return picturePasswordSettings.value?.icon_style;
+    },
+    set(value) {
+      if (Object.values(PicturePasswordIconStyle).includes(value)) {
+        modifyPicturePasswordSetting('icon_style', value);
+      }
+    },
+  });
+  const picturePasswordShowIconText = computed({
+    get() {
+      return picturePasswordSettings.value?.show_icon_text;
+    },
+    set(value) {
+      modifyPicturePasswordSetting('show_icon_text', Boolean(value));
+    },
+  });
 
   // Actions
   function setLoading(loading) {
@@ -45,17 +84,15 @@ export default function useFacilityEditor(facilityId) {
     setLoading(true);
 
     try {
-      const [facilityConfig] = await Promise.all([fetchFacilityConfig(), fetchFacilities()]);
+      await Promise.all([fetchFacilityConfig(), fetchFacilities()]);
 
       // Facility name set with watcher
-      facilityDatasetId.value = facilityConfig.id;
+      facilityDatasetId.value = settings.value.id;
       facilityName.value = facility.value.name;
-      settings.value = { ...facilityConfig };
-      settingsCopy.value = { ...facilityConfig };
+      settingsCopy.value = { ...settings.value };
       setLoading(false);
     } catch (error) {
       facilityName.value = '';
-      settings.value = {};
       settingsCopy.value = {};
       setLoading(false);
       throw error;
@@ -74,8 +111,33 @@ export default function useFacilityEditor(facilityId) {
     }
   }
 
-  function modifyAllSettings(newSettings) {
-    settings.value = Object.assign({}, settings.value, newSettings);
+  function modifySignInOption(value) {
+    if (value === OptionsForSignIn.PICTURE_PASSWORD) {
+      modifySetting('learner_can_login_with_no_password', true);
+      // Default
+      modifySetting('picture_password_settings', {
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: false,
+      });
+    } else {
+      modifySetting('learner_can_login_with_no_password', value === OptionsForSignIn.USERNAME_ONLY);
+      modifySetting('picture_password_settings', null);
+    }
+  }
+
+  function modifyPicturePasswordSetting(name, value) {
+    if (signInOptions.value.includes(OptionsForSignIn.PICTURE_PASSWORD)) {
+      modifySetting('picture_password_settings', {
+        ...picturePasswordSettings.value,
+        [name]: value,
+      });
+    }
+  }
+
+  function modifyExtraFields(newExtraFields) {
+    settings.value = Object.assign({}, settings.value, {
+      extra_fields: newExtraFields,
+    });
   }
 
   function copySettings() {
@@ -89,7 +151,6 @@ export default function useFacilityEditor(facilityId) {
   function resetState() {
     facilityDatasetId.value = '';
     facilityName.value = '';
-    settings.value = {};
     settingsCopy.value = {};
     isFacilityPinValid.value = false;
     setLoading(false);
@@ -127,7 +188,7 @@ export default function useFacilityEditor(facilityId) {
       method: 'POST',
       data: payload,
     });
-    modifyAllSettings({ extra_fields: response.data.extra_fields });
+    modifyExtraFields(response.data.extra_fields);
     await saveFacilityConfig();
   }
 
@@ -136,7 +197,7 @@ export default function useFacilityEditor(facilityId) {
       url: urls['kolibri:core:facilitydataset_update_pin'](facilityDatasetId.value),
       method: 'PATCH',
     });
-    modifyAllSettings({ extra_fields: response.data.extra_fields });
+    modifyExtraFields(response.data.extra_fields);
     await saveFacilityConfig();
   }
 
@@ -152,10 +213,19 @@ export default function useFacilityEditor(facilityId) {
     // Computed
     settingsHaveChanged,
     isPinSet,
+    isAttendanceFeatureEnabled,
+    isPictureLoginFeatureEnabled,
+    signInOption,
+    signInOptions,
+    picturePasswordSettings,
+    picturePasswordStyle,
+    picturePasswordShowIconText,
     // Actions
     fetchFacility,
     modifySetting,
-    modifyAllSettings,
+    modifySignInOption,
+    modifyPicturePasswordSetting,
+    modifyExtraFields,
     copySettings,
     undoSettingsChange,
     resetState,

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -34,7 +34,7 @@
         class="facility-loader"
       />
       <template v-else-if="settings !== null">
-        <div class="mb">
+        <section class="facility-name facility-settings">
           <h2>{{ coreString('facilityLabel') }}</h2>
           <p class="current-facility-name">
             {{ coreString('facilityNameWithId', { facilityName: facilityName, id: lastPartId }) }}
@@ -46,47 +46,116 @@
               @click="showEditFacilityModal = true"
             />
           </p>
-        </div>
+        </section>
 
-        <div class="mb">
+        <!-- Users Section -->
+        <section class="facility-settings users">
+          <h3>{{ coreString('usersLabel') }}</h3>
           <div class="settings">
-            <template v-for="setting in settingsList">
-              <template
-                v-if="
-                  setting.key !== 'learner_can_edit_password' &&
-                    setting.key !== 'learner_can_login_with_no_password'
-                "
-              >
-                <KCheckbox
-                  :key="setting.key"
-                  :label="setting.label$()"
-                  :checked="settings[setting.key]"
-                  @change="toggleSetting(setting.key)"
-                />
-              </template>
-              <template v-else-if="setting.key === 'learner_can_login_with_no_password'">
-                <KCheckbox
-                  :key="setting.key"
-                  :label="learnerNeedPasswordToLogin$()"
-                  :checked="!settings['learner_can_login_with_no_password']"
-                  @change="toggleSetting('learner_can_login_with_no_password')"
-                />
-                <KCheckbox
-                  :key="setting.key + 'learner_can_edit_password'"
-                  :disabled="settings['learner_can_login_with_no_password']"
-                  :label="learnerCanEditPassword$()"
-                  :checked="settings['learner_can_edit_password']"
-                  class="checkbox-password"
-                  @change="toggleSetting('learner_can_edit_password')"
-                />
-              </template>
-            </template>
+            <KCheckbox
+              v-model="settings.learner_can_edit_username"
+              :label="learnerCanEditUsername$()"
+              data-testid="learner_can_edit_username"
+            />
+            <KCheckbox
+              v-model="settings.learner_can_edit_name"
+              :label="learnerCanEditName$()"
+              data-testid="learner_can_edit_name"
+            />
+            <KCheckbox
+              v-model="settings.learner_can_sign_up"
+              :label="learnerCanSignUp$()"
+              data-testid="learner_can_sign_up"
+            />
+            <KCheckbox
+              v-if="isAttendanceFeatureEnabled"
+              v-model="settings.enable_mark_attendance"
+              :label="enableMarkAttendance$()"
+              data-testid="enable_mark_attendance"
+            />
           </div>
+        </section>
 
-          <div></div>
-        </div>
+        <!-- Resources Section -->
+        <section class="facility-settings resources">
+          <h3>{{ coreString('resourcesLabel') }}</h3>
+          <div class="settings">
+            <KCheckbox
+              v-model="settings.show_download_button_in_learn"
+              :label="showDownloadButtonInLearn$()"
+              data-testid="show_download_button_in_learn"
+            />
+          </div>
+        </section>
 
-        <div class="">
+        <!-- How learners sign in Section -->
+        <section class="facility-settings learner-signin">
+          <h3>{{ howLearnersSignIn$() }}</h3>
+          <div class="settings">
+            <KRadioButtonGroup>
+              <KRadioButton
+                v-model="signInOption"
+                :label="enterUsernameAndPassword$()"
+                :buttonValue="OptionsForSignIn.USERNAME_PASSWORD"
+                :data-testid="OptionsForSignIn.USERNAME_PASSWORD"
+              />
+              <KCheckbox
+                v-if="signInOption === OptionsForSignIn.USERNAME_PASSWORD"
+                v-model="settings.learner_can_edit_password"
+                :label="learnerCanEditPassword$()"
+                class="nested-settings"
+                data-testid="learner_can_edit_password"
+              />
+
+              <KRadioButton
+                v-model="signInOption"
+                :label="enterUsernameOnly$()"
+                :buttonValue="OptionsForSignIn.USERNAME_ONLY"
+                :data-testid="OptionsForSignIn.USERNAME_ONLY"
+              />
+
+              <KRadioButton
+                v-if="isPictureLoginFeatureEnabled"
+                v-model="signInOption"
+                :label="picturePassword$()"
+                :buttonValue="OptionsForSignIn.PICTURE_PASSWORD"
+                :description="picturePasswordDescription$()"
+                :data-testid="OptionsForSignIn.PICTURE_PASSWORD"
+              />
+              <KRadioButtonGroup
+                v-if="
+                  isPictureLoginFeatureEnabled && signInOption === OptionsForSignIn.PICTURE_PASSWORD
+                "
+                class="nested-settings picture-password-settings"
+                :aria-label="iconStyle$()"
+              >
+                <KRadioButton
+                  v-model="picturePasswordStyle"
+                  :label="childFriendlyIcons$()"
+                  :buttonValue="PicturePasswordIconStyle.COLORFUL"
+                  data-testid="child_friendly_icons"
+                />
+                <KRadioButton
+                  v-model="picturePasswordStyle"
+                  :label="standardIcons$()"
+                  :buttonValue="PicturePasswordIconStyle.STANDARD"
+                  data-testid="standard_icons"
+                />
+                <hr
+                  class="divider"
+                  :style="dividerStyle"
+                >
+                <KCheckbox
+                  v-model="picturePasswordShowIconText"
+                  :label="showIconNames$()"
+                  data-testid="show_icon_text"
+                />
+              </KRadioButtonGroup>
+            </KRadioButtonGroup>
+          </div>
+        </section>
+
+        <section>
           <h2>{{ deviceManagementPin$() }}</h2>
 
           <p>{{ deviceManagementDescription$() }}</p>
@@ -111,7 +180,7 @@
               />
             </template>
           </KButton>
-        </div>
+        </section>
 
         <div
           v-if="isAppContext"
@@ -187,7 +256,7 @@
 
   import { mapGetters } from 'vuex';
   import { ref, onMounted, computed } from 'vue';
-  import camelCase from 'lodash/camelCase';
+  import { useRoute } from 'vue-router/composables';
   import commonCoreStrings, { coreString } from 'kolibri/uiText/commonCoreStrings';
   import urls from 'kolibri/urls';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
@@ -195,9 +264,11 @@
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import { handleApiError } from 'kolibri/utils/appError';
-  import { createTranslator, currentLanguage } from 'kolibri/utils/i18n';
-  import { useRoute } from 'vue-router/composables';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+  import { createTranslator } from 'kolibri/utils/i18n';
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+
+  import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
   import useFacilityEditor from '../../composables/useFacilityEditor';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import RemovePinModal from './RemovePinModal';
@@ -223,27 +294,20 @@
     },
   });
   const facilityConfigPageStrings = createTranslator('FacilityConfigPage', {
-    // These are not going to be picked up by the linter because snake cased versions
-    // are used to get the keys to these strings.
-    /* eslint-disable kolibri/vue-no-unused-translations */
-    learnerCanEditName: {
-      message: 'Allow learners to edit their full name',
-      context: "Option on 'Facility settings' page.",
-    },
-    learnerCanEditPassword: {
-      message: 'Allow learners to edit their password when signed in',
-      context: "Option on 'Facility settings' page.",
-    },
     learnerCanEditUsername: {
       message: 'Allow learners to edit their username',
+      context: "Option on 'Facility settings' page.",
+    },
+    learnerCanEditName: {
+      message: 'Allow learners to edit their full name',
       context: "Option on 'Facility settings' page.",
     },
     learnerCanSignUp: {
       message: 'Allow learners to create accounts',
       context: "Option on 'Facility settings' page.",
     },
-    learnerNeedPasswordToLogin: {
-      message: 'Require password for learners',
+    learnerCanEditPassword: {
+      message: 'Allow learners to edit their password when signed in',
       context: "Option on 'Facility settings' page.",
     },
     showDownloadButtonInLearn: {
@@ -254,7 +318,6 @@
       message: 'Allow coaches to take attendance (English only)',
       context: "Option on 'Facility settings' page.",
     },
-    /* eslint-enable kolibri/vue-no-unused-translations */
     saveFailure: {
       message: 'There was a problem saving your settings',
       context: 'Status report after the facility change operation.',
@@ -294,16 +357,6 @@
     },
   });
 
-  // See FacilityDataset in core.auth.models for details
-  const settingKeys = [
-    'learner_can_edit_username',
-    'learner_can_edit_password',
-    'learner_can_edit_name',
-    'learner_can_sign_up',
-    'learner_can_login_with_no_password',
-    'show_download_button_in_learn',
-  ];
-
   export default {
     name: 'FacilityConfigPage',
     metaInfo() {
@@ -334,8 +387,12 @@
         facilityDataLoading,
         settingsHaveChanged,
         isPinSet,
+        isAttendanceFeatureEnabled,
+        isPictureLoginFeatureEnabled,
+        signInOption,
+        picturePasswordStyle,
+        picturePasswordShowIconText,
         fetchFacility,
-        modifySetting,
         undoSettingsChange,
         saveFacilityName,
         saveFacilityConfig,
@@ -347,7 +404,11 @@
         pageHeader$,
         pageDescription$,
         deviceSettings$,
-        learnerNeedPasswordToLogin$,
+        learnerCanEditUsername$,
+        learnerCanEditName$,
+        learnerCanSignUp$,
+        showDownloadButtonInLearn$,
+        enableMarkAttendance$,
         learnerCanEditPassword$,
         deviceManagementPin$,
         deviceManagementDescription$,
@@ -355,7 +416,17 @@
         saveSuccess$,
         saveFailure$,
       } = facilityConfigPageStrings;
-
+      const {
+        howLearnersSignIn$,
+        enterUsernameAndPassword$,
+        enterUsernameOnly$,
+        picturePassword$,
+        picturePasswordDescription$,
+        childFriendlyIcons$,
+        standardIcons$,
+        showIconNames$,
+        iconStyle$,
+      } = picturePasswordStrings;
       const { pinPlaceholder$ } = pinAuthenticationModalStrings;
       const { changeLocation$ } = deviceSettingsPageStrings;
 
@@ -365,19 +436,6 @@
       const handleViewModal = ref(false);
       const handleChangePinModal = ref(false);
       const handleRemovePinModal = ref(false);
-
-      // This dynamic templating for these settings will be refactored later
-      const _settingKeys = computed(() => {
-        return currentLanguage === 'en'
-          ? settingKeys.concat('enable_mark_attendance')
-          : settingKeys;
-      });
-      const settingsList = computed(() => {
-        return _settingKeys.value.map(key => ({
-          key,
-          label$: () => facilityConfigPageStrings.$tr(camelCase(key)),
-        }));
-      });
 
       // computed
       const deviceSettingsUrl = computed(() => {
@@ -391,9 +449,7 @@
         return facilityId ? facilityId.slice(0, 4) : '';
       });
       const changePINLabel = computed(() => {
-        /* eslint-disable kolibri/vue-no-undefined-string-uses */
         return `${changeLocation$()} ${pinPlaceholder$()}`;
-        /* eslint-enable */
       });
       const viewPINLabel = computed(() => {
         return `${coreString('viewAction')} ${pinPlaceholder$()}`;
@@ -417,10 +473,6 @@
             createSnackbar(coreString('changesNotSavedNotification'));
           }
         }
-      }
-
-      function toggleSetting(settingName) {
-        modifySetting(settingName, !settings.value[settingName]);
       }
 
       async function saveConfig() {
@@ -486,8 +538,13 @@
       });
 
       return {
-        pageLoading,
+        // Constants
+        OptionsForSignIn,
+        PicturePasswordIconStyle,
+
+        // State
         isAppContext,
+        pageLoading,
         isSuperuser,
         userIsMultiFacilityAdmin,
         facilityName,
@@ -497,7 +554,6 @@
         settingsHaveChanged,
         isPinSet,
         showEditFacilityModal,
-        settingsList,
         createPinShow,
         handleViewModal,
         handleChangePinModal,
@@ -505,10 +561,14 @@
         deviceSettingsUrl,
         lastPartId,
         dropdownOptions,
+        isAttendanceFeatureEnabled,
+        isPictureLoginFeatureEnabled,
+        signInOption,
+        picturePasswordStyle,
+        picturePasswordShowIconText,
 
         // Functions
         submitFacilityName,
-        toggleSetting,
         saveConfig,
         handleCreatePinSubmit,
         handleChangePinSubmit,
@@ -520,15 +580,31 @@
         pageHeader$,
         pageDescription$,
         deviceSettings$,
-        learnerNeedPasswordToLogin$,
+        learnerCanEditUsername$,
+        learnerCanEditName$,
+        learnerCanSignUp$,
+        enableMarkAttendance$,
         learnerCanEditPassword$,
+        showDownloadButtonInLearn$,
         deviceManagementPin$,
         deviceManagementDescription$,
         createPinBtn$,
+        howLearnersSignIn$,
+        enterUsernameAndPassword$,
+        enterUsernameOnly$,
+        picturePassword$,
+        picturePasswordDescription$,
+        childFriendlyIcons$,
+        standardIcons$,
+        showIconNames$,
+        iconStyle$,
       };
     },
     computed: {
       ...mapGetters(['facilityPageLinks']),
+      dividerStyle() {
+        return `color : ${this.$themeTokens.fineLine}`;
+      },
     },
   };
 
@@ -537,18 +613,18 @@
 
 <style lang="scss" scoped>
 
-  .mb {
-    margin-bottom: 2rem;
+  .facility-settings {
+    margin-bottom: 20px;
+  }
+
+  .facility-settings > h3 {
+    margin: 8px 0;
   }
 
   .settings > label {
     margin-bottom: 2rem;
     font-weight: bold;
     cursor: pointer;
-  }
-
-  .checkbox-password {
-    margin-left: 24px;
   }
 
   .save-button {
@@ -564,6 +640,21 @@
   .save-changes-button {
     margin-top: 24px;
     margin-left: -8px;
+  }
+
+  .nested-settings {
+    // radio button width: 24px,
+    // label left padding: 8px,
+    // adjustment: -1px (slight left padding on checkbox)
+    margin-left: #{24px + 8px - 1px};
+  }
+
+  .picture-password-settings {
+    margin-top: 12px;
+  }
+
+  .divider {
+    border-style: solid;
   }
 
 </style>

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -1,11 +1,12 @@
 import { render, screen, fireEvent, within } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line
+import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import useFacilityEditor from '../../composables/useFacilityEditor';
 import ConfigPage from '../FacilityConfigPage';
-import makeStore from '../../__tests__/utils/makeStore';
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../../device/frontend/views/DeviceSettingsPage/api.js', () => ({
@@ -33,6 +34,50 @@ function createMockFacilityConfig(overrides = {}) {
     learner_can_sign_up: false,
     learner_can_login_with_no_password: false,
     show_download_button_in_learn: false,
+    picture_password_settings: null,
+  });
+
+  // Create base mocks that can be overridden
+  const baseModifySetting = jest.fn((name, value) => {
+    settings.value[name] = value;
+  });
+  const baseModifySignInOption = jest.fn();
+  const baseModifyPicturePasswordSetting = jest.fn();
+
+  // Allow overrides to replace the mocks
+  const modifySetting = overrides.modifySetting || baseModifySetting;
+  const modifySignInOption = overrides.modifySignInOption || baseModifySignInOption;
+  const modifyPicturePasswordSetting =
+    overrides.modifyPicturePasswordSetting || baseModifyPicturePasswordSetting;
+
+  // Mock getters/setters for computed properties that call the modify functions
+  const signInOptionValue = ref(overrides.signInOption || OptionsForSignIn.USERNAME_PASSWORD);
+  const signInOption = computed({
+    get: () => signInOptionValue.value,
+    set: value => {
+      signInOptionValue.value = value;
+      modifySignInOption(value);
+    },
+  });
+
+  const picturePasswordStyleValue = ref(
+    overrides.picturePasswordStyle || PicturePasswordIconStyle.COLORFUL,
+  );
+  const picturePasswordStyle = computed({
+    get: () => picturePasswordStyleValue.value,
+    set: value => {
+      picturePasswordStyleValue.value = value;
+      modifyPicturePasswordSetting('icon_style', value);
+    },
+  });
+
+  const picturePasswordShowIconTextValue = ref(overrides.picturePasswordShowIconText || false);
+  const picturePasswordShowIconText = computed({
+    get: () => picturePasswordShowIconTextValue.value,
+    set: value => {
+      picturePasswordShowIconTextValue.value = value;
+      modifyPicturePasswordSetting('show_icon_text', value);
+    },
   });
 
   return {
@@ -43,10 +88,16 @@ function createMockFacilityConfig(overrides = {}) {
     facilityDataLoading: ref(false),
     settingsHaveChanged: ref(false),
     isPinSet: ref(null),
-    fetchFacility: jest.fn(),
-    modifySetting: jest.fn((name, value) => {
-      settings.value[name] = value;
+    isAttendanceFeatureEnabled: ref(true),
+    isPictureLoginFeatureEnabled: ref(true),
+    picturePasswordSettings: ref({
+      icon_style: PicturePasswordIconStyle.COLORFUL,
+      show_icon_text: false,
     }),
+    fetchFacility: jest.fn(),
+    modifySetting,
+    modifySignInOption,
+    modifyPicturePasswordSetting,
     copySettings: jest.fn(),
     undoSettingsChange: jest.fn(),
     saveFacilityName: jest.fn(),
@@ -54,6 +105,10 @@ function createMockFacilityConfig(overrides = {}) {
     setPin: jest.fn(),
     unsetPin: jest.fn(),
     ...overrides,
+    // these already have overrides applied
+    signInOption,
+    picturePasswordStyle,
+    picturePasswordShowIconText,
   };
 }
 
@@ -61,10 +116,8 @@ function renderPage({ props = {}, isAppContext = false, mockFacilityConfig = {} 
   useUser.mockImplementation(() => useUserMock({ isAppContext }));
   useFacilityEditor.mockImplementation(() => createMockFacilityConfig(mockFacilityConfig));
 
-  const store = makeStore();
-  const dispatch = jest.spyOn(store, 'dispatch');
-  const utils = render(ConfigPage, { props, store });
-  return { ...utils, store, dispatch };
+  const utils = render(ConfigPage, { props });
+  return { ...utils };
 }
 
 describe('facility config page view', () => {
@@ -77,31 +130,152 @@ describe('facility config page view', () => {
 
   it('shows all facility setting checkboxes to the admin', () => {
     renderPage();
-    const labels = [
-      'Allow learners to edit their username',
-      'Allow learners to edit their full name',
-      'Allow learners to create accounts',
-      'Require password for learners',
-      'Allow learners to edit their password when signed in',
-      "Show 'download' button with resources",
-      'Allow coaches to take attendance (English only)',
-    ];
-    labels.forEach(label => {
-      expect(screen.getByLabelText(label)).toBeInTheDocument();
-    });
+    // Users section
+    expect(screen.getByTestId('learner_can_edit_username')).toBeInTheDocument();
+    expect(screen.getByTestId('learner_can_edit_name')).toBeInTheDocument();
+    expect(screen.getByTestId('learner_can_sign_up')).toBeInTheDocument();
+
+    // Resources section
+    expect(screen.getByTestId('show_download_button_in_learn')).toBeInTheDocument();
+
+    // How learners sign in section - radio buttons
+    expect(screen.getByTestId(OptionsForSignIn.USERNAME_PASSWORD)).toBeInTheDocument();
+    expect(screen.getByTestId(OptionsForSignIn.USERNAME_ONLY)).toBeInTheDocument();
+    expect(screen.getByTestId(OptionsForSignIn.PICTURE_PASSWORD)).toBeInTheDocument();
   });
 
   it('updates a facility setting when the admin toggles a checkbox', async () => {
-    const modifySettingMock = jest.fn();
-    renderPage({ mockFacilityConfig: { modifySetting: modifySettingMock } });
-    await fireEvent.click(screen.getByLabelText('Allow learners to edit their username'));
-    expect(modifySettingMock).toHaveBeenCalledWith('learner_can_edit_username', true);
+    const settings = ref({});
+    renderPage({ mockFacilityConfig: { settings } });
+    await fireEvent.click(screen.getByTestId('learner_can_edit_username'));
+    expect(settings.value.learner_can_edit_username).toBe(true);
+  });
+
+  it('updates learner_can_edit_name when toggling the checkbox', async () => {
+    const settings = ref({});
+    renderPage({ mockFacilityConfig: { settings } });
+    await fireEvent.click(screen.getByTestId('learner_can_edit_name'));
+    expect(settings.value.learner_can_edit_name).toBe(true);
+  });
+
+  it('updates learner_can_sign_up when toggling the checkbox', async () => {
+    const settings = ref({});
+    renderPage({ mockFacilityConfig: { settings } });
+    await fireEvent.click(screen.getByTestId('learner_can_sign_up'));
+    expect(settings.value.learner_can_sign_up).toBe(true);
+  });
+
+  it('updates enable_mark_attendance when toggling the checkbox', async () => {
+    const settings = ref({});
+    renderPage({ mockFacilityConfig: { settings } });
+    await fireEvent.click(screen.getByTestId('enable_mark_attendance'));
+    expect(settings.value.enable_mark_attendance).toBe(true);
+  });
+
+  it('updates show_download_button_in_learn when toggling the checkbox', async () => {
+    const settings = ref({});
+    renderPage({ mockFacilityConfig: { settings } });
+    await fireEvent.click(screen.getByTestId('show_download_button_in_learn'));
+    expect(settings.value.show_download_button_in_learn).toBe(true);
+  });
+
+  it('updates learner_can_edit_password when toggling the checkbox', async () => {
+    const mockFacilityConfig = createMockFacilityConfig();
+    renderPage({ mockFacilityConfig });
+    const checkbox = screen.getByTestId('learner_can_edit_password');
+    await fireEvent.click(checkbox);
+    expect(mockFacilityConfig.settings.value.learner_can_edit_password).toBe(true);
+  });
+
+  it('updates show_icon_text when toggling the checkbox', async () => {
+    const mockModifyPicturePasswordSetting = jest.fn();
+    renderPage({
+      mockFacilityConfig: {
+        modifyPicturePasswordSetting: mockModifyPicturePasswordSetting,
+        signInOption: OptionsForSignIn.PICTURE_PASSWORD,
+      },
+    });
+    await fireEvent.click(screen.getByTestId('show_icon_text'));
+    expect(mockModifyPicturePasswordSetting).toHaveBeenCalledWith('show_icon_text', true);
+  });
+
+  it('calls modifySignInOption when selecting username_password radio button', async () => {
+    const mockModifySignInOption = jest.fn();
+    renderPage({ mockFacilityConfig: { modifySignInOption: mockModifySignInOption } });
+    await fireEvent.click(screen.getByTestId(OptionsForSignIn.USERNAME_PASSWORD));
+    expect(mockModifySignInOption).toHaveBeenCalledWith(OptionsForSignIn.USERNAME_PASSWORD);
+    expect(screen.getByTestId('learner_can_edit_password')).toBeInTheDocument();
+  });
+
+  it('calls modifySignInOption when selecting username_only radio button', async () => {
+    const mockModifySignInOption = jest.fn();
+    renderPage({
+      mockFacilityConfig: createMockFacilityConfig({ modifySignInOption: mockModifySignInOption }),
+    });
+    await fireEvent.click(screen.getByTestId(OptionsForSignIn.USERNAME_ONLY));
+    expect(mockModifySignInOption).toHaveBeenCalledWith(OptionsForSignIn.USERNAME_ONLY);
+    expect(() => screen.getByTestId('learner_can_edit_password')).toThrow();
+  });
+
+  it('calls modifySignInOption when selecting picture_password radio button', async () => {
+    const mockModifySignInOption = jest.fn();
+    renderPage({ mockFacilityConfig: { modifySignInOption: mockModifySignInOption } });
+    await fireEvent.click(screen.getByTestId(OptionsForSignIn.PICTURE_PASSWORD));
+    expect(mockModifySignInOption).toHaveBeenCalledWith(OptionsForSignIn.PICTURE_PASSWORD);
+    expect(screen.getByTestId('child_friendly_icons')).toBeInTheDocument();
+    expect(screen.getByTestId('standard_icons')).toBeInTheDocument();
+    expect(screen.getByTestId('show_icon_text')).toBeInTheDocument();
+  });
+
+  it('calls modifyPicturePasswordSetting when selecting child_friendly_icons radio button', async () => {
+    const mockFacilityConfig = createMockFacilityConfig({
+      signInOption: OptionsForSignIn.PICTURE_PASSWORD,
+      picturePasswordStyle: PicturePasswordIconStyle.STANDARD,
+      picturePasswordShowIconText: false,
+    });
+    renderPage({ mockFacilityConfig });
+
+    await fireEvent.click(screen.getByTestId('child_friendly_icons'));
+    expect(mockFacilityConfig.modifyPicturePasswordSetting).toHaveBeenCalledWith(
+      'icon_style',
+      PicturePasswordIconStyle.COLORFUL,
+    );
+  });
+
+  it('calls modifyPicturePasswordSetting when selecting standard radio button', async () => {
+    const mockFacilityConfig = createMockFacilityConfig({
+      signInOption: OptionsForSignIn.PICTURE_PASSWORD,
+      picturePasswordStyle: PicturePasswordIconStyle.COLORFUL,
+      picturePasswordShowIconText: false,
+    });
+    renderPage({ mockFacilityConfig });
+
+    await fireEvent.click(screen.getByTestId('standard_icons'));
+    expect(mockFacilityConfig.modifyPicturePasswordSetting).toHaveBeenCalledWith(
+      'icon_style',
+      PicturePasswordIconStyle.STANDARD,
+    );
+  });
+
+  it('calls modifyPicturePasswordSetting when checking show_icon_text', async () => {
+    const mockFacilityConfig = createMockFacilityConfig({
+      signInOption: OptionsForSignIn.PICTURE_PASSWORD,
+      picturePasswordStyle: PicturePasswordIconStyle.COLORFUL,
+      picturePasswordShowIconText: false,
+    });
+    renderPage({ mockFacilityConfig });
+
+    await fireEvent.click(screen.getByTestId('show_icon_text'));
+    expect(mockFacilityConfig.modifyPicturePasswordSetting).toHaveBeenCalledWith(
+      'show_icon_text',
+      true,
+    );
   });
 
   it('saves changes when the admin clicks Save changes', async () => {
     const saveFacilityConfigMock = jest.fn();
     renderPage({ mockFacilityConfig: { saveFacilityConfig: saveFacilityConfigMock } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('saveChangesAction') }));
     expect(saveFacilityConfigMock).toHaveBeenCalled();
   });
 
@@ -110,9 +284,11 @@ describe('facility config page view', () => {
       renderPage({ isAppContext: false });
       const bottomBar = screen.getByTestId('bottom-bar');
       const pageContainer = screen.getByTestId('page-container');
-      expect(within(bottomBar).getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
       expect(
-        within(pageContainer).queryByRole('button', { name: 'Save changes' }),
+        within(bottomBar).getByRole('button', { name: coreString('saveChangesAction') }),
+      ).toBeInTheDocument();
+      expect(
+        within(pageContainer).queryByRole('button', { name: coreString('saveChangesAction') }),
       ).not.toBeInTheDocument();
     });
   });
@@ -123,10 +299,10 @@ describe('facility config page view', () => {
       const bottomBar = screen.getByTestId('bottom-bar');
       const pageContainer = screen.getByTestId('page-container');
       expect(
-        within(bottomBar).queryByRole('button', { name: 'Save changes' }),
+        within(bottomBar).queryByRole('button', { name: coreString('saveChangesAction') }),
       ).not.toBeInTheDocument();
       expect(
-        within(pageContainer).getByRole('button', { name: 'Save changes' }),
+        within(pageContainer).getByRole('button', { name: coreString('saveChangesAction') }),
       ).toBeInTheDocument();
     });
   });

--- a/packages/kolibri-common/composables/__mocks__/useFacility.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacility.js
@@ -1,4 +1,5 @@
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { OptionsForSignIn } from '../../constants/Auth';
 
 const MOCK_DEFAULTS = {
   selectedFacility: ref({}),
@@ -12,6 +13,10 @@ const MOCK_DEFAULTS = {
 
 const MOCK_DEFAULTS_CONFIG = {
   facilityConfig: ref({}),
+  isAttendanceFeatureEnabled: computed(() => true),
+  isPictureLoginFeatureEnabled: computed(() => true),
+  signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
+  picturePasswordSettings: computed(() => null),
   fetchFacilityConfig: jest.fn(),
 };
 

--- a/packages/kolibri-common/composables/__tests__/useFacility.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useFacility.spec.js
@@ -4,11 +4,15 @@ import useUser from 'kolibri/composables/useUser';
 import Lockr from 'lockr';
 import useFacilities from '../useFacilities';
 import useFacility, { useFacilityConfig } from '../useFacility';
+import { OptionsForSignIn } from '../../constants/Auth';
 
 jest.mock('kolibri-common/apiResources/FacilityDatasetResource');
 jest.mock('kolibri/composables/useUser');
 jest.mock('lockr');
 jest.mock('../useFacilities');
+jest.mock('kolibri/utils/i18n', () => ({
+  currentLanguage: 'en',
+}));
 
 // Reset module-level state between tests
 jest.mock('../useFacility', () => {
@@ -72,7 +76,7 @@ describe('useFacility', () => {
       expect(currentFacilityName.value).toBeUndefined();
     });
 
-    it('returns undefined facilityId initially', () => {
+    it('returns undefined for facilityId initially', () => {
       useFacilities.mockReturnValue({
         fetchFacilities: jest.fn(),
         getFacility: jest.fn().mockReturnValue(null),
@@ -95,6 +99,21 @@ describe('useFacility', () => {
       });
 
       const { selectedFacility } = useFacility();
+      expect(selectedFacility.value).toEqual(mockFacilities[0]);
+    });
+
+    it('uses userFacilityId when no Lockr facility is saved', () => {
+      useUser.mockReturnValue({
+        userFacilityId: ref('facility-1'),
+      });
+
+      useFacilities.mockReturnValue({
+        fetchFacilities: jest.fn(),
+        getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
+      });
+
+      const { selectedFacility, facilityId } = useFacility();
+      expect(facilityId.value).toBe('facility-1');
       expect(selectedFacility.value).toEqual(mockFacilities[0]);
     });
 
@@ -267,6 +286,100 @@ describe('useFacilityConfig', () => {
     it('returns empty facilityConfig initially', () => {
       const { facilityConfig } = useFacilityConfig('facility-1');
       expect(facilityConfig.value).toEqual({});
+    });
+
+    it('returns isAttendanceFeatureEnabled as true when currentLanguage is en', () => {
+      const { isAttendanceFeatureEnabled } = useFacilityConfig('facility-1');
+      expect(isAttendanceFeatureEnabled.value).toBe(true);
+    });
+
+    it('returns isPictureLoginFeatureEnabled as true when currentLanguage is en', () => {
+      const { isPictureLoginFeatureEnabled } = useFacilityConfig('facility-1');
+      expect(isPictureLoginFeatureEnabled.value).toBe(true);
+    });
+
+    it('returns signInOptions with USERNAME_PASSWORD by default', () => {
+      const { signInOptions } = useFacilityConfig('facility-1');
+      // Default config has learner_can_login_with_no_password: false, so USERNAME_PASSWORD
+      expect(signInOptions.value).toEqual([OptionsForSignIn.USERNAME_PASSWORD]);
+    });
+
+    it('returns null for picturePasswordSettings initially', () => {
+      const { picturePasswordSettings } = useFacilityConfig('facility-1');
+      expect(picturePasswordSettings.value).toBeNull();
+    });
+  });
+
+  describe('signInOptions computed', () => {
+    it('includes PICTURE_PASSWORD when picture_password_settings is set', () => {
+      const configWithPicturePassword = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'colorful' },
+      };
+
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithPicturePassword]);
+
+      const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
+
+      return fetchFacilityConfig().then(() => {
+        expect(signInOptions.value).toContain(OptionsForSignIn.PICTURE_PASSWORD);
+      });
+    });
+
+    it('includes USERNAME_ONLY when learner_can_login_with_no_password is true', () => {
+      const configWithUsernameOnly = {
+        ...mockFacilityConfig,
+        learner_can_login_with_no_password: true,
+      };
+
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithUsernameOnly]);
+
+      const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
+
+      return fetchFacilityConfig().then(() => {
+        expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_ONLY);
+      });
+    });
+
+    it('includes USERNAME_PASSWORD when learner_can_login_with_no_password is false', () => {
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
+
+      const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
+
+      return fetchFacilityConfig().then(() => {
+        expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_PASSWORD);
+      });
+    });
+  });
+
+  describe('picturePasswordSettings computed', () => {
+    it('returns picture_password_settings when PICTURE_PASSWORD is in signInOptions', () => {
+      const configWithPicturePassword = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'colorful', show_icon_names: false },
+        learner_can_login_with_no_password: true,
+      };
+
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithPicturePassword]);
+
+      const { fetchFacilityConfig, picturePasswordSettings } = useFacilityConfig('facility-1');
+
+      return fetchFacilityConfig().then(() => {
+        expect(picturePasswordSettings.value).toEqual({
+          icon_style: 'colorful',
+          show_icon_names: false,
+        });
+      });
+    });
+
+    it('returns null when PICTURE_PASSWORD is not in signInOptions', () => {
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
+
+      const { fetchFacilityConfig, picturePasswordSettings } = useFacilityConfig('facility-1');
+
+      return fetchFacilityConfig().then(() => {
+        expect(picturePasswordSettings.value).toBeNull();
+      });
     });
   });
 

--- a/packages/kolibri-common/composables/useFacility.js
+++ b/packages/kolibri-common/composables/useFacility.js
@@ -1,8 +1,10 @@
 import { ref, computed } from 'vue';
 import isPlainObject from 'lodash/isPlainObject';
+import { currentLanguage } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import Lockr from 'lockr';
+import { OptionsForSignIn } from '../constants/Auth';
 import useFacilities from './useFacilities';
 
 const selectedFacilityId = ref(Lockr.get('facilityId') || null);
@@ -86,6 +88,34 @@ export function useFacilityConfig(facilityId) {
   const _facilityId = facilityId;
   const facilityConfig = ref({});
 
+  // computed feature flags
+  const _isEnglish = () => currentLanguage === 'en';
+  const isAttendanceFeatureEnabled = computed(_isEnglish);
+  const isPictureLoginFeatureEnabled = computed(_isEnglish);
+
+  // computed
+  const signInOptions = computed(() => {
+    const options = [];
+    // If not null, then we have picture password settings
+    if (facilityConfig.value.picture_password_settings) {
+      options.push(OptionsForSignIn.PICTURE_PASSWORD);
+    }
+    // This can be enabled still, even with picture password enabled
+    if (facilityConfig.value.learner_can_login_with_no_password) {
+      options.push(OptionsForSignIn.USERNAME_ONLY);
+    } else {
+      options.push(OptionsForSignIn.USERNAME_PASSWORD);
+    }
+    return options;
+  });
+  const picturePasswordSettings = computed(() => {
+    // should always be null when not enabled, but this keeps it in sync regardless
+    if (signInOptions.value.includes(OptionsForSignIn.PICTURE_PASSWORD)) {
+      return facilityConfig.value.picture_password_settings;
+    }
+    return null;
+  });
+
   /**
    * Get the current selected facility's config
    * @param {string|null} [facilityId]
@@ -116,6 +146,10 @@ export function useFacilityConfig(facilityId) {
 
   return {
     facilityConfig,
+    isAttendanceFeatureEnabled,
+    isPictureLoginFeatureEnabled,
+    signInOptions,
+    picturePasswordSettings,
     fetchFacilityConfig,
   };
 }

--- a/packages/kolibri-common/constants/Auth.js
+++ b/packages/kolibri-common/constants/Auth.js
@@ -1,0 +1,10 @@
+export const PicturePasswordIconStyle = {
+  COLORFUL: 'colorful',
+  STANDARD: 'standard',
+};
+
+export const OptionsForSignIn = {
+  USERNAME_PASSWORD: 'username_password',
+  USERNAME_ONLY: 'username_only',
+  PICTURE_PASSWORD: 'picture_password',
+};

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -23,6 +23,43 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
   learnerCreationDisabled: {
     message: 'Learner creation is currently disabled due to reaching limit of 1300 learners.',
     context:
-      'Message shown to admins when they cannot create new learner accounts because the facility has reached the picture password learner limit.',
+    'Message shown to admins when they cannot create new learner accounts because the facility has reached the picture password learner limit.',
+  },
+  howLearnersSignIn: {
+    message: 'How learners sign in',
+    context: 'Section heading on Facility settings page',
+  },
+  enterUsernameAndPassword: {
+    message: 'Enter username and password',
+    context: 'Radio option on Facility settings page for login method',
+  },
+  enterUsernameOnly: {
+    message: 'Enter username only',
+    context: 'Radio option on Facility settings page for login method',
+  },
+  picturePassword: {
+    message: 'Picture password',
+    context: 'Radio option on Facility settings page for login method',
+  },
+  picturePasswordDescription: {
+    message:
+      'Learners sign in by selecting a 3-picture sequence, with the option to use a username instead.',
+    context: 'Description for picture password login method',
+  },
+  childFriendlyIcons: {
+    message: 'Child-friendly icons',
+    context: 'Radio option for picture password icon style',
+  },
+  standardIcons: {
+    message: 'Standard icons',
+    context: 'Radio option for picture password icon style',
+  },
+  showIconNames: {
+    message: 'Show icon names',
+    context: 'Checkbox option for picture password settings',
+  },
+  iconStyle: {
+    message: 'Icon style',
+    context: 'Label for icon style radio group',
   },
 });

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -23,7 +23,7 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
   learnerCreationDisabled: {
     message: 'Learner creation is currently disabled due to reaching limit of 1300 learners.',
     context:
-    'Message shown to admins when they cannot create new learner accounts because the facility has reached the picture password learner limit.',
+      'Message shown to admins when they cannot create new learner accounts because the facility has reached the picture password learner limit.',
   },
   howLearnersSignIn: {
     message: 'How learners sign in',


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds new strings for picture password settings in the facility settings
- Adds constants for referencing various sign-in option configuration settings
- Adds new computed helpers to `useFacilityConfig` for sign-in settings
- Moves attendance enabled computed value to `useFacilityConfig` 
- Updates `useFacilityEditor` to leverage new computed helpers in `useFacilityConfig` and provide dedicated computed values for the config page component
- Refactors facility page to use static templates for settings instead of dynamic settings list
- Updates tests for the composables and the page

| Before | After |
| --- | --- |
| <img width="1834" height="1583" alt="image" src="https://github.com/user-attachments/assets/e93a46d0-410d-467c-921b-b59828945030" /> | <img width="1834" height="1583" alt="image" src="https://github.com/user-attachments/assets/82beeb4b-a2ee-40f0-beed-ba23c87d06ae" /> | 


## References
<!--
 * references to related issues and PRs
-->
closes: https://github.com/learningequality/kolibri/issues/14356


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Open facility settings
2. Apply various combinations of settings
3. Save the settings
4. Refresh
5. Ensure settings were saved correctly

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI kickstarted the refactor, then I finished myself. Then I had AI update the tests, with rounds of critiques from me.