### PR TITLE
Prioritize course content download based on learner progress

### DIFF
--- a/kolibri/conftest.py
+++ b/kolibri/conftest.py
@@ -3,8 +3,15 @@ import shutil
 
 import pytest
 
+from kolibri.core.utils.cache import process_cache
+
 # referenced in pytest.ini
 TEMP_KOLIBRI_HOME = "./.pytest_kolibri_home"
+
+
+@pytest.fixture(autouse=True)
+def clear_process_cache():
+    process_cache.clear()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/kolibri/core/content/migrations/0043_contentrequest_priority.py
+++ b/kolibri/core/content/migrations/0043_contentrequest_priority.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("content", "0042_remove_modality"),
+    ]
+
+    operations = [
+        # Add the column as nullable with no default so the DB ALTER is lock-free
+        # on large tables (no backfill happens at migration time).  Existing rows
+        # will have NULL until the backfill_content_request_priority task runs.
+        migrations.AddField(
+            model_name="contentrequest",
+            name="priority",
+            field=models.IntegerField(null=True, blank=True),
+        ),
+    ]

--- a/kolibri/core/content/migrations/0044_contentrequest_priority_default.py
+++ b/kolibri/core/content/migrations/0044_contentrequest_priority_default.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("content", "0043_contentrequest_priority"),
+    ]
+
+    operations = [
+        # Step 2: attach the default (ContentRequestPriority.REGULAR = 20) and
+        # choices now that the column exists.  This operation only updates
+        # Django's in-memory schema; no rows are touched here — existing NULL
+        # rows are backfilled asynchronously by backfill_content_request_priority.
+        migrations.AlterField(
+            model_name="contentrequest",
+            name="priority",
+            field=models.IntegerField(
+                default=20,
+                choices=[
+                    (5, "CRITICAL"),
+                    (10, "URGENT"),
+                    (15, "HIGH"),
+                    (20, "REGULAR"),
+                    (25, "LOW"),
+                ],
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -430,6 +430,14 @@ class ChannelMetadata(base_models.ChannelMetadata):
         ContentCacheKey.update_cache_key()
 
 
+class ContentRequestPriority(ChoicesEnum):
+    CRITICAL = 5
+    URGENT = 10
+    HIGH = 15
+    REGULAR = 20
+    LOW = 25
+
+
 class ContentRequestType(ChoicesEnum):
     Download = "DOWNLOAD"
     Removal = "REMOVAL"
@@ -495,6 +503,12 @@ class ContentRequest(models.Model):
 
     contentnode_id = UUIDField()
     metadata = JSONField(null=True)
+    priority = models.IntegerField(
+        default=ContentRequestPriority.REGULAR,
+        choices=ContentRequestPriority.choices(),
+        null=True,
+        blank=True,
+    )
 
     objects = ContentRequestManager()
 

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -7,6 +7,7 @@ from kolibri.core.content.constants.transfer_types import COPY_METHOD
 from kolibri.core.content.constants.transfer_types import DOWNLOAD_METHOD
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentRequest
+from kolibri.core.content.models import ContentRequestPriority
 from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import ContentRequestType
@@ -350,6 +351,20 @@ def remoteresourceimport(
         channel_id, peer_id=peer_id, baseurl=baseurl, node_ids=[node_id]
     )
     import_manager.run()
+
+
+@register_task(
+    queue=QUEUE,
+    long_running=False,
+)
+def backfill_content_request_priority():
+    """
+    Backfills priority=ContentRequestPriority.REGULAR on ContentRequest rows where priority is NULL
+    (i.e. rows that pre-date the priority column).
+    """
+    ContentRequest.objects.filter(priority__isnull=True).update(
+        priority=ContentRequestPriority.REGULAR
+    )
 
 
 def enqueue_automatic_resource_import_if_needed(instance_id=None):

--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -19,6 +19,7 @@ from kolibri.core.content.constants.kind_to_learningactivity import kind_activit
 from kolibri.core.content.kolibri_plugin import synchronize_content_requests
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.tasks import backfill_content_request_priority
 from kolibri.core.content.tasks import enqueue_automatic_resource_import_if_needed
 from kolibri.core.content.utils.annotation import calculate_included_languages
 from kolibri.core.content.utils.annotation import calculate_ordered_categories
@@ -368,3 +369,13 @@ def contentnode_modality_annotation_update():
     annotate modality for all ContentNodes based on options.modality
     """
     annotate_modality(ContentNode.objects.all())
+
+
+@version_upgrade(old_version="<0.19.4")
+def backfill_content_request_priority_upgrade():
+    """
+    Enqueues a background task to set priority=ContentRequestPriority.REGULAR on any ContentRequest rows that
+    pre-date the priority column.  Running this asynchronously avoids a long-running
+    UPDATE that would stall the upgrade on large tables.
+    """
+    backfill_content_request_priority.enqueue_if_not_active()

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -7,6 +7,11 @@ from django.dispatch import receiver
 from morango.models.core import Store
 
 from kolibri.core.auth.models import AbstractFacilityDataModel
+from kolibri.core.content.models import ContentRequestPriority
+from kolibri.core.utils.cache import process_cache
+
+
+_CONTENT_ASSIGNMENT_INSTANCE_CACHE_TIMEOUT = 300
 
 ContentAssignment = namedtuple(
     "ContentAssignment", ["contentnode_id", "source_model", "source_id", "metadata"]
@@ -33,10 +38,16 @@ class ContentAssignmentManager:
         "filters",
         "lookup_field",
         "lookup_func",
+        "content_download_priority_func",
     )
 
     def __init__(
-        self, one_to_many=False, filters=None, lookup_field=None, lookup_func=None
+        self,
+        one_to_many=False,
+        filters=None,
+        lookup_field=None,
+        lookup_func=None,
+        content_download_priority_func=None,
     ):
         """
         :param one_to_many: indicating that the associated model maps to multiple content nodes
@@ -48,6 +59,9 @@ class ContentAssignmentManager:
         :param lookup_func: a function which receives the value of `lookup_field` to return nodes
             and metadata
         :type lookup_func: callable<tuple[contentnode_id: str, metadata: None|dict]>
+        :param content_download_priority_func: a function which receives the model instance and contentnode_id and returns a ,
+                                this will represent the priority for downloading the content associated with that contentnode
+        :type content_download_priority_func: callable<int>
         """
         self.model = None
         self.name = None
@@ -55,6 +69,7 @@ class ContentAssignmentManager:
         self.filters = filters
         self.lookup_field = lookup_field
         self.lookup_func = lookup_func
+        self.content_download_priority_func = content_download_priority_func
 
     def contribute_to_class(self, model, attribute_name):
         """
@@ -145,6 +160,35 @@ class ContentAssignmentManager:
                 dataset_id, transfer_session_id
             ):
                 yield assignment
+
+    @classmethod
+    def _get_cached_model_instance(cls, manager, source_id):
+        cache_key = "CONTENT_ASSIGNMENT_INSTANCE_{}_{}".format(
+            manager.model.morango_model_name, source_id
+        )
+        if cache_key not in process_cache:
+            instance = manager.model.objects.filter(pk=source_id).first()
+            process_cache.set(
+                cache_key, instance, _CONTENT_ASSIGNMENT_INSTANCE_CACHE_TIMEOUT
+            )
+        else:
+            instance = process_cache.get(cache_key)
+        return instance
+
+    @classmethod
+    def get_content_download_priority(cls, assignment):
+        for manager in CONTENT_ASSIGNMENT_MANAGER_REGISTRY.values():
+            if manager.model.morango_model_name == assignment.source_model:
+                if manager.content_download_priority_func:
+                    instance = cls._get_cached_model_instance(
+                        manager, assignment.source_id
+                    )
+                    if instance:
+                        return manager.content_download_priority_func(
+                            instance, assignment.contentnode_id
+                        )
+
+        return ContentRequestPriority.REGULAR
 
     def _get_modified_store(self, transfer_session_id):
         """

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -84,7 +84,10 @@ def create_content_download_requests(facility, assignments, source_instance_id=N
         related_removals.delete()
 
         logger.debug("Creating content download request for {}".format(assignment))
-        ContentDownloadRequest.objects.get_or_create(
+        obj, created = ContentDownloadRequest.objects.get_or_create(
+            source_model=assignment.source_model,
+            source_id=assignment.source_id,
+            contentnode_id=assignment.contentnode_id,
             defaults=dict(
                 facility_id=facility.id,
                 reason=ContentRequestReason.SyncInitiated,
@@ -92,10 +95,14 @@ def create_content_download_requests(facility, assignments, source_instance_id=N
                 source_instance_id=source_instance_id,
                 metadata=assignment.metadata,
             ),
-            source_model=assignment.source_model,
-            source_id=assignment.source_id,
-            contentnode_id=assignment.contentnode_id,
         )
+        if created:
+            # compute the priority here to prevent having to compute this if we don't end up creating a request,
+            # since this can be expensive to compute
+            obj.priority = ContentAssignmentManager.get_content_download_priority(
+                assignment
+            )
+            obj.save(update_fields=["priority"])
 
 
 def _get_related_contentnode_ids_for_removal(assignment):
@@ -437,7 +444,7 @@ def incomplete_downloads_queryset():
     """
     qs = (
         ContentDownloadRequest.objects.filter(status__in=INCOMPLETE_STATUSES)
-        .order_by("requested_at")
+        .order_by("priority", "requested_at")
         .annotate(
             has_metadata=Exists(
                 ContentNode.objects.filter(pk=OuterRef("contentnode_id"))

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -1,6 +1,9 @@
 import hashlib
 
 from django.db import models
+from django.db.models import OuterRef
+from django.db.models import Q
+from django.db.models import Subquery
 from django.db.utils import IntegrityError
 from morango.models import UUIDField
 
@@ -10,8 +13,10 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.utils.sync import ClassroomPartitionFactory
+from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.fields import DateTimeTzField
+from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
 
@@ -92,6 +97,90 @@ class CourseSession(AbstractFacilityDataModel):
         return "CourseSession {} for Classroom {}".format(
             self.title, self.collection.name
         )
+
+    def get_resume_data(self, user):
+        """
+        Returns resume state for a given user within this course session.
+
+        :param user: A FacilityUser instance
+        :return: dict with keys:
+            - started (bool)
+            - active_test (dict with unit_id and test_type, or None)
+            - resume_position (dict with unit_id, lesson_id, resource_id, or None)
+        """
+        result = {
+            "started": False,
+            "active_test": None,
+            "resume_position": None,
+        }
+
+        unit_test_assignments_qs = self.unit_test_assignments.filter(
+            collection__membership__user=user
+        )
+
+        unit_test_active = unit_test_assignments_qs.filter(closed=False).first()
+        if unit_test_active:
+            result["active_test"] = {
+                "unit_id": unit_test_active.unit_contentnode_id,
+                "test_type": unit_test_active.test_type,
+            }
+            result["started"] = True
+            return result
+
+        most_recent_pre_test_completed = (
+            unit_test_assignments_qs.filter(
+                closed=True,
+                test_type=TestType.Pre,
+            )
+            .annotate(
+                unit_sort_order=Subquery(
+                    ContentNode.objects.filter(
+                        id=OuterRef("unit_contentnode_id")
+                    ).values("lft")[:1]
+                ),
+            )
+            .order_by("-unit_sort_order")
+            .first()
+        )
+
+        if not most_recent_pre_test_completed:
+            return result
+
+        result["started"] = True
+        unit_contentnode_id = most_recent_pre_test_completed.unit_contentnode_id
+
+        first_incomplete_resource = (
+            ContentNode.objects.filter(
+                parent__parent=unit_contentnode_id,
+                available=True,
+            )
+            .annotate(
+                learner_progress=Subquery(
+                    ContentSummaryLog.objects.filter(
+                        user=user,
+                        content_id=OuterRef("content_id"),
+                    ).values("progress")[:1]
+                ),
+            )
+            .filter(Q(learner_progress__lt=1) | Q(learner_progress__isnull=True))
+            .order_by("lft")
+            .first()
+        )
+
+        if first_incomplete_resource:
+            result["resume_position"] = {
+                "unit_id": unit_contentnode_id,
+                "lesson_id": first_incomplete_resource.parent_id,
+                "resource_id": first_incomplete_resource.id,
+            }
+        else:
+            result["resume_position"] = {
+                "unit_id": unit_contentnode_id,
+                "lesson_id": None,
+                "resource_id": None,
+            }
+
+        return result
 
     def pre_save(self, **kwargs):
         super().pre_save(**kwargs)

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -5,6 +5,7 @@ from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
 from django.db.utils import IntegrityError
+from le_utils.constants import modalities
 from morango.models import UUIDField
 
 from kolibri.core.auth.constants import role_kinds
@@ -14,11 +15,15 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.utils.sync import ClassroomPartitionFactory
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import ContentRequestPriority
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.fields import DateTimeTzField
 from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.utils.cache import process_cache
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
+
+_COURSE_SESSION_PRIORITY_CACHE_TIMEOUT = 300
 
 
 def course_assignment_lookup(course_id):
@@ -28,6 +33,10 @@ def course_assignment_lookup(course_id):
     :return: a tuple of contentnode_id and metadata
     """
     return (course_id, {"import_descendants": True})
+
+
+def course_content_download_priority(course_session, contentnode_id):
+    return course_session.get_course_content_download_priority(contentnode_id)
 
 
 class TestType(ChoicesEnum):
@@ -91,6 +100,7 @@ class CourseSession(AbstractFacilityDataModel):
         filters=dict(is_active=True),
         lookup_field="course",
         lookup_func=course_assignment_lookup,
+        content_download_priority_func=course_content_download_priority,
     )
 
     def __str__(self):
@@ -181,6 +191,153 @@ class CourseSession(AbstractFacilityDataModel):
             }
 
         return result
+
+    def _get_units(self):
+        """
+        Returns a queryset of ContentNodes that are units within the course.
+        """
+        return ContentNode.objects.filter(parent_id=self.course).order_by("lft")
+
+    def _get_unit_id_for(self, contentnode):
+        """
+        Return the unit id to which a contentnode belongs, or None if it doesn't belong to any unit.
+        """
+        if contentnode.modality == modalities.UNIT:
+            return contentnode.id
+        elif contentnode.modality == modalities.LESSON:
+            return contentnode.parent_id
+        else:
+            return contentnode.parent.parent_id if contentnode.parent else None
+
+    def _get_assigned_user(self):
+        """
+        Empiric way to get a user who is taking the course when we don't have a specific user. Usually for LOD devices there is only one user,
+        so this will work fine, but for multi-user devices we just take the first one for simplicity.
+        Alternatively, we could check the user activity and see the last user who logged in, or we could also
+        try to use all assigned users in the device to set the priority based on everyone.
+        In any case, the active unit, and active test will always be the same for all users assigned to the course, so this
+        additional effort would be to set critical priority for current resources.
+        """
+        cache_key = "COURSE_SESSION_ASSIGNED_USER_{}".format(self.pk)
+        if cache_key not in process_cache:
+            user = FacilityUser.objects.filter(
+                memberships__collection__assigned_courses__course_session=self,
+            ).first()
+            process_cache.set(cache_key, user, _COURSE_SESSION_PRIORITY_CACHE_TIMEOUT)
+        else:
+            user = process_cache.get(cache_key)
+        return user
+
+    def _get_cached_resume_data(self, user):
+        cache_key = "COURSE_SESSION_RESUME_DATA_{}_{}".format(self.pk, user.pk)
+        if cache_key not in process_cache:
+            resume_data = self.get_resume_data(user)
+            process_cache.set(
+                cache_key, resume_data, _COURSE_SESSION_PRIORITY_CACHE_TIMEOUT
+            )
+        else:
+            resume_data = process_cache.get(cache_key)
+        return resume_data
+
+    def _get_cached_unit_ids(self):
+        cache_key = "COURSE_SESSION_UNIT_IDS_{}".format(self.pk)
+        if cache_key not in process_cache:
+            unit_ids = list(self._get_units().values_list("id", flat=True))
+            process_cache.set(
+                cache_key, unit_ids, _COURSE_SESSION_PRIORITY_CACHE_TIMEOUT
+            )
+        else:
+            unit_ids = process_cache.get(cache_key)
+        return unit_ids
+
+    def _get_unit_priority(self, requested_unit_index, active_unit_index):
+        """
+        Returns priority based on whether the requested node's unit is before or after the active unit.
+        """
+        if requested_unit_index < active_unit_index:
+            return ContentRequestPriority.LOW
+        return ContentRequestPriority.REGULAR
+
+    def _get_active_unit_priority(
+        self, contentnode_id, requested_contentnode, resume_position
+    ):
+        """
+        Returns priority for a node that belongs to the currently active unit.
+        Checks whether the node is the active lesson, a child of it (URGENT), or elsewhere in the unit (HIGH).
+        """
+        active_lesson_id = resume_position.get("lesson_id")
+        if active_lesson_id:
+            if contentnode_id == active_lesson_id:
+                return ContentRequestPriority.URGENT
+            if (
+                requested_contentnode.modality != modalities.LESSON
+                and requested_contentnode.parent_id == active_lesson_id
+            ):
+                return ContentRequestPriority.URGENT
+        return ContentRequestPriority.HIGH
+
+    def get_course_content_download_priority(self, contentnode_id):
+        """
+        Determine the priority for downloading a content node based on the user's progress in the course.
+
+        Priority levels (highest to lowest):
+        * CRITICAL: the exact resource currently being resumed, or the active pre/post-test unit node
+        * URGENT: the active lesson itself, or any resource that is a direct child of the active lesson
+        * HIGH: any other node within the currently active unit (but outside the active lesson)
+        * REGULAR: nodes in future (not-yet-reached) units, or when priority cannot be determined
+        * LOW: nodes in past (already-completed) units
+        """
+        requested_contentnode = (
+            ContentNode.objects.select_related("parent")
+            .filter(id=contentnode_id)
+            .first()
+        )
+        if (
+            not requested_contentnode
+            or requested_contentnode.modality == modalities.COURSE
+        ):
+            return ContentRequestPriority.REGULAR
+
+        user = self._get_assigned_user()
+        if not user:
+            return ContentRequestPriority.REGULAR
+
+        resume_data = self._get_cached_resume_data(user)
+        if not resume_data or not resume_data.get("started"):
+            return ContentRequestPriority.REGULAR
+
+        active_test = resume_data.get("active_test") or {}
+        resume_position = resume_data.get("resume_position") or {}
+
+        if (
+            resume_position.get("resource_id") == contentnode_id
+            or active_test.get("unit_id") == contentnode_id
+        ):
+            return ContentRequestPriority.CRITICAL
+
+        active_unit_id = active_test.get("unit_id") or resume_position.get("unit_id")
+        course_unit_ids = self._get_cached_unit_ids()
+
+        if not active_unit_id or active_unit_id not in course_unit_ids:
+            return ContentRequestPriority.REGULAR
+
+        requested_unit_id = self._get_unit_id_for(requested_contentnode)
+        active_unit_index = course_unit_ids.index(active_unit_id)
+        requested_unit_index = (
+            course_unit_ids.index(requested_unit_id)
+            if requested_unit_id in course_unit_ids
+            else None
+        )
+
+        if requested_unit_index is None:
+            return ContentRequestPriority.REGULAR
+
+        if requested_unit_index != active_unit_index:
+            return self._get_unit_priority(requested_unit_index, active_unit_index)
+
+        return self._get_active_unit_priority(
+            contentnode_id, requested_contentnode, resume_position
+        )
 
     def pre_save(self, **kwargs):
         super().pre_save(**kwargs)

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -192,23 +192,6 @@ class CourseSession(AbstractFacilityDataModel):
 
         return result
 
-    def _get_units(self):
-        """
-        Returns a queryset of ContentNodes that are units within the course.
-        """
-        return ContentNode.objects.filter(parent_id=self.course).order_by("lft")
-
-    def _get_unit_id_for(self, contentnode):
-        """
-        Return the unit id to which a contentnode belongs, or None if it doesn't belong to any unit.
-        """
-        if contentnode.modality == modalities.UNIT:
-            return contentnode.id
-        elif contentnode.modality == modalities.LESSON:
-            return contentnode.parent_id
-        else:
-            return contentnode.parent.parent_id if contentnode.parent else None
-
     def _get_assigned_user(self):
         """
         Empiric way to get a user who is taking the course when we don't have a specific user. Usually for LOD devices there is only one user,
@@ -239,24 +222,18 @@ class CourseSession(AbstractFacilityDataModel):
             resume_data = process_cache.get(cache_key)
         return resume_data
 
-    def _get_cached_unit_ids(self):
-        cache_key = "COURSE_SESSION_UNIT_IDS_{}".format(self.pk)
+    def _get_cached_unit(self, unit_id):
+        cache_key = "COURSE_SESSION_UNIT_{}_{}".format(self.pk, unit_id)
         if cache_key not in process_cache:
-            unit_ids = list(self._get_units().values_list("id", flat=True))
-            process_cache.set(
-                cache_key, unit_ids, _COURSE_SESSION_PRIORITY_CACHE_TIMEOUT
+            unit = (
+                ContentNode.objects.filter(id=unit_id, parent_id=self.course)
+                .values("id", "lft", "rght")
+                .first()
             )
+            process_cache.set(cache_key, unit, _COURSE_SESSION_PRIORITY_CACHE_TIMEOUT)
         else:
-            unit_ids = process_cache.get(cache_key)
-        return unit_ids
-
-    def _get_unit_priority(self, requested_unit_index, active_unit_index):
-        """
-        Returns priority based on whether the requested node's unit is before or after the active unit.
-        """
-        if requested_unit_index < active_unit_index:
-            return ContentRequestPriority.LOW
-        return ContentRequestPriority.REGULAR
+            unit = process_cache.get(cache_key)
+        return unit
 
     def _get_active_unit_priority(
         self, contentnode_id, requested_contentnode, resume_position
@@ -287,11 +264,7 @@ class CourseSession(AbstractFacilityDataModel):
         * REGULAR: nodes in future (not-yet-reached) units, or when priority cannot be determined
         * LOW: nodes in past (already-completed) units
         """
-        requested_contentnode = (
-            ContentNode.objects.select_related("parent")
-            .filter(id=contentnode_id)
-            .first()
-        )
+        requested_contentnode = ContentNode.objects.filter(id=contentnode_id).first()
         if (
             not requested_contentnode
             or requested_contentnode.modality == modalities.COURSE
@@ -316,28 +289,25 @@ class CourseSession(AbstractFacilityDataModel):
             return ContentRequestPriority.CRITICAL
 
         active_unit_id = active_test.get("unit_id") or resume_position.get("unit_id")
-        course_unit_ids = self._get_cached_unit_ids()
-
-        if not active_unit_id or active_unit_id not in course_unit_ids:
+        active_unit = self._get_cached_unit(active_unit_id)
+        if not active_unit:
             return ContentRequestPriority.REGULAR
 
-        requested_unit_id = self._get_unit_id_for(requested_contentnode)
-        active_unit_index = course_unit_ids.index(active_unit_id)
-        requested_unit_index = (
-            course_unit_ids.index(requested_unit_id)
-            if requested_unit_id in course_unit_ids
-            else None
-        )
+        if (
+            requested_contentnode.lft >= active_unit["lft"]
+            and requested_contentnode.rght <= active_unit["rght"]
+        ):
+            # The requested contentnode belongs to the active unit
+            return self._get_active_unit_priority(
+                contentnode_id, requested_contentnode, resume_position
+            )
 
-        if requested_unit_index is None:
+        if requested_contentnode.lft > active_unit["rght"]:
+            # It belongs to a future unit
             return ContentRequestPriority.REGULAR
 
-        if requested_unit_index != active_unit_index:
-            return self._get_unit_priority(requested_unit_index, active_unit_index)
-
-        return self._get_active_unit_priority(
-            contentnode_id, requested_contentnode, resume_position
-        )
+        # It belongs to a past unit
+        return ContentRequestPriority.LOW
 
     def pre_save(self, **kwargs):
         super().pre_save(**kwargs)

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -2,16 +2,20 @@ import uuid
 
 from django.test import TestCase
 from django.utils import timezone
+from le_utils.constants import modalities
 
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import ContentRequestPriority
 from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import CourseSessionAssignment
 from kolibri.core.courses.models import TestType
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.utils.cache import process_cache
 
 DUMMY_PASSWORD = "password"
 
@@ -93,7 +97,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertIsNone(result["resume_position"])
 
     def test_active_test_returns_started_with_active_test(self):
-        assignment = UnitTestAssignment.objects.create(
+        UnitTestAssignment.objects.create(
             course_session=self.course_session,
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
@@ -109,10 +113,8 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertEqual(result["active_test"]["test_type"], TestType.Pre)
         self.assertIsNone(result["resume_position"])
 
-        assignment.delete()
-
     def test_completed_pre_test_marks_started(self):
-        assignment = UnitTestAssignment.objects.create(
+        UnitTestAssignment.objects.create(
             course_session=self.course_session,
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
@@ -126,10 +128,8 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertTrue(result["started"])
         self.assertIsNone(result["active_test"])
 
-        assignment.delete()
-
     def test_resume_position_has_incomplete_resource(self):
-        assignment = UnitTestAssignment.objects.create(
+        UnitTestAssignment.objects.create(
             course_session=self.course_session,
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
@@ -147,10 +147,8 @@ class CourseSessionGetResumeDataTestCase(TestCase):
             result["resume_position"]["resource_id"], self.resource_node.id
         )
 
-        assignment.delete()
-
     def test_resume_position_is_unit_level_when_all_resources_complete(self):
-        assignment = UnitTestAssignment.objects.create(
+        UnitTestAssignment.objects.create(
             course_session=self.course_session,
             unit_contentnode_id=self.unit_node.id,
             collection=self.classroom,
@@ -175,8 +173,6 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertIsNone(result["resume_position"]["lesson_id"])
         self.assertIsNone(result["resume_position"]["resource_id"])
 
-        assignment.delete()
-
     def test_unassigned_learner_returns_defaults(self):
         """A learner not in the classroom should see no active tests."""
         other_learner = FacilityUser.objects.create(
@@ -195,3 +191,308 @@ class CourseSessionGetResumeDataTestCase(TestCase):
 
         self.assertFalse(result["started"])
         self.assertIsNone(result["active_test"])
+
+
+class CourseSessionGetContentDownloadPriorityTestCase(TestCase):
+    """
+    Tests for CourseSession.get_course_content_download_priority.
+
+    Priority rules:
+    - CRITICAL: the exact resource being resumed, or the active test unit node
+    - URGENT: the active lesson itself, or any resource that is a direct child of the active lesson
+    - HIGH: any other node within the currently active unit (outside the active lesson)
+    - REGULAR: a node in a future unit, a node outside any unit, the course node
+            itself, or when priority cannot be determined
+    - LOW: a node in a past unit
+    """
+
+    databases = "__all__"
+
+    def setUp(self):
+        # get_course_content_download_priority caches per-session data in process_cache.
+        # Clear it before each test to prevent stale values from a prior test (which shares
+        # the same course_session.pk via setUpTestData) from leaking into the next test.
+        process_cache.clear()
+
+    @classmethod
+    def _create_unit(cls, channel_id, course_node, suffix):
+        """Creates a unit with one lesson and one resource, returning all three nodes."""
+        unit = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=course_node,
+            available=True,
+            title="Unit {}".format(suffix),
+            modality=modalities.UNIT,
+        )
+        lesson = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=unit,
+            available=True,
+            title="Lesson {}".format(suffix),
+            modality=modalities.LESSON,
+        )
+        resource = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=lesson,
+            available=True,
+            title="Resource {}".format(suffix),
+        )
+        return unit, lesson, resource
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+        cls.facility = Facility.objects.create(name="TestFacility2")
+        cls.classroom = Classroom.objects.create(
+            name="TestClassroom2", parent=cls.facility
+        )
+        cls.coach = FacilityUser.objects.create(
+            username="coach2", facility=cls.facility
+        )
+        cls.coach.set_password(DUMMY_PASSWORD)
+        cls.coach.save()
+        cls.classroom.add_coach(cls.coach)
+
+        cls.learner = FacilityUser.objects.create(
+            username="learner2", facility=cls.facility
+        )
+        cls.learner.set_password(DUMMY_PASSWORD)
+        cls.learner.save()
+        cls.classroom.add_member(cls.learner)
+
+        channel_id = uuid.uuid4().hex
+
+        cls.course_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            title="Priority Test Course",
+            modality=modalities.COURSE,
+        )
+
+        # Units inserted in order — MPTT assigns lft on insert, preserving order
+        cls.unit1_node, cls.lesson1_node, cls.resource1_node = cls._create_unit(
+            channel_id, cls.course_node, "1"
+        )
+        cls.unit2_node, cls.lesson2_node, cls.resource2_node = cls._create_unit(
+            channel_id, cls.course_node, "2"
+        )
+
+        cls.course_session = CourseSession.objects.create(
+            course=cls.course_node.id,
+            title="Priority Test Session",
+            is_active=True,
+            collection=cls.classroom,
+            created_by=cls.coach,
+        )
+        CourseSessionAssignment.objects.create(
+            course_session=cls.course_session,
+            collection=cls.classroom,
+            assigned_by=cls.coach,
+        )
+
+    def _complete_pre_test(self, unit_node):
+        return UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+
+    def _activate_pre_test(self, unit_node):
+        return UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=False,
+            activated_by=self.coach,
+        )
+
+    def test_returns_regular_for_nonexistent_contentnode(self):
+        priority = self.course_session.get_course_content_download_priority(
+            uuid.uuid4().hex
+        )
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)
+
+    def test_returns_regular_for_course_node(self):
+        priority = self.course_session.get_course_content_download_priority(
+            self.course_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)
+
+    def test_returns_regular_when_no_user_assigned(self):
+        # Create a session with no assigned users
+        other_classroom = Classroom.objects.create(
+            name="EmptyClassroom", parent=self.facility
+        )
+        session = CourseSession.objects.create(
+            course=self.course_node.id,
+            title="No User Session",
+            is_active=True,
+            collection=other_classroom,
+            created_by=self.coach,
+        )
+        priority = session.get_course_content_download_priority(self.resource1_node.id)
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)
+
+    def test_returns_regular_when_course_not_started(self):
+        # Learner is assigned but no pre-test has been completed
+        priority = self.course_session.get_course_content_download_priority(
+            self.resource1_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)
+
+    def test_returns_critical_for_active_test_unit(self):
+        self._activate_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            self.unit1_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.CRITICAL)
+
+    def test_returns_critical_for_current_resume_resource(self):
+        # Pre-test for unit1 completed, resource1 is incomplete -> resume resource
+        self._complete_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            self.resource1_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.CRITICAL)
+
+    def test_returns_urgent_for_active_lesson(self):
+        # Pre-test for unit1 completed. lesson1 is the active lesson -> URGENT
+        self._complete_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            self.lesson1_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.URGENT)
+
+    def test_returns_urgent_for_resource_in_active_lesson(self):
+        # Pre-test for unit1 is completed. resource1 is the first incomplete resource
+        # (resume target -> CRITICAL). A second resource in the same active lesson should
+        # get URGENT.
+        channel_id = self.unit1_node.channel_id
+        second_resource = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=self.lesson1_node,
+            available=True,
+            title="Resource 1b",
+        )
+        self._complete_pre_test(self.unit1_node)
+        # Confirm resource1 is the resume target (CRITICAL)
+        self.assertEqual(
+            self.course_session.get_course_content_download_priority(
+                self.resource1_node.id
+            ),
+            ContentRequestPriority.CRITICAL,
+        )
+        # second_resource is in the same active lesson but not the resume target
+        priority = self.course_session.get_course_content_download_priority(
+            second_resource.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.URGENT)
+
+    def test_completed_resource_in_active_lesson_becomes_urgent(self):
+        # Pre-test for unit1 completed. resource1 is complete, so second_resource
+        # becomes the resume target (CRITICAL); resource1 should still be URGENT
+        # (same active lesson).
+        channel_id = self.unit1_node.channel_id
+        second_resource = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=self.lesson1_node,
+            available=True,
+            title="Resource 1b",
+        )
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=self.resource1_node.content_id,
+            channel_id=channel_id,
+            kind="video",
+            progress=1.0,
+            start_timestamp=timezone.now(),
+        )
+        self._complete_pre_test(self.unit1_node)
+        self.assertEqual(
+            self.course_session.get_course_content_download_priority(
+                second_resource.id
+            ),
+            ContentRequestPriority.CRITICAL,
+        )
+        self.assertEqual(
+            self.course_session.get_course_content_download_priority(
+                self.resource1_node.id
+            ),
+            ContentRequestPriority.URGENT,
+        )
+
+    def test_returns_high_for_resource_in_active_unit_but_different_lesson(self):
+        # Pre-test for unit1 completed. A resource in a different lesson of unit1
+        # (not the active lesson) should get HIGH.
+        channel_id = self.unit1_node.channel_id
+        other_lesson = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=self.unit1_node,
+            available=True,
+            title="Lesson 1b",
+            modality=modalities.LESSON,
+        )
+        other_resource = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=other_lesson,
+            available=True,
+            title="Resource in other lesson",
+        )
+        self._complete_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            other_resource.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.HIGH)
+
+    def test_returns_regular_for_resource_in_future_unit(self):
+        # Active unit is unit1; resource2 is in unit2 (future)
+        self._complete_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            self.resource2_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)
+
+    def test_returns_low_for_resource_in_past_unit(self):
+        # Active unit is unit2; resource1 is in unit1 (past)
+        self._complete_pre_test(self.unit1_node)
+        self._complete_pre_test(self.unit2_node)
+        priority = self.course_session.get_course_content_download_priority(
+            self.resource1_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.LOW)
+
+    def test_returns_regular_for_node_outside_any_unit(self):
+        # A contentnode that is not under any course unit
+        orphan_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=self.course_node.channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            title="Orphan Resource",
+        )
+        self._complete_pre_test(self.unit1_node)
+        priority = self.course_session.get_course_content_download_priority(
+            orphan_node.id
+        )
+        self.assertEqual(priority, ContentRequestPriority.REGULAR)

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -1,0 +1,197 @@
+import uuid
+
+from django.test import TestCase
+from django.utils import timezone
+
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.content.models import ContentNode
+from kolibri.core.courses.models import CourseSession
+from kolibri.core.courses.models import TestType
+from kolibri.core.courses.models import UnitTestAssignment
+from kolibri.core.logger.models import ContentSummaryLog
+
+DUMMY_PASSWORD = "password"
+
+
+class CourseSessionGetResumeDataTestCase(TestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+        cls.facility = Facility.objects.create(name="TestFacility")
+        cls.classroom = Classroom.objects.create(
+            name="TestClassroom", parent=cls.facility
+        )
+        cls.coach = FacilityUser.objects.create(username="coach", facility=cls.facility)
+        cls.coach.set_password(DUMMY_PASSWORD)
+        cls.coach.save()
+        cls.classroom.add_coach(cls.coach)
+
+        cls.learner = FacilityUser.objects.create(
+            username="learner", facility=cls.facility
+        )
+        cls.learner.set_password(DUMMY_PASSWORD)
+        cls.learner.save()
+        cls.classroom.add_member(cls.learner)
+
+        channel_id = uuid.uuid4().hex
+
+        cls.course_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            available=True,
+            title="Test Course",
+        )
+
+        cls.unit_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=cls.course_node,
+            available=True,
+            title="Test Unit",
+        )
+
+        # A lesson node (child of unit)
+        cls.lesson_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=cls.unit_node,
+            available=True,
+            title="Test Lesson",
+        )
+
+        # A resource node (child of lesson, grandchild of unit)
+        cls.resource_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            channel_id=channel_id,
+            content_id=uuid.uuid4().hex,
+            parent=cls.lesson_node,
+            available=True,
+            title="Test Resource",
+        )
+
+        cls.course_session = CourseSession.objects.create(
+            course=cls.course_node.id,
+            title="Test Course Session",
+            is_active=True,
+            collection=cls.classroom,
+            created_by=cls.coach,
+        )
+
+    def test_not_started_returns_defaults(self):
+        result = self.course_session.get_resume_data(self.learner)
+        self.assertFalse(result["started"])
+        self.assertIsNone(result["active_test"])
+        self.assertIsNone(result["resume_position"])
+
+    def test_active_test_returns_started_with_active_test(self):
+        assignment = UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=False,
+            activated_by=self.coach,
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertTrue(result["started"])
+        self.assertEqual(result["active_test"]["unit_id"], self.unit_node.id)
+        self.assertEqual(result["active_test"]["test_type"], TestType.Pre)
+        self.assertIsNone(result["resume_position"])
+
+        assignment.delete()
+
+    def test_completed_pre_test_marks_started(self):
+        assignment = UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertTrue(result["started"])
+        self.assertIsNone(result["active_test"])
+
+        assignment.delete()
+
+    def test_resume_position_has_incomplete_resource(self):
+        assignment = UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertIsNotNone(result["resume_position"])
+        self.assertEqual(result["resume_position"]["unit_id"], self.unit_node.id)
+        self.assertEqual(result["resume_position"]["lesson_id"], self.lesson_node.id)
+        self.assertEqual(
+            result["resume_position"]["resource_id"], self.resource_node.id
+        )
+
+        assignment.delete()
+
+    def test_resume_position_is_unit_level_when_all_resources_complete(self):
+        assignment = UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=self.resource_node.content_id,
+            channel_id=self.resource_node.channel_id,
+            kind="video",
+            progress=1.0,
+            start_timestamp=timezone.now(),
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertTrue(result["started"])
+        self.assertIsNotNone(result["resume_position"])
+        self.assertEqual(result["resume_position"]["unit_id"], self.unit_node.id)
+        self.assertIsNone(result["resume_position"]["lesson_id"])
+        self.assertIsNone(result["resume_position"]["resource_id"])
+
+        assignment.delete()
+
+    def test_unassigned_learner_returns_defaults(self):
+        """A learner not in the classroom should see no active tests."""
+        other_learner = FacilityUser.objects.create(
+            username="other_learner", facility=self.facility
+        )
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=False,
+            activated_by=self.coach,
+        )
+
+        result = self.course_session.get_resume_data(other_learner)
+
+        self.assertFalse(result["started"])
+        self.assertIsNone(result["active_test"])

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -15,7 +15,6 @@ from kolibri.core.courses.models import CourseSessionAssignment
 from kolibri.core.courses.models import TestType
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import ContentSummaryLog
-from kolibri.core.utils.cache import process_cache
 
 DUMMY_PASSWORD = "password"
 
@@ -207,12 +206,6 @@ class CourseSessionGetContentDownloadPriorityTestCase(TestCase):
     """
 
     databases = "__all__"
-
-    def setUp(self):
-        # get_course_content_download_priority caches per-session data in process_cache.
-        # Clear it before each test to prevent stale values from a prior test (which shares
-        # the same course_session.pk via setUpTestData) from leaking into the next test.
-        process_cache.clear()
 
     @classmethod
     def _create_unit(cls, channel_id, course_node, suffix):
@@ -481,18 +474,3 @@ class CourseSessionGetContentDownloadPriorityTestCase(TestCase):
             self.resource1_node.id
         )
         self.assertEqual(priority, ContentRequestPriority.LOW)
-
-    def test_returns_regular_for_node_outside_any_unit(self):
-        # A contentnode that is not under any course unit
-        orphan_node = ContentNode.objects.create(
-            id=uuid.uuid4().hex,
-            channel_id=self.course_node.channel_id,
-            content_id=uuid.uuid4().hex,
-            available=True,
-            title="Orphan Resource",
-        )
-        self._complete_pre_test(self.unit1_node)
-        priority = self.course_session.get_course_content_download_priority(
-            orphan_node.id
-        )
-        self.assertEqual(priority, ContentRequestPriority.REGULAR)

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -19,7 +19,6 @@ from kolibri.core.content.api import ContentNodeViewset
 from kolibri.core.content.api import UserContentNodeViewset
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
-from kolibri.core.courses.models import TestType
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import exam_assignment_lookup
 from kolibri.core.lessons.models import Lesson
@@ -470,82 +469,5 @@ class LearnerCourseViewset(ReadOnlyValuesViewset):
 
     @action(detail=True, methods=["get"])
     def resume(self, request, pk=None):
-        response_data = {
-            "started": False,
-            "active_test": None,
-            "resume_position": None,
-        }
-
         course_session = self.get_object()
-        unit_test_assignments_qs = course_session.unit_test_assignments.filter(
-            collection__membership__user=request.user
-        )
-        unit_test_active = unit_test_assignments_qs.filter(
-            closed=False,
-        ).first()
-
-        if unit_test_active:
-            response_data["active_test"] = {
-                "unit_id": unit_test_active.unit_contentnode_id,
-                "test_type": unit_test_active.test_type,
-            }
-            response_data["started"] = True
-            return Response(response_data)
-
-        most_recent_pre_test_completed = (
-            unit_test_assignments_qs.filter(
-                closed=True,
-                test_type=TestType.Pre,
-            )
-            .annotate(
-                unit_sort_order=Subquery(
-                    ContentNode.objects.filter(
-                        id=OuterRef("unit_contentnode_id")
-                    ).values("lft")[:1]
-                ),
-            )
-            .order_by("-unit_sort_order")
-            .first()
-        )
-
-        if not most_recent_pre_test_completed:
-            # Course not started yet
-            return Response(response_data)
-
-        # it has at least one pre-test completed, so mark as started
-        response_data["started"] = True
-
-        unit_contentnode_id = most_recent_pre_test_completed.unit_contentnode_id
-        first_incomplete_resource = (
-            ContentNode.objects.filter(
-                parent__parent=unit_contentnode_id,
-                available=True,
-            )
-            .annotate(
-                learner_progress=Subquery(
-                    ContentSummaryLog.objects.filter(
-                        user=request.user,
-                        content_id=OuterRef("content_id"),
-                    ).values("progress")[:1]
-                ),
-            )
-            .filter(Q(learner_progress__lt=1) | Q(learner_progress__isnull=True))
-            .order_by("lft")
-            .first()
-        )
-
-        if first_incomplete_resource:
-            response_data["resume_position"] = {
-                "unit_id": unit_contentnode_id,
-                "lesson_id": first_incomplete_resource.parent_id,
-                "resource_id": first_incomplete_resource.id,
-            }
-        else:
-            # All resources in the unit are complete, so resume at unit level
-            response_data["resume_position"] = {
-                "unit_id": unit_contentnode_id,
-                "lesson_id": None,
-                "resource_id": None,
-            }
-
-        return Response(response_data)
+        return Response(course_session.get_resume_data(request.user))


### PR DESCRIPTION
## Summary
* Adds a new `priority` field to `ContentRequest` module.
* Migrates `get_resume_data` to be defined in the CourseSession model class.
* Adds a new `content_download_priority_func` property to ContentAssignmentManager to define a function that returns the priority of a given content node.
* Implements `get_course_content_download_priority` method on CourseSession model to map the priority of a content node based on instructions of #14285.

## References
Closes #14285.

## Reviewer guidance

* Go to coach > courses.
* Create/Assign a new course to an LOD device.
* Activate the new course, and the first unit test.
* On the LOD device, check that the course is imported after activating the course.
* Check that you can access the resources in the course.
* Check that the object models of `ContentDownloadRequest` have a priority assigned based on the learner's progress. Check what happens if there is a pre/post test active, what if the course hasn't yet been started, and what if a resource is currently active.

## AI usage

I have used AI to run the `priority` migration, to migrate the `get_resume_data` method to the CourseSession model, and to create unit tests.