### PR TITLE
Check progress before notifications in coach lesson report status

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -61,7 +61,6 @@ from kolibri.core.notifications.api import parse_summarylog
 from kolibri.core.notifications.api import quiz_answered_notification
 from kolibri.core.notifications.api import quiz_completed_notification
 from kolibri.core.notifications.api import quiz_started_notification
-from kolibri.core.notifications.api import start_lesson_assessment
 from kolibri.core.notifications.api import start_lesson_resource
 from kolibri.core.notifications.tasks import wrap_to_save_queue
 from kolibri.utils.time_utils import local_now
@@ -900,22 +899,19 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
     ):
         if user is None:
             return
-        if "lesson_id" in context:
-            wrap_to_save_queue(parse_attemptslog, attemptlog)
+        if "lesson_id" in context or "course_session_id" in context:
+            wrap_to_save_queue(
+                parse_attemptslog,
+                attemptlog,
+                getattr(context, "node_id", None),
+                course_session_id=getattr(context, "course_session_id", None),
+            )
         if created and "quiz_id" in context:
             wrap_to_save_queue(
                 quiz_answered_notification, attemptlog, context["quiz_id"]
             )
         if "course_session_id" in context and "lesson_id" not in context:
-            if "node_id" in context:
-                if attemptlog.masterylog:
-                    wrap_to_save_queue(
-                        start_lesson_assessment,
-                        attemptlog,
-                        context["node_id"],
-                        course_session_id=context["course_session_id"],
-                    )
-            elif created and "unit_id" in context:
+            if created and "unit_id" in context:
                 wrap_to_save_queue(
                     quiz_answered_notification,
                     attemptlog,

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -923,7 +923,10 @@ def parse_attemptslog(attemptlog):
     if not lessons:
         return
 
-    needs_help = _get_user_needs_help(attemptlog)
+    summarylog = attemptlog.masterylog.summarylog
+    needs_help = _is_summary_log_incompleted(summarylog) and _get_user_needs_help(
+        attemptlog
+    )
     notifications = []
     for lesson, contentnode_id in lessons:
         if needs_help:

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -571,63 +571,6 @@ def _get_help_needed_notification(attemptlog, contentnode_id, lesson):
         return help_needed_notification
 
 
-def _create_needs_help_notification(attemptlog, contentnode_id, lesson):
-    needs_help = _get_user_needs_help(attemptlog)
-    if not needs_help:
-        return
-
-    return _get_help_needed_notification(attemptlog, contentnode_id, lesson)
-
-
-def start_lesson_assessment(
-    attemptlog, contentnode_id, lesson_id=None, course_session_id=None
-):
-    lesson = _get_lesson_dict(
-        lesson_id,
-        course_session_id=course_session_id,
-        user=attemptlog.user,
-        node_id=contentnode_id,
-    )
-    if lesson:
-        notifications = [
-            _create_needs_help_notification(attemptlog, contentnode_id, lesson),
-        ]
-        notifications += check_and_created_started(
-            lesson, attemptlog.user_id, contentnode_id, attemptlog.start_timestamp
-        )
-        if attemptlog.answer:
-            notifications.append(
-                check_and_created_answered_lesson(
-                    lesson,
-                    attemptlog.user_id,
-                    contentnode_id,
-                    attemptlog.end_timestamp,
-                )
-            )
-
-        save_notifications(notifications)
-
-
-def update_lesson_assessment(
-    attemptlog, contentnode_id, lesson_id=None, course_session_id=None
-):
-    lesson = _get_lesson_dict(
-        lesson_id,
-        course_session_id=course_session_id,
-        user=attemptlog.user,
-        node_id=contentnode_id,
-    )
-    if lesson:
-        notifications = [
-            _create_needs_help_notification(attemptlog, contentnode_id, lesson),
-            check_and_created_answered_lesson(
-                lesson, attemptlog.user_id, contentnode_id, attemptlog.end_timestamp
-            ),
-        ]
-
-        save_notifications(notifications)
-
-
 def parse_summarylog(summarylog):
     """
     Method called by the ContentSummaryLogSerializer everytime the
@@ -906,7 +849,7 @@ def create_examattemptslog(examlog, timestamp):
     created_quiz_notification(examlog, event_type, timestamp)
 
 
-def parse_attemptslog(attemptlog):
+def parse_attemptslog(attemptlog, contentnode_id=None, course_session_id=None):
     """
     Method called by the AttemptLogSerializer everytime the
     attemptlog is updated.
@@ -916,10 +859,20 @@ def parse_attemptslog(attemptlog):
     # This event should not be triggered when an anonymous Learner is interacting with an Exercise:
     if not attemptlog.masterylog:
         return
-    # This event should not be triggered when a Learner is interacting with an Exercise outside of a Lesson:
-    lessons = get_assignments(
-        attemptlog.user, attemptlog.masterylog.summarylog, attempt=True
-    )
+
+    if course_session_id and contentnode_id:
+        lesson = _get_lesson_dict(
+            course_session_id=course_session_id,
+            user=attemptlog.user,
+            node_id=contentnode_id,
+        )
+        lessons = [(lesson, contentnode_id)] if lesson else []
+    else:
+        # This event should not be triggered when a Learner is interacting
+        # with an Exercise outside of a Lesson:
+        lessons = get_assignments(
+            attemptlog.user, attemptlog.masterylog.summarylog, attempt=True
+        )
     if not lessons:
         return
 

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -47,9 +47,7 @@ from kolibri.core.notifications.api import parse_summarylog
 from kolibri.core.notifications.api import quiz_answered_notification
 from kolibri.core.notifications.api import quiz_completed_notification
 from kolibri.core.notifications.api import quiz_started_notification
-from kolibri.core.notifications.api import start_lesson_assessment
 from kolibri.core.notifications.api import start_lesson_resource
-from kolibri.core.notifications.api import update_lesson_assessment
 from kolibri.core.notifications.models import HelpReason
 from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.core.notifications.models import NotificationEventType
@@ -671,37 +669,6 @@ class NotificationsAPITestCase(APITestCase):
 
     @patch("kolibri.core.notifications.api.create_notification")
     @patch("kolibri.core.notifications.api.save_notifications")
-    def test_start_lesson_assessment_with_no_notification(
-        self, save_notifications, create_notification
-    ):
-        attemptlog1 = self._create_mock_attemptlog()
-        start_lesson_assessment(attemptlog1, self.node_1.id, self.lesson_id)
-        assert save_notifications.called
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Started,
-            attemptlog1.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog1.start_timestamp,
-            course_session_id=None,
-        )
-
-        create_notification.assert_any_call(
-            NotificationObjectType.Lesson,
-            NotificationEventType.Started,
-            attemptlog1.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            timestamp=attemptlog1.start_timestamp,
-            course_session_id=None,
-        )
-
-    @patch("kolibri.core.notifications.api.create_notification")
-    @patch("kolibri.core.notifications.api.save_notifications")
     def test_parse_attemptslog_create_on_new_attempt_with_no_notification(
         self, save_notifications, create_notification
     ):
@@ -734,37 +701,6 @@ class NotificationsAPITestCase(APITestCase):
         )
 
     @patch("kolibri.core.notifications.api.create_notification")
-    @patch("kolibri.core.notifications.api.save_notifications")
-    def test_start_lesson_assessment_with_notification(
-        self, save_notifications, create_notification
-    ):
-        attemptlog1 = self._create_mock_attemptlog()
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Resource,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog1.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog1.start_timestamp,
-        )
-
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Lesson,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog1.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            timestamp=attemptlog1.start_timestamp,
-        )
-
-        attemptlog2 = self._create_mock_attemptlog(
-            sessionlog=attemptlog1.sessionlog, masterylog=attemptlog1.masterylog
-        )
-        start_lesson_assessment(attemptlog2, self.node_1.id, self.lesson_id)
-        assert create_notification.called is False
-
-    @patch("kolibri.core.notifications.api.create_notification")
     def test_parse_attemptslog_create_on_new_attempt_with_notification(
         self, create_notification
     ):
@@ -795,67 +731,6 @@ class NotificationsAPITestCase(APITestCase):
         notifications = create_notification.call_args_list
         assert not any(
             [call[1] == NotificationEventType.Help for call in notifications]
-        )
-
-    @patch("kolibri.core.notifications.api.create_notification")
-    @patch("kolibri.core.notifications.api.save_notifications")
-    def test_update_lesson_assessment_with_needs_help(
-        self, save_notifications, create_notification
-    ):
-        # 1 wrong interaction til now
-        attemptlog1 = self._create_mock_attemptlog()
-
-        attemptlog2 = self._create_mock_attemptlog(
-            sessionlog=attemptlog1.sessionlog, masterylog=attemptlog1.masterylog
-        )
-        attemptlog2.interaction_history = [
-            {"type": "answer", "correct": 0}
-            for _ in range(NEEDS_HELP_NOTIFICATION_THRESHOLD - 1)
-        ]
-        attemptlog2.save()
-
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Resource,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog2.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog2.start_timestamp,
-        )
-
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Lesson,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog2.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            timestamp=attemptlog2.start_timestamp,
-        )
-        update_lesson_assessment(attemptlog2, self.node_1.id, self.lesson_id)
-        assert save_notifications.called
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Help,
-            attemptlog2.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            reason=HelpReason.Multiple,
-            timestamp=attemptlog2.end_timestamp,
-            course_session_id=None,
-        )
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Answered,
-            attemptlog2.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog2.end_timestamp,
-            course_session_id=None,
         )
 
     @patch("kolibri.core.notifications.api.create_notification")
@@ -910,64 +785,6 @@ class NotificationsAPITestCase(APITestCase):
 
     @patch("kolibri.core.notifications.api.create_notification")
     @patch("kolibri.core.notifications.api.save_notifications")
-    def test_update_lesson_assessment_with_needs_help_on_one_attempt(
-        self, save_notifications, create_notification
-    ):
-        attemptlog = self._create_mock_attemptlog()
-        interactions = [
-            {"type": "answer", "correct": 0}
-            for _ in range(NEEDS_HELP_NOTIFICATION_THRESHOLD)
-        ]
-        attemptlog.interaction_history = interactions
-        attemptlog.save()
-
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Resource,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog.start_timestamp,
-        )
-
-        LearnerProgressNotification.objects.create(
-            notification_object=NotificationObjectType.Lesson,
-            notification_event=NotificationEventType.Started,
-            user_id=attemptlog.user_id,
-            classroom_id=self.classroom.id,
-            lesson_id=self.lesson_id,
-            timestamp=attemptlog.start_timestamp,
-        )
-        update_lesson_assessment(attemptlog, self.node_1.id, self.lesson_id)
-        assert save_notifications.called
-
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Help,
-            attemptlog.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            reason=HelpReason.Multiple,
-            timestamp=attemptlog.end_timestamp,
-            course_session_id=None,
-        )
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Answered,
-            attemptlog.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog.end_timestamp,
-            course_session_id=None,
-        )
-
-    @patch("kolibri.core.notifications.api.create_notification")
-    @patch("kolibri.core.notifications.api.save_notifications")
     def test_parse_attemptslog_update_attempt_with_needs_help_on_one_attempt(
         self, save_notifications, create_notification
     ):
@@ -1010,46 +827,6 @@ class NotificationsAPITestCase(APITestCase):
             contentnode_id=self.node_1.id,
             reason=HelpReason.Multiple,
             timestamp=attemptlog.end_timestamp,
-            course_session_id=None,
-        )
-
-    @patch("kolibri.core.notifications.api.create_notification")
-    @patch("kolibri.core.notifications.api.save_notifications")
-    def test_start_lesson_assessment_with_needs_help_no_started(
-        self, save_notifications, create_notification
-    ):
-        attemptlog = self._create_mock_attemptlog()
-        interactions = [
-            {"type": "answer", "correct": 0}
-            for _ in range(NEEDS_HELP_NOTIFICATION_THRESHOLD)
-        ]
-        attemptlog.interaction_history = interactions
-        attemptlog.save()
-
-        start_lesson_assessment(attemptlog, self.node_1.id, self.lesson_id)
-        assert save_notifications.called
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Help,
-            attemptlog.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            reason=HelpReason.Multiple,
-            timestamp=attemptlog.end_timestamp,
-            course_session_id=None,
-        )
-
-        create_notification.assert_any_call(
-            NotificationObjectType.Resource,
-            NotificationEventType.Started,
-            attemptlog.user_id,
-            self.classroom.id,
-            assignment_collections=[self.classroom.id],
-            lesson_id=self.lesson_id,
-            contentnode_id=self.node_1.id,
-            timestamp=attemptlog.start_timestamp,
             course_session_id=None,
         )
 
@@ -2121,7 +1898,7 @@ class CourseSessionNotificationsTestCase(APITestCase):
         attemptlog = self._create_course_exercise_attemptlog(
             num_failed_interactions=NEEDS_HELP_NOTIFICATION_THRESHOLD
         )
-        start_lesson_assessment(
+        parse_attemptslog(
             attemptlog,
             self.exercise_node.id,
             course_session_id=self.course_session.id,
@@ -2141,7 +1918,7 @@ class CourseSessionNotificationsTestCase(APITestCase):
         attemptlog = self._create_course_exercise_attemptlog(
             num_failed_interactions=NEEDS_HELP_NOTIFICATION_THRESHOLD - 1
         )
-        start_lesson_assessment(
+        parse_attemptslog(
             attemptlog,
             self.exercise_node.id,
             course_session_id=self.course_session.id,

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -1194,6 +1194,28 @@ class NotificationsAPITestCase(APITestCase):
         # Keeps the timestamp of the first failed attempt
         assert notification.timestamp == attemptlog1.end_timestamp
 
+    def test_parse_attemptslog_no_needs_help_when_exercise_already_completed(self):
+        # Mark the exercise as completed before any attempts
+        self.summarylog1.progress = 1.0
+        self.summarylog1.completion_timestamp = local_now()
+        self.summarylog1.save()
+
+        attemptlog = self._create_mock_attemptlog()
+        attemptlog.interaction_history = [
+            {"type": "answer", "correct": 0}
+            for _ in range(NEEDS_HELP_NOTIFICATION_THRESHOLD)
+        ]
+        attemptlog.save()
+
+        parse_attemptslog(attemptlog)
+
+        assert not LearnerProgressNotification.objects.filter(
+            notification_event=NotificationEventType.Help,
+            user_id=attemptlog.user_id,
+            lesson_id=self.lesson_id,
+            contentnode_id=self.node_1.id,
+        ).exists()
+
 
 class BulkNotificationsAPITestCase(APITestCase):
     databases = "__all__"

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -176,11 +176,12 @@ def content_status_serializer(lesson_data, learners_data, classroom):  # noqa C9
 
     def get_status(log):
         """
-        Read the dict from a content summary log values query and return the status
-        In the case that we have found a needs help notification for the user and content node
-        in question, return that they need help, otherwise return status based on their
-        current progress.
+        Read the dict from a content summary log values query and return the status.
+        Progress is the source of truth: if progress == 1, the learner has completed
+        regardless of notification state. Otherwise, check for needs help notifications.
         """
+        if log["progress"] == 1:
+            return COMPLETED
         content_id = log["content_id"]
         if content_id in content_map.values():
             # Don't try to lookup anything if we don't know the content_id
@@ -195,8 +196,6 @@ def content_status_serializer(lesson_data, learners_data, classroom):  # noqa C9
                     # or if we have and the timestamp is earlier than that on the needs_help event
                     if key not in completed or completed[key] < needs_help[key]:
                         return HELP_NEEDED
-        if log["progress"] == 1:
-            return COMPLETED
         if log["kind"] == content_kinds.EXERCISE:
             # if there are no attempt logs for this exercise, status is NOT_STARTED
             if not log["attempts_exist"]:

--- a/kolibri/plugins/coach/frontend/modules/classSummary/__tests__/summary.spec.js
+++ b/kolibri/plugins/coach/frontend/modules/classSummary/__tests__/summary.spec.js
@@ -1,4 +1,5 @@
 import store, { _itemMap, _statusMap } from '../index';
+import { STATUSES } from '../constants';
 import sampleServerResponse from './sampleServerResponse';
 import expectedState from './sampleState';
 
@@ -71,5 +72,76 @@ describe('coach summary module', () => {
       },
     };
     expect(_statusMap(statuses, 'content_id')).toEqual(output);
+  });
+
+  describe('APPLY_NOTIFICATION_UPDATES', () => {
+    it('does not overwrite a completed content status with a lesser status', () => {
+      const state = {
+        contentLearnerStatusMap: {
+          content_1: {
+            learner_1: {
+              content_id: 'content_1',
+              learner_id: 'learner_1',
+              status: STATUSES.completed,
+              last_activity: new Date('2023-10-05T10:00:00Z'),
+              time_spent: 100,
+            },
+          },
+        },
+        examLearnerStatusMap: {},
+        examMap: {},
+      };
+
+      store.mutations.APPLY_NOTIFICATION_UPDATES(state, {
+        contentLearnerStatusMapUpdates: [
+          {
+            content_id: 'content_1',
+            learner_id: 'learner_1',
+            status: 'Answered',
+            last_activity: new Date('2023-10-05T11:00:00Z'),
+          },
+        ],
+        examLearnerStatusMapUpdates: [],
+      });
+
+      // Status should remain Completed
+      expect(state.contentLearnerStatusMap.content_1.learner_1.status).toBe(STATUSES.completed);
+      // But last_activity should be updated
+      expect(state.contentLearnerStatusMap.content_1.learner_1.last_activity).toEqual(
+        new Date('2023-10-05T11:00:00Z'),
+      );
+    });
+
+    it('allows updating a non-completed content status', () => {
+      const state = {
+        contentLearnerStatusMap: {
+          content_1: {
+            learner_1: {
+              content_id: 'content_1',
+              learner_id: 'learner_1',
+              status: STATUSES.started,
+              last_activity: new Date('2023-10-05T10:00:00Z'),
+              time_spent: 50,
+            },
+          },
+        },
+        examLearnerStatusMap: {},
+        examMap: {},
+      };
+
+      store.mutations.APPLY_NOTIFICATION_UPDATES(state, {
+        contentLearnerStatusMapUpdates: [
+          {
+            content_id: 'content_1',
+            learner_id: 'learner_1',
+            status: STATUSES.completed,
+            last_activity: new Date('2023-10-05T11:00:00Z'),
+          },
+        ],
+        examLearnerStatusMapUpdates: [],
+      });
+
+      expect(state.contentLearnerStatusMap.content_1.learner_1.status).toBe(STATUSES.completed);
+    });
   });
 });

--- a/kolibri/plugins/coach/frontend/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/frontend/modules/classSummary/index.js
@@ -405,7 +405,14 @@ export default {
         const path = [update.content_id, update.learner_id];
         const currentStatus = get(contentLearnerStatusMap, path);
         if (currentStatus) {
-          Object.assign(currentStatus, update);
+          // Don't allow a completed status to be overwritten by a lesser status
+          // e.g. when a learner continues answering after completing an exercise
+          if (currentStatus.status === STATUSES.completed && update.status !== STATUSES.completed) {
+            // Update metadata like last_activity but preserve the completed status
+            Object.assign(currentStatus, update, { status: STATUSES.completed });
+          } else {
+            Object.assign(currentStatus, update);
+          }
         } else {
           set(state.contentLearnerStatusMap, path, {
             ...update,

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -11,6 +11,12 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons import models
 from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.test.helpers import EvaluationMixin
+from kolibri.core.notifications.models import HelpReason
+from kolibri.core.notifications.models import LearnerProgressNotification
+from kolibri.core.notifications.models import NotificationEventType
+from kolibri.core.notifications.models import NotificationObjectType
+from kolibri.plugins.coach.class_summary_api import content_status_serializer
+from kolibri.utils.time_utils import local_now
 
 DUMMY_PASSWORD = "password"
 
@@ -202,6 +208,63 @@ class ClassSummaryTestCase(EvaluationMixin, APITestCase):
                 if previous_try
                 else 0,
             )
+
+    def test_completed_exercise_with_help_notification_shows_completed(self):
+        """Regression test for #14515: progress=1.0 should override help status."""
+        learner = self.users[0]
+        node = self.content_nodes[0]
+        summarylog = self.summary_logs[0][0]
+        summarylog.progress = 1.0
+        summarylog.save()
+
+        LearnerProgressNotification.objects.create(
+            notification_object=NotificationObjectType.Resource,
+            notification_event=NotificationEventType.Help,
+            user_id=learner.id,
+            classroom_id=self.classroom.id,
+            lesson_id=self.lesson.id,
+            contentnode_id=node.id,
+            reason=HelpReason.Multiple,
+            timestamp=local_now(),
+        )
+
+        lesson_data = [{"id": self.lesson.id, "node_ids": [node.id]}]
+        learners_data = [{"id": learner.id}]
+        result = content_status_serializer(lesson_data, learners_data, self.classroom)
+        status = next(
+            r["status"]
+            for r in result
+            if r["learner_id"] == learner.id and r["content_id"] == node.content_id
+        )
+        self.assertEqual(status, "Completed")
+
+    def test_incomplete_exercise_with_help_notification_shows_help_needed(self):
+        learner = self.users[0]
+        node = self.content_nodes[0]
+        summarylog = self.summary_logs[0][0]
+        summarylog.progress = 0.3
+        summarylog.save()
+
+        LearnerProgressNotification.objects.create(
+            notification_object=NotificationObjectType.Resource,
+            notification_event=NotificationEventType.Help,
+            user_id=learner.id,
+            classroom_id=self.classroom.id,
+            lesson_id=self.lesson.id,
+            contentnode_id=node.id,
+            reason=HelpReason.Multiple,
+            timestamp=local_now(),
+        )
+
+        lesson_data = [{"id": self.lesson.id, "node_ids": [node.id]}]
+        learners_data = [{"id": learner.id}]
+        result = content_status_serializer(lesson_data, learners_data, self.classroom)
+        status = next(
+            r["status"]
+            for r in result
+            if r["learner_id"] == learner.id and r["content_id"] == node.content_id
+        )
+        self.assertEqual(status, "HelpNeeded")
 
 
 class ClassSummaryDiffTestCase(EvaluationMixin, APITestCase):


### PR DESCRIPTION
## Summary

In `content_status_serializer`, the `get_status()` function checked notification state before checking `ContentSummaryLog.progress`. This meant a stale or missing Completed notification could cause a Help notification to override actual completion — showing "Needs help" for a learner who had finished an exercise.

The fix moves the `progress == 1` check above the notification check, making progress the source of truth.

## References

- Fixes #14515

## Reviewer guidance

- The fix is a reorder in `kolibri/plugins/coach/class_summary_api.py:178-180` — `progress == 1` now short-circuits before notification checks
- The regression tests in `test_needs_help_bug.py` cover two failure paths: missing Completed notification, and Help notification with a later timestamp than Completed
- The easiest way to replicate the original bug would be to complete an exercise, then keep answering and get 4 questions incorrect - I think. But it's also possible that this bug is only showing up due to failure to write the completed notification to disk properly.

## AI usage

Claude Code investigated the bug, wrote regression tests, and implemented the fix. The approach and fix were reviewed by a developer throughout.