### PR TITLE
Handle deleted course content gracefully on courses pages

### DIFF
--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -189,6 +189,7 @@ class ContentNodeGranularSerializer(serializers.ModelSerializer):
             "importable",
             "is_leaf",
             "kind",
+            "modality",
             "num_coach_contents",
             "on_device_resources",
             "title",

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -732,6 +732,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "id": c1_id,
                 "title": "root",
                 "kind": "topic",
+                "modality": None,
                 "is_leaf": False,
                 "available": False,
                 "total_resources": 2,
@@ -748,6 +749,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c2_id,
                         "title": "c1",
                         "kind": "video",
+                        "modality": None,
                         "is_leaf": True,
                         "available": False,
                         "total_resources": 1,
@@ -763,6 +765,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c3_id,
                         "title": "c2",
                         "kind": "topic",
+                        "modality": None,
                         "is_leaf": False,
                         "available": False,
                         "total_resources": 1,
@@ -812,6 +815,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "id": c1_id,
                 "title": "root",
                 "kind": "topic",
+                "modality": None,
                 "is_leaf": False,
                 "available": False,
                 "total_resources": 1,
@@ -828,6 +832,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c2_id,
                         "title": "c1",
                         "kind": "video",
+                        "modality": None,
                         "is_leaf": True,
                         "available": False,
                         "total_resources": 0,
@@ -843,6 +848,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c3_id,
                         "title": "c2",
                         "kind": "topic",
+                        "modality": None,
                         "is_leaf": False,
                         "available": False,
                         "total_resources": 1,
@@ -891,6 +897,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "id": c1_id,
                 "title": "root",
                 "kind": "topic",
+                "modality": None,
                 "is_leaf": False,
                 "available": False,
                 "total_resources": 1,
@@ -907,6 +914,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c2_id,
                         "title": "c1",
                         "kind": "video",
+                        "modality": None,
                         "is_leaf": True,
                         "available": False,
                         "total_resources": 0,
@@ -922,6 +930,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                         "id": c3_id,
                         "title": "c2",
                         "kind": "topic",
+                        "modality": None,
                         "is_leaf": False,
                         "available": False,
                         "total_resources": 1,
@@ -951,6 +960,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "id": c1_id,
                 "title": "c1",
                 "kind": "video",
+                "modality": None,
                 "is_leaf": True,
                 "available": True,
                 "total_resources": 1,
@@ -980,6 +990,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "id": c1_id,
                 "title": "c1",
                 "kind": "video",
+                "modality": None,
                 "is_leaf": True,
                 "available": False,
                 "total_resources": 0,
@@ -994,6 +1005,15 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
                 "ancestors": list(c1.get_ancestors().values("id", "title")),
             },
         )
+
+    def test_contentnode_granular_includes_modality(self):
+        c1 = content.ContentNode.objects.get(title="c1")
+        content.ContentNode.objects.filter(pk=c1.pk).update(modality="COURSE")
+        response = self.client.get(
+            reverse("kolibri:core:contentnode_granular-detail", kwargs={"pk": c1.id}),
+            data={"for_export": True},
+        )
+        self.assertEqual(response.data["modality"], "COURSE")
 
     def test_contentnode_retrieve(self):
         c1_id = content.ContentNode.objects.get(title="c1").id

--- a/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useCourseSession.spec.js
@@ -156,6 +156,21 @@ describe('useCourseSession', () => {
 
       expect(course.value).toEqual(mockCourse);
     });
+
+    it('should set contentMissing when fetchTree fails', async () => {
+      ContentNodeResource.fetchTree.mockRejectedValue(new Error('Content not found'));
+
+      const { contentMissing, courseSession, course, pageLoading } = useCourseSession(
+        ref(mockCourseSessionId),
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(contentMissing.value).toBe(true);
+      expect(course.value).toBe(null);
+      expect(courseSession.value).toEqual(mockCourseSession);
+      expect(pageLoading.value).toBe(false);
+    });
   });
 
   describe('units computed', () => {

--- a/kolibri/plugins/coach/frontend/composables/useCourseSession.js
+++ b/kolibri/plugins/coach/frontend/composables/useCourseSession.js
@@ -46,11 +46,18 @@ export default function useCourseSession(courseSessionId) {
   // Informative loading state (ie, we're re-fetching the last unit test, activating/closing)
   const dataLoading = ref(false);
 
+  // Whether the course content is missing (deleted from device).
+  // The courses list page detects this via a backend `missing_resource` annotation on the
+  // session queryset. This composable detects it at fetch time via a failed fetchTree call,
+  // which is needed because the detail page fetches the content tree independently.
+  const contentMissing = ref(false);
+
   // -----------
   // Data fetching
   // -----------
   function fetchCourseSession() {
     pageLoading.value = true;
+    contentMissing.value = false;
     if (!courseSessionId.value) {
       // Reset to avoid stale data
       courseSession.value = null;
@@ -62,10 +69,14 @@ export default function useCourseSession(courseSessionId) {
     CourseSessionResource.fetchModel({ id: courseSessionId.value })
       .then(session => {
         courseSession.value = session;
-        return ContentNodeResource.fetchTree({ id: session.course });
+        return ContentNodeResource.fetchTree({ id: session.course }).catch(() => {
+          contentMissing.value = true;
+          return null;
+        });
       })
       .then(courseData => {
         course.value = courseData;
+        if (!courseData) return null;
         return CourseSessionResource.lastUnitTest({ id: courseSessionId.value });
       })
       .then(testData => {
@@ -271,6 +282,7 @@ export default function useCourseSession(courseSessionId) {
     dataLoading,
 
     // Raw data
+    contentMissing,
     courseSession,
     course,
     activeTest,

--- a/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CourseSummaryPage.vue
@@ -16,7 +16,7 @@
         />
         <CoachHeader
           hideClassName
-          :title="course?.title || ''"
+          :title="course?.title || courseSession?.title || ''"
         >
           <template #actions>
             <KButton :text="optionsLabel$()">
@@ -31,6 +31,7 @@
           </template>
         </CoachHeader>
       </div>
+      <MissingResourceAlert v-if="contentMissing" />
       <div
         v-if="courseSession"
         class="content"
@@ -48,6 +49,7 @@
             />
             <KSwitch
               :value="courseSession.active"
+              :disabled="contentMissing"
               @change="toggleCourseActive"
             />
           </div>
@@ -299,6 +301,7 @@
   import { computed, getCurrentInstance, ref, watch } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import ElapsedTime from 'kolibri-common/components/ElapsedTime';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert.vue';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import AccordionContainer from 'kolibri-common/components/accordion/AccordionContainer';
@@ -332,6 +335,7 @@
       LearningObjectivesReport,
       LearnersReport,
       LearningObjectiveSidePanel,
+      MissingResourceAlert,
       Recipients,
     },
     setup() {
@@ -391,6 +395,7 @@
 
       // Use the composable for all course session state
       const {
+        contentMissing,
         dataLoading,
         pageLoading,
         course,
@@ -747,6 +752,7 @@
 
       return {
         backRoute,
+        contentMissing,
         dataLoading,
         pageLoading,
         course,

--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -2,6 +2,10 @@
 
   <CoachAppBarPage showSubNav>
     <KPageContainer>
+      <MissingResourceAlert
+        v-if="anyContentMissing"
+        data-testid="missing-resource-alert"
+      />
       <CoachHeader :title="coursesLabel$()">
         <template #actions>
           <KButton
@@ -119,7 +123,7 @@
                   <KIconButton icon="optionsVertical">
                     <template #menu>
                       <KDropdownMenu
-                        :options="courseMenuOptions"
+                        :options="courseMenuOptions(course)"
                         @select="selection => handleCourseMenuSelect(selection, course)"
                       />
                     </template>
@@ -181,6 +185,7 @@
 <script>
 
   import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert.vue';
   import CoreTable from 'kolibri/components/CoreTable';
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import { coreString as translateCoreString } from 'kolibri/uiText/commonCoreStrings';
@@ -211,6 +216,7 @@
       DeleteCourseConfirmationModal,
       CoreTable,
       FilterTextbox,
+      MissingResourceAlert,
     },
     setup() {
       const route = useRoute();
@@ -400,6 +406,10 @@
         }
       };
 
+      const anyContentMissing = computed(() =>
+        (classCourses.value || []).some(c => c.contentMissing),
+      );
+
       const coreString = (key, args) => translateCoreString(key, args);
       const coachString = (key, args) => coachStrings.$tr(key, args);
       const loadClassData = async classId => {
@@ -445,6 +455,7 @@
         entireClassLabel$,
         show,
         windowIsSmall,
+        anyContentMissing,
         classCourses,
         coursesAreLoading,
         emptyPlusCloudSvg,
@@ -497,11 +508,16 @@
         ];
       },
       courseMenuOptions() {
-        return [
-          this.courseDetailsAction$(),
-          this.editRecipientsAction$(),
-          this.coreString('deleteAction'),
-        ];
+        return course => {
+          if (course.contentMissing) {
+            return [this.coreString('deleteAction')];
+          }
+          return [
+            this.courseDetailsAction$(),
+            this.editRecipientsAction$(),
+            this.coreString('deleteAction'),
+          ];
+        };
       },
       recipientOptions() {
         const groupOptions = (this.learnerGroups || []).map(group => ({

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
@@ -1,0 +1,265 @@
+import { render, screen } from '@testing-library/vue';
+import Vuex from 'vuex';
+import VueRouter from 'vue-router';
+import { ref } from 'vue';
+import '@testing-library/jest-dom';
+import CoursesRootPage from '../CoursesRootPage.vue';
+
+// Stub all heavy dependencies
+jest.mock('kolibri-common/apiResources/CourseSessionResource');
+jest.mock('kolibri-common/apiResources/ContentNodeResource');
+jest.mock('kolibri/composables/useSnackbar', () => ({
+  __esModule: true,
+  default: () => ({ createSnackbar: jest.fn() }),
+}));
+
+const mockCoursesRef = ref([]);
+const mockCoursesAreLoading = ref(false);
+const mockCourses = {
+  courses: mockCoursesRef,
+  coursesAreLoading: mockCoursesAreLoading,
+  setCourses: jest.fn(),
+  updateCourse: jest.fn(),
+  removeCourse: jest.fn(),
+  refreshClassCourses: jest.fn().mockResolvedValue([]),
+  classId: ref('class-123'),
+};
+
+jest.mock('../../../composables/useCourses', () => ({
+  useCourses: () => mockCourses,
+}));
+
+jest.mock('../composables/useAssignCourse', () => ({
+  __esModule: true,
+  default: () => ({
+    resetAssignment: jest.fn(),
+    selectCourse: jest.fn(),
+    setCourseVisibility: jest.fn(),
+    setExistingAssignment: jest.fn(),
+  }),
+}));
+
+jest.mock('kolibri-common/strings/coursesStrings', () => ({
+  coursesStrings: new Proxy(
+    {},
+    {
+      get: (_, key) => {
+        if (key === '$tr') return jest.fn(key => key);
+        return jest.fn(() => key);
+      },
+    },
+  ),
+}));
+
+jest.mock('kolibri/uiText/commonCoreStrings', () => {
+  const coreString = jest.fn(key => key);
+  return {
+    coreString,
+    coreStrings: new Proxy(
+      {},
+      {
+        get: (_, key) => {
+          if (key === '$tr') return coreString;
+          return jest.fn(() => key);
+        },
+      },
+    ),
+  };
+});
+
+jest.mock('vue-router/composables', () => ({
+  useRoute: () => ({
+    params: { classId: 'class-123' },
+    query: {},
+    name: 'CoursesRoot',
+  }),
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../views/common/commonCoachStrings', () => ({
+  coachStrings: new Proxy(
+    {},
+    {
+      get: (_, key) => {
+        if (key === '$tr') return jest.fn(key => key);
+        return jest.fn(() => key);
+      },
+    },
+  ),
+}));
+
+function makeStore() {
+  return new Vuex.Store({
+    actions: {
+      initClassInfo: jest.fn(),
+      notLoading: jest.fn(),
+      handleApiError: jest.fn(),
+    },
+    modules: {
+      classSummary: {
+        namespaced: true,
+        state: { id: 'class-123' },
+        getters: {
+          groups: () => [],
+        },
+      },
+    },
+  });
+}
+
+const STUBS = {
+  CoachAppBarPage: {
+    name: 'CoachAppBarPage',
+    template: '<div><slot /></div>',
+  },
+  CoachHeader: {
+    name: 'CoachHeader',
+    template: '<div><slot name="actions" /></div>',
+  },
+  CoreTable: {
+    name: 'CoreTable',
+    template: '<div data-testid="courses-table"><slot name="headers" /><slot name="tbody" /></div>',
+  },
+  FilterTextbox: {
+    name: 'FilterTextbox',
+    template: '<div />',
+  },
+  AssignCourseSuccessModal: {
+    name: 'AssignCourseSuccessModal',
+    template: '<div />',
+  },
+  DeleteCourseConfirmationModal: {
+    name: 'DeleteCourseConfirmationModal',
+    template: '<div />',
+  },
+  RouterView: {
+    name: 'RouterView',
+    template: '<div />',
+  },
+  MissingResourceAlert: {
+    name: 'MissingResourceAlert',
+    template: '<div data-testid="missing-resource-alert">Resources missing</div>',
+  },
+  KDropdownMenu: {
+    name: 'KDropdownMenu',
+    props: ['options'],
+    template:
+      '<ul data-testid="dropdown-menu"><li v-for="opt in options" :key="opt">{{ opt }}</li></ul>',
+  },
+  KSwitch: {
+    name: 'KSwitch',
+    props: ['disabled', 'checked', 'value', 'name'],
+    template:
+      '<button data-testid="visibility-toggle" role="switch" :disabled="disabled" :aria-checked="String(!!value)" />',
+  },
+};
+
+describe('CoursesRootPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCoursesRef.value = [];
+    mockCoursesAreLoading.value = false;
+  });
+
+  describe('MissingResourceAlert', () => {
+    it('should show MissingResourceAlert when any course has contentMissing', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+        { id: 'session-2', title: 'Course 2', active: true, contentMissing: true },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      expect(screen.getByTestId('missing-resource-alert')).toBeInTheDocument();
+    });
+
+    it('should not show MissingResourceAlert when no courses have contentMissing', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+        { id: 'session-2', title: 'Course 2', active: true, contentMissing: false },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      expect(screen.queryByTestId('missing-resource-alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('course menu options when content is missing', () => {
+    it('should only show delete option for courses with missing content', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: true },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      const menu = screen.getByTestId('dropdown-menu');
+      expect(menu).toHaveTextContent('deleteAction');
+      expect(menu).not.toHaveTextContent('courseDetailsAction$');
+      expect(menu).not.toHaveTextContent('editRecipientsAction$');
+    });
+
+    it('should show all options for courses with content present', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      const menu = screen.getByTestId('dropdown-menu');
+      expect(menu).toHaveTextContent('courseDetailsAction$');
+      expect(menu).toHaveTextContent('editRecipientsAction$');
+      expect(menu).toHaveTextContent('deleteAction');
+    });
+  });
+
+  describe('visibility toggle when content is missing', () => {
+    it('should disable visibility toggle for courses with missing content', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: true },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toBeDisabled();
+    });
+
+    it('should enable visibility toggle for courses with content present', () => {
+      mockCoursesRef.value = [
+        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+      ];
+
+      render(CoursesRootPage, {
+        store: makeStore(),
+        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
+        stubs: STUBS,
+      });
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toBeEnabled();
+    });
+  });
+});

--- a/kolibri/plugins/device/frontend/views/SelectContentPage/ContentNodeRow.vue
+++ b/kolibri/plugins/device/frontend/views/SelectContentPage/ContentNodeRow.vue
@@ -15,10 +15,18 @@
     <td class="title">
       <KLabeledIcon>
         <template #icon>
-          <ContentIcon :kind="node.kind" />
+          <KIcon
+            v-if="isCourse"
+            icon="course"
+            style="top: 4px"
+          />
+          <ContentIcon
+            v-else
+            :kind="node.kind"
+          />
         </template>
         <KRouterLink
-          v-if="isTopic"
+          v-if="isTopic && !isCourse"
           name="select-node"
           :text="node.title"
           :to="getLinkObject(node)"
@@ -27,7 +35,7 @@
           v-else
           dir="auto"
         >
-          {{ node.title }}
+          {{ displayTitle }}
         </span>
         <CoachContentLabel
           class="coach-content-label"
@@ -98,8 +106,23 @@
       isTopic() {
         return this.node.kind === ContentNodeKinds.TOPIC;
       },
+      isCourse() {
+        return this.node.modality === 'COURSE';
+      },
       importing() {
         return this.node.updated_resource && !this.node.available;
+      },
+      displayTitle() {
+        if (this.isCourse) {
+          return this.$tr('coursePrefixedTitle', { title: this.node.title });
+        }
+        return this.node.title;
+      },
+    },
+    $trs: {
+      coursePrefixedTitle: {
+        message: 'Course: {title}',
+        context: 'Displayed in the content import list to indicate the item is a course',
       },
     },
   };

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
@@ -114,4 +114,48 @@ describe('contentNodeRow component', () => {
     const { KCheckbox } = getElements(wrapper);
     expect(KCheckbox().props().indeterminate).toEqual(true);
   });
+
+  describe('course modality nodes', () => {
+    it('does not render a link for course nodes even though they are topics', () => {
+      const wrapper = makeWrapper({
+        node: {
+          title: 'My Course',
+          kind: 'topic',
+          modality: 'COURSE',
+          id: 'course_1',
+        },
+      });
+      const { goToTopicButton } = getElements(wrapper);
+      expect(goToTopicButton().exists()).toEqual(false);
+    });
+
+    it('uses the course icon instead of topic icon for course nodes', () => {
+      const wrapper = makeWrapper({
+        node: {
+          title: 'My Course',
+          kind: 'topic',
+          modality: 'COURSE',
+          id: 'course_1',
+        },
+      });
+      const kIcons = wrapper.findAllComponents({ name: 'KIcon' });
+      const courseIcon = kIcons.wrappers.find(w => w.props('icon') === 'course');
+      expect(courseIcon).toBeTruthy();
+      expect(wrapper.findComponent({ name: 'ContentIcon' }).exists()).toBe(false);
+    });
+
+    it('prepends "Course: " to the title for course nodes', () => {
+      const wrapper = makeWrapper({
+        node: {
+          title: 'My Course',
+          kind: 'topic',
+          modality: 'COURSE',
+          id: 'course_1',
+        },
+      });
+      const { titleText } = getElements(wrapper);
+      expect(titleText()).toContain('Course:');
+      expect(titleText()).toContain('My Course');
+    });
+  });
 });

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/__tests__/UnitTreeAccordion.spec.js
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/__tests__/UnitTreeAccordion.spec.js
@@ -1,0 +1,87 @@
+import { render, waitFor } from '@testing-library/vue';
+import LearningActivities from 'kolibri-constants/labels/LearningActivities';
+import Modalities from 'kolibri-constants/Modalities';
+import UnitTreeAccordion from '../index.vue';
+
+jest.mock('../../../../composables/useContentNodeProgress');
+jest.mock('../../../../composables/useBookmarks');
+jest.mock('../../useCourseContentProgressTracking');
+
+const createResource = (id, overrides = {}) => ({
+  id,
+  title: `Resource ${id}`,
+  parent: 'lesson-1',
+  lft: 1,
+  kind: 'video',
+  content_id: `content-${id}`,
+  duration: 100,
+  available: true,
+  learning_activities: [LearningActivities.WATCH],
+  ...overrides,
+});
+
+const createLesson = (id, resources = []) => ({
+  id,
+  title: `Lesson ${id}`,
+  modality: Modalities.LESSON,
+  children: { results: resources },
+});
+
+const createUnitTree = (lessons = []) => ({
+  id: 'unit-1',
+  title: 'Unit 1',
+  modality: Modalities.UNIT,
+  options: {},
+  children: { results: lessons },
+});
+
+function renderComponent(props = {}) {
+  return render(UnitTreeAccordion, {
+    props: {
+      unitTree: createUnitTree([
+        createLesson('lesson-1', [
+          createResource('r1'),
+          createResource('r2', { available: false }),
+          createResource('r3'),
+        ]),
+      ]),
+      currentLessonId: 'lesson-1',
+      maxResourceLft: 999,
+      ...props,
+    },
+  });
+}
+
+describe('UnitTreeAccordion', () => {
+  describe('unavailable resources', () => {
+    it('renders a missing-resource item with a warning icon for unavailable resources', async () => {
+      const { container } = renderComponent();
+      await waitFor(() => {
+        expect(container.querySelector('.missing-resource')).not.toBeNull();
+      });
+      const missingItems = container.querySelectorAll('.missing-resource');
+      expect(missingItems).toHaveLength(1);
+      // Warning icon is present inside the missing resource item
+      expect(missingItems[0].querySelector('svg')).not.toBeNull();
+    });
+
+    it('renders available resources as interactive tree items, not as missing', async () => {
+      const { container } = renderComponent();
+      await waitFor(() => {
+        expect(container.querySelectorAll('.resource-item').length).toBeGreaterThan(0);
+      });
+      // 2 available resources render as normal tree items
+      expect(container.querySelectorAll('.resource-item')).toHaveLength(2);
+    });
+
+    it('does not render an interactive tree item for the unavailable resource', async () => {
+      const { container } = renderComponent();
+      await waitFor(() => {
+        expect(container.querySelectorAll('.resource-item').length).toBeGreaterThan(0);
+      });
+      // Total items in the resource list: 2 tree items + 1 missing item = 3
+      const resourceList = container.querySelector('.resource-list');
+      expect(resourceList.children).toHaveLength(3);
+    });
+  });
+});

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/index.vue
@@ -83,72 +83,88 @@
           </template>
           <template #content>
             <ul class="resource-list">
-              <TreeItem
-                v-for="resource in getResources(lesson)"
-                :key="resource.id"
-                :title="resource.title"
-                class="resource-item"
-                :selected="resource.id === currentResourceId"
-                :disabled="!maxResourceLft || resource.lft > maxResourceLft"
-                @click="onResourceClick(resource)"
-              >
-                <template
-                  v-if="resource.duration"
-                  #description
+              <template v-for="resource in getResources(lesson)">
+                <li
+                  v-if="resource.available === false"
+                  :key="resource.id"
+                  class="missing-resource"
                 >
-                  <TimeDuration
-                    :seconds="resource.duration"
-                    class="duration"
-                  />
-                </template>
-                <template #leading-actions>
-                  <LearningActivityIcon
-                    :kind="resource.learning_activities"
+                  <KIcon
+                    icon="warning"
                     class="item-icon"
+                    :color="$themePalette.yellow.v_600"
                   />
-                </template>
-                <template #trailing-actions>
-                  <div class="selected-trailing-icons">
-                    <template v-if="resource.id === currentResourceId">
-                      <KIconButton
-                        :icon="bookmarksMap[resource.id] ? 'bookmark' : 'bookmarkEmpty'"
-                        :disabled="loadingBookmarksMap[resource.id]"
+                  <span class="missing-resource-text">
+                    {{ resourceNotFoundOnDevice$() }}
+                  </span>
+                </li>
+                <TreeItem
+                  v-else
+                  :key="resource.id + '-resource'"
+                  :title="resource.title"
+                  class="resource-item"
+                  :selected="resource.id === currentResourceId"
+                  :disabled="!maxResourceLft || resource.lft > maxResourceLft"
+                  @click="onResourceClick(resource)"
+                >
+                  <template
+                    v-if="resource.duration"
+                    #description
+                  >
+                    <TimeDuration
+                      :seconds="resource.duration"
+                      class="duration"
+                    />
+                  </template>
+                  <template #leading-actions>
+                    <LearningActivityIcon
+                      :kind="resource.learning_activities"
+                      class="item-icon"
+                    />
+                  </template>
+                  <template #trailing-actions>
+                    <div class="selected-trailing-icons">
+                      <template v-if="resource.id === currentResourceId">
+                        <KIconButton
+                          :icon="bookmarksMap[resource.id] ? 'bookmark' : 'bookmarkEmpty'"
+                          :disabled="loadingBookmarksMap[resource.id]"
+                          :color="$themePalette.grey.v_400"
+                          :tooltip="
+                            bookmarksMap[resource.id] ? removeFromBookmarks$() : saveToBookmarks$()
+                          "
+                          @click.stop="toggleBookmark(resource)"
+                        />
+                        <KIconButton
+                          v-if="
+                            currentResourceProgressSessionReady &&
+                              (contentNodeProgressMap[resource.content_id] || 0) < 1
+                          "
+                          icon="check"
+                          :color="$themePalette.grey.v_400"
+                          :tooltip="markAsCompleteAction$()"
+                          @click.stop="onCompleteClick()"
+                        />
+                      </template>
+                      <KIcon
+                        v-if="contentNodeProgressMap[resource.content_id] === 1"
+                        class="item-icon"
+                        icon="mastered"
                         :color="$themePalette.grey.v_400"
-                        :tooltip="
-                          bookmarksMap[resource.id] ? removeFromBookmarks$() : saveToBookmarks$()
-                        "
-                        @click.stop="toggleBookmark(resource)"
                       />
-                      <KIconButton
-                        v-if="
-                          currentResourceProgressSessionReady &&
-                            (contentNodeProgressMap[resource.content_id] || 0) < 1
-                        "
-                        icon="check"
-                        :color="$themePalette.grey.v_400"
-                        :tooltip="markAsCompleteAction$()"
-                        @click.stop="onCompleteClick()"
+                      <KIcon
+                        v-else-if="contentNodeProgressMap[resource.content_id] > 0"
+                        class="item-icon"
+                        icon="inProgress"
                       />
-                    </template>
-                    <KIcon
-                      v-if="contentNodeProgressMap[resource.content_id] === 1"
-                      class="item-icon"
-                      icon="mastered"
-                      :color="$themePalette.grey.v_400"
-                    />
-                    <KIcon
-                      v-else-if="contentNodeProgressMap[resource.content_id] > 0"
-                      class="item-icon"
-                      icon="inProgress"
-                    />
-                    <KIcon
-                      v-else
-                      class="item-icon"
-                      icon="notStarted"
-                    />
-                  </div>
-                </template>
-              </TreeItem>
+                      <KIcon
+                        v-else
+                        class="item-icon"
+                        icon="notStarted"
+                      />
+                    </div>
+                  </template>
+                </TreeItem>
+              </template>
             </ul>
           </template>
         </AccordionItem>
@@ -227,7 +243,13 @@
 
       const { preTestLabel$, postTestLabel$, currentLabel$, markAsCompleteAction$ } =
         coursesStrings;
-      const { completedLabel$, ratioLabel$, saveToBookmarks$, removeFromBookmarks$ } = coreStrings;
+      const {
+        completedLabel$,
+        ratioLabel$,
+        saveToBookmarks$,
+        removeFromBookmarks$,
+        resourceNotFoundOnDevice$,
+      } = coreStrings;
 
       const isPostTestCompleted = computed(() => {
         if (props.isUnitComplete) {
@@ -305,6 +327,7 @@
         saveToBookmarks$,
         removeFromBookmarks$,
         markAsCompleteAction$,
+        resourceNotFoundOnDevice$,
       };
     },
     props: {
@@ -393,6 +416,18 @@
   .current-label {
     padding: 2px 5px;
     border-radius: 10px;
+  }
+
+  .missing-resource {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    height: 52px;
+    padding: 12px 16px;
+  }
+
+  .missing-resource-text {
+    font-size: 14px;
   }
 
   .resource-list {

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/__tests__/CourseUnitView.spec.js
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/__tests__/CourseUnitView.spec.js
@@ -788,7 +788,10 @@ describe('CourseUnitView', () => {
 
       await waitFor(() => {
         expect(LearnerCourseResource.fetchModel).toHaveBeenCalledWith({ id: COURSE_ID });
-        expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({ id: UNIT_1 });
+        expect(ContentNodeResource.fetchTree).toHaveBeenCalledWith({
+          id: UNIT_1,
+          params: { no_available_filtering: true },
+        });
       });
     });
 

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/index.vue
@@ -154,6 +154,9 @@
         fetchMethod: () =>
           ContentNodeResource.fetchTree({
             id: props.unitId,
+            // Include unavailable nodes so missing resources show a
+            // warning in the navigation panel instead of disappearing.
+            params: { no_available_filtering: true },
           }),
       });
 


### PR DESCRIPTION
## Summary

Gracefully handle deleted course content on the courses list and detail pages (fixes #14142).

When a course's content is deleted from the device:
- A warning banner (`MissingResourceAlert`) appears on both the courses list and course detail pages
- The visibility toggle is disabled so coaches can't make broken courses visible to learners
- The dropdown menu only shows "Delete" (hides "Course details" and "Edit recipients" to prevent errors)
- The course detail page remains accessible with session metadata and title, rather than redirecting to an error page

## References

Fixes #14142

## Reviewer guidance

To test, delete a channel via Device > Channels that backs a course, then navigate to Coach > Courses:
- Warning banner should appear above the course list
- Visibility toggle should be disabled for affected courses
- Dropdown menu should only show "Delete" for affected courses
- Clicking into the course session should load the detail page with a warning banner and title intact, not redirect to an error page

Verify happy path is unaffected: courses with all content present should have full menu options, working visibility toggle, and no warning banner.

**Also please see** that @marcellamaki 's comment [here](https://github.com/learningequality/kolibri/issues/14142#issuecomment-4179312029) is addressed

>We should only allow import of the complete course, not folder navigation/partial import on the device admin side. We'll update as follows
>
>If course: 
>
>- no link
>- use courses icon instead of folder
>- append 'Course: ' to the course name


## AI usage

Implemented with Claude Code. I directed the approach (graceful degradation vs error page, which menu options to hide, using existing `MissingResourceAlert`), reviewed all generated code, and ran tests throughout.