### PR TITLE
Add modal for reaching picture-password learner limit

### DIFF
--- a/kolibri/plugins/facility/frontend/views/LearnerLimitReachedModal.vue
+++ b/kolibri/plugins/facility/frontend/views/LearnerLimitReachedModal.vue
@@ -1,0 +1,65 @@
+<template>
+
+  <KModal
+    :title="learnerLimitReachedHeading$()"
+    @submit="$emit('close')"
+    @cancel="$emit('close')"
+  >
+    <p data-testid="context-paragraph">{{ learnerLimitReachedContext$() }}</p>
+    <p data-testid="notice-paragraph">{{ learnerLimitReachedNotice$() }}</p>
+    <template #actions>
+      <KButtonGroup>
+        <KButton
+          appearance="flat-button"
+          :text="goToFacilitySettingsLabel$()"
+          @click="navigateToFacilitySettings"
+        />
+        <KButton
+          :text="closeLabel$()"
+          type="submit"
+        />
+      </KButtonGroup>
+    </template>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { useRouter } from 'vue-router/composables';
+  import { coreString } from 'kolibri/uiText/commonCoreStrings';
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import { PageNames } from '../constants.js';
+
+  export default {
+    name: 'LearnerLimitReachedModal',
+    setup() {
+      const router = useRouter();
+
+      const {
+        learnerLimitReachedHeading$,
+        learnerLimitReachedContext$,
+        learnerLimitReachedNotice$,
+        goToFacilitySettingsLabel$,
+      } = picturePasswordStrings;
+
+      function navigateToFacilitySettings() {
+        router.push({ name: PageNames.FACILITY_CONFIG_PAGE });
+      }
+
+      return {
+        // strings
+        learnerLimitReachedHeading$,
+        learnerLimitReachedContext$,
+        learnerLimitReachedNotice$,
+        goToFacilitySettingsLabel$,
+        closeLabel$: () => coreString('closeAction'),
+
+        // functions
+        navigateToFacilitySettings,
+      };
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/frontend/views/__tests__/LearnerLimitReachedModal.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/LearnerLimitReachedModal.spec.js
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, within } from '@testing-library/vue';
+import { useRouter } from 'vue-router/composables';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import { PageNames } from '../../constants.js';
+import LearnerLimitReachedModal from '../LearnerLimitReachedModal.vue';
+
+jest.mock('vue-router/composables', () => ({
+  useRouter: jest.fn(),
+}));
+
+const {
+  learnerLimitReachedHeading$,
+  learnerLimitReachedContext$,
+  learnerLimitReachedNotice$,
+  goToFacilitySettingsLabel$,
+} = picturePasswordStrings;
+
+function renderModal() {
+  const closeHandler = jest.fn();
+  const utils = render(LearnerLimitReachedModal, {
+    listeners: {
+      close: closeHandler,
+    },
+  });
+  return { ...utils, closeHandler };
+}
+
+describe('LearnerLimitReachedModal', () => {
+  it('renders the modal with correct heading and body text', () => {
+    renderModal();
+
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeInTheDocument();
+    expect(within(modal).getByText(learnerLimitReachedHeading$())).toBeInTheDocument();
+    expect(
+      within(modal).getByTestId('context-paragraph', learnerLimitReachedContext$()),
+    ).toBeInTheDocument();
+    expect(
+      within(modal).getByTestId('notice-paragraph', learnerLimitReachedNotice$()),
+    ).toBeInTheDocument();
+  });
+
+  it('renders both action buttons', () => {
+    renderModal();
+
+    const modal = screen.getByRole('dialog');
+    expect(
+      within(modal).getByRole('button', { name: goToFacilitySettingsLabel$() }),
+    ).toBeInTheDocument();
+    expect(
+      within(modal).getByRole('button', { name: coreString('closeAction') }),
+    ).toBeInTheDocument();
+  });
+
+  it('emits close event when close button is clicked', async () => {
+    const { closeHandler } = renderModal();
+
+    const modal = screen.getByRole('dialog');
+    await fireEvent.click(within(modal).getByRole('button', { name: coreString('closeAction') }));
+
+    expect(closeHandler).toHaveBeenCalled();
+  });
+
+  it('navigates to facility settings when button is clicked', async () => {
+    const push = jest.fn();
+    useRouter.mockReturnValue({
+      push,
+    });
+    renderModal();
+
+    const modal = screen.getByRole('dialog');
+    await fireEvent.click(
+      within(modal).getByRole('button', { name: goToFacilitySettingsLabel$() }),
+    );
+
+    expect(push).toHaveBeenCalledWith({
+      name: PageNames.FACILITY_CONFIG_PAGE,
+    });
+  });
+});

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -1,0 +1,28 @@
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export const picturePasswordStrings = createTranslator('PicturePasswordStrings', {
+  learnerLimitReachedHeading: {
+    message: 'Learner limit reached',
+    context:
+      'Title for the modal for that notifies admins when facility reaches the learner limit.',
+  },
+  learnerLimitReachedContext: {
+    message:
+      'This facility is using picture passwords, which are available only for facilities with fewer than 1300 learners.',
+    context: 'Part of the learner limit notice modal that provides context for the notice.',
+  },
+  learnerLimitReachedNotice: {
+    message:
+      "You've reached this limit. To add more learners, change the learner sign-in method in Facility settings.",
+    context: 'Part of the learner limit notice modal that provides instruction for the notice.',
+  },
+  goToFacilitySettingsLabel: {
+    message: 'Go to facility settings',
+    context: 'Button label for navigating to facility settings page.',
+  },
+  learnerCreationDisabled: {
+    message: 'Learner creation is currently disabled due to reaching limit of 1300 learners.',
+    context:
+      'Message shown to admins when they cannot create new learner accounts because the facility has reached the picture password learner limit.',
+  },
+});


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds modal for notifying admins that the facility has reached the learner limit for having picture passwords enabled
- Adds additional `learnerCreationDisabled` string for later use, but does not add specced "Learn more" string since it already exists in core strings
- Adds a simple render test for the modal

<img width="952" height="688" alt="Screenshot from 2026-04-02 15-33-27" src="https://github.com/user-attachments/assets/291ff9ed-b67c-46eb-a616-c95d104ee8fe" />


## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/kolibri/issues/14420

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
You can't really review it because it isn't implemented :melting_face: 

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I tasked AI with implementing it, then refactored things myself until satisfied.