### PR TITLE
Migrate epub viewer TOC tests from vue test utils to Vue testing library

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
@@ -58,13 +58,15 @@ describe('Table of Contents Section', () => {
   });
 
   it('applies the appropriate top-level styling class for root level sections', () => {
-    const { container } = renderComponent({ section, depth: 0 });
-    expect(container.firstElementChild).toHaveClass('toc-list-item-top-level');
+    renderComponent({ section, depth: 0 });
+    const listItem = screen.getByText('Top level section').closest('li');
+    expect(listItem).toHaveClass('toc-list-item-top-level');
   });
 
   it('does not apply the top-level styling class for nested sections', () => {
-    const { container } = renderComponent({ section, depth: 1 });
-    expect(container.firstElementChild).not.toHaveClass('toc-list-item-top-level');
+    renderComponent({ section, depth: 1 });
+    const listItem = screen.getByText('Top level section').closest('li');
+    expect(listItem).not.toHaveClass('toc-list-item-top-level');
   });
 
   it('visually highlights the section if it is the current section', () => {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import TableOfContentsSection from '../TableOfContentsSection';
 
 const section = {
@@ -27,9 +28,10 @@ const sectionWithSubItems = {
     },
   ],
 };
-function createWrapper({ section, depth, currentSection } = {}) {
-  return mount(TableOfContentsSection, {
-    propsData: {
+
+function renderComponent({ section, depth, currentSection } = {}) {
+  return render(TableOfContentsSection, {
+    props: {
       section,
       depth,
       currentSection,
@@ -38,85 +40,53 @@ function createWrapper({ section, depth, currentSection } = {}) {
 }
 
 describe('Table of Contents Section', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 0,
-    });
-    expect(wrapper.exists()).toBe(true);
+  it('renders a section label correctly', () => {
+    renderComponent({ section, depth: 0 });
+    expect(screen.getByText('Top level section')).toBeInTheDocument();
   });
 
-  it('should handle section with no sub items', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 0,
-    });
-
-    expect(wrapper.find('ul.toc-list').exists()).toBe(false);
+  it('renders nested sub-items when a section has subitems', () => {
+    renderComponent({ section: sectionWithSubItems, depth: 0 });
+    expect(screen.getByText('Top level section')).toBeInTheDocument();
+    expect(screen.getByText('Second level section')).toBeInTheDocument();
+    expect(screen.getByText('Third level section')).toBeInTheDocument();
   });
 
-  it('should handle section with sub items', () => {
-    const wrapper = createWrapper({
-      section: sectionWithSubItems,
-      depth: 0,
-    });
-    expect(
-      wrapper.find('ul.toc-list').findAll('[data-testid="table-of-contents-section"]').length,
-    ).toBe(2);
+  it('displays the href as fallback text if the label is empty', () => {
+    renderComponent({ section: sectionWithEmptyLabel, depth: 0 });
+    expect(screen.getByText('href1')).toBeInTheDocument();
   });
 
-  it('should display href if label is empty', () => {
-    const wrapper = createWrapper({
-      section: sectionWithEmptyLabel,
-      depth: 0,
-    });
-    expect(wrapper.findComponent({ name: 'KButton' }).text()).toBe(sectionWithEmptyLabel.href);
+  it('applies the appropriate top-level styling class for root level sections', () => {
+    const { container } = renderComponent({ section, depth: 0 });
+    expect(container.firstElementChild).toHaveClass('toc-list-item-top-level');
   });
 
-  it('should not have a custom class if not top level section', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 1,
-    });
-    expect(wrapper.classes()).not.toContain('toc-list-item-top-level');
+  it('does not apply the top-level styling class for nested sections', () => {
+    const { container } = renderComponent({ section, depth: 1 });
+    expect(container.firstElementChild).not.toHaveClass('toc-list-item-top-level');
   });
 
-  it('should have a custom class if top level section', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 0,
-    });
-    expect(wrapper.classes()).toContain('toc-list-item-top-level');
+  it('visually highlights the section if it is the current section', () => {
+    renderComponent({ section, depth: 0, currentSection: section });
+    const button = screen.getByText('Top level section').closest('.toc-list-item-button');
+    expect(button).toHaveClass('toc-list-item-button-current');
   });
 
-  it('should add a custom class if a current section is provided and matches section', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 0,
-      currentSection: section,
-    });
-    expect(wrapper.findComponent({ name: 'KButton' }).classes()).toContain(
-      'toc-list-item-button-current',
-    );
-  });
-
-  it('should not add a custom class if a current section is provided but does not match section', () => {
-    const wrapper = createWrapper({
+  it('does not highlight the section if it is not the current section', () => {
+    renderComponent({
       section,
       depth: 0,
       currentSection: { label: 'Random section', href: 'href' },
     });
-    expect(wrapper.findComponent({ name: 'KButton' }).classes()).not.toContain(
-      'toc-list-item-button-current',
-    );
+    const button = screen.getByText('Top level section').closest('.toc-list-item-button');
+    expect(button).not.toHaveClass('toc-list-item-button-current');
   });
 
-  it('should emit an event if section is clicked', () => {
-    const wrapper = createWrapper({
-      section,
-      depth: 0,
-    });
-    wrapper.findComponent({ name: 'KButton' }).trigger('click');
-    expect(wrapper.emitted().tocNavigation[0][0]).toBe(section);
+  it('emits a navigation event when the section is clicked', async () => {
+    const { emitted } = renderComponent({ section, depth: 0 });
+    await fireEvent.click(screen.getByText('Top level section'));
+    expect(emitted()).toHaveProperty('tocNavigation');
+    expect(emitted().tocNavigation[0][0]).toEqual(section);
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSectionSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSectionSideBar.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import TableOfContentsSideBar from '../TableOfContentsSideBar';
 
 const toc = [
@@ -24,9 +25,10 @@ const currentSection = {
   label: 'Third level section',
   href: 'href3',
 };
-function createWrapper({ toc, currentSection } = {}) {
-  return mount(TableOfContentsSideBar, {
-    propsData: {
+
+function renderComponent({ toc, currentSection } = {}) {
+  return render(TableOfContentsSideBar, {
+    props: {
       toc,
       currentSection,
     },
@@ -34,47 +36,31 @@ function createWrapper({ toc, currentSection } = {}) {
 }
 
 describe('Table of Contents Side Bar', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper({
-      toc,
-    });
-    expect(wrapper.exists()).toBe(true);
-  });
-  it('should create a button for each section', () => {
-    const wrapper = createWrapper({
-      toc,
-    });
-    expect(wrapper.findAllComponents({ name: 'KButton' }).length).toBe(3);
+  it('renders the sidebar with all sections', () => {
+    renderComponent({ toc });
+    expect(screen.getByText('Top level section')).toBeInTheDocument();
+    expect(screen.getByText('Second level section')).toBeInTheDocument();
+    expect(screen.getByText('Third level section')).toBeInTheDocument();
   });
 
-  it('should create a ul for each section', () => {
-    const wrapper = createWrapper({
-      toc,
-    });
-    expect(wrapper.findAll('ul').length).toBe(3);
+  it('renders the correct nested list structure for the given toc', () => {
+    renderComponent({ toc });
+    expect(screen.getAllByRole('list')).toHaveLength(3);
   });
 
-  it('should emit an event if section is clicked', () => {
-    const wrapper = createWrapper({
-      toc,
-    });
-    const allSectionButtons = wrapper.findAllComponents({ name: 'KButton' });
-    allSectionButtons.wrappers[allSectionButtons.length - 1].trigger('click');
-    expect(wrapper.emitted().tocNavigation[0][0]).toEqual({
+  it('emits a tocNavigation event when a specific section is clicked', async () => {
+    const { emitted } = renderComponent({ toc });
+    await fireEvent.click(screen.getByText('Third level section'));
+    expect(emitted()).toHaveProperty('tocNavigation');
+    expect(emitted().tocNavigation[0][0]).toEqual({
       label: 'Third level section',
       href: 'href3',
     });
   });
 
-  it('should add a class to current section if provided', () => {
-    const wrapper = createWrapper({
-      toc,
-      currentSection,
-    });
-    const allSectionButtons = wrapper.findAllComponents({ name: 'KButton' });
-    const allSectionButtonsWithCustomClass = allSectionButtons.filter(button =>
-      button.classes().includes('toc-list-item-button-current'),
-    );
-    expect(allSectionButtonsWithCustomClass.length).toEqual(1);
+  it('visually highlights the currently active section', () => {
+    renderComponent({ toc, currentSection });
+    const activeButton = screen.getByText('Third level section').closest('.toc-list-item-button');
+    expect(activeButton).toHaveClass('toc-list-item-button-current');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
@@ -1,18 +1,20 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import TocButton from '../TocButton';
 
-function createWrapper() {
-  return mount(TocButton);
+function renderComponent() {
+  return render(TocButton);
 }
 
 describe('Table of contents button', () => {
-  it('should mount', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.exists()).toBe(true);
+  it('renders the table of contents button', () => {
+    renderComponent();
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
-  it('should emit an event when the button is clicked', () => {
-    const wrapper = createWrapper();
-    wrapper.find('button').trigger('click');
-    expect(wrapper.emitted().click).toBeTruthy();
+
+  it('emits a click event when the button is interacted with', async () => {
+    const { emitted } = renderComponent();
+    await fireEvent.click(screen.getByRole('button'));
+    expect(emitted()).toHaveProperty('click');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
@@ -9,12 +9,12 @@ function renderComponent() {
 describe('Table of contents button', () => {
   it('renders the table of contents button', () => {
     renderComponent();
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /toggle table of contents/i })).toBeInTheDocument();
   });
 
   it('emits a click event when the button is interacted with', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button'));
+    await fireEvent.click(screen.getByRole('button', { name: /toggle table of contents/i }));
     expect(emitted()).toHaveProperty('click');
   });
 });


### PR DESCRIPTION
## Summary
* **Description of the change:** Migrated the Vue test suites for the epub viewer's table of contents capability (`TocButton.spec.js`, `TableOfContentsSection.spec.js`, and `TableOfContentsSectionSideBar.spec.js`) from `@vue/test-utils` to Vue Testing Library (`@testing-library/vue`). Refactored queries to test purely from a user's perspective, avoiding tight coupling to component internals. 
* **Manual verification steps performed:** Executed `pnpm run test-jest -- --testPathPattern epub_viewer` to ensure all 47 test cases in the `epub_viewer` suite passed successfully. Verified that NO residual `@vue/test-utils` imports remain in the targeted files.
* **Screenshots / Recordings:** N/A (Purely a testing refactor, no UI logic modified).

## References
Resolves #14189 

## Reviewer guidance
* **How to test:** 
  Reviewers can fetch this branch locally and run `pnpm run test-jest -- --testPathPattern epub_viewer` to verify the tests pass organically. All tests follow standard user-experience workflows (e.g. `fireEvent.click`).
* **Implementation Notes (Risk/Context):** 
  There are no risky changes to core UI routing. However, while converting the test suite, I intentionally prioritized `screen.getByText` queries for the navigation sections over `getByRole('button')`. This was done purposefully to gracefully handle `KButton` (when rendered as a basic link) internally lacking an explicit `role="button"`. This strategy strictly mirrors the current preferred VTL patterns established in the reference file `packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js`.

## AI usage

 I used Gemini to help structure this PR description, and help to fix the linting error and 
brainstormed the `@testing-library/vue` refactoring approach with Gemini,I reviewed the generated test files to verify the queries correctly addressed `KButton` accessibility limitations and ran the full testing suite to ensure backward compatibility.