### PR TITLE
Update CreateSessionSerializer to support learners logging in with a picture password

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -13,6 +13,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
@@ -1157,7 +1158,8 @@ class SetNonSpecifiedPasswordView(views.APIView):
 
 
 class CreateSessionSerializer(serializers.Serializer):
-    username = serializers.CharField(required=False, default=None)
+    # allow_blank so that picture-password requests can omit username entirely
+    username = serializers.CharField(required=False, default=None, allow_blank=True)
     user_id = HexOnlyUUIDField(required=False, default=None)
     password = serializers.CharField(
         default="",
@@ -1171,6 +1173,23 @@ class CreateSessionSerializer(serializers.Serializer):
         required=False,
     )
     auth_token = serializers.CharField(required=False, default=None)
+    picture_password = serializers.CharField(
+        required=False,
+        default=None,
+        allow_null=True,
+        allow_blank=False,
+        # Format is exactly three dot-separated integers, each 1–2 digits
+        # (icon indices 0–99), e.g. "3.7.12". min/max_length are a fast
+        # pre-check; the regex is the authoritative format constraint.
+        min_length=5,
+        max_length=8,
+        validators=[
+            RegexValidator(
+                r"^\d{1,2}\.\d{1,2}\.\d{1,2}$",
+                message="picture_password must be three dot-separated integers.",
+            )
+        ],
+    )
 
     def validate(self, attrs):
         username = attrs.get("username")
@@ -1178,6 +1197,7 @@ class CreateSessionSerializer(serializers.Serializer):
         facility = attrs.get("facility")
         user_id = attrs.get("user_id")
         auth_token = attrs.get("auth_token")
+        picture_password = attrs.get("picture_password")
 
         request = self.context.get("request")
 
@@ -1196,17 +1216,27 @@ class CreateSessionSerializer(serializers.Serializer):
                     id=user_id, facility=facility
                 ).first()
 
-        # username/password authentication
-        if user is None:
-            # Otherwise attempt full authentication
-            user = authenticate(username=username, password=password, facility=facility)
+        # picture password authentication
+        if user is None and picture_password is not None:
+            user = authenticate(
+                request, picture_password=picture_password, facility=facility
+            )
+
+        # username/password authentication — intentionally skipped when
+        # picture_password was supplied (even if picture-password auth failed),
+        # so a failed picture-password attempt cannot fall through to a
+        # username/password login with whatever credentials were also sent.
+        if user is None and picture_password is None:
+            user = authenticate(
+                request, username=username, password=password, facility=facility
+            )
 
         if user is not None and user.is_active:
             attrs["user"] = user
             return attrs
 
         # Otherwise, throw a meaningful validation error
-        self._throw_validation_error(username, password, facility)
+        self._throw_validation_error(username, password, facility, picture_password)
 
     def _check_os_user(self, request, username):
         app_auth_token = request.COOKIES.get(APP_AUTH_TOKEN_COOKIE_NAME)
@@ -1218,11 +1248,27 @@ class CreateSessionSerializer(serializers.Serializer):
             except ValidationError as e:
                 logger.error(e)
 
-    def _throw_validation_error(self, username, password, facility):
+    def _throw_validation_error(
+        self, username, password, facility, picture_password=None
+    ):
         """
         Throw a RestValidationError with a helpful error message
         depending on what went wrong with authentication.
         """
+        if picture_password is not None:
+            raise RestValidationError(
+                detail={
+                    "picture_password": [
+                        {
+                            "id": error_constants.NOT_FOUND,
+                            "metadata": {
+                                "field": "picture_password",
+                                "message": "No learner found with that picture password.",
+                            },
+                        }
+                    ]
+                }
+            )
         # Find the FacilityUser we're looking for
         try:
             unauthenticated_user = FacilityUser.objects.get(
@@ -1338,7 +1384,10 @@ class SessionViewSet(viewsets.ViewSet):
         for field, field_errors in errors.items():
             for error in field_errors:
                 error_list.append(error)
-                if error.get("id") == error_constants.INVALID_CREDENTIALS:
+                if (
+                    isinstance(error, dict)
+                    and error.get("id") == error_constants.INVALID_CREDENTIALS
+                ):
                     response_status = status.HTTP_401_UNAUTHORIZED
 
         return Response(error_list, status=response_status)

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -63,9 +63,6 @@ class FacilityUserBackend:
                 )
             except Facility.DoesNotExist:
                 return None
-        # Two separate .filter() calls are intentional: chaining role and
-        # devicepermissions conditions in one call would produce a cross-product
-        # JOIN that returns false positives for users with multiple related rows.
         return (
             FacilityUser.objects.filter(
                 picture_password=picture_password,

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -6,6 +6,7 @@ backends are checked in the order they're listed.
 from django.contrib.sessions.backends.db import SessionStore as DBStore
 from django.db.models import Q
 
+from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Session
 
@@ -26,8 +27,7 @@ class FacilityUserBackend:
         :param username: a string
         :param password: a string
         :param kwargs: a dict of additional credentials (see `keyword`s)
-        :keyword facility: a Facility object (required as an object when picture_password
-            is used, because _authenticate_picture_password accesses facility.dataset_id)
+        :keyword facility: a Facility object or facility pk
         :keyword picture_password: a dot-separated picture sequence string
         :return: A FacilityUser instance if successful, or None if authentication failed.
         """
@@ -52,15 +52,24 @@ class FacilityUserBackend:
     def _authenticate_picture_password(self, picture_password, facility):
         if not facility:
             return None
+        # Resolve dataset_id to leverage the (dataset, picture_password) unique
+        # index. facility may be a Facility object or a raw pk/UUID.
+        if hasattr(facility, "dataset_id"):
+            dataset_id = facility.dataset_id
+        else:
+            try:
+                dataset_id = Facility.objects.values_list("dataset_id", flat=True).get(
+                    pk=facility
+                )
+            except Facility.DoesNotExist:
+                return None
         # Two separate .filter() calls are intentional: chaining role and
         # devicepermissions conditions in one call would produce a cross-product
         # JOIN that returns false positives for users with multiple related rows.
         return (
             FacilityUser.objects.filter(
                 picture_password=picture_password,
-                # Filter by dataset_id (not facility) to leverage the
-                # (dataset, picture_password) unique index on FacilityUser.
-                dataset_id=facility.dataset_id,
+                dataset_id=dataset_id,
                 # Restrict to learners only (no facility roles).
                 roles__isnull=True,
             )

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -4,6 +4,7 @@ The appropriate classes should be listed in the AUTHENTICATION_BACKENDS. Note th
 backends are checked in the order they're listed.
 """
 from django.contrib.sessions.backends.db import SessionStore as DBStore
+from django.db.models import Q
 
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Session
@@ -25,10 +26,20 @@ class FacilityUserBackend:
         :param username: a string
         :param password: a string
         :param kwargs: a dict of additional credentials (see `keyword`s)
-        :keyword facility: a Facility object or facility ID
+        :keyword facility: a Facility object (required as an object when picture_password
+            is used, because _authenticate_picture_password accesses facility.dataset_id)
+        :keyword picture_password: a dot-separated picture sequence string
         :return: A FacilityUser instance if successful, or None if authentication failed.
         """
         facility = kwargs.get(FACILITY_CREDENTIAL_KEY, None)
+        picture_password = kwargs.get("picture_password", None)
+
+        # Picture password authentication path.
+        # The None check is load-bearing: filter(picture_password=None) would
+        # match rows where the column IS NULL, returning an arbitrary learner.
+        if picture_password is not None:
+            return self._authenticate_picture_password(picture_password, facility)
+
         # First, attempt case-sensitive login
         user = self.authenticate_case_sensitive(username, password, facility)
         if user:
@@ -37,6 +48,29 @@ class FacilityUserBackend:
         # If case-sensitive login fails, attempt case-insensitive login
         user = self.authenticate_case_insensitive(username, password, facility)
         return user
+
+    def _authenticate_picture_password(self, picture_password, facility):
+        if not facility:
+            return None
+        # Two separate .filter() calls are intentional: chaining role and
+        # devicepermissions conditions in one call would produce a cross-product
+        # JOIN that returns false positives for users with multiple related rows.
+        return (
+            FacilityUser.objects.filter(
+                picture_password=picture_password,
+                # Filter by dataset_id (not facility) to leverage the
+                # (dataset, picture_password) unique index on FacilityUser.
+                dataset_id=facility.dataset_id,
+                # Restrict to learners only (no facility roles).
+                roles__isnull=True,
+            )
+            .filter(
+                # Exclude device superusers; allow users with no devicepermissions row.
+                Q(devicepermissions__is_superuser=False)
+                | Q(devicepermissions__isnull=True)
+            )
+            .first()
+        )
 
     def _authenticate_users(self, users, password, facility):
         if facility:

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1813,6 +1813,7 @@ class PicturePasswordLoginTestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIsInstance(response.data, list)
         self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
 
     def test_picture_password_no_match_returns_not_found(self):
@@ -1825,6 +1826,7 @@ class PicturePasswordLoginTestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIsInstance(response.data, list)
         self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
 
     def test_coach_not_authenticated_via_picture_password(self):
@@ -1841,6 +1843,7 @@ class PicturePasswordLoginTestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIsInstance(response.data, list)
         self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
 
     def test_admin_not_authenticated_via_picture_password(self):
@@ -1857,6 +1860,7 @@ class PicturePasswordLoginTestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIsInstance(response.data, list)
         self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
 
     def test_picture_password_none_falls_through_to_username_path(self):
@@ -1866,6 +1870,63 @@ class PicturePasswordLoginTestCase(APITestCase):
                 "username": self.learner.username,
                 "password": DUMMY_PASSWORD,
                 "picture_password": None,
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user_id"], self.learner.id)
+
+    def test_picture_password_omitted_falls_through_to_username_path(self):
+        # Omitting the field entirely should behave identically to sending null,
+        # confirming the serializer default=None wiring.
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "username": self.learner.username,
+                "password": DUMMY_PASSWORD,
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user_id"], self.learner.id)
+
+    def test_picture_password_empty_string_rejected_by_serializer(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={"picture_password": "", "facility": self.facility.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_picture_password_too_long_rejected_by_serializer(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={"picture_password": "1.2.3.4.5", "facility": self.facility.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_picture_password_invalid_format_rejected_by_serializer(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={"picture_password": "abc", "facility": self.facility.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_picture_password_and_username_password_picture_password_takes_precedence(
+        self,
+    ):
+        # When both picture_password and username/password are supplied,
+        # the picture-password path is used; username/password is ignored.
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "1.2.3",
+                "username": self.learner.username,
+                "password": DUMMY_PASSWORD,
                 "facility": self.facility.id,
             },
             format="json",

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1779,6 +1779,125 @@ class LoginLogoutTestCase(APITestCase):
         self.assertEqual(response.data[0]["id"], error_constants.MISSING_PASSWORD)
 
 
+class PicturePasswordLoginTestCase(APITestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.other_facility = FacilityFactory.create()
+        cls.learner = FacilityUserFactory.create(facility=cls.facility)
+        cls.learner.picture_password = "1.2.3"
+        cls.learner.save(update_fields=["picture_password"])
+
+    def test_valid_picture_password_creates_session(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user_id"], self.learner.id)
+
+    def test_picture_password_wrong_facility_returns_not_found(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.other_facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_picture_password_no_match_returns_not_found(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "9.9.9",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_coach_not_authenticated_via_picture_password(self):
+        coach = FacilityUserFactory.create(facility=self.facility)
+        coach.picture_password = "4.5.6"
+        coach.save(update_fields=["picture_password"])
+        self.facility.add_coach(coach)
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "4.5.6",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_admin_not_authenticated_via_picture_password(self):
+        admin = FacilityUserFactory.create(facility=self.facility)
+        admin.picture_password = "7.8.9"
+        admin.save(update_fields=["picture_password"])
+        self.facility.add_admin(admin)
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "7.8.9",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_picture_password_none_falls_through_to_username_path(self):
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "username": self.learner.username,
+                "password": DUMMY_PASSWORD,
+                "picture_password": None,
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user_id"], self.learner.id)
+
+
+class PicturePasswordPasswordlessLoginTestCase(APITestCase):
+    """Passwordless login must still work when picture-password feature is enabled."""
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.facility.dataset.learner_can_login_with_no_password = True
+        cls.facility.dataset.learner_can_edit_password = False
+        cls.facility.dataset.save()
+
+    def test_passwordless_login_unaffected_by_picture_password_feature(self):
+        learner = FacilityUserFactory.create(facility=self.facility)
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={"username": learner.username, "facility": self.facility.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["user_id"], learner.id)
+
+
 class SignUpBase:
     @classmethod
     def setUpTestData(cls):

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from ..backends import FacilityUserBackend
 from ..models import Facility
 from ..models import FacilityUser
+from .helpers import create_superuser
 
 
 class FacilityUserBackendTestCase(TestCase):
@@ -102,3 +103,98 @@ class FacilityUserBackendTestCase(TestCase):
         self.assertIsNone(
             FacilityUserBackend().authenticate(self.request, "Mike", "goo")
         )
+
+
+class PicturePasswordBackendTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="Pic Facility")
+        cls.other_facility = Facility.objects.create(name="Other Facility")
+        cls.learner = FacilityUser.objects.create(
+            username="learner",
+            facility=cls.facility,
+            picture_password="1.2.3",
+        )
+        cls.request = mock.Mock()
+
+    def test_valid_picture_password_returns_learner(self):
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="1.2.3",
+            facility=self.facility,
+        )
+        self.assertEqual(user, self.learner)
+
+    def test_picture_password_wrong_facility_returns_none(self):
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="1.2.3",
+            facility=self.other_facility,
+        )
+        self.assertIsNone(user)
+
+    def test_picture_password_no_match_returns_none(self):
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="9.9.9",
+            facility=self.facility,
+        )
+        self.assertIsNone(user)
+
+    def test_picture_password_no_facility_returns_none(self):
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="1.2.3",
+        )
+        self.assertIsNone(user)
+
+    def test_coach_not_returned_by_picture_password(self):
+        coach = FacilityUser.objects.create(
+            username="coach",
+            facility=self.facility,
+            picture_password="4.5.6",
+        )
+        self.facility.add_coach(coach)
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="4.5.6",
+            facility=self.facility,
+        )
+        self.assertIsNone(user)
+
+    def test_admin_not_returned_by_picture_password(self):
+        admin = FacilityUser.objects.create(
+            username="admin",
+            facility=self.facility,
+            picture_password="7.8.9",
+        )
+        self.facility.add_admin(admin)
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="7.8.9",
+            facility=self.facility,
+        )
+        self.assertIsNone(user)
+
+    def test_device_superuser_not_returned_by_picture_password(self):
+        superuser = create_superuser(self.facility, username="superuser")
+        superuser.picture_password = "2.4.6"
+        superuser.save(update_fields=["picture_password"])
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="2.4.6",
+            facility=self.facility,
+        )
+        self.assertIsNone(user)
+
+    def test_picture_password_none_does_not_use_picture_path(self):
+        # When picture_password is None, falls through to username/password path
+        # (which returns None for non-existent username)
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            username="nobody",
+            password="wrong",
+            picture_password=None,
+            facility=self.facility,
+        )
+        self.assertIsNone(user)

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -125,6 +125,14 @@ class PicturePasswordBackendTestCase(TestCase):
         )
         self.assertEqual(user, self.learner)
 
+    def test_valid_picture_password_with_facility_pk_returns_learner(self):
+        user = FacilityUserBackend().authenticate(
+            self.request,
+            picture_password="1.2.3",
+            facility=self.facility.pk,
+        )
+        self.assertEqual(user, self.learner)
+
     def test_picture_password_wrong_facility_returns_none(self):
         user = FacilityUserBackend().authenticate(
             self.request,


### PR DESCRIPTION

## Summary
This PR updates CreateSessionSerializer and FacilityUserBackend to support learners logging in with a picture password sequence when picture login is enabled on a facility. It adds picture password as a new authentication method for FacilityUser accounts, alongside the existing username/password path.
Picture password is expressed as three dot-separated integers (e.g. "3.7.12"), corresponding to icon indices.
closes  #14408
## References

 #14408
## Reviewer guidance

1. Does it make sense?
2.  Verify that splitting the roles and `devicepermissions` conditions across two chained `.filter()` calls is necessary and that collapsing them into one would produce incorrect results.
3.  Check that when picture_password is supplied but fails.

## AI usage
Used to plan!