### PR TITLE
Fix mark-all-present switch requiring two clicks after modal cancel

### DIFF
--- a/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
+++ b/kolibri/plugins/coach/frontend/composables/useAttendanceForm.js
@@ -26,6 +26,7 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
   const previouslyEnrolledMap = ref({});
   const enrolledLearnerIds = ref(null);
   const showMarkAllModal = ref(false);
+  const pendingMarkAll = ref(false);
   const pendingRoute = ref(null);
 
   const backRoute = computed(() => ({
@@ -95,6 +96,12 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
       sortedLearners.value.length > 0 && currentPresentCount.value === sortedLearners.value.length,
   );
 
+  // The switch should appear checked if all learners are genuinely present, OR if the
+  // user has clicked "mark all present" and is seeing the confirmation modal (pendingMarkAll).
+  // When the modal is canceled, pendingMarkAll resets to false, which changes this computed
+  // from true → false and gives Vue a real prop change to re-render the KSwitch correctly.
+  const markAllPresent = computed(() => allPresent.value || pendingMarkAll.value);
+
   function setAllLearners(value) {
     const newMap = {};
     sortedLearners.value.forEach(l => {
@@ -106,6 +113,7 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
 
   function handleMarkAllChange(checked) {
     if (checked) {
+      pendingMarkAll.value = true;
       showMarkAllModal.value = true;
     } else {
       setAllLearners(false);
@@ -114,10 +122,12 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
 
   function confirmMarkAll() {
     setAllLearners(true);
+    pendingMarkAll.value = false;
     showMarkAllModal.value = false;
   }
 
   function cancelMarkAll() {
+    pendingMarkAll.value = false;
     showMarkAllModal.value = false;
   }
 
@@ -167,6 +177,7 @@ export default function useAttendanceForm({ hasChanges, markClean, submitting, o
     absentCount,
     currentAbsentCount,
     allPresent,
+    markAllPresent,
     showMarkAllModal,
     pendingRoute,
     isPresent,

--- a/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
+++ b/kolibri/plugins/coach/frontend/views/attendance/AttendanceFormTable.vue
@@ -31,7 +31,7 @@
               <KSwitch
                 name="mark-all-present"
                 :ariaLabelledBy="'mark-all-present-label'"
-                :value="allPresent"
+                :value="markAllSwitchValue"
                 @change="handleMarkAllChange"
               />
             </div>
@@ -200,7 +200,7 @@
       const {
         sortedLearners,
         sortedPreviouslyEnrolled,
-        allPresent,
+        markAllPresent: markAllSwitchValue,
         presentCount: presentCountValue,
         absentCount: absentCountValue,
         currentAbsentCount: currentAbsentCountValue,
@@ -250,7 +250,7 @@
         confirmButtonStyles,
         allItems,
         sortedLearners,
-        allPresent,
+        markAllSwitchValue,
         presentCount: presentCountValue,
         absentCount: absentCountValue,
         currentAbsentCount: currentAbsentCountValue,

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
@@ -300,6 +300,37 @@ describe('AttendanceNewPage', () => {
     expect(buttons.length).toBe(2);
   });
 
+  it('re-opens modal on a single click after "Go back" was clicked in the mark-all modal', async () => {
+    // Regression: after cancelling the modal, the KSwitch stayed visually "on" even though
+    // allPresent was false. The next click fired @change(false) instead of @change(true),
+    // so the modal never re-opened — requiring a second click to trigger it again.
+    renderNewPage();
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // First click — opens modal
+    await fireEvent.click(getMarkAllSwitch());
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Click "Go back" inside the modal
+    await fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    // Switch should be visually unchecked after cancellation
+    expect(getMarkAllSwitch().checked).toBe(false);
+
+    // Second click — should open the modal again in a single click
+    await fireEvent.click(getMarkAllSwitch());
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
   it('marks all learners present after confirming modal', async () => {
     renderNewPage();
     await waitFor(() => {

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
@@ -3,8 +3,10 @@ import VueRouter from 'vue-router';
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import { createLocalVue } from '@vue/test-utils';
 import store from 'kolibri/store';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
 // eslint-disable-next-line import/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar';
+import { attendanceStrings } from 'kolibri-common/strings/attendanceStrings';
 import classSummaryModule from '../../../modules/classSummary';
 /* eslint-disable import/named */
 import { useAttendance, useAttendanceMock } from '../../../composables/useAttendance';
@@ -250,15 +252,15 @@ describe('AttendanceNewPage', () => {
   it('updates present/absent counts when toggling a learner', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('0 present')).toBeInTheDocument();
-      expect(screen.getByText('3 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 0 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 3 }))).toBeInTheDocument();
     });
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
 
     await waitFor(() => {
-      expect(screen.getByText('1 present')).toBeInTheDocument();
-      expect(screen.getByText('2 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 1 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 2 }))).toBeInTheDocument();
     });
   });
 
@@ -316,7 +318,7 @@ describe('AttendanceNewPage', () => {
     });
 
     // Click "Go back" inside the modal
-    await fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('goBackAction') }));
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
@@ -342,11 +344,11 @@ describe('AttendanceNewPage', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByText('Mark all present'));
+    await fireEvent.click(screen.getByText(attendanceStrings.markAllPresentAction$()));
 
     await waitFor(() => {
-      expect(screen.getByText('3 present')).toBeInTheDocument();
-      expect(screen.getByText('0 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 3 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 0 }))).toBeInTheDocument();
     });
   });
 
@@ -357,7 +359,9 @@ describe('AttendanceNewPage', () => {
     });
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
-    await fireEvent.click(screen.getByRole('button', { name: 'Submit attendance' }));
+    await fireEvent.click(
+      screen.getByRole('button', { name: attendanceStrings.submitAttendanceAction$() }),
+    );
     await global.flushPromises();
 
     expect(createSession).toHaveBeenCalledWith(
@@ -382,7 +386,9 @@ describe('AttendanceNewPage', () => {
     const initialRoute = router.currentRoute.name;
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
-    await fireEvent.click(screen.getByRole('button', { name: 'Submit attendance' }));
+    await fireEvent.click(
+      screen.getByRole('button', { name: attendanceStrings.submitAttendanceAction$() }),
+    );
     await global.flushPromises();
 
     expect(createSnackbar).toHaveBeenCalled();
@@ -447,16 +453,16 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('2 present')).toBeInTheDocument();
-      expect(screen.getByText('1 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 2 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 1 }))).toBeInTheDocument();
     });
 
     // Toggle Bob from absent to present — 1 change
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     await waitFor(() => {
-      expect(screen.getByText('3 present')).toBeInTheDocument();
-      expect(screen.getByText('0 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 3 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 0 }))).toBeInTheDocument();
     });
   });
 
@@ -465,7 +471,7 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: coreString('saveAction') })).toBeDisabled();
     });
   });
 
@@ -481,14 +487,14 @@ describe('AttendanceEditPage', () => {
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('saveAction') }));
 
     await waitFor(() => {
       const modal = screen.getByRole('dialog');
       expect(modal).toBeInTheDocument();
       expect(modal).toHaveTextContent('1');
-      expect(modal).toHaveTextContent('3 present');
-      expect(modal).toHaveTextContent('0 absent');
+      expect(modal).toHaveTextContent(attendanceStrings.presentCount$({ count: 3 }));
+      expect(modal).toHaveTextContent(attendanceStrings.absentCount$({ count: 0 }));
     });
   });
 
@@ -504,7 +510,7 @@ describe('AttendanceEditPage', () => {
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save to open modal
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('saveAction') }));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -538,7 +544,7 @@ describe('AttendanceEditPage', () => {
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('saveAction') }));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -558,10 +564,12 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('There are no learners in this class')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.noLearnersInClassMessage$())).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: coreString('saveAction') }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows previously enrolled section (no save button) when all learners are removed but records exist', async () => {
@@ -572,11 +580,17 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Alice' })),
+      ).toBeInTheDocument();
     });
 
-    expect(screen.queryByText('There are no learners in this class')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(attendanceStrings.noLearnersInClassMessage$()),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: coreString('saveAction') }),
+    ).not.toBeInTheDocument();
   });
 
   it('does not show learners added after the session was created', async () => {
@@ -601,7 +615,9 @@ describe('AttendanceEditPage', () => {
 
     // Bob joined after this session — should not appear at all
     expect(screen.queryByText('Bob')).not.toBeInTheDocument();
-    expect(screen.queryByText('Bob (Previously enrolled)')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Bob' })),
+    ).not.toBeInTheDocument();
   });
 
   it('shows searchable list for previously enrolled when no current learners exist', async () => {
@@ -615,12 +631,16 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Alice' })),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Bob' })),
+      ).toBeInTheDocument();
     });
 
     // Search box should be present for filtering previously enrolled learners
-    expect(screen.getByPlaceholderText('Search for a learner')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(attendanceStrings.searchPlaceholder$())).toBeInTheDocument();
 
     // Both previously enrolled toggles should be disabled
     const aliceSwitch = document.querySelector('input[name="attendance-removed-learner-a"]');
@@ -644,8 +664,12 @@ describe('AttendanceEditPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
-      expect(screen.getByText('Charlie (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Bob' })),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Charlie' })),
+      ).toBeInTheDocument();
     });
   });
 
@@ -661,7 +685,9 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(attendanceStrings.previouslyEnrolledLabel$({ name: 'Bob' })),
+      ).toBeInTheDocument();
     });
 
     const removedSwitch = document.querySelector('input[name="attendance-removed-learner-b"]');
@@ -683,8 +709,8 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('2 present')).toBeInTheDocument();
-      expect(screen.getByText('1 absent')).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.presentCount$({ count: 2 }))).toBeInTheDocument();
+      expect(screen.getByText(attendanceStrings.absentCount$({ count: 1 }))).toBeInTheDocument();
     });
   });
 
@@ -704,7 +730,7 @@ describe('AttendanceEditPage', () => {
     });
 
     // 3 total present (Alice current + Bob and Charlie previously enrolled), 0 absent.
-    expect(screen.getByText('3 present')).toBeInTheDocument();
-    expect(screen.getByText('0 absent')).toBeInTheDocument();
+    expect(screen.getByText(attendanceStrings.presentCount$({ count: 3 }))).toBeInTheDocument();
+    expect(screen.getByText(attendanceStrings.absentCount$({ count: 0 }))).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

After clicking **Go back** in the *Mark all N learners as present* confirmation modal, the **Mark all learners present** switch required two clicks to re-open the modal instead of one.

**Root cause:** `KSwitch` optimistically toggles its internal checked state when clicked. `handleMarkAllChange(true)` was called but instead of updating the actual attendance state, a modal was shown. The `:value` binding (`allPresent`) stayed `false` both before the click and after the cancel — so Vue saw no prop change, never re-rendered the switch, and it remained visually *on*. The next click then fired `@change(false)` (a no-op), and only the second click fired `@change(true)` to re-open the modal.

**Fix:** Introduced a `pendingMarkAll` ref in `useAttendanceForm.js` that is set to `true` when the modal opens and back to `false` when the modal is cancelled or confirmed. The switch now binds to `markAllPresent = computed(() => allPresent.value || pendingMarkAll.value)`. When the modal is cancelled, `pendingMarkAll` flips `false`, which changes the computed from `true → false` — giving Vue a real reactive update to re-render the `KSwitch` back to its unchecked state.

A regression test was added to `AttendancePages.spec.js` that reproduces the exact sequence: open modal → click Go back → verify switch is unchecked → verify one click re-opens the modal.

![Screen Recording 2026-04-10 at 10 55 00](https://github.com/user-attachments/assets/2cb07fca-6790-4bbc-a170-3f2d5da51591)

## References

Fixes learningequality/kolibri#14416

## Reviewer guidance

1. Install the build from https://github.com/learningequality/kolibri/releases/tag/v0.19.3-rc1
2. Go to `Coach > Class home > class > Mark attendance`

Reproduce the original bug:
- With some learners absent, click the **Mark all learners present** switch
- In the confirmation modal, click **Go back**
- Click the switch again — before this fix, the modal did not reopen; a second click was required

With this fix, one click after cancelling the modal is sufficient to re-open it.

## AI usage

Implemented with Claude Code. The root cause analysis, fix, and regression test were AI-generated. I reviewed the generated code for correctness and unnecessary complexity, verified the approach against existing test patterns, and confirmed all 26 tests pass.