### PR TITLE
Add utility for picture passwords exhaustion

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections import OrderedDict
 from datetime import timedelta
 from itertools import groupby
 from uuid import UUID
@@ -86,6 +87,7 @@ from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facilit
 from kolibri.core.auth.permissions.general import DenyAll
 from kolibri.core.auth.tasks import cleanup_expired_deleted_users
 from kolibri.core.auth.utils.delete import delete_imported_user
+from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exhausted
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access
@@ -844,6 +846,10 @@ def _map_dataset(facility):
     return dataset
 
 
+def _picture_passwords_exhausted(facility):
+    return are_picture_passwords_exhausted(facility["dataset__id"])
+
+
 class FacilityViewSet(ValuesViewset):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)
@@ -861,7 +867,14 @@ class FacilityViewSet(ValuesViewset):
 
     values = tuple(facility_values + dataset_keys)
 
-    field_map = {"dataset": _map_dataset}
+    # regular dict can be used after removal for support of python3.6
+    field_map = OrderedDict(
+        [
+            # must precede _map_dataset since it depends on the dataset ID
+            ("picture_passwords_exhausted", _picture_passwords_exhausted),
+            ("dataset", _map_dataset),
+        ]
+    )
 
     def annotate_queryset(self, queryset):
         transfer_session_dataset_filter = Func(

--- a/kolibri/core/auth/constants/picture_passwords.py
+++ b/kolibri/core/auth/constants/picture_passwords.py
@@ -1,4 +1,24 @@
+import json
+from pathlib import Path
+
+
 # Upper bound on auto-assignment: reserve a small buffer below the total
 # number of unique 3-pick permutations (12P3 = 1320) so assignment never
 # exhausts the pool entirely.
 LEARNER_PICTURE_PASSWORD_LIMIT = 1300
+
+# mapping of integer IDs to KDS icon names for picture-based login.
+#
+# IMPORTANT — treat this mapping as an append-only registry:
+#   IDs are immutable once assigned.
+#   Pictures can be added but NEVER removed or reassigned.
+#   Changing or removing an ID would invalidate stored sequences
+#   or point them to the wrong picture.
+PICTURE_PASSWORD_SET = {
+    int(key): value
+    for key, value in json.loads(
+        (Path(__file__).resolve().parent / "picture_passwords_set.json").read_text()
+    ).items()
+}
+
+SEQUENCE_LENGTH = 3

--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -10,6 +10,7 @@ from kolibri.core.auth.sync_operations import KolibriNetworkInitializeOperation
 from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
 from kolibri.core.auth.sync_operations import KolibriSyncOperationMixin
 from kolibri.core.auth.tasks import cleanupsync
+from kolibri.core.auth.utils.picture_passwords import get_learner_count
 from kolibri.plugins.hooks import register_hook
 
 
@@ -104,3 +105,4 @@ class AuthSyncHook(FacilityDataSyncHook):
                 FacilityUser
             )
             cleanup_sessions(user_ids)
+            get_learner_count.clear(dataset_id)

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -12,7 +12,6 @@ from rest_framework.validators import UniqueTogetherValidator
 from .constants import collection_kinds
 from .constants import facility_presets
 from .constants import role_kinds
-from .constants.picture_passwords import LEARNER_PICTURE_PASSWORD_LIMIT
 from .errors import IncompatibleDeviceSettingError
 from .errors import InvalidCollectionHierarchy
 from .errors import InvalidMembershipError
@@ -27,6 +26,7 @@ from .models import Membership
 from .models import Role
 from .models import validate_username_allowed_chars
 from .models import validate_username_max_length
+from .utils.picture_passwords import are_picture_passwords_exhausted
 from .utils.picture_passwords import assign_picture_password
 from kolibri.core import error_constants
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
@@ -183,15 +183,14 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             instance = super().create(validated_data)
             facility = instance.facility
-            if facility.dataset.picture_password_settings is not None:
-                learner_count = FacilityUser.objects.filter(
-                    facility=facility, roles__isnull=True
-                ).count()
-                if learner_count < LEARNER_PICTURE_PASSWORD_LIMIT:
-                    try:
-                        assign_picture_password(instance, facility)
-                    except NoAvailableSequences:
-                        pass
+            if (
+                facility.dataset.picture_password_settings is not None
+                and not are_picture_passwords_exhausted(instance.dataset_id)
+            ):
+                try:
+                    assign_picture_password(instance, instance.facility)
+                except NoAvailableSequences:
+                    pass
         return instance
 
     def _validate_extra_demographics(self, attrs, facility):

--- a/kolibri/core/auth/signals.py
+++ b/kolibri/core/auth/signals.py
@@ -4,6 +4,7 @@ from django.dispatch import receiver
 
 from .models import FacilityUser
 from .models import Membership
+from .models import Role
 from .utils.picture_passwords import get_learner_count
 from kolibri.core.notifications.models import LearnerProgressNotification
 
@@ -28,11 +29,11 @@ def cascade_delete_user(sender, instance=None, *args, **kwargs):
     LearnerProgressNotification.objects.filter(user_id=instance.id).delete()
 
 
-@receiver(post_save, sender=FacilityUser)
-def post_save_clear_learner_count(sender, instance=None, *args, **kwargs):
+@receiver([post_save, pre_delete], sender=FacilityUser)
+def facility_user_clear_learner_count(sender, instance=None, *args, **kwargs):
     get_learner_count.clear(instance.dataset_id)
 
 
-@receiver(pre_delete, sender=FacilityUser)
-def pre_delete_clear_learner_count(sender, instance=None, *args, **kwargs):
+@receiver([post_save, pre_delete], sender=Role)
+def role_clear_learner_count(sender, instance=None, *args, **kwargs):
     get_learner_count.clear(instance.dataset_id)

--- a/kolibri/core/auth/signals.py
+++ b/kolibri/core/auth/signals.py
@@ -1,8 +1,10 @@
+from django.db.models.signals import post_save
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
 from .models import FacilityUser
 from .models import Membership
+from .utils.picture_passwords import get_learner_count
 from kolibri.core.notifications.models import LearnerProgressNotification
 
 
@@ -24,3 +26,13 @@ def cascade_delete_user(sender, instance=None, *args, **kwargs):
     objects whose user is the instance's user.
     """
     LearnerProgressNotification.objects.filter(user_id=instance.id).delete()
+
+
+@receiver(post_save, sender=FacilityUser)
+def post_save_clear_learner_count(sender, instance=None, *args, **kwargs):
+    get_learner_count.clear(instance.dataset_id)
+
+
+@receiver(pre_delete, sender=FacilityUser)
+def pre_delete_clear_learner_count(sender, instance=None, *args, **kwargs):
+    get_learner_count.clear(instance.dataset_id)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -13,7 +13,6 @@ from django.db.models.signals import pre_delete
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
-from mock import MagicMock
 from mock import patch
 from morango.constants import transfer_stages
 from morango.constants import transfer_statuses
@@ -33,10 +32,8 @@ from rest_framework.test import APITransactionTestCase
 from .. import models
 from ..constants import role_kinds
 from ..constants.facility_presets import mappings
-from ..constants.picture_passwords import LEARNER_PICTURE_PASSWORD_LIMIT
 from ..models import Facility
 from ..serializers import _prepare_for_bulk_create
-from ..serializers import FacilityUserSerializer
 from .helpers import create_superuser
 from .helpers import DUMMY_PASSWORD
 from .helpers import provision_device
@@ -3673,25 +3670,15 @@ class FacilityUserSerializerPicturePasswordTestCase(APITestCase):
         user = models.FacilityUser.objects.get(id=response.data["id"])
         self.assertIsNone(user.picture_password)
 
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
     def test_new_learner_no_picture_password_when_learner_count_at_limit(self):
-        """Learner creation succeeds without picture_password when facility is at or above the limit.
+        """Learner creation succeeds without picture_password when facility is at or above the limit."""
+        FacilityUserFactory.create(facility=self.facility)
+        FacilityUserFactory.create(facility=self.facility)
 
-        Tests the serializer directly to avoid patching Django ORM methods globally
-        during a live HTTP request (where filter() is called in many other places).
-        The patch scopes only to FacilityUser.objects.filter; is_valid() uses
-        FacilityUser.objects.get() (not filter()) so validation is unaffected.
-        """
-        mock_qs = MagicMock()
-        mock_qs.count.return_value = LEARNER_PICTURE_PASSWORD_LIMIT
-
-        with patch.object(models.FacilityUser.objects, "filter", return_value=mock_qs):
-            serializer = FacilityUserSerializer(
-                data={
-                    "username": "limituser",
-                    "password": DUMMY_PASSWORD,
-                    "facility": str(self.facility.id),
-                }
-            )
-            self.assertTrue(serializer.is_valid(), serializer.errors)
-            instance = serializer.save()
-        self.assertIsNone(instance.picture_password)
+        response = self._create_user_via_api()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user = models.FacilityUser.objects.get(id=response.data["id"])
+        self.assertIsNone(user.picture_password)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -768,6 +768,66 @@ class FacilityAPITestCase(APITestCase):
         assert dataset.learner_can_login_with_no_password is False
         assert dataset.show_download_button_in_learn is True
 
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
+    def test_picture_passwords_exhausted_false_when_learner_count_below_limit(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility1,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:facility-detail",
+                kwargs={"pk": self.facility1.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["picture_passwords_exhausted"])
+
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
+    def test_picture_passwords_exhausted_true_when_learner_count_reaches_limit(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility1,
+        )
+        FacilityUserFactory.create(facility=self.facility1)
+        response = self.client.get(
+            reverse(
+                "kolibri:core:facility-detail",
+                kwargs={"pk": self.facility1.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["picture_passwords_exhausted"])
+
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
+    def test_picture_passwords_exhausted_ignores_non_learner_users(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility1,
+        )
+        coach = FacilityUserFactory.create(facility=self.facility1)
+        self.facility1.add_coach(coach)
+        admin = FacilityUserFactory.create(facility=self.facility1)
+        self.facility1.add_admin(admin)
+
+        response = self.client.get(
+            reverse(
+                "kolibri:core:facility-detail",
+                kwargs={"pk": self.facility1.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["picture_passwords_exhausted"])
+
 
 def _add_demographic_schema_to_facility(facility):
     facility.dataset.extra_fields.update(

--- a/kolibri/core/auth/test/test_hooks.py
+++ b/kolibri/core/auth/test/test_hooks.py
@@ -64,6 +64,7 @@ class CleanUpTaskOperationTestCase(TestCase):
         )
 
 
+@mock.patch("kolibri.core.auth.kolibri_plugin.get_learner_count")
 @mock.patch("kolibri.core.auth.kolibri_plugin.Session")
 class AuthSyncHookSessionCleanupTestCase(TestCase):
 
@@ -93,7 +94,7 @@ class AuthSyncHookSessionCleanupTestCase(TestCase):
         self.hook = AuthSyncHook()
         self.now = now()
 
-    def test_post_transfer__not_receiver(self, mock_session):
+    def test_post_transfer__not_receiver(self, mock_session, mock_learner_count):
         """Test that post_transfer does nothing when not receiving data"""
         self.context.is_receiver = False
         self.hook.post_transfer(
@@ -105,7 +106,9 @@ class AuthSyncHookSessionCleanupTestCase(TestCase):
         )
         mock_session.delete_all_sessions.assert_not_called()
 
-    def test_post_transfer__no_soft_deleted_users(self, mock_session):
+    def test_post_transfer__no_soft_deleted_users(
+        self, mock_session, mock_learner_count
+    ):
         """Test that post_transfer does nothing when there are no soft-deleted users"""
         self.context.is_receiver = True
         # Create a regular (non-deleted) user
@@ -127,7 +130,31 @@ class AuthSyncHookSessionCleanupTestCase(TestCase):
         )
         mock_session.delete_all_sessions.assert_not_called()
 
-    def test_post_transfer__with_soft_deleted_users(self, mock_session):
+    def test_post_transfer__clear_learner_count(self, mock_session, mock_learner_count):
+        """Test that post_transfer clears learner count"""
+        self.context.is_receiver = True
+        # Create a regular (non-deleted) user
+        user = FacilityUser.objects.create(
+            username="regular_user",
+            facility=self.facility,
+        )
+        # Mock transfer session to return this user's ID
+        self.mock_transfer_session.get_touched_record_ids_for_model.return_value = [
+            user.id
+        ]
+
+        self.hook.post_transfer(
+            dataset_id=self.facility.dataset_id,
+            local_is_single_user=False,
+            remote_is_single_user=False,
+            single_user_id=None,
+            context=self.context,
+        )
+        mock_learner_count.clear.assert_called_once_with(self.facility.dataset_id)
+
+    def test_post_transfer__with_soft_deleted_users(
+        self, mock_session, mock_learner_count
+    ):
         """Test that post_transfer cleans up sessions for soft-deleted users"""
         self.context.is_receiver = True
         # Create soft-deleted users

--- a/kolibri/core/auth/test/test_picture_passwords.py
+++ b/kolibri/core/auth/test/test_picture_passwords.py
@@ -1,4 +1,6 @@
+import factory
 import mock
+from django.db.models.signals import post_save
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from mock import patch
@@ -195,13 +197,12 @@ class AssignPicturePasswordTestCase(TestCase):
 
 
 class PicturePasswordsExhaustionTestCase(TestCase):
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         cls.facility = Facility.objects.create(name="Test Facility")
         cls.learner_sequence = 0
-
-    def setUp(self):
-        get_learner_count.clear(self.facility.dataset_id)
 
     def _create_user(self):
         """
@@ -232,7 +233,18 @@ class PicturePasswordsExhaustionTestCase(TestCase):
         self.facility.add_role(admin, ADMIN)
         self.assertEqual(get_learner_count(self.facility.dataset_id), 1)
 
+    def test_get_learner_count__signals(self):
+        self._create_user()
+        self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+        user_x = self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 3)
+        user_x.delete()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+
+    @factory.django.mute_signals(post_save)
     def test_get_learner_count__cache_and_clear(self):
+        get_learner_count.clear(self.facility.dataset_id)
         self._create_user()
         self._create_user()
         self.assertEqual(get_learner_count(self.facility.dataset_id), 2)

--- a/kolibri/core/auth/test/test_picture_passwords.py
+++ b/kolibri/core/auth/test/test_picture_passwords.py
@@ -233,7 +233,7 @@ class PicturePasswordsExhaustionTestCase(TestCase):
         self.facility.add_role(admin, ADMIN)
         self.assertEqual(get_learner_count(self.facility.dataset_id), 1)
 
-    def test_get_learner_count__signals(self):
+    def test_get_learner_count__user_signals(self):
         self._create_user()
         self._create_user()
         self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
@@ -241,6 +241,13 @@ class PicturePasswordsExhaustionTestCase(TestCase):
         self.assertEqual(get_learner_count(self.facility.dataset_id), 3)
         user_x.delete()
         self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+
+    def test_get_learner_count__role_signals(self):
+        self._create_user()
+        admin = self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+        self.facility.add_role(admin, ADMIN)
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 1)
 
     @factory.django.mute_signals(post_save)
     def test_get_learner_count__cache_and_clear(self):

--- a/kolibri/core/auth/test/test_picture_passwords.py
+++ b/kolibri/core/auth/test/test_picture_passwords.py
@@ -1,16 +1,22 @@
 import mock
 from django.db.utils import IntegrityError
 from django.test import TestCase
+from mock import patch
 
 from ..models import Facility
 from ..models import FacilityUser
+from .helpers import create_superuser
+from .helpers import DUMMY_PASSWORD
+from kolibri.core.auth.constants.picture_passwords import PICTURE_PASSWORD_SET
+from kolibri.core.auth.constants.picture_passwords import SEQUENCE_LENGTH
+from kolibri.core.auth.constants.role_kinds import ADMIN
 from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.errors import SequenceAlreadyAssigned
+from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exhausted
 from kolibri.core.auth.utils.picture_passwords import assign_picture_password
 from kolibri.core.auth.utils.picture_passwords import get_all_valid_sequences
 from kolibri.core.auth.utils.picture_passwords import get_assigned_sequences
-from kolibri.core.auth.utils.picture_passwords import PICTURE_PASSWORD_SET
-from kolibri.core.auth.utils.picture_passwords import SEQUENCE_LENGTH
+from kolibri.core.auth.utils.picture_passwords import get_learner_count
 
 
 class GetAllValidSequencesTestCase(TestCase):
@@ -186,3 +192,66 @@ class AssignPicturePasswordTestCase(TestCase):
         )
         self.assertIsNotNone(db_value)
         self.assertEqual(learner.picture_password, db_value)
+
+
+class PicturePasswordsExhaustionTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="Test Facility")
+        cls.learner_sequence = 0
+
+    def setUp(self):
+        get_learner_count.clear(self.facility.dataset_id)
+
+    def _create_user(self):
+        """
+        :return: FacilityUser object
+        :rtype: FacilityUser
+        """
+        self.learner_sequence += 1
+        return FacilityUser.objects.create(
+            username=f"user_{self.learner_sequence}",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    def test_get_learner_count__basic(self):
+        self._create_user()
+        self._create_user()
+        self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 3)
+
+    def test_get_learner_count__no_superusers(self):
+        create_superuser(self.facility)
+        self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 1)
+
+    def test_get_learner_count__no_roles(self):
+        self._create_user()
+        admin = self._create_user()
+        self.facility.add_role(admin, ADMIN)
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 1)
+
+    def test_get_learner_count__cache_and_clear(self):
+        self._create_user()
+        self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+        self._create_user()
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 2)
+        get_learner_count.clear(self.facility.dataset_id)
+        self.assertEqual(get_learner_count(self.facility.dataset_id), 3)
+
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
+    def test_are_picture_passwords_exhausted__false(self):
+        self._create_user()
+        self.assertFalse(are_picture_passwords_exhausted(self.facility.dataset_id))
+
+    @patch(
+        "kolibri.core.auth.utils.picture_passwords.LEARNER_PICTURE_PASSWORD_LIMIT", 2
+    )
+    def test_are_picture_passwords_exhausted__true(self):
+        self._create_user()
+        self._create_user()
+        self.assertTrue(are_picture_passwords_exhausted(self.facility.dataset_id))

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -1,34 +1,15 @@
-import json
 import logging
 import random
 from itertools import permutations
-from pathlib import Path
 
 from django.db.utils import IntegrityError
 
+from kolibri.core.auth.constants.picture_passwords import PICTURE_PASSWORD_SET
+from kolibri.core.auth.constants.picture_passwords import SEQUENCE_LENGTH
 from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.errors import SequenceAlreadyAssigned
 from kolibri.core.auth.models import FacilityUser
 
-# mapping of integer IDs to KDS icon names for picture-based login.
-#
-# IMPORTANT — treat this mapping as an append-only registry:
-#   IDs are immutable once assigned.
-#   Pictures can be added but NEVER removed or reassigned.
-#   Changing or removing an ID would invalidate stored sequences
-#   or point them to the wrong picture.
-PICTURE_PASSWORD_SET = {
-    int(key): value
-    for key, value in json.loads(
-        (
-            Path(__file__).resolve().parent.parent
-            / "constants"
-            / "picture_passwords_set.json"
-        ).read_text()
-    ).items()
-}
-
-SEQUENCE_LENGTH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 class LearnerCounterCache(object):
+    """
+    Learner calculation specifically for picture password login since only learners who have no role
+    and are not superusers should be included
+    """
+
     key = "learner_count_{dataset_id}"
     timeout = 300
 

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -2,16 +2,97 @@ import logging
 import random
 from itertools import permutations
 
+from django.db.models.functions import Coalesce
 from django.db.utils import IntegrityError
 
+from kolibri.core.auth.constants.picture_passwords import LEARNER_PICTURE_PASSWORD_LIMIT
 from kolibri.core.auth.constants.picture_passwords import PICTURE_PASSWORD_SET
 from kolibri.core.auth.constants.picture_passwords import SEQUENCE_LENGTH
 from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.errors import SequenceAlreadyAssigned
+from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.utils.cache import process_cache as cache
 
 
 logger = logging.getLogger(__name__)
+
+
+class LearnerCounterCache(object):
+    key = "learner_count_{dataset_id}"
+    timeout = 300
+
+    def count(self, dataset_id):
+        """
+        Queries for the quantity of learners in a particular facility given its dataset ID
+
+        :param dataset_id: The ID of the facility dataset
+        :type dataset_id: str
+        :return: The number of learners in the facility (associated with the dataset)
+        :rtype: int
+        """
+        return (
+            FacilityUser.objects.annotate(
+                is_superuser=Coalesce("devicepermissions__is_superuser", False),
+            )
+            .filter(
+                dataset_id=dataset_id,
+                roles__isnull=True,
+                is_superuser=False,
+            )
+            .count()
+        )
+
+    def clear(self, dataset_id=None):
+        """
+        Clears the cache entry for the specified dataset, or all datasets if none specified.
+
+        :param dataset_id: The ID of the dataset to clear from the cache.
+        :type dataset_id: str|None
+        """
+        dataset_ids = []
+        if dataset_id is not None:
+            dataset_ids.append(dataset_id)
+        else:
+            dataset_ids = Facility.objects.values_list(
+                "dataset_id", flat=True
+            ).distinct()
+
+        for dataset_id in dataset_ids:
+            key = self.key.format(dataset_id=dataset_id)
+            cache.delete(key)
+
+    def __call__(self, dataset_id):
+        """
+        Queries for the quantity of learners in a particular facility given its dataset ID
+
+        :param dataset_id: The ID of the dataset whose count needs to be retrieved.
+        :type dataset_id: str
+        :return: The number of learners in the facility (associated with the dataset)
+        :rtype: int
+        """
+        key = self.key.format(dataset_id=dataset_id)
+        count = cache.get(key)
+        if count is None:
+            count = self.count(dataset_id)
+            cache.set(key, count, self.timeout)
+        return count
+
+
+get_learner_count = LearnerCounterCache()
+
+
+def are_picture_passwords_exhausted(dataset_id):
+    """
+    Determines whether the maximum number of picture passwords have been granted for a
+    given facility dataset.
+
+    :param dataset_id: The ID of the facility dataset to check
+    :type dataset_id: str
+    :return: `True` if the number of picture passwords has reached the defined limit
+    :rtype: bool
+    """
+    return get_learner_count(dataset_id) >= LEARNER_PICTURE_PASSWORD_LIMIT
 
 
 def get_all_valid_sequences(picture_set):


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds cached counter class for calculating effective learner count for picture password assignment
  - Excludes superusers unlike a previous calculation since superusers must use passwords
- Adds `are_picture_passwords_exhausted` utility to compare count with threshold
- Moves constants that were defined in picture passwords' utils to new dedicated constants file
- Adds `picture_passwords_exhausted` to the facility response-- the motivation to have the count cached
- Integrates various hooks to ensure the cached learner count is cleared when applicable
- Adds tests for new code and simplifies new tests

## References
<!--
 * references to related issues and PRs
-->
In preparation for https://github.com/learningequality/kolibri/issues/14426


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Do tests cover new code?
- Are there any cases where the cache isn't being cleared where it should?

