### PR TITLE
Automate npm package publishing

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -122,7 +122,7 @@ async function generateAssetComment(github, context) {
 }
 
 
-async function findComment(github, context, issue_number) {
+async function findComment(github, context, issue_number, header) {
   let comment;
   let page = 1
   while (!comment) {
@@ -136,11 +136,30 @@ async function findComment(github, context, issue_number) {
     if (!comments.length) {
       return;
     }
-    comment = comments.find(c => c.body && c.body.includes(buildArtifactsHeader))
+    comment = comments.find(c => c.body && c.body.includes(header))
     if (comment) {
       return comment.id.toString()
     }
     page += 1;
+  }
+}
+
+async function upsertComment(github, context, issue_number, header, body) {
+  const commentId = await findComment(github, context, issue_number, header);
+  if (commentId) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: commentId,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number,
+      body,
+    });
   }
 }
 
@@ -162,4 +181,5 @@ module.exports = {
   findComment,
   generateAssetComment,
   uploadReleaseAsset,
+  upsertComment,
 }

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,35 +1,40 @@
-name: Publish package to npm
+name: Publish packages to npm
 
 on:
-    workflow_dispatch:
-      # Inputs the workflow accepts.
-      inputs:
-        npm_package:
-          description: 'Package to publish to NPM'
-          required: true
-          type: choice
-          options:
-            - 'browserslist-config-kolibri'
-            - 'eslint-plugin-kolibri'
-            - 'kolibri'
-            - 'kolibri-app'
-            - 'kolibri-build'
-            - 'kolibri-format'
-            - 'kolibri-glob'
-            - 'kolibri-i18n'
-            - 'kolibri-jest-config'
-            - 'kolibri-logging'
-            - 'kolibri-module'
-            - 'kolibri-plugin-data'
-            - 'kolibri-tools'
-            - 'kolibri-viewer'
+  push:
+    branches:
+      - develop
+    paths:
+      - 'packages/**'
+  workflow_dispatch:
+    inputs:
+      npm_package:
+        description: 'Package to publish (or "all" to auto-detect)'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - 'browserslist-config-kolibri'
+          - 'eslint-plugin-kolibri'
+          - 'kolibri'
+          - 'kolibri-app'
+          - 'kolibri-build'
+          - 'kolibri-format'
+          - 'kolibri-glob'
+          - 'kolibri-i18n'
+          - 'kolibri-jest-config'
+          - 'kolibri-logging'
+          - 'kolibri-module'
+          - 'kolibri-plugin-data'
+          - 'kolibri-tools'
+          - 'kolibri-viewer'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write  # Required for npm provenance
+      id-token: write  # Required for npm OIDC trusted publishing
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -40,23 +45,10 @@ jobs:
         uses: pnpm/action-setup@v5
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Create tag
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const packageJson = require(`./packages/${{ github.event.inputs.npm_package }}/package.json`)
-            const version = packageJson.version
-            const tagname = `npm/${{ github.event.inputs.npm_package }}/${version}`
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/tags/${tagname}`,
-              sha: context.sha
-            })
-      - name: Build package
-        run: pnpm --filter ${{ github.event.inputs.npm_package }} run build || true
       - name: Publish to npm
-        run: pnpm --filter ${{ github.event.inputs.npm_package }} publish --provenance --access public --no-git-checks
-        env:
-          # NPM_API_TOKEN is an organization-level secret
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_API_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.npm_package }}" != "all" ]; then
+            ./scripts/npm_publish.sh "${{ github.event.inputs.npm_package }}"
+          else
+            ./scripts/npm_publish.sh
+          fi

--- a/.github/workflows/npm_version_check.yml
+++ b/.github/workflows/npm_version_check.yml
@@ -1,0 +1,65 @@
+name: npm Package Version Check
+
+on:
+  pull_request:
+    paths:
+      - 'packages/*/package.json'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+      - name: Check for version changes and comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const fs = require('fs');
+            const utils = require('./.github/githubUtils.js');
+
+            const base = context.payload.pull_request.base.sha;
+
+            const changed = execSync(`git diff --name-only ${base} -- 'packages/*/package.json'`)
+              .toString().trim().split('\n').filter(Boolean);
+
+            const rows = [];
+            for (const file of changed) {
+              let oldPkg;
+              try {
+                oldPkg = JSON.parse(execSync(`git show ${base}:${file}`, { encoding: 'utf8' }));
+              } catch {
+                continue; // new package
+              }
+
+              const newPkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+              if (newPkg.private) continue;
+
+              if (oldPkg.version !== newPkg.version) {
+                rows.push(`| ${newPkg.name} | ${oldPkg.version} | ${newPkg.version} |`);
+              }
+            }
+
+            const header = '**npm Package Versions**';
+            const prNumber = context.payload.pull_request.number;
+
+            if (rows.length) {
+              const body = `### ${header}\n\nMerging this PR will publish the following packages to npm:\n\n| Package | Current | New |\n|-|-|-|\n${rows.join('\n')}`;
+              await utils.upsertComment(github, context, prNumber, header, body);
+            } else {
+              const commentId = await utils.findComment(github, context, prNumber, header);
+              if (commentId) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: commentId,
+                });
+              }
+            }

--- a/.github/workflows/pr_build_comment.yml
+++ b/.github/workflows/pr_build_comment.yml
@@ -29,34 +29,10 @@ jobs:
             const fs = require('fs');
             const prNumber = Number(fs.readFileSync('./pr_number'));
             return prNumber
-      - name: Find build comment
-        id: find-comment
+      - name: Post build comment
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const utils = require('./.github/githubUtils.js')
-            return await utils.findComment(github, context, ${{steps.pr-number.outputs.result}})
-      - name: Create build comment
-        if: ${{!steps.find-comment.outputs.result}}
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-              github.rest.issues.createComment({
-                issue_number: ${{steps.pr-number.outputs.result}},
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: ${{ steps.comment-text.outputs.result }}
-              })
-      - name: Update build comment
-        if: ${{steps.find-comment.outputs.result}}
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-              github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: ${{steps.find-comment.outputs.result}},
-                body: ${{ steps.comment-text.outputs.result }}
-              })
+            await utils.upsertComment(github, context, ${{steps.pr-number.outputs.result}}, '**Build Artifacts**', ${{ steps.comment-text.outputs.result }})

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -11,3 +11,49 @@ Kolibri releases are `tracked in Notion <https://www.notion.so/learningequality/
 * Additional guidance on performing release steps
 
 We also maintain a small set of `release process automation scripts <https://github.com/learningequality/kolibri-release-utils/>`__ which automate some processes.
+
+
+npm packages
+============
+
+Packages in ``packages/`` are published to npm independently of Kolibri releases. Not all packages are published — those with ``"private": true`` in their ``package.json`` are skipped (currently ``kolibri-common``, ``kolibri-sandbox``, and ``kolibri-zip``).
+
+Automatic publishing
+--------------------
+
+When code merging to ``develop`` changes files in ``packages/``, the ``npm_publish.yml`` workflow compares each public package's version against npm and publishes any that are newer. Packages are published in dependency order — if one fails, dependents are not published.
+
+Authentication uses npm OIDC trusted publishing (no API tokens).
+
+The workflow can also be triggered manually from the Actions tab — either for a specific package or for all packages.
+
+Bumping a version
+-----------------
+
+.. code-block:: bash
+
+   ./scripts/bump_version.sh <package-name> <patch|minor|major>
+
+Commit the resulting ``package.json`` change and merge to ``develop``.
+
+Workspace dependencies are published with ``^`` ranges, so patch and minor bumps don't require re-publishing dependents. Major bumps are breaking — bump dependents in the same PR.
+
+First publish of a new package
+------------------------------
+
+The automated workflow skips packages that don't yet exist on npm. To first-publish:
+
+.. code-block:: bash
+
+   pnpm --filter <package-name> publish --access public
+
+Then configure OIDC trusted publishing for the package on npmjs.com.
+
+Provenance
+----------
+
+Every publish includes an SLSA provenance attestation linking the npm version to the exact commit and workflow run:
+
+.. code-block:: bash
+
+   ./scripts/npm_provenance.sh <package-name> [version]

--- a/packages/kolibri-sandbox/package.json
+++ b/packages/kolibri-sandbox/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kolibri-sandbox",
+  "private": true,
   "version": "0.1.0",
   "description": "A library for providing a secure sandbox environment for Kolibri.",
   "main": "src/mainClient.js",

--- a/packages/kolibri-zip/package.json
+++ b/packages/kolibri-zip/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kolibri-zip",
+  "private": true,
   "version": "0.1.0",
   "description": "A library for reading and writing zip files",
   "main": "src/index.js",

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <package-name> <patch|minor|major>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 kolibri-format patch"
+  echo "  $0 kolibri-format minor"
+  echo "  $0 kolibri-format major"
+  exit 1
+fi
+
+package="$1"
+bump="$2"
+
+if [[ "$bump" != "patch" && "$bump" != "minor" && "$bump" != "major" ]]; then
+  echo "Error: bump type must be patch, minor, or major (got: $bump)"
+  exit 1
+fi
+
+# Verify the package exists in the workspace
+pkg_dir="packages/$package"
+if [ ! -f "$pkg_dir/package.json" ]; then
+  echo "Error: $pkg_dir/package.json not found"
+  exit 1
+fi
+
+old_version=$(node -e "console.log(require('./$pkg_dir/package.json').version)")
+
+pnpm --filter "$package" exec npm version "$bump" --no-git-tag-version
+
+new_version=$(node -e "console.log(require('./$pkg_dir/package.json').version)")
+echo "$package: $old_version → $new_version"

--- a/scripts/npm_provenance.sh
+++ b/scripts/npm_provenance.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <package-name> [version]"
+  echo ""
+  echo "Examples:"
+  echo "  $0 kolibri-format 1.0.1    # specific version"
+  echo "  $0 kolibri-format           # latest version"
+  exit 1
+fi
+
+package="$1"
+version="${2:-$(npm view "$package" version 2>/dev/null)}" || {
+  echo "Error: package '$package' not found on npm"
+  exit 1
+}
+
+attestation_url="https://registry.npmjs.org/-/npm/v1/attestations/${package}@${version}"
+response=$(curl -sf "$attestation_url") || {
+  echo "Error: no attestations found for ${package}@${version}"
+  exit 1
+}
+
+# Find the SLSA provenance attestation and decode the payload
+provenance=$(node -e "
+  const data = JSON.parse(process.argv[1]);
+  const slsa = data.attestations.find(
+    a => a.predicateType === 'https://slsa.dev/provenance/v1'
+  );
+  if (!slsa) {
+    console.error('No SLSA provenance attestation found');
+    process.exit(1);
+  }
+  const payload = JSON.parse(
+    Buffer.from(slsa.bundle.dsseEnvelope.payload, 'base64').toString()
+  );
+  const dep = payload.predicate.buildDefinition.resolvedDependencies[0];
+  const commit = dep.digest.gitCommit;
+  const ref = dep.uri.split('@')[1];
+  const runUrl = payload.predicate.runDetails.metadata.invocationId;
+  console.log(commit);
+  console.log(runUrl);
+  console.log(ref);
+" "$response")
+
+commit=$(echo "$provenance" | sed -n '1p')
+run_url=$(echo "$provenance" | sed -n '2p')
+ref=$(echo "$provenance" | sed -n '3p')
+
+echo "${package}@${version}"
+echo "  Commit: $commit"
+echo "  Run:    $run_url"
+echo "  Branch: $ref"

--- a/scripts/npm_publish.sh
+++ b/scripts/npm_publish.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish npm packages.
+#
+# Usage:
+#   ./scripts/npm_publish.sh              # auto-detect and publish all changed packages
+#   ./scripts/npm_publish.sh kolibri-format  # publish a specific package
+
+FILTER=""
+
+if [ $# -ge 1 ]; then
+  # Specific package requested
+  FILTER="--filter $1"
+  echo "Publishing $1"
+else
+  # Auto-detect packages with newer versions than npm
+  for pkg_dir in packages/*/; do
+    [ -f "$pkg_dir/package.json" ] || continue
+
+    name=$(node -e "console.log(require('./$pkg_dir/package.json').name)")
+    private=$(node -e "console.log(require('./$pkg_dir/package.json').private || false)")
+    repo_version=$(node -e "console.log(require('./$pkg_dir/package.json').version)")
+
+    if [ "$private" = "true" ]; then
+      echo "Skipping $name (private)"
+      continue
+    fi
+
+    npm_version=$(npm view "$name" version 2>/dev/null) || {
+      if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        echo "Skipping $name (not on npm — first publish must be done locally)"
+        continue
+      else
+        echo "Will publish $name: first publish ($repo_version)"
+        FILTER="$FILTER --filter $name"
+        continue
+      fi
+    }
+
+    is_newer=$(node -e "
+      const [a, b] = ['$repo_version', '$npm_version'].map(
+        v => v.split('.').map(Number)
+      );
+      const gt = a[0] > b[0] || (a[0] === b[0] && (a[1] > b[1] || (a[1] === b[1] && a[2] > b[2])));
+      console.log(gt);
+    ")
+
+    if [ "$is_newer" = "true" ]; then
+      echo "Will publish $name: $npm_version → $repo_version"
+      FILTER="$FILTER --filter $name"
+    else
+      echo "Skipping $name ($repo_version is not newer than $npm_version)"
+    fi
+  done
+fi
+
+if [ -z "$FILTER" ]; then
+  echo "No packages need publishing"
+  exit 0
+fi
+
+echo "Filter: $FILTER"
+
+PUBLISH_ARGS="--access public --no-git-checks"
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  PUBLISH_ARGS="$PUBLISH_ARGS --provenance"
+fi
+
+# shellcheck disable=SC2086
+pnpm $FILTER -r publish $PUBLISH_ARGS


### PR DESCRIPTION
## Summary

Automates npm package publishing when versions are bumped and merged to `develop`. Replaces the manual-only `workflow_dispatch` with auto-detection that compares repo versions against npm and publishes any that are newer. Uses OIDC trusted publishing instead of the expired `NPM_API_TOKEN`.

Also adds helper scripts for version bumping and provenance lookup, a PR comment that alerts when package versions change, and documentation for the npm release process.

## References

Closes learningequality/kolibri-ecosystem#50

## Reviewer guidance

- `scripts/npm_publish.sh` contains the core detection and publish logic — verify the semver comparison and the `GITHUB_ACTIONS` branching for first-time publishes
- `.github/githubUtils.js` changes the `findComment` signature to require a `header` parameter — `pr_build_comment.yml` is updated to pass it, verify nothing breaks
- OIDC trusted publishing needs to be configured on npmjs.com per-package before this workflow will actually succeed — this PR is the code side only

## AI usage

Used Claude Code for the full implementation. Brainstormed the design collaboratively, then executed the implementation plan. Reviewed all generated code through two local review cycles, addressing feedback on code reuse and consolidation.