### PR TITLE
Register task to assign picture password

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -16,12 +16,15 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import transaction
+from django.db.models import BooleanField
+from django.db.models import Case
 from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import TextField
 from django.db.models import Value
+from django.db.models import When
 from django.db.models.functions import Cast
 from django.http import Http404
 from django.http import HttpResponseBadRequest
@@ -89,6 +92,8 @@ from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
 from kolibri.core.auth.tasks import cleanup_expired_deleted_users
 from kolibri.core.auth.utils.delete import delete_imported_user
 from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exhausted
+from kolibri.core.auth.utils.picture_passwords import get_assigned_sequences
+from kolibri.core.auth.utils.picture_passwords import PICTURE_PASSWORD_SEQUENCE_COUNT
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access
@@ -288,15 +293,13 @@ class FacilityDatasetViewSet(ValuesViewset):
         except FacilityDataset.DoesNotExist:
             raise Http404("Facility not found")
 
-    MAX_LEARNERS_FOR_PICTURE_LOGIN = 1300
-
     @decorators.action(
         methods=["post"],
         detail=True,
-        url_path="enable-picture-login",
+        url_path="save-facility-login-settings",
         permission_classes=[IsAuthenticated],
     )
-    def enable_picture_login(self, request, pk):
+    def save_facility_login_settings(self, request, pk):
         try:
             dataset = FacilityDataset.objects.get(pk=pk)
         except FacilityDataset.DoesNotExist:
@@ -306,52 +309,69 @@ class FacilityDatasetViewSet(ValuesViewset):
             raise PermissionDenied("You do not have permission to update this facility")
 
         facility = Facility.objects.get(dataset_id=pk)
-        picture_password_settings = request.data.get("picture_password_settings")
-        if not picture_password_settings:
-            return Response(
-                {"detail": "picture_password_settings is required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
-        learner_count = (
-            FacilityUser.objects.filter(facility=facility, roles__isnull=True)
-            .exclude(devicepermissions__is_superuser=True)
-            .count()
+        new_pps = request.data.get("picture_password_settings")
+        learner_can_login_with_no_password = request.data.get(
+            "learner_can_login_with_no_password"
         )
-        if learner_count > self.MAX_LEARNERS_FOR_PICTURE_LOGIN:
+        learner_can_edit_password = request.data.get("learner_can_edit_password")
+
+        currently_enabled = dataset.picture_password_settings is not None
+        enabling = not currently_enabled and new_pps is not None
+
+        if enabling:
+            assigned = get_assigned_sequences(facility)
+            if len(assigned) >= PICTURE_PASSWORD_SEQUENCE_COUNT:
+                return Response(
+                    {"detail": "Picture passwords exhausted for this facility."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            dataset.picture_password_settings = new_pps
+            dataset.learner_can_login_with_no_password = True
+            dataset.learner_can_edit_password = False
+            dataset.save()
+
+            job, _ = assign_picture_passwords_to_facility.validate_job_data(
+                request.user,
+                data={"facility_id": facility.id},
+            )
+            job_id = assign_picture_passwords_to_facility.enqueue(job=job)
+            enqueued_job = job_storage.get_job(job_id)
             return Response(
                 {
-                    "detail": "Facility has too many learners ({count}) for picture login. Maximum is {max}.".format(
-                        count=learner_count,
-                        max=self.MAX_LEARNERS_FOR_PICTURE_LOGIN,
-                    )
+                    "id": enqueued_job.job_id,
+                    "status": enqueued_job.state,
+                    "percentage": enqueued_job.percentage_progress,
+                    "cancellable": enqueued_job.cancellable,
+                    "facility_id": enqueued_job.facility_id,
+                    "extra_metadata": enqueued_job.extra_metadata,
                 },
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_202_ACCEPTED,
             )
 
-        dataset.picture_password_settings = picture_password_settings
-        dataset.learner_can_edit_password = False
-        dataset.learner_can_login_with_no_password = True
-        dataset.save()
+        if currently_enabled and new_pps is not None:
+            dataset.picture_password_settings = new_pps
+            dataset.save()
+            return Response(
+                FacilityDatasetSerializer(dataset).data, status=status.HTTP_200_OK
+            )
 
-        job, _ = assign_picture_passwords_to_facility.validate_job_data(
-            request.user,
-            data={
-                "facility_id": facility.id,
-            },
-        )
-        job_id = assign_picture_passwords_to_facility.enqueue(job=job)
-        enqueued_job = job_storage.get_job(job_id)
+        if new_pps is None:
+            dataset.picture_password_settings = None
+            if learner_can_login_with_no_password:
+                dataset.learner_can_login_with_no_password = True
+                dataset.learner_can_edit_password = False
+            else:
+                dataset.learner_can_login_with_no_password = False
+                if learner_can_edit_password is not None:
+                    dataset.learner_can_edit_password = learner_can_edit_password
+            dataset.save()
+            return Response(
+                FacilityDatasetSerializer(dataset).data, status=status.HTTP_200_OK
+            )
+
         return Response(
-            {
-                "id": enqueued_job.job_id,
-                "status": enqueued_job.state,
-                "percentage": enqueued_job.percentage_progress,
-                "cancellable": enqueued_job.cancellable,
-                "facility_id": enqueued_job.facility_id,
-                "extra_metadata": enqueued_job.extra_metadata,
-            },
-            status=status.HTTP_202_ACCEPTED,
+            {"detail": "Invalid request."}, status=status.HTTP_400_BAD_REQUEST
         )
 
 
@@ -930,6 +950,7 @@ class FacilityViewSet(ValuesViewset):
         "num_users",
         "last_successful_sync",
         "last_failed_sync",
+        "picture_passwords_exhausted",
     ]
 
     values = tuple(facility_values + dataset_keys)
@@ -988,6 +1009,26 @@ class FacilityViewSet(ValuesViewset):
                     )
                     .order_by("-last_activity_timestamp")
                     .values("last_activity_timestamp")[:1]
+                )
+            )
+            .annotate(
+                _assigned_picture_passwords=SQCount(
+                    FacilityUser.objects.filter(
+                        facility=OuterRef("id"),
+                        roles__isnull=True,
+                        picture_password__isnull=False,
+                    ),
+                    field="id",
+                ),
+            )
+            .annotate(
+                picture_passwords_exhausted=Case(
+                    When(
+                        _assigned_picture_passwords__gte=PICTURE_PASSWORD_SEQUENCE_COUNT,
+                        then=Value(True),
+                    ),
+                    default=Value(False),
+                    output_field=BooleanField(),
                 )
             )
         )

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -295,15 +295,14 @@ class FacilityDatasetViewSet(ValuesViewset):
         permission_classes=[IsAuthenticated],
     )
     def save_facility_login_settings(self, request, pk):
-        try:
-            dataset = FacilityDataset.objects.get(pk=pk)
-        except FacilityDataset.DoesNotExist:
-            raise Http404("Facility not found")
 
+        dataset = self.get_object()
         if not request.user.can_update(dataset):
-            raise PermissionDenied("You do not have permission to update this facility")
+            raise PermissionDenied(
+                "You do not have permission to update this facility's login settings"
+            )
 
-        facility = Facility.objects.get(dataset_id=pk)
+        facility = Facility.objects.get(dataset_id=dataset.id)
 
         new_pps = request.data.get("picture_password_settings")
         learner_can_login_with_no_password = request.data.get(
@@ -315,7 +314,7 @@ class FacilityDatasetViewSet(ValuesViewset):
         enabling = not currently_enabled and new_pps is not None
 
         if enabling:
-            if are_picture_passwords_exhausted(pk):
+            if are_picture_passwords_exhausted(dataset.id):
                 return Response(
                     {"detail": "Picture passwords exhausted for this facility."},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -333,12 +332,15 @@ class FacilityDatasetViewSet(ValuesViewset):
             enqueued_job = job_storage.get_job(job_id)
             return Response(
                 {
-                    "id": enqueued_job.job_id,
-                    "status": enqueued_job.state,
-                    "percentage": enqueued_job.percentage_progress,
-                    "cancellable": enqueued_job.cancellable,
-                    "facility_id": enqueued_job.facility_id,
-                    "extra_metadata": enqueued_job.extra_metadata,
+                    "dataset": FacilityDatasetSerializer(dataset).data,
+                    "task": {
+                        "id": enqueued_job.job_id,
+                        "status": enqueued_job.state,
+                        "percentage": enqueued_job.percentage_progress,
+                        "cancellable": enqueued_job.cancellable,
+                        "facility_id": enqueued_job.facility_id,
+                        "extra_metadata": enqueued_job.extra_metadata,
+                    },
                 },
                 status=status.HTTP_202_ACCEPTED,
             )
@@ -347,7 +349,8 @@ class FacilityDatasetViewSet(ValuesViewset):
             dataset.picture_password_settings = new_pps
             dataset.save()
             return Response(
-                FacilityDatasetSerializer(dataset).data, status=status.HTTP_200_OK
+                {"dataset": FacilityDatasetSerializer(dataset).data},
+                status=status.HTTP_200_OK,
             )
 
         if new_pps is None:
@@ -361,7 +364,8 @@ class FacilityDatasetViewSet(ValuesViewset):
                     dataset.learner_can_edit_password = learner_can_edit_password
             dataset.save()
             return Response(
-                FacilityDatasetSerializer(dataset).data, status=status.HTTP_200_OK
+                {"dataset": FacilityDatasetSerializer(dataset).data},
+                status=status.HTTP_200_OK,
             )
 
         return Response(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -289,19 +289,12 @@ class FacilityDatasetViewSet(ValuesViewset):
             raise Http404("Facility not found")
 
     @decorators.action(
-        methods=["post"],
+        methods=["patch"],
         detail=True,
         url_path="save-facility-login-settings",
-        permission_classes=[IsAuthenticated],
     )
     def save_facility_login_settings(self, request, pk):
-
         dataset = self.get_object()
-        if not request.user.can_update(dataset):
-            raise PermissionDenied(
-                "You do not have permission to update this facility's login settings"
-            )
-
         facility = Facility.objects.get(dataset_id=dataset.id)
 
         new_pps = request.data.get("picture_password_settings")

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -331,6 +331,7 @@ class FacilityDatasetViewSet(ValuesViewset):
 
         dataset.picture_password_settings = picture_password_settings
         dataset.learner_can_edit_password = False
+        dataset.learner_can_login_with_no_password = True
         dataset.save()
 
         job, _ = assign_picture_passwords_to_facility.validate_job_data(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -85,6 +85,7 @@ from kolibri.core.auth.constants.demographics import DEFERRED
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
 from kolibri.core.auth.permissions.general import DenyAll
+from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
 from kolibri.core.auth.tasks import cleanup_expired_deleted_users
 from kolibri.core.auth.utils.delete import delete_imported_user
 from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exhausted
@@ -104,6 +105,7 @@ from kolibri.core.query import annotate_array_aggregate
 from kolibri.core.query import SQCount
 from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.tasks.exceptions import JobRunning
+from kolibri.core.tasks.main import job_storage
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.core.utils.token_generator import TokenGenerator
 from kolibri.core.utils.urls import reverse_path
@@ -285,6 +287,71 @@ class FacilityDatasetViewSet(ValuesViewset):
             return Response(FacilityDatasetSerializer(dataset).data)
         except FacilityDataset.DoesNotExist:
             raise Http404("Facility not found")
+
+    MAX_LEARNERS_FOR_PICTURE_LOGIN = 1300
+
+    @decorators.action(
+        methods=["post"],
+        detail=True,
+        url_path="enable-picture-login",
+        permission_classes=[IsAuthenticated],
+    )
+    def enable_picture_login(self, request, pk):
+        try:
+            dataset = FacilityDataset.objects.get(pk=pk)
+        except FacilityDataset.DoesNotExist:
+            raise Http404("Facility not found")
+
+        if not request.user.can_update(dataset):
+            raise PermissionDenied("You do not have permission to update this facility")
+
+        facility = Facility.objects.get(dataset_id=pk)
+        picture_password_settings = request.data.get("picture_password_settings")
+        if not picture_password_settings:
+            return Response(
+                {"detail": "picture_password_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        learner_count = (
+            FacilityUser.objects.filter(facility=facility, roles__isnull=True)
+            .exclude(devicepermissions__is_superuser=True)
+            .count()
+        )
+        if learner_count > self.MAX_LEARNERS_FOR_PICTURE_LOGIN:
+            return Response(
+                {
+                    "detail": "Facility has too many learners ({count}) for picture login. Maximum is {max}.".format(
+                        count=learner_count,
+                        max=self.MAX_LEARNERS_FOR_PICTURE_LOGIN,
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        dataset.picture_password_settings = picture_password_settings
+        dataset.learner_can_edit_password = False
+        dataset.save()
+
+        job, _ = assign_picture_passwords_to_facility.validate_job_data(
+            request.user,
+            data={
+                "facility_id": facility.id,
+            },
+        )
+        job_id = assign_picture_passwords_to_facility.enqueue(job=job)
+        enqueued_job = job_storage.get_job(job_id)
+        return Response(
+            {
+                "id": enqueued_job.job_id,
+                "status": enqueued_job.state,
+                "percentage": enqueued_job.percentage_progress,
+                "cancellable": enqueued_job.cancellable,
+                "facility_id": enqueued_job.facility_id,
+                "extra_metadata": enqueued_job.extra_metadata,
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
 
 
 class IsPINValidView(views.APIView):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -16,15 +16,12 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import transaction
-from django.db.models import BooleanField
-from django.db.models import Case
 from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import TextField
 from django.db.models import Value
-from django.db.models import When
 from django.db.models.functions import Cast
 from django.http import Http404
 from django.http import HttpResponseBadRequest
@@ -92,8 +89,6 @@ from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
 from kolibri.core.auth.tasks import cleanup_expired_deleted_users
 from kolibri.core.auth.utils.delete import delete_imported_user
 from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exhausted
-from kolibri.core.auth.utils.picture_passwords import get_assigned_sequences
-from kolibri.core.auth.utils.picture_passwords import PICTURE_PASSWORD_SEQUENCE_COUNT
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access
@@ -320,8 +315,7 @@ class FacilityDatasetViewSet(ValuesViewset):
         enabling = not currently_enabled and new_pps is not None
 
         if enabling:
-            assigned = get_assigned_sequences(facility)
-            if len(assigned) >= PICTURE_PASSWORD_SEQUENCE_COUNT:
+            if are_picture_passwords_exhausted(pk):
                 return Response(
                     {"detail": "Picture passwords exhausted for this facility."},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -950,7 +944,6 @@ class FacilityViewSet(ValuesViewset):
         "num_users",
         "last_successful_sync",
         "last_failed_sync",
-        "picture_passwords_exhausted",
     ]
 
     values = tuple(facility_values + dataset_keys)
@@ -1009,26 +1002,6 @@ class FacilityViewSet(ValuesViewset):
                     )
                     .order_by("-last_activity_timestamp")
                     .values("last_activity_timestamp")[:1]
-                )
-            )
-            .annotate(
-                _assigned_picture_passwords=SQCount(
-                    FacilityUser.objects.filter(
-                        facility=OuterRef("id"),
-                        roles__isnull=True,
-                        picture_password__isnull=False,
-                    ),
-                    field="id",
-                ),
-            )
-            .annotate(
-                picture_passwords_exhausted=Case(
-                    When(
-                        _assigned_picture_passwords__gte=PICTURE_PASSWORD_SEQUENCE_COUNT,
-                        then=Value(True),
-                    ),
-                    default=Value(False),
-                    output_field=BooleanField(),
                 )
             )
         )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -21,8 +21,10 @@ from kolibri.core.auth.constants.user_kinds import ADMIN
 from kolibri.core.auth.constants.user_kinds import ASSIGNABLE_COACH
 from kolibri.core.auth.constants.user_kinds import COACH
 from kolibri.core.auth.constants.user_kinds import SUPERUSER
+from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.utils.picture_passwords import assign_picture_password
 from kolibri.core.auth.utils.sync import find_soud_sync_sessions
 from kolibri.core.auth.utils.sync import validate_and_create_sync_credentials
 from kolibri.core.auth.utils.users import get_remote_user_info
@@ -775,3 +777,54 @@ def cleanup_expired_deleted_users():
         job = get_current_job()
         # Re-enqueue to run again in 24 hours
         job.retry_in(datetime.timedelta(days=1))
+
+
+class AssignPicturePasswordsValidator(JobValidator):
+    facility_id = serializers.PrimaryKeyRelatedField(
+        queryset=Facility.objects.all(), source="facility"
+    )
+
+    def validate(self, data):
+        facility = data["facility"]
+        return {
+            "kwargs": {"facility_id": facility.id},
+            "facility_id": facility.id,
+            "extra_metadata": dict(facility_id=facility.id),
+        }
+
+
+@register_task(
+    validator=AssignPicturePasswordsValidator,
+    track_progress=True,
+    cancellable=False,
+    permission_classes=[IsAdminForJob],
+    queue=facility_task_queue,
+)
+def assign_picture_passwords_to_facility(facility_id):
+    """
+    Bulk-assign picture passwords to all learners in a facility
+    that do not already have one.
+    """
+    facility = Facility.objects.get(id=facility_id)
+    learners = FacilityUser.objects.filter(
+        facility=facility,
+        roles__isnull=True,
+        picture_password__isnull=True,
+    ).exclude(devicepermissions__is_superuser=True)
+
+    total = learners.count()
+    job = get_current_job()
+    if job:
+        job.update_progress(0, total)
+
+    for i, learner in enumerate(learners.iterator(), start=1):
+        try:
+            assign_picture_password(learner, facility)
+        except NoAvailableSequences:
+            if job:
+                job.update_metadata(
+                    error="No available picture password sequences remaining."
+                )
+            raise
+        if job:
+            job.update_progress(i, total)

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -54,7 +54,6 @@ from kolibri.core.tasks.validation import JobValidator
 from kolibri.core.utils.retry import retry
 from kolibri.utils.translation import gettext as _
 
-
 logger = logging.getLogger(__name__)
 SOUD_SYNC_PROCESSING_JOB_ID = "50"
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -25,6 +25,7 @@ from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.utils.picture_passwords import assign_picture_password
+from kolibri.core.auth.utils.picture_passwords import get_learner_count
 from kolibri.core.auth.utils.sync import find_soud_sync_sessions
 from kolibri.core.auth.utils.sync import validate_and_create_sync_credentials
 from kolibri.core.auth.utils.users import get_remote_user_info
@@ -812,7 +813,7 @@ def assign_picture_passwords_to_facility(facility_id):
         picture_password__isnull=True,
     ).exclude(devicepermissions__is_superuser=True)
 
-    total = learners.count()
+    total = get_learner_count.count(facility.dataset_id)
     job = get_current_job()
     if job:
         job.update_progress(0, total)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -43,6 +43,7 @@ from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants import demographics
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.errors import NoAvailableSequences
+from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.signals import cascade_delete_user
 from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
@@ -2485,7 +2486,7 @@ class FacilityDatasetAPITestCase(APITestCase):
         self.assertEqual(response.data["extra_fields"]["pin_code"], None)
 
 
-class EnablePictureLoginAPITestCase(APITestCase):
+class SaveFacilityLoginSettingsAPITestCase(APITestCase):
     databases = "__all__"
 
     @classmethod
@@ -2499,29 +2500,14 @@ class EnablePictureLoginAPITestCase(APITestCase):
         cls.coach = FacilityUserFactory.create(facility=cls.facility)
         cls.facility.add_coach(cls.coach)
 
-    def _enable_picture_login_url(self):
+    def _url(self):
         return reverse(
-            "kolibri:core:facilitydataset-enable-picture-login",
+            "kolibri:core:facilitydataset-save-facility-login-settings",
             kwargs={"pk": self.facility.dataset_id},
         )
 
     def _picture_password_settings(self):
         return {"icon_style": "standard", "show_icon_text": True}
-
-    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
-    @patch(
-        "kolibri.core.auth.api.FacilityDatasetViewSet.MAX_LEARNERS_FOR_PICTURE_LOGIN",
-        0,
-    )
-    def test_enable_rejected_for_too_many_learners(self, mock_task):
-        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
-            self._enable_picture_login_url(),
-            {"picture_password_settings": self._picture_password_settings()},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 400)
-        mock_task.validate_job_data.assert_not_called()
 
     def _setup_task_mocks(self, mock_storage, mock_task):
         from kolibri.core.tasks.job import Job
@@ -2532,27 +2518,31 @@ class EnablePictureLoginAPITestCase(APITestCase):
         mock_enqueued_job = Job(func="test_func", facility_id=self.facility.id)
         mock_enqueued_job.job_id = "test-job-id"
         mock_storage.get_job.return_value = mock_enqueued_job
-        mock_storage.get_orm_job.return_value = type(
-            "OrmJob",
-            (),
-            {
-                "scheduled_time": timezone.now(),
-                "repeat": 0,
-                "interval": 0,
-                "retry_interval": None,
-                "max_retries": None,
-            },
-        )()
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
+    @patch("kolibri.core.auth.api.PICTURE_PASSWORD_SEQUENCE_COUNT", new=1)
+    def test_enable_rejected_when_exhausted(self, mock_assigned, mock_task):
+        mock_assigned.return_value = {"1.2.3"}
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_task.validate_job_data.assert_not_called()
 
     @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
     @patch("kolibri.core.auth.api.job_storage")
+    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
     def test_enable_enqueues_task_and_returns_task_object(
-        self, mock_storage, mock_task
+        self, mock_assigned, mock_storage, mock_task
     ):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.post(
-            self._enable_picture_login_url(),
+            self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
         )
@@ -2560,27 +2550,93 @@ class EnablePictureLoginAPITestCase(APITestCase):
         self.assertEqual(response.data["id"], "test-job-id")
         mock_task.validate_job_data.assert_called_once()
         mock_task.enqueue.assert_called_once()
+        dataset = FacilityDataset.objects.get(pk=self.facility.dataset_id)
+        self.assertEqual(
+            dataset.picture_password_settings, self._picture_password_settings()
+        )
+        self.assertTrue(dataset.learner_can_login_with_no_password)
+        self.assertFalse(dataset.learner_can_edit_password)
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    def test_update_settings_does_not_enqueue_task(self, mock_task):
+        dataset = self.facility.dataset
+        dataset.picture_password_settings = self._picture_password_settings()
+        dataset.learner_can_login_with_no_password = True
+        dataset.learner_can_edit_password = False
+        dataset.save()
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        new_settings = {"icon_style": "colorful", "show_icon_text": False}
+        response = self.client.post(
+            self._url(),
+            {"picture_password_settings": new_settings},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_task.validate_job_data.assert_not_called()
+        dataset.refresh_from_db()
+        self.assertEqual(dataset.picture_password_settings, new_settings)
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    def test_disable_to_username_only(self, mock_task):
+        dataset = self.facility.dataset
+        dataset.picture_password_settings = self._picture_password_settings()
+        dataset.learner_can_login_with_no_password = True
+        dataset.learner_can_edit_password = False
+        dataset.save()
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._url(),
+            {
+                "picture_password_settings": None,
+                "learner_can_login_with_no_password": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_task.validate_job_data.assert_not_called()
+        dataset.refresh_from_db()
+        self.assertIsNone(dataset.picture_password_settings)
+        self.assertTrue(dataset.learner_can_login_with_no_password)
+        self.assertFalse(dataset.learner_can_edit_password)
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    def test_disable_to_username_and_password(self, mock_task):
+        dataset = self.facility.dataset
+        dataset.picture_password_settings = self._picture_password_settings()
+        dataset.learner_can_login_with_no_password = True
+        dataset.learner_can_edit_password = False
+        dataset.save()
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._url(),
+            {
+                "picture_password_settings": None,
+                "learner_can_login_with_no_password": False,
+                "learner_can_edit_password": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_task.validate_job_data.assert_not_called()
+        dataset.refresh_from_db()
+        self.assertIsNone(dataset.picture_password_settings)
+        self.assertFalse(dataset.learner_can_login_with_no_password)
+        self.assertTrue(dataset.learner_can_edit_password)
 
     @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
     @patch("kolibri.core.auth.api.job_storage")
-    def test_enable_does_not_assign_inline(self, mock_storage, mock_task):
+    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
+    def test_enable_does_not_assign_inline(
+        self, mock_assigned, mock_storage, mock_task
+    ):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         self.client.post(
-            self._enable_picture_login_url(),
+            self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
         )
         mock_task.assert_not_called()
-
-    def test_enable_requires_picture_password_settings(self):
-        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
-            self._enable_picture_login_url(),
-            {},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 400)
 
 
 @patch("kolibri.core.auth.tasks.get_current_job", return_value=None)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -45,6 +45,7 @@ from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.errors import NoAvailableSequences
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.signals import cascade_delete_user
+from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
 from kolibri.core.device.models import OSUser
 from kolibri.core.device.utils import set_device_settings
 
@@ -2482,6 +2483,166 @@ class FacilityDatasetAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["extra_fields"]["pin_code"], None)
+
+
+class EnablePictureLoginAPITestCase(APITestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
+        cls.learner = FacilityUserFactory.create(facility=cls.facility)
+        cls.coach = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_coach(cls.coach)
+
+    def _enable_picture_login_url(self):
+        return reverse(
+            "kolibri:core:facilitydataset-enable-picture-login",
+            kwargs={"pk": self.facility.dataset_id},
+        )
+
+    def _picture_password_settings(self):
+        return {"icon_style": "standard", "show_icon_text": True}
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    @patch(
+        "kolibri.core.auth.api.FacilityDatasetViewSet.MAX_LEARNERS_FOR_PICTURE_LOGIN",
+        0,
+    )
+    def test_enable_rejected_for_too_many_learners(self, mock_task):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._enable_picture_login_url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_task.validate_job_data.assert_not_called()
+
+    def _setup_task_mocks(self, mock_storage, mock_task):
+        from kolibri.core.tasks.job import Job
+
+        mock_job = Job(func="test_func", facility_id=self.facility.id)
+        mock_task.validate_job_data.return_value = (mock_job, {})
+        mock_task.enqueue.return_value = "test-job-id"
+        mock_enqueued_job = Job(func="test_func", facility_id=self.facility.id)
+        mock_enqueued_job.job_id = "test-job-id"
+        mock_storage.get_job.return_value = mock_enqueued_job
+        mock_storage.get_orm_job.return_value = type(
+            "OrmJob",
+            (),
+            {
+                "scheduled_time": timezone.now(),
+                "repeat": 0,
+                "interval": 0,
+                "retry_interval": None,
+                "max_retries": None,
+            },
+        )()
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    @patch("kolibri.core.auth.api.job_storage")
+    def test_enable_enqueues_task_and_returns_task_object(
+        self, mock_storage, mock_task
+    ):
+        self._setup_task_mocks(mock_storage, mock_task)
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._enable_picture_login_url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.data["id"], "test-job-id")
+        mock_task.validate_job_data.assert_called_once()
+        mock_task.enqueue.assert_called_once()
+
+    @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
+    @patch("kolibri.core.auth.api.job_storage")
+    def test_enable_does_not_assign_inline(self, mock_storage, mock_task):
+        self._setup_task_mocks(mock_storage, mock_task)
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        self.client.post(
+            self._enable_picture_login_url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        mock_task.assert_not_called()
+
+    def test_enable_requires_picture_password_settings(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._enable_picture_login_url(),
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+@patch("kolibri.core.auth.tasks.get_current_job", return_value=None)
+@patch("kolibri.core.auth.tasks.assign_picture_password")
+class AssignPicturePasswordsTaskTestCase(APITestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+
+    def _create_learner(self, username, picture_password=None):
+        user = FacilityUserFactory.create(facility=self.facility, username=username)
+        if picture_password:
+            user.picture_password = picture_password
+            user.save(update_fields=["picture_password"])
+        return user
+
+    def test_assigns_to_learners_without_picture_password(
+        self, mock_assign, mock_get_job
+    ):
+        learner1 = self._create_learner("learner1")
+        learner2 = self._create_learner("learner2")
+        assign_picture_passwords_to_facility(self.facility.id)
+        called_user_ids = {c[0][0].id for c in mock_assign.call_args_list}
+        self.assertIn(learner1.id, called_user_ids)
+        self.assertIn(learner2.id, called_user_ids)
+
+    def test_skips_learners_with_existing_picture_password(
+        self, mock_assign, mock_get_job
+    ):
+        self._create_learner("already_has", picture_password="1.2.3")
+        learner_without = self._create_learner("needs_one")
+        assign_picture_passwords_to_facility(self.facility.id)
+        called_user_ids = {c[0][0].id for c in mock_assign.call_args_list}
+        self.assertNotIn(
+            FacilityUser.objects.get(username="already_has").id, called_user_ids
+        )
+        self.assertIn(learner_without.id, called_user_ids)
+
+    def test_skips_coaches_and_admins(self, mock_assign, mock_get_job):
+        admin = FacilityUserFactory.create(
+            facility=self.facility, username="admin_user"
+        )
+        self.facility.add_admin(admin)
+        coach = FacilityUserFactory.create(
+            facility=self.facility, username="coach_user"
+        )
+        self.facility.add_coach(coach)
+        learner = self._create_learner("just_a_learner")
+        assign_picture_passwords_to_facility(self.facility.id)
+        called_user_ids = {c[0][0].id for c in mock_assign.call_args_list}
+        self.assertNotIn(admin.id, called_user_ids)
+        self.assertNotIn(coach.id, called_user_ids)
+        self.assertIn(learner.id, called_user_ids)
+
+    def test_raises_on_no_available_sequences(self, mock_assign, mock_get_job):
+        mock_assign.side_effect = NoAvailableSequences("No sequences left")
+        self._create_learner("victim")
+        with self.assertRaises(NoAvailableSequences):
+            assign_picture_passwords_to_facility(self.facility.id)
 
 
 class IsPINValidAPITestCase(APITestCase):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2511,7 +2511,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         return {"icon_style": "standard", "show_icon_text": True}
 
     def test_requires_authenticated_user(self):
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
@@ -2520,7 +2520,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
 
     def test_forbidden_for_non_admin_user(self):
         self.client.login(username=self.non_admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
@@ -2541,7 +2541,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
     @patch("kolibri.core.auth.api.are_picture_passwords_exhausted", return_value=True)
     def test_enable_rejected_when_exhausted(self, mock_exhausted, mock_task):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
@@ -2556,7 +2556,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
     ):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",
@@ -2585,7 +2585,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         dataset.save()
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         new_settings = {"icon_style": "colorful", "show_icon_text": False}
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {"picture_password_settings": new_settings},
             format="json",
@@ -2603,7 +2603,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         dataset.learner_can_edit_password = False
         dataset.save()
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {
                 "picture_password_settings": None,
@@ -2626,7 +2626,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         dataset.learner_can_edit_password = False
         dataset.save()
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        response = self.client.post(
+        response = self.client.patch(
             self._url(),
             {
                 "picture_password_settings": None,
@@ -2647,7 +2647,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
     def test_enable_does_not_assign_inline(self, mock_storage, mock_task):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
-        self.client.post(
+        self.client.patch(
             self._url(),
             {"picture_password_settings": self._picture_password_settings()},
             format="json",

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -49,6 +49,7 @@ from kolibri.core.auth.signals import cascade_delete_user
 from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
 from kolibri.core.device.models import OSUser
 from kolibri.core.device.utils import set_device_settings
+from kolibri.core.tasks.job import Job
 
 
 class FacilityFactory(factory.DjangoModelFactory):
@@ -2528,8 +2529,6 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def _setup_task_mocks(self, mock_storage, mock_task):
-        from kolibri.core.tasks.job import Job
-
         mock_job = Job(func="test_func", facility_id=self.facility.id)
         mock_task.validate_job_data.return_value = (mock_job, {})
         mock_task.enqueue.return_value = "test-job-id"

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2495,6 +2495,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         cls.facility = FacilityFactory.create()
         cls.superuser = create_superuser(cls.facility)
         cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.non_admin = FacilityUserFactory.create(facility=cls.facility)
         cls.facility.add_admin(cls.admin)
         cls.learner = FacilityUserFactory.create(facility=cls.facility)
         cls.coach = FacilityUserFactory.create(facility=cls.facility)
@@ -2508,6 +2509,23 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
 
     def _picture_password_settings(self):
         return {"icon_style": "standard", "show_icon_text": True}
+
+    def test_requires_authenticated_user(self):
+        response = self.client.post(
+            self._url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_forbidden_for_non_admin_user(self):
+        self.client.login(username=self.non_admin.username, password=DUMMY_PASSWORD)
+        response = self.client.post(
+            self._url(),
+            {"picture_password_settings": self._picture_password_settings()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def _setup_task_mocks(self, mock_storage, mock_task):
         from kolibri.core.tasks.job import Job
@@ -2544,7 +2562,11 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 202)
-        self.assertEqual(response.data["id"], "test-job-id")
+        self.assertEqual(response.data["task"]["id"], "test-job-id")
+        self.assertEqual(
+            response.data["dataset"]["picture_password_settings"],
+            self._picture_password_settings(),
+        )
         mock_task.validate_job_data.assert_called_once()
         mock_task.enqueue.assert_called_once()
         dataset = FacilityDataset.objects.get(pk=self.facility.dataset_id)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2520,10 +2520,8 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
         mock_storage.get_job.return_value = mock_enqueued_job
 
     @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
-    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
-    @patch("kolibri.core.auth.api.PICTURE_PASSWORD_SEQUENCE_COUNT", new=1)
-    def test_enable_rejected_when_exhausted(self, mock_assigned, mock_task):
-        mock_assigned.return_value = {"1.2.3"}
+    @patch("kolibri.core.auth.api.are_picture_passwords_exhausted", return_value=True)
+    def test_enable_rejected_when_exhausted(self, mock_exhausted, mock_task):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.post(
             self._url(),
@@ -2535,9 +2533,8 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
 
     @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
     @patch("kolibri.core.auth.api.job_storage")
-    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
     def test_enable_enqueues_task_and_returns_task_object(
-        self, mock_assigned, mock_storage, mock_task
+        self, mock_storage, mock_task
     ):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
@@ -2625,10 +2622,7 @@ class SaveFacilityLoginSettingsAPITestCase(APITestCase):
 
     @patch("kolibri.core.auth.api.assign_picture_passwords_to_facility")
     @patch("kolibri.core.auth.api.job_storage")
-    @patch("kolibri.core.auth.api.get_assigned_sequences", return_value=set())
-    def test_enable_does_not_assign_inline(
-        self, mock_assigned, mock_storage, mock_task
-    ):
+    def test_enable_does_not_assign_inline(self, mock_storage, mock_task):
         self._setup_task_mocks(mock_storage, mock_task)
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         self.client.post(

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -112,10 +112,6 @@ def get_all_valid_sequences(picture_set):
     }
 
 
-# This is not same as LEARNER_PICTURE_PASSWORD_LIMIT
-PICTURE_PASSWORD_SEQUENCE_COUNT = len(get_all_valid_sequences(PICTURE_PASSWORD_SET))
-
-
 def get_assigned_sequences(facility):
     """
     Return the set of picture_password values already assigned to

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -112,6 +112,10 @@ def get_all_valid_sequences(picture_set):
     }
 
 
+# This is not same as LEARNER_PICTURE_PASSWORD_LIMIT
+PICTURE_PASSWORD_SEQUENCE_COUNT = len(get_all_valid_sequences(PICTURE_PASSWORD_SET))
+
+
 def get_assigned_sequences(facility):
     """
     Return the set of picture_password values already assigned to

--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -564,17 +564,22 @@ describe('useFacilityEditor', () => {
   });
 
   describe('saveFacilityConfig', () => {
-    it('saves facility config and copies settings', async () => {
+    it('saves facility config excluding login settings fields', async () => {
       const { saveFacilityConfig, settings, facilityDatasetId } = useFacilityEditor(mockFacilityId);
-      settings.value = mockFacilityConfig;
+      settings.value = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'standard', show_icon_text: true },
+      };
       facilityDatasetId.value = mockDatasetId;
 
       await saveFacilityConfig();
 
-      expect(FacilityDatasetResource.saveModel).toHaveBeenCalledWith({
-        id: mockDatasetId,
-        data: mockFacilityConfig,
-      });
+      const savedData = FacilityDatasetResource.saveModel.mock.calls[0][0].data;
+      expect(savedData).not.toHaveProperty('picture_password_settings');
+      expect(savedData).not.toHaveProperty('learner_can_login_with_no_password');
+      expect(savedData).not.toHaveProperty('learner_can_edit_password');
+      expect(savedData).toHaveProperty('learner_can_edit_username');
+      expect(savedData).toHaveProperty('id');
     });
   });
 
@@ -633,65 +638,85 @@ describe('useFacilityEditor', () => {
     });
   });
 
-  describe('enablePictureLogin', () => {
-    const mockPicturePasswordSettings = { icon_style: 'standard', show_icon_text: true };
-
+  describe('saveFacilityLoginSettings', () => {
     beforeEach(() => {
-      urls['kolibri:core:facilitydataset_enable_picture_login'] = jest
+      urls['kolibri:core:facilitydataset_save_facility_login_settings'] = jest
         .fn()
-        .mockReturnValue('/api/facility_dataset/enable_picture_login/');
+        .mockReturnValue('/api/facility_dataset/save_facility_login_settings/');
     });
 
-    it('calls the enable-picture-login endpoint via POST', async () => {
-      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
-      client.mockResolvedValue(mockTaskResponse);
+    it('calls the save-facility-login-settings endpoint via POST with login fields', async () => {
+      client.mockResolvedValue({ data: {} });
 
-      const { enablePictureLogin, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      const { saveFacilityLoginSettings, settings, facilityDatasetId } =
+        useFacilityEditor(mockFacilityId);
+      settings.value = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'standard', show_icon_text: true },
+        learner_can_login_with_no_password: true,
+        learner_can_edit_password: false,
+      };
       facilityDatasetId.value = mockDatasetId;
 
-      await enablePictureLogin(mockPicturePasswordSettings);
+      await saveFacilityLoginSettings();
 
       expect(client).toHaveBeenCalledWith({
-        url: '/api/facility_dataset/enable_picture_login/',
+        url: '/api/facility_dataset/save_facility_login_settings/',
         method: 'POST',
-        data: { picture_password_settings: mockPicturePasswordSettings },
+        data: {
+          picture_password_settings: { icon_style: 'standard', show_icon_text: true },
+          learner_can_login_with_no_password: true,
+          learner_can_edit_password: false,
+        },
       });
     });
 
-    it('stores the returned task id', async () => {
-      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
-      client.mockResolvedValue(mockTaskResponse);
+    it('stores the returned task id when a task is enqueued', async () => {
+      client.mockResolvedValue({ data: { id: 'task-123', status: 'QUEUED' } });
 
-      const { enablePictureLogin, pictureLoginTaskId, facilityDatasetId } =
+      const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
         useFacilityEditor(mockFacilityId);
+      settings.value = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'standard', show_icon_text: true },
+        learner_can_login_with_no_password: true,
+        learner_can_edit_password: false,
+      };
       facilityDatasetId.value = mockDatasetId;
 
-      await enablePictureLogin(mockPicturePasswordSettings);
+      await saveFacilityLoginSettings();
 
       expect(pictureLoginTaskId.value).toBe('task-123');
     });
 
-    it('does not modify facility settings', async () => {
-      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
-      client.mockResolvedValue(mockTaskResponse);
+    it('does not set task id when no task is enqueued', async () => {
+      client.mockResolvedValue({ data: { id: 'dataset-id' } });
 
-      const { enablePictureLogin, settings, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
+        useFacilityEditor(mockFacilityId);
       settings.value = { ...mockFacilityConfig };
       facilityDatasetId.value = mockDatasetId;
 
-      await enablePictureLogin(mockPicturePasswordSettings);
+      await saveFacilityLoginSettings();
 
-      expect(settings.value).toEqual(mockFacilityConfig);
+      expect(pictureLoginTaskId.value).toBeNull();
     });
 
-    it('returns the task data from the response', async () => {
+    it('returns the response data', async () => {
       const mockTaskData = { id: 'task-123', status: 'QUEUED', percentage: 0 };
       client.mockResolvedValue({ data: mockTaskData });
 
-      const { enablePictureLogin, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      const { saveFacilityLoginSettings, settings, facilityDatasetId } =
+        useFacilityEditor(mockFacilityId);
+      settings.value = {
+        ...mockFacilityConfig,
+        picture_password_settings: { icon_style: 'standard', show_icon_text: true },
+        learner_can_login_with_no_password: true,
+        learner_can_edit_password: false,
+      };
       facilityDatasetId.value = mockDatasetId;
 
-      const result = await enablePictureLogin(mockPicturePasswordSettings);
+      const result = await saveFacilityLoginSettings();
 
       expect(result).toEqual(mockTaskData);
     });

--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -645,7 +645,7 @@ describe('useFacilityEditor', () => {
         .mockReturnValue('/api/facility_dataset/save_facility_login_settings/');
     });
 
-    it('calls the save-facility-login-settings endpoint via POST with login fields', async () => {
+    it('calls the save-facility-login-settings endpoint via PATCH with login fields', async () => {
       client.mockResolvedValue({ data: {} });
 
       const { saveFacilityLoginSettings, settings, facilityDatasetId } =
@@ -662,7 +662,7 @@ describe('useFacilityEditor', () => {
 
       expect(client).toHaveBeenCalledWith({
         url: '/api/facility_dataset/save_facility_login_settings/',
-        method: 'POST',
+        method: 'PATCH',
         data: {
           picture_password_settings: { icon_style: 'standard', show_icon_text: true },
           learner_can_login_with_no_password: true,

--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -672,7 +672,10 @@ describe('useFacilityEditor', () => {
     });
 
     it('stores the returned task id when a task is enqueued', async () => {
-      client.mockResolvedValue({ data: { id: 'task-123', status: 'QUEUED' } });
+      client.mockResolvedValue({
+        status: 202,
+        data: { dataset: {}, task: { id: 'task-123', status: 'QUEUED' } },
+      });
 
       const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
         useFacilityEditor(mockFacilityId);
@@ -690,7 +693,7 @@ describe('useFacilityEditor', () => {
     });
 
     it('does not set task id when no task is enqueued', async () => {
-      client.mockResolvedValue({ data: { id: 'dataset-id' } });
+      client.mockResolvedValue({ status: 200, data: { dataset: { id: 'dataset-id' } } });
 
       const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
         useFacilityEditor(mockFacilityId);
@@ -703,8 +706,11 @@ describe('useFacilityEditor', () => {
     });
 
     it('returns the response data', async () => {
-      const mockTaskData = { id: 'task-123', status: 'QUEUED', percentage: 0 };
-      client.mockResolvedValue({ data: mockTaskData });
+      const mockTaskData = {
+        dataset: { id: 'dataset-id' },
+        task: { id: 'task-123', status: 'QUEUED', percentage: 0 },
+      };
+      client.mockResolvedValue({ status: 202, data: mockTaskData });
 
       const { saveFacilityLoginSettings, settings, facilityDatasetId } =
         useFacilityEditor(mockFacilityId);

--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -632,4 +632,68 @@ describe('useFacilityEditor', () => {
       expect(facilityDataLoading.value).toBe(false);
     });
   });
+
+  describe('enablePictureLogin', () => {
+    const mockPicturePasswordSettings = { icon_style: 'standard', show_icon_text: true };
+
+    beforeEach(() => {
+      urls['kolibri:core:facilitydataset_enable_picture_login'] = jest
+        .fn()
+        .mockReturnValue('/api/facility_dataset/enable_picture_login/');
+    });
+
+    it('calls the enable-picture-login endpoint via POST', async () => {
+      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
+      client.mockResolvedValue(mockTaskResponse);
+
+      const { enablePictureLogin, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      facilityDatasetId.value = mockDatasetId;
+
+      await enablePictureLogin(mockPicturePasswordSettings);
+
+      expect(client).toHaveBeenCalledWith({
+        url: '/api/facility_dataset/enable_picture_login/',
+        method: 'POST',
+        data: { picture_password_settings: mockPicturePasswordSettings },
+      });
+    });
+
+    it('stores the returned task id', async () => {
+      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
+      client.mockResolvedValue(mockTaskResponse);
+
+      const { enablePictureLogin, pictureLoginTaskId, facilityDatasetId } =
+        useFacilityEditor(mockFacilityId);
+      facilityDatasetId.value = mockDatasetId;
+
+      await enablePictureLogin(mockPicturePasswordSettings);
+
+      expect(pictureLoginTaskId.value).toBe('task-123');
+    });
+
+    it('does not modify facility settings', async () => {
+      const mockTaskResponse = { data: { id: 'task-123', status: 'QUEUED' } };
+      client.mockResolvedValue(mockTaskResponse);
+
+      const { enablePictureLogin, settings, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      settings.value = { ...mockFacilityConfig };
+      facilityDatasetId.value = mockDatasetId;
+
+      await enablePictureLogin(mockPicturePasswordSettings);
+
+      expect(settings.value).toEqual(mockFacilityConfig);
+    });
+
+    it('returns the task data from the response', async () => {
+      const mockTaskData = { id: 'task-123', status: 'QUEUED', percentage: 0 };
+      client.mockResolvedValue({ data: mockTaskData });
+
+      const { enablePictureLogin, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      facilityDatasetId.value = mockDatasetId;
+
+      const result = await enablePictureLogin(mockPicturePasswordSettings);
+
+      expect(result).toEqual(mockTaskData);
+    });
+  });
 });

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -1,5 +1,6 @@
 import { ref, computed } from 'vue';
 import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import client from 'kolibri/client';
@@ -214,11 +215,7 @@ export default function useFacilityEditor(facilityId) {
   const pictureLoginTaskId = ref(null);
 
   async function saveFacilityLoginSettings() {
-    const data = {
-      picture_password_settings: settings.value.picture_password_settings,
-      learner_can_login_with_no_password: settings.value.learner_can_login_with_no_password,
-      learner_can_edit_password: settings.value.learner_can_edit_password,
-    };
+    const data = pick(settings.value, LOGIN_SETTINGS_FIELDS);
     const response = await client({
       url: urls['kolibri:core:facilitydataset_save_facility_login_settings'](
         facilityDatasetId.value,
@@ -226,8 +223,8 @@ export default function useFacilityEditor(facilityId) {
       method: 'POST',
       data,
     });
-    if (response.data.id && response.data.status) {
-      pictureLoginTaskId.value = response.data.id;
+    if (response.status === 202 && response.data.task?.id) {
+      pictureLoginTaskId.value = response.data.task.id;
     }
     copySettings();
     return response.data;

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -201,6 +201,18 @@ export default function useFacilityEditor(facilityId) {
     await saveFacilityConfig();
   }
 
+  const pictureLoginTaskId = ref(null);
+
+  async function enablePictureLogin(picturePasswordSettings) {
+    const response = await client({
+      url: urls['kolibri:core:facilitydataset_enable_picture_login'](facilityDatasetId.value),
+      method: 'POST',
+      data: { picture_password_settings: picturePasswordSettings },
+    });
+    pictureLoginTaskId.value = response.data.id;
+    return response.data;
+  }
+
   return {
     // State
     facilityId,
@@ -210,6 +222,7 @@ export default function useFacilityEditor(facilityId) {
     settingsCopy,
     isFacilityPinValid,
     facilityDataLoading,
+    pictureLoginTaskId,
     // Computed
     settingsHaveChanged,
     isPinSet,
@@ -234,5 +247,6 @@ export default function useFacilityEditor(facilityId) {
     setPin,
     unsetPin,
     setLoading,
+    enablePictureLogin,
   };
 }

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -220,7 +220,7 @@ export default function useFacilityEditor(facilityId) {
       url: urls['kolibri:core:facilitydataset_save_facility_login_settings'](
         facilityDatasetId.value,
       ),
-      method: 'POST',
+      method: 'PATCH',
       data,
     });
     if (response.status === 202 && response.data.task?.id) {

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -174,10 +174,20 @@ export default function useFacilityEditor(facilityId) {
     return facility;
   }
 
+  const LOGIN_SETTINGS_FIELDS = [
+    'picture_password_settings',
+    'learner_can_login_with_no_password',
+    'learner_can_edit_password',
+  ];
+
   async function saveFacilityConfig() {
+    const data = { ...settings.value };
+    for (const field of LOGIN_SETTINGS_FIELDS) {
+      delete data[field];
+    }
     await FacilityDatasetResource.saveModel({
       id: facilityDatasetId.value,
-      data: settings.value,
+      data,
     });
     copySettings();
   }
@@ -203,13 +213,23 @@ export default function useFacilityEditor(facilityId) {
 
   const pictureLoginTaskId = ref(null);
 
-  async function enablePictureLogin(picturePasswordSettings) {
+  async function saveFacilityLoginSettings() {
+    const data = {
+      picture_password_settings: settings.value.picture_password_settings,
+      learner_can_login_with_no_password: settings.value.learner_can_login_with_no_password,
+      learner_can_edit_password: settings.value.learner_can_edit_password,
+    };
     const response = await client({
-      url: urls['kolibri:core:facilitydataset_enable_picture_login'](facilityDatasetId.value),
+      url: urls['kolibri:core:facilitydataset_save_facility_login_settings'](
+        facilityDatasetId.value,
+      ),
       method: 'POST',
-      data: { picture_password_settings: picturePasswordSettings },
+      data,
     });
-    pictureLoginTaskId.value = response.data.id;
+    if (response.data.id && response.data.status) {
+      pictureLoginTaskId.value = response.data.id;
+    }
+    copySettings();
     return response.data;
   }
 
@@ -247,6 +267,6 @@ export default function useFacilityEditor(facilityId) {
     setPin,
     unsetPin,
     setLoading,
-    enablePictureLogin,
+    saveFacilityLoginSettings,
   };
 }

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -150,6 +150,13 @@
                   data-testid="show_icon_text"
                 />
               </KRadioButtonGroup>
+              <div
+                v-if="pictureLoginTaskLoading"
+                class="nested-settings picture-password-assignment-status"
+                data-testid="picture_password_assignment_status"
+              >
+                <KCircularLoader :size="24" />
+              </div>
             </KRadioButtonGroup>
           </div>
         </section>
@@ -195,7 +202,7 @@
             class="save-changes-button"
             :text="coreString('saveChangesAction')"
             name="save-settings"
-            :disabled="!settingsHaveChanged"
+            :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
             @click="saveConfig()"
           />
         </div>
@@ -242,7 +249,7 @@
         appearance="raised-button"
         :text="coreString('saveChangesAction')"
         name="save-settings"
-        :disabled="!settingsHaveChanged"
+        :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
         @click="saveConfig()"
       />
     </BottomAppBar>
@@ -254,14 +261,16 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { ref, onMounted, computed } from 'vue';
   import { useRoute } from 'vue-router/composables';
+  import { ref, onMounted, computed, watch } from 'vue';
   import commonCoreStrings, { coreString } from 'kolibri/uiText/commonCoreStrings';
   import urls from 'kolibri/urls';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
   import useUser from 'kolibri/composables/useUser';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useTaskPolling from 'kolibri-common/composables/useTaskPolling';
+  import { TaskStatuses } from 'kolibri-common/utils/syncTaskUtils';
   import { handleApiError } from 'kolibri/utils/appError';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
   import { createTranslator } from 'kolibri/utils/i18n';
@@ -391,12 +400,14 @@
         signInOption,
         picturePasswordStyle,
         picturePasswordShowIconText,
+        pictureLoginTaskId,
         fetchFacility,
         undoSettingsChange,
         saveFacilityName,
         saveFacilityConfig,
         setPin,
         unsetPin,
+        enablePictureLogin,
       } = useFacilityEditor(facilityId);
 
       const {
@@ -476,8 +487,13 @@
 
       async function saveConfig() {
         try {
+          const hadPicturePasswordSettings = Boolean(settings.value.picture_password_settings);
           await saveFacilityConfig();
           createSnackbar(saveSuccess$());
+          const hasPicturePasswordSettings = Boolean(settings.value.picture_password_settings);
+          if (!hadPicturePasswordSettings && hasPicturePasswordSettings) {
+            await handleEnablePictureLogin(settings.value.picture_password_settings);
+          }
         } catch (error) {
           createSnackbar(saveFailure$());
           undoSettingsChange();
@@ -536,6 +552,37 @@
         }
       });
 
+      const { tasks: facilityTasks } = useTaskPolling('facility_task');
+      const pictureLoginTaskLoading = ref(false);
+
+      const pictureLoginTask = computed(() => {
+        if (!pictureLoginTaskId.value) return null;
+        return facilityTasks.value.find(t => t.id === pictureLoginTaskId.value) || null;
+      });
+
+      watch(pictureLoginTask, task => {
+        if (!task) return;
+        if (task.status === TaskStatuses.FAILED) {
+          pictureLoginTaskLoading.value = false;
+          pictureLoginTaskId.value = null;
+          createSnackbar(saveFailure$());
+        } else if (task.status === TaskStatuses.COMPLETED) {
+          pictureLoginTaskLoading.value = false;
+          pictureLoginTaskId.value = null;
+          createSnackbar(saveSuccess$());
+        }
+      });
+
+      async function handleEnablePictureLogin(picturePasswordSettings) {
+        try {
+          pictureLoginTaskLoading.value = true;
+          await enablePictureLogin(picturePasswordSettings);
+        } catch (error) {
+          pictureLoginTaskLoading.value = false;
+          createSnackbar(saveFailure$());
+        }
+      }
+
       return {
         // Constants
         OptionsForSignIn,
@@ -565,6 +612,7 @@
         signInOption,
         picturePasswordStyle,
         picturePasswordShowIconText,
+        pictureLoginTaskLoading, // eslint-disable-line
 
         // Functions
         submitFacilityName,
@@ -574,6 +622,7 @@
         handleRemovePinSubmit,
         handleCreatePin,
         handleSelect,
+        handleEnablePictureLogin, // eslint-disable-line
 
         // Strings
         pageHeader$,
@@ -649,6 +698,13 @@
   }
 
   .picture-password-settings {
+    margin-top: 12px;
+  }
+
+  .picture-password-assignment-status {
+    display: flex;
+    gap: 8px;
+    align-items: center;
     margin-top: 12px;
   }
 

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -150,13 +150,6 @@
                   data-testid="show_icon_text"
                 />
               </KRadioButtonGroup>
-              <div
-                v-if="pictureLoginTaskLoading"
-                class="nested-settings picture-password-assignment-status"
-                data-testid="picture_password_assignment_status"
-              >
-                <KCircularLoader :size="24" />
-              </div>
             </KRadioButtonGroup>
           </div>
         </section>
@@ -190,21 +183,29 @@
 
         <div
           v-if="isAppContext"
+          class="save-changes-row"
           :style="{
             marginTop: '32px',
             borderTop: '1px solid',
             borderTopColor: $themeTokens.fineLine,
           }"
         >
-          <KButton
-            :primary="true"
-            appearance="raised-button"
-            class="save-changes-button"
-            :text="coreString('saveChangesAction')"
-            name="save-settings"
-            :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
-            @click="saveConfig()"
-          />
+          <div class="save-changes-inline-group">
+            <KButton
+              :primary="true"
+              appearance="raised-button"
+              class="save-changes-button"
+              :text="coreString('saveChangesAction')"
+              name="save-settings"
+              :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
+              @click="saveConfig()"
+            />
+            <KCircularLoader
+              v-if="pictureLoginTaskLoading"
+              :size="24"
+              data-testid="picture_password_assignment_status"
+            />
+          </div>
         </div>
       </template>
 
@@ -242,16 +243,25 @@
     </KPageContainer>
 
     <BottomAppBar data-testid="bottom-bar">
-      <KButton
+      <div
         v-if="!isAppContext"
-        :primary="true"
-        class="save-button"
-        appearance="raised-button"
-        :text="coreString('saveChangesAction')"
-        name="save-settings"
-        :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
-        @click="saveConfig()"
-      />
+        class="bottom-bar-save-group"
+      >
+        <KButton
+          :primary="true"
+          class="save-button"
+          appearance="raised-button"
+          :text="coreString('saveChangesAction')"
+          name="save-settings"
+          :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
+          @click="saveConfig()"
+        />
+        <KCircularLoader
+          v-if="pictureLoginTaskLoading"
+          :size="24"
+          data-testid="picture_password_assignment_status"
+        />
+      </div>
     </BottomAppBar>
   </FacilityAppBarPage>
 
@@ -488,7 +498,8 @@
       async function saveConfig() {
         try {
           pictureLoginTaskLoading.value = true;
-          await Promise.all([saveFacilityConfig(), saveFacilityLoginSettings()]);
+          await saveFacilityConfig();
+          await saveFacilityLoginSettings();
           if (!pictureLoginTaskId.value) {
             createSnackbar(saveSuccess$());
           }
@@ -667,8 +678,7 @@
   }
 
   .save-button {
-    position: absolute;
-    right: 25px;
+    flex: 0 0 auto;
   }
 
   .facility-loader {
@@ -676,9 +686,32 @@
     margin-bottom: -0.5em; // To align with the text
   }
 
-  .save-changes-button {
+  .save-changes-row {
+    display: flex;
+    justify-content: flex-start;
+  }
+
+  .save-changes-inline-group {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
     margin-top: 24px;
     margin-left: -8px;
+  }
+
+  .save-changes-button {
+    flex: 0 0 auto;
+    margin-top: 0;
+    margin-left: 0;
+  }
+
+  .bottom-bar-save-group {
+    position: absolute;
+    top: 20px;
+    right: 25px;
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
   }
 
   .nested-settings {
@@ -689,13 +722,6 @@
   }
 
   .picture-password-settings {
-    margin-top: 12px;
-  }
-
-  .picture-password-assignment-status {
-    display: flex;
-    gap: 8px;
-    align-items: center;
     margin-top: 12px;
   }
 

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -247,6 +247,11 @@
         v-if="!isAppContext"
         class="bottom-bar-save-group"
       >
+        <KCircularLoader
+          v-if="pictureLoginTaskLoading"
+          :size="24"
+          data-testid="picture_password_assignment_status"
+        />
         <KButton
           :primary="true"
           class="save-button"
@@ -255,11 +260,6 @@
           name="save-settings"
           :disabled="!settingsHaveChanged || pictureLoginTaskLoading"
           @click="saveConfig()"
-        />
-        <KCircularLoader
-          v-if="pictureLoginTaskLoading"
-          :size="24"
-          data-testid="picture_password_assignment_status"
         />
       </div>
     </BottomAppBar>
@@ -688,30 +688,23 @@
 
   .save-changes-row {
     display: flex;
-    justify-content: flex-start;
   }
 
-  .save-changes-inline-group {
+  .save-changes-inline-group,
+  .bottom-bar-save-group {
     display: inline-flex;
     gap: 8px;
     align-items: center;
+  }
+
+  .save-changes-inline-group {
     margin-top: 24px;
-    margin-left: -8px;
   }
 
   .save-changes-button {
     flex: 0 0 auto;
     margin-top: 0;
     margin-left: 0;
-  }
-
-  .bottom-bar-save-group {
-    position: absolute;
-    top: 20px;
-    right: 25px;
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
   }
 
   .nested-settings {

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -405,9 +405,9 @@
         undoSettingsChange,
         saveFacilityName,
         saveFacilityConfig,
+        saveFacilityLoginSettings,
         setPin,
         unsetPin,
-        enablePictureLogin,
       } = useFacilityEditor(facilityId);
 
       const {
@@ -487,16 +487,18 @@
 
       async function saveConfig() {
         try {
-          const hadPicturePasswordSettings = Boolean(settings.value.picture_password_settings);
-          await saveFacilityConfig();
-          createSnackbar(saveSuccess$());
-          const hasPicturePasswordSettings = Boolean(settings.value.picture_password_settings);
-          if (!hadPicturePasswordSettings && hasPicturePasswordSettings) {
-            await handleEnablePictureLogin(settings.value.picture_password_settings);
+          pictureLoginTaskLoading.value = true;
+          await Promise.all([saveFacilityConfig(), saveFacilityLoginSettings()]);
+          if (!pictureLoginTaskId.value) {
+            createSnackbar(saveSuccess$());
           }
         } catch (error) {
           createSnackbar(saveFailure$());
           undoSettingsChange();
+        } finally {
+          if (!pictureLoginTaskId.value) {
+            pictureLoginTaskLoading.value = false;
+          }
         }
       }
 
@@ -573,16 +575,6 @@
         }
       });
 
-      async function handleEnablePictureLogin(picturePasswordSettings) {
-        try {
-          pictureLoginTaskLoading.value = true;
-          await enablePictureLogin(picturePasswordSettings);
-        } catch (error) {
-          pictureLoginTaskLoading.value = false;
-          createSnackbar(saveFailure$());
-        }
-      }
-
       return {
         // Constants
         OptionsForSignIn,
@@ -612,7 +604,7 @@
         signInOption,
         picturePasswordStyle,
         picturePasswordShowIconText,
-        pictureLoginTaskLoading, // eslint-disable-line
+        pictureLoginTaskLoading,
 
         // Functions
         submitFacilityName,
@@ -622,7 +614,6 @@
         handleRemovePinSubmit,
         handleCreatePin,
         handleSelect,
-        handleEnablePictureLogin, // eslint-disable-line
 
         // Strings
         pageHeader$,

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -14,6 +14,13 @@ jest.mock('../../../../device/frontend/views/DeviceSettingsPage/api.js', () => (
 }));
 jest.mock('kolibri/composables/useSnackbar');
 jest.mock('../../composables/useFacilityEditor');
+jest.mock('kolibri-common/composables/useTaskPolling', () => {
+  const { ref } = require('vue');
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({ tasks: ref([]) })),
+  };
+});
 jest.mock('../FacilityAppBarPage', () => ({
   name: 'FacilityAppBarPage',
   render(h) {
@@ -109,6 +116,8 @@ function createMockFacilityConfig(overrides = {}) {
     signInOption,
     picturePasswordStyle,
     picturePasswordShowIconText,
+    pictureLoginTaskId: ref(null),
+    saveFacilityLoginSettings: jest.fn().mockResolvedValue({}),
   };
 }
 
@@ -125,6 +134,7 @@ describe('facility config page view', () => {
   beforeEach(() => {
     useSnackbar.mockImplementation(() => useSnackbarMock({ createSnackbar }));
     useUser.mockImplementation(() => useUserMock({ isAppContext: false }));
+    useFacilityEditor.mockImplementation(() => createMockFacilityConfig());
     createSnackbar.mockReset();
   });
 


### PR DESCRIPTION
## Summary
- Background task to assign picture passwords to learners when picture login is first enabled for a facility.
- Single API action to save all facility login-related settings (picture login on/off, options, username/password rules) in one place.
- Response returns updated facility settings, and when a task is started it also returns task info so the app can track it.
- Frontend uses that action for login settings, keeps other settings on the normal save path.
<img width="1464" height="566" alt="Screenshot from 2026-04-14 22-37-21" src="https://github.com/user-attachments/assets/c5b3bbc8-3736-4b4d-8575-ba59db3274ce" />

## References
closes #14354 

## Reviewer guidance
- Add a temporary delay in `kolibri/core/auth/tasks.py` inside `assign_picture_passwords_to_facility`  so the task runs long enough to visibly show spinners.
- Log in as a facility admin/superuser in the browser.
- Navigate to Facility > Settings.
- switch to Picture password and click Save changes.
- Confirm UI behavior: save button becomes disabled and spinner appears next to the save button (or bottom bar save, depending on context).
- Run backend tests for this feature:
`pytest kolibri/core/auth/test/test_api.py`
- Run frontend tests for editor/config flow:
`kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.`js

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI tools were used to explore and validate approaches for the implementation logic. They also assisted in generating initial versions of the test cases, which were then reviewed and refined to align with the codebase and requirements. 