### PR TITLE
Use VTL v1 syntax for stubs.

### DIFF
--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -35,11 +35,9 @@ const CLASS_ID = 'class-abc';
 function renderComponent(props = {}) {
   return render(AllPasswordsPage, {
     props: { classId: CLASS_ID, ...props },
-    global: {
-      stubs: {
-        ImmersivePage: {
-          template: '<div><slot /></div>',
-        },
+    stubs: {
+      ImmersivePage: {
+        template: '<div><slot /></div>',
       },
     },
   });


### PR DESCRIPTION
## Summary
Stubs were being passed under a `global` key, which is invalid syntax for the version of Vue Testing Library/Vue Test Utils that we're using - instead they should be passed directly as "stubs".

This meant that in the test, the ImmersivePage was not being stubbed. When I merged another PR that added the useRoute composable to the Immersive Page, this broke tests.

## References
Combination of #14547 and #14541 being merged independently

## Reviewer guidance
Test should now pass.

## AI usage
I had Claude analyse the failing tests and identify the issue, then create a fix. I then reviewed the documentation of the testing libraries to confirm that this was an accurate diagnosis, and confirmed that the tests did indeed now pass.