### PR TITLE
Update user edit page and user table for picture login

### DIFF
--- a/kolibri/plugins/facility/frontend/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/frontend/views/UserEditPage.vue
@@ -9,6 +9,7 @@
       <form
         v-if="!loading"
         class="form"
+        data-testid="form"
         @submit.prevent="submitForm"
       >
         <section>
@@ -38,6 +39,7 @@
           <section
             v-if="showPicturePasswordSection"
             class="picture-password-section"
+            data-testid="picture-password-section"
           >
             <h3>
               {{ picturePassword$() }}
@@ -70,10 +72,12 @@
               :disabled="formDisabled"
               :label="coreString('userTypeLabel')"
               :options="userTypeOptions"
+              data-testid="user-type"
             />
             <div
               v-if="disableLearnerRoleOption"
               class="learner-limit-message"
+              data-testid="learner-limit-message"
             >
               <KIcon
                 class="icon"
@@ -84,6 +88,7 @@
                 <KButton
                   appearance="basic-link"
                   :text="coreString('learnMoreAction')"
+                  data-testid="learner-limit-modal-trigger"
                   @click="isLearnerLimitModalOpen = true"
                 />
               </p>
@@ -157,6 +162,7 @@
       </form>
       <LearnerLimitReachedModal
         v-if="isLearnerLimitModalOpen"
+        data-testid="learner-limit-modal"
         @close="isLearnerLimitModalOpen = false"
       />
     </KPageContainer>

--- a/kolibri/plugins/facility/frontend/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/frontend/views/UserEditPage.vue
@@ -11,11 +11,11 @@
         class="form"
         @submit.prevent="submitForm"
       >
-        <h1>
-          {{ $tr('editUserDetailsHeader') }}
-        </h1>
-
         <section>
+          <h1>
+            {{ $tr('editUserDetailsHeader') }}
+          </h1>
+
           <FullNameTextbox
             ref="fullNameTextbox"
             :autofocus="true"
@@ -34,6 +34,16 @@
             :isUniqueValidator="usernameIsUnique"
             :errors.sync="caughtErrors"
           />
+
+          <section
+            v-if="showPicturePasswordSection"
+            class="picture-password-section"
+          >
+            <h3>
+              {{ picturePassword$() }}
+            </h3>
+            <UserPicturePassword :picturePassword="userPicturePassword" />
+          </section>
 
           <template v-if="editingSuperAdmin">
             <h2 class="header user-type">
@@ -56,11 +66,28 @@
           <template v-else>
             <KSelect
               v-model="typeSelected"
-              class="select"
+              :class="{ select: true, 'learner-role-disabled': disableLearnerRoleOption }"
               :disabled="formDisabled"
               :label="coreString('userTypeLabel')"
               :options="userTypeOptions"
             />
+            <div
+              v-if="disableLearnerRoleOption"
+              class="learner-limit-message"
+            >
+              <KIcon
+                class="icon"
+                icon="warningIncomplete"
+              />
+              <p :style="{ color: $themeTokens.annotation }">
+                {{ learnerCreationDisabled$() }}
+                <KButton
+                  appearance="basic-link"
+                  :text="coreString('learnMoreAction')"
+                  @click="isLearnerLimitModalOpen = true"
+                />
+              </p>
+            </div>
 
             <fieldset
               v-if="coachIsSelected"
@@ -128,6 +155,10 @@
           </KButtonGroup>
         </div>
       </form>
+      <LearnerLimitReachedModal
+        v-if="isLearnerLimitModalOpen"
+        @close="isLearnerLimitModalOpen = false"
+      />
     </KPageContainer>
   </ImmersivePage>
 
@@ -156,7 +187,10 @@
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import { handleApiError } from 'kolibri/utils/appError';
   import useFacility from 'kolibri-common/composables/useFacility';
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import UserPicturePassword from 'kolibri-common/components/UserPicturePassword.vue';
   import IdentifierTextbox from './users/sidePanels/UserCreate/IdentifierTextbox.vue';
+  import LearnerLimitReachedModal from './LearnerLimitReachedModal.vue';
 
   export default {
     name: 'UserEditPage',
@@ -174,19 +208,29 @@
       UsernameTextbox,
       UserTypeDisplay,
       ExtraDemographics,
+      LearnerLimitReachedModal,
+      UserPicturePassword,
     },
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
       const { currentUserId, logout } = useUser();
-      const { updateFacilityConfig, facilityConfig } = useFacility();
+      const { updateFacilityConfig, selectedFacility, facilityConfig } = useFacility();
+      const { picturePassword$, learnerCreationDisabled$ } = picturePasswordStrings;
+
       return {
+        // state
+        currentUserId,
+        facilityConfig,
+        selectedFacility,
+        // actions
         logout,
         createSnackbar,
-        currentUserId,
         updateFacilityConfig,
-        facilityConfig,
         handleApiError,
+        // strings
+        learnerCreationDisabled$,
+        picturePassword$,
       };
     },
     data() {
@@ -207,6 +251,8 @@
         userCopy: {},
         caughtErrors: [],
         status: '',
+        userPicturePassword: null,
+        isLearnerLimitModalOpen: false,
       };
     },
     computed: {
@@ -228,6 +274,7 @@
           {
             label: this.coreString('learnerLabel'),
             value: UserKinds.LEARNER,
+            disabled: this.disableLearnerRoleOption,
           },
           {
             label: this.coreString('coachLabel'),
@@ -256,6 +303,23 @@
 
         return '';
       },
+      picturePasswordEnabled() {
+        return Boolean(this.facilityConfig.picture_password_settings);
+      },
+      disableLearnerRoleOption() {
+        return (
+          this.picturePasswordEnabled &&
+          this.selectedFacility.picture_passwords_exhausted &&
+          this.kind !== UserKinds.LEARNER
+        );
+      },
+      showPicturePasswordSection() {
+        return (
+          this.picturePasswordEnabled &&
+          this.kind === UserKinds.LEARNER &&
+          Boolean(this.userPicturePassword)
+        );
+      },
       newUserKind() {
         const { value } = this.typeSelected;
         if (value === UserKinds.COACH && this.classCoachIsSelected) {
@@ -278,6 +342,7 @@
         this.gender = user.gender;
         this.birthYear = user.birth_year;
         this.extraDemographics = user.extra_demographics;
+        this.userPicturePassword = user.picture_password;
         this.setKind(user);
         this.makeCopyOfUser(user);
       });
@@ -358,6 +423,11 @@
       submitForm() {
         this.formSubmitted = true;
 
+        if (this.disableLearnerRoleOption && this.newUserKind === UserKinds.LEARNER) {
+          this.isLearnerLimitModalOpen = true;
+          return;
+        }
+
         if (!this.formIsValid) {
           return this.focusOnInvalidField();
         }
@@ -434,7 +504,7 @@
 
   .coach-selector {
     padding: 0;
-    margin: 0;
+    margin: 0 0 10px;
     border: 0;
   }
 
@@ -460,6 +530,35 @@
   .buttons {
     button:first-of-type {
       margin-left: 0;
+    }
+  }
+
+  .learner-role-disabled {
+    margin-bottom: 4px;
+  }
+
+  .learner-limit-message {
+    display: flex;
+    align-items: baseline;
+    margin-bottom: 12px;
+
+    .icon {
+      flex-shrink: 0;
+      margin-top: 2px;
+      font-size: 14px;
+    }
+
+    p {
+      margin: 0 0 0 4px;
+      font-size: 14px;
+    }
+  }
+
+  .picture-password-section {
+    margin: 12px 0 24px;
+
+    h3 {
+      margin-bottom: 8px;
     }
   }
 

--- a/kolibri/plugins/facility/frontend/views/__tests__/UserEditPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/UserEditPage.spec.js
@@ -1,0 +1,298 @@
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
+import { ref } from 'vue';
+import VueRouter from 'vue-router';
+import { UserKinds } from 'kolibri/constants';
+import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
+import makeStore from '../../__tests__/utils/makeStore';
+import UserEditPage from '../UserEditPage.vue';
+import { PageNames } from '../../constants';
+
+jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri-common/composables/useFacility');
+jest.mock('kolibri-common/apiResources/FacilityUserResource');
+
+const facilityId = 'test-facility-id';
+
+const mockUser = {
+  id: 'current-user-id',
+  username: 'testuser',
+  full_name: 'Test User',
+  id_number: '',
+  gender: '',
+  birth_year: '',
+  extra_demographics: null,
+  picture_password: '1.2.3',
+  facility: facilityId,
+  roles: [],
+  member_of: [],
+};
+
+function createUser(kind = UserKinds.LEARNER, overrides = {}) {
+  const roles = [];
+
+  if (kind !== UserKinds.LEARNER) {
+    roles.push({
+      kind,
+      collection: facilityId,
+    });
+  }
+
+  return {
+    ...mockUser,
+    ...overrides,
+    roles,
+  };
+}
+
+function createRouter() {
+  return new VueRouter({
+    routes: [
+      {
+        path: '/facility/users/:id/edit/',
+        name: PageNames.USER_EDIT_PAGE,
+        params: { id: 'current-user-id' },
+        component: UserEditPage,
+      },
+      {
+        name: PageNames.USER_MGMT_PAGE,
+        path: '/:facility_id?/users/',
+      },
+    ],
+  });
+}
+
+async function renderPage({
+  mockFacility = {},
+  mockFacilityConfig = {},
+  mockUserFetch = null,
+  currentUserId = 'current-user-id',
+} = {}) {
+  useFacility.mockImplementation(() =>
+    useFacilityMock({
+      ...mockFacility,
+      facilityId,
+      facilityConfig: ref(mockFacilityConfig),
+    }),
+  );
+
+  const user = mockUserFetch || createUser();
+  useUser.mockImplementation(() =>
+    useUserMock({
+      currentUserId,
+      ...user,
+      isAppContext: false,
+    }),
+  );
+
+  FacilityUserResource.fetchModel.mockResolvedValue(user);
+
+  const router = createRouter();
+  const store = makeStore();
+
+  await router.push({ name: PageNames.USER_EDIT_PAGE, params: { id: 'test-user-id' } });
+
+  const utils = render(UserEditPage, {
+    router,
+    store,
+  });
+
+  return { ...utils, router, store };
+}
+
+describe('UserEditPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('picture password section', () => {
+    it('does not show picture password section when feature is disabled', async () => {
+      await renderPage();
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).queryByTestId('picture-password-section')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not show picture password section for non-learners', async () => {
+      await renderPage({
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.ADMIN),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).queryByTestId('picture-password-section')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not show picture password section for super-users', async () => {
+      await renderPage({
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.SUPERUSER, { is_superuser: true }),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).queryByTestId('picture-password-section')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not show picture password section when user has no picture password', async () => {
+      await renderPage({
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.LEARNER, { picture_password: null }),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).queryByTestId('picture-password-section')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows picture password section for learners with picture passwords enabled', async () => {
+      await renderPage({
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).getByTestId('picture-password-section')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('learner role option disabling', () => {
+    it('does not disable learner option when picture passwords are not exhausted', async () => {
+      await renderPage({
+        mockUserFetch: createUser(UserKinds.ADMIN),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).getByTestId('user-type')).not.toHaveClass('learner-role-disabled');
+      });
+    });
+
+    it('does not disable learner option for existing learners', async () => {
+      await renderPage({
+        mockFacility: {
+          selectedFacility: ref({
+            picture_passwords_exhausted: true,
+          }),
+        },
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).getByTestId('user-type')).not.toHaveClass('learner-role-disabled');
+      });
+    });
+
+    it('disables learner option when passwords exhausted and editing non-learner', async () => {
+      await renderPage({
+        mockFacility: {
+          selectedFacility: ref({
+            picture_passwords_exhausted: true,
+          }),
+        },
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.ADMIN),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).getByTestId('user-type')).toHaveClass('learner-role-disabled');
+      });
+    });
+
+    it('shows learner limit message when learner option is disabled', async () => {
+      await renderPage({
+        mockFacility: {
+          selectedFacility: ref({
+            picture_passwords_exhausted: true,
+          }),
+        },
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.ADMIN),
+      });
+
+      await waitFor(() => {
+        const form = screen.getByTestId('form');
+        expect(within(form).getByTestId('learner-limit-message')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('LearnerLimitReachedModal', () => {
+    it('does not show modal by default', async () => {
+      await renderPage();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('learner-limit-modal')).not.toBeInTheDocument();
+      });
+    });
+
+    it('opens modal when trying to save as learner with disabled option', async () => {
+      await renderPage({
+        mockFacility: {
+          selectedFacility: ref({
+            picture_passwords_exhausted: true,
+          }),
+        },
+        mockFacilityConfig: {
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        },
+        mockUserFetch: createUser(UserKinds.ADMIN),
+      });
+
+      let triggerButton;
+
+      await waitFor(() => {
+        triggerButton = screen.getByTestId('learner-limit-modal-trigger');
+        expect(triggerButton).toBeInTheDocument();
+      });
+
+      await fireEvent.click(triggerButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('learner-limit-modal')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/kolibri/plugins/facility/frontend/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/frontend/views/users/NewUsersPage.vue
@@ -152,6 +152,7 @@
           :dataLoading="dataLoading"
           :selectedUsers.sync="selectedUsers"
           :numAppliedFilters="numAppliedFilters"
+          :pictureLoginEnabled="pictureLoginEnabled"
           @clearSelectedUsers="clearSelectedUsers"
           @change="onChange"
         />
@@ -217,6 +218,7 @@
 
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import usePreviousRoute from 'kolibri-common/composables/usePreviousRoute';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 
   import { UserKinds } from 'kolibri/constants';
@@ -251,6 +253,7 @@
       const route = useRoute();
       const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
+      const { setFacilityId, facilityConfig } = useFacility();
       const isMoveToTrashModalOpen = ref(false);
 
       const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
@@ -300,6 +303,9 @@
       // Use our new composables
       const { searchTerm, filterTextboxRef } = useUsersTableSearch();
       const { currentPage, itemsPerPage } = usePagination({ usersCount, totalPages });
+      const pictureLoginEnabled = computed(() =>
+        Boolean(facilityConfig.value.picture_password_settings),
+      );
 
       const {
         newUser$,
@@ -354,12 +360,14 @@
       }
 
       onMounted(() => {
+        setFacilityId(activeFacilityId);
         fetchClasses();
       });
 
       return {
         pageLoading,
         usersTableStyles,
+        pictureLoginEnabled,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/index.vue
@@ -168,6 +168,7 @@
           :dataLoading="dataLoading"
           :selectedUsers.sync="selectedUsers"
           :numAppliedFilters="numAppliedFilters"
+          :pictureLoginEnabled="pictureLoginEnabled"
           @clearSelectedUsers="clearSelectedUsers"
           @change="onChange"
         />
@@ -202,6 +203,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import useUser from 'kolibri/composables/useUser';
   import { UserKinds } from 'kolibri/constants';
@@ -239,6 +241,7 @@
       const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin, isAppContext } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
+      const { setFacilityId, facilityConfig } = useFacility();
       const isMoveToTrashModalOpen = ref(false);
 
       const {
@@ -275,7 +278,11 @@
       const { searchTerm, filterTextboxRef } = useUsersTableSearch();
       const { currentPage, itemsPerPage } = usePagination({ usersCount, totalPages });
       const { windowIsSmall, windowIsShort } = useKResponsiveWindow();
+      const pictureLoginEnabled = computed(() =>
+        Boolean(facilityConfig.value.picture_password_settings),
+      );
       onMounted(() => {
+        setFacilityId(activeFacilityId);
         fetchClasses();
       });
 
@@ -344,6 +351,7 @@
         pageLoading,
         windowIsSmall,
         usersTableStyles,
+        pictureLoginEnabled,
         // Route utilities
         overrideRoute,
         PageNames,

--- a/kolibri/plugins/facility/frontend/views/users/common/UsersTable.vue
+++ b/kolibri/plugins/facility/frontend/views/users/common/UsersTable.vue
@@ -98,7 +98,7 @@
                   :user="content"
                 >
                   <KDropdownMenu
-                    :options="getManageUserOptions(content.id)"
+                    :options="getManageUserOptions(content)"
                     @select="handleManageUserAction($event, content)"
                     @close="activeRowId = null"
                   />
@@ -144,6 +144,7 @@
   import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
   import BirthYearDisplayText from 'kolibri-common/components/userAccounts/BirthYearDisplayText';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import { UserKinds } from 'kolibri/constants';
   import useUser from 'kolibri/composables/useUser';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
@@ -454,16 +455,21 @@
         userToChange.value = null;
       };
 
-      const getManageUserOptions = userId => {
-        return [
-          { label: coreStrings.editDetailsAction$(), value: Modals.EDIT_USER },
-          { label: resetPassword$(), value: Modals.RESET_USER_PASSWORD },
-          {
-            label: coreStrings.deleteAction$(),
-            value: Modals.DELETE_USER,
-            disabled: userId === currentUserId.value,
-          },
-        ];
+      const getManageUserOptions = user => {
+        const options = [{ label: coreStrings.editDetailsAction$(), value: Modals.EDIT_USER }];
+        const hideResetPassword = props.pictureLoginEnabled && user.kind === UserKinds.LEARNER;
+
+        if (!hideResetPassword) {
+          options.push({ label: resetPassword$(), value: Modals.RESET_USER_PASSWORD });
+        }
+
+        options.push({
+          label: coreStrings.deleteAction$(),
+          value: Modals.DELETE_USER,
+          disabled: user.id === currentUserId.value,
+        });
+
+        return options;
       };
       const handleSelectedButtonState = id => {
         activeRowId.value = id;
@@ -534,6 +540,10 @@
       numAppliedFilters: {
         type: Number,
         required: true,
+      },
+      pictureLoginEnabled: {
+        type: Boolean,
+        default: false,
       },
     },
   };

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -1,0 +1,93 @@
+<template>
+
+  <ol class="picture-password-icons">
+    <li
+      v-for="(icon, index) in picturePasswordIcons"
+      :key="`${icon.label}-${index}`"
+    >
+      <figure>
+        <KIcon
+          class="icon"
+          :icon="icon.iconName"
+        />
+        <figcaption :style="{ color: $themeTokens.annotation }">
+          {{ icon.label }}
+        </figcaption>
+      </figure>
+    </li>
+  </ol>
+
+</template>
+
+
+<script>
+
+  import { computed } from 'vue';
+  import useFacility from 'kolibri-common/composables/useFacility';
+  import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
+
+  export default {
+    name: 'UserPicturePassword',
+    setup(props) {
+      const { facilityConfig } = useFacility();
+
+      const picturePasswordIcons = computed(() =>
+        getPicturePasswordIcons(
+          props.picturePassword,
+          facilityConfig.value.picture_password_settings?.icon_style,
+        ),
+      );
+
+      return {
+        // state
+        picturePasswordIcons,
+      };
+    },
+    props: {
+      picturePassword: {
+        type: String,
+        required: true,
+        validator(value) {
+          return (value || '').split('.').length === 3;
+        },
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .picture-password-icons {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 0;
+    margin: 0;
+
+    li {
+      margin: 0;
+      list-style: none;
+    }
+
+    figure {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0;
+    }
+
+    .icon {
+      // 46px renders a raw icon of roughly 32px, matching design spec
+      width: 46px;
+      height: 46px;
+    }
+
+    figcaption {
+      margin-top: 4px;
+      font-size: 12px;
+    }
+  }
+
+</style>

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/vue';
+import { ref } from 'vue';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
+import UserPicturePassword from '../UserPicturePassword.vue';
+
+jest.mock('kolibri-common/composables/useFacility');
+
+describe('UserPicturePassword', () => {
+  it('renders expected captions for picturePassword 3.7.12', () => {
+    useFacility.mockImplementation(() =>
+      useFacilityMock({
+        facilityConfig: ref({
+          picture_password_settings: {
+            icon_style: PicturePasswordIconStyle.COLORFUL,
+          },
+        }),
+      }),
+    );
+
+    const { container } = render(UserPicturePassword, {
+      props: {
+        picturePassword: '3.7.12',
+      },
+    });
+
+    const captions = Array.from(container.querySelectorAll('figcaption')).map(node =>
+      node.textContent.trim(),
+    );
+
+    expect(captions).toEqual(['moon', 'water', 'bird']);
+  });
+});

--- a/packages/kolibri-common/utils/__tests__/picturePassword.spec.js
+++ b/packages/kolibri-common/utils/__tests__/picturePassword.spec.js
@@ -26,13 +26,21 @@ describe('getPicturePasswordIcons', () => {
 
     it('includes iconColorful when iconStyle is "colorful"', () => {
       const result = getPicturePasswordIcons('1', 'colorful');
-      expect(result[0]).toMatchObject({ label: 'alpha', iconColorful: 'alphaColorful' });
+      expect(result[0]).toMatchObject({
+        label: 'alpha',
+        iconColorful: 'alphaColorful',
+        iconName: 'alphaColorful',
+      });
       expect(result[0]).not.toHaveProperty('iconStandard');
     });
 
     it('includes iconStandard when iconStyle is "standard"', () => {
       const result = getPicturePasswordIcons('2', 'standard');
-      expect(result[0]).toMatchObject({ label: 'bravo', iconStandard: 'bravoStandard' });
+      expect(result[0]).toMatchObject({
+        label: 'bravo',
+        iconStandard: 'bravoStandard',
+        iconName: 'bravoStandard',
+      });
       expect(result[0]).not.toHaveProperty('iconColorful');
     });
 

--- a/packages/kolibri-common/utils/picturePassword.js
+++ b/packages/kolibri-common/utils/picturePassword.js
@@ -1,4 +1,5 @@
 import { PICTURE_PASSWORD_SET } from 'kolibri/constants';
+import { PicturePasswordIconStyle } from '../constants/Auth';
 
 /**
  * Resolves a `picture_password` string into an ordered array of icon descriptor objects.
@@ -20,9 +21,9 @@ export function getPicturePasswordIcons(picturePassword, iconStyle = null) {
         return null;
       }
       const result = { label: entry.name };
-      if (iconStyle === 'colorful') {
+      if (iconStyle === PicturePasswordIconStyle.COLORFUL) {
         result.iconColorful = entry.iconColorful;
-      } else if (iconStyle === 'standard') {
+      } else if (iconStyle === PicturePasswordIconStyle.STANDARD) {
         result.iconStandard = entry.iconStandard;
       }
       return result;

--- a/packages/kolibri-common/utils/picturePassword.js
+++ b/packages/kolibri-common/utils/picturePassword.js
@@ -6,7 +6,7 @@ import { PicturePasswordIconStyle } from '../constants/Auth';
  *
  * @param {string|null} picturePassword - Dot-separated string of icon IDs, e.g. "3.7.12"
  * @param {string|null} [iconStyle] - Optional display style: "colorful" or "standard"
- * @returns {Array<{label: string, iconColorful?: string, iconStandard?: string}>}
+ * @returns {Array<{label: string, iconName: string, iconColorful?: string, iconStandard?: string}>}
  */
 export function getPicturePasswordIcons(picturePassword, iconStyle = null) {
   if (!picturePassword) {
@@ -22,9 +22,9 @@ export function getPicturePasswordIcons(picturePassword, iconStyle = null) {
       }
       const result = { label: entry.name };
       if (iconStyle === PicturePasswordIconStyle.COLORFUL) {
-        result.iconColorful = entry.iconColorful;
+        result.iconName = result.iconColorful = entry.iconColorful;
       } else if (iconStyle === PicturePasswordIconStyle.STANDARD) {
-        result.iconStandard = entry.iconStandard;
+        result.iconName = result.iconStandard = entry.iconStandard;
       }
       return result;
     })


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds new `UserPicturePassword` component for rendering a picture password with semantic structure
- Modifies the user edit page:
  - To show the picture password of a learner if they have one and feature is enabled
  - Shows alert for when picture passwords are exhausted and disallows learner creation
  - Minor structural changes
  - Uses accessible friendly structure for showing picture password
- Updates user tables to hide reset password option for learners when picture password feature is enabled
- Adds frontend tests for the new changes

| Learner | Coach |
| --- | --- |
| <img width="1090" height="1737" alt="Screenshot from 2026-04-09 15-18-04" src="https://github.com/user-attachments/assets/5f719fb1-f83d-448c-b822-5263d46bbfef" /> | <img width="1090" height="1737" alt="Screenshot from 2026-04-09 15-18-17" src="https://github.com/user-attachments/assets/d18bd59a-9aea-4214-b75d-e3be1f202dec" /> |

## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/kolibri/issues/14426


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- modify `LEARNER_PICTURE_PASSWORD_LIMIT` in `kolibri/core/auth/constants/picture_passwords.py` to temporarily lower the learner limit
- is the learner option disabled for coaches when over the limit?
- does a learner's picture password show?
- is there a reset password menu options for learners in the user table?

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used AI to implement most of the changes at first. Then I revised much of the changes to the user edit page to simplify and improve it. Then used AI to help write the tests, which it got stuck, then I got stuck, then figured it out.