### PR TITLE
Exclude frontend/ directories from sdist instead of old assets/

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,10 +33,10 @@ recursive-include kolibri/plugins/*/build *.json
 
 recursive-exclude kolibri/* *pyc
 recursive-exclude kolibri/* *pyo
-recursive-exclude kolibri/core/assets *
-recursive-exclude kolibri/core/node_modules *
-recursive-exclude kolibri/plugins/*/assets *
-recursive-exclude kolibri/plugins/*/node_modules *
+prune kolibri/core/frontend
+prune kolibri/core/node_modules
+prune kolibri/plugins/*/frontend
+prune kolibri/plugins/*/node_modules
 exclude kolibri/*/buildConfig.js
 exclude kolibri/plugins/*/buildConfig.js
 


### PR DESCRIPTION
## Summary

The frontend source migration from `assets/src/` to `frontend/` (PR #14009) didn't update `MANIFEST.in`. The old `recursive-exclude` rules for `assets/` directories were stale, so `graft kolibri/core` and `graft kolibri/plugins` were pulling all frontend source files into the sdist. Replace the `assets` exclusions with `frontend` exclusions.

## References

Fixes the packaging oversight from #14009

## Reviewer guidance

Check the whl artifact built on the PR and verify no `frontend/` directories are included.

## AI usage

Used Claude Code to identify and fix the stale `MANIFEST.in` exclusions.