### PR TITLE
Add npm package publish check tooling and bump versions

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -177,9 +177,105 @@ async function uploadReleaseAsset(github, context, filePath, release_id) {
   });
 }
 
+const npmVersionsHeader = '**npm Package Versions**';
+
+/**
+ * Generate the npm version check report body. Runs in pull_request context
+ * (no write permissions needed). Returns { body, hasContent } where body
+ * is the markdown comment text (or null if no packages were affected).
+ */
+function generateNpmVersionReport(baseSha) {
+  const { execSync } = require('child_process');
+
+  // Find all changed files under packages/
+  const allChanged = execSync(`git diff --name-only ${baseSha} -- packages/`)
+    .toString().trim().split('\n').filter(Boolean);
+
+  // Group changed files by package directory
+  const changedByPkg = {};
+  for (const file of allChanged) {
+    const parts = file.split('/');
+    if (parts.length < 2) continue;
+    const pkgDir = parts.slice(0, 2).join('/');
+    if (!changedByPkg[pkgDir]) changedByPkg[pkgDir] = [];
+    changedByPkg[pkgDir].push(file);
+  }
+
+  const publishRows = [];
+  const warningRows = [];
+
+  for (const [pkgDir, files] of Object.entries(changedByPkg)) {
+    const pkgJsonPath = path.join(pkgDir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) continue;
+
+    const newPkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    if (newPkg.private === true || newPkg.private === 'true') continue;
+
+    let oldPkg;
+    try {
+      oldPkg = JSON.parse(execSync(`git show ${baseSha}:${pkgJsonPath}`, { encoding: 'utf8' }));
+    } catch {
+      // New package — will be published
+      publishRows.push(`| ${newPkg.name} | _new_ | ${newPkg.version} |`);
+      continue;
+    }
+
+    const versionBumped = oldPkg.version !== newPkg.version;
+    if (versionBumped) {
+      publishRows.push(`| ${newPkg.name} | ${oldPkg.version} | ${newPkg.version} |`);
+    } else {
+      const count = files.length;
+      warningRows.push(`| ${newPkg.name} | ${newPkg.version} | ${count} |`);
+    }
+  }
+
+  const sections = [];
+  if (publishRows.length) {
+    sections.push(
+      `Merging this PR will publish the following packages to npm:\n\n` +
+      `| Package | Current | New |\n|-|-|-|\n${publishRows.join('\n')}`
+    );
+  }
+  if (warningRows.length) {
+    sections.push(
+      `> [!WARNING]\n` +
+      `> The following packages have changed files but no version bump:\n\n` +
+      `| Package | Version | Changed files |\n|-|-|-|\n${warningRows.join('\n')}\n\n` +
+      `If these changes affect published code, consider bumping the version.`
+    );
+  }
+
+  if (sections.length) {
+    return `### ${npmVersionsHeader}\n\n${sections.join('\n\n')}`;
+  }
+  return null;
+}
+
+/**
+ * Post or update the npm version check comment on a PR. Runs in
+ * workflow_run context (with write permissions). Pass body from
+ * generateNpmVersionReport, or null to delete any existing comment.
+ */
+async function postNpmVersionComment(github, context, prNumber, body) {
+  if (body) {
+    await upsertComment(github, context, prNumber, npmVersionsHeader, body);
+  } else {
+    const commentId = await findComment(github, context, prNumber, npmVersionsHeader);
+    if (commentId) {
+      await github.rest.issues.deleteComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: commentId,
+      });
+    }
+  }
+}
+
 module.exports = {
   findComment,
   generateAssetComment,
+  generateNpmVersionReport,
+  postNpmVersionComment,
   uploadReleaseAsset,
   upsertComment,
 }

--- a/.github/workflows/npm_version_check.yml
+++ b/.github/workflows/npm_version_check.yml
@@ -3,13 +3,11 @@ name: npm Package Version Check
 on:
   pull_request:
     paths:
-      - 'packages/*/package.json'
+      - 'packages/**'
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -17,49 +15,18 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
-      - name: Check for version changes and comment
+      - name: Generate version report
         uses: actions/github-script@v8
         with:
           script: |
-            const { execSync } = require('child_process');
             const fs = require('fs');
             const utils = require('./.github/githubUtils.js');
-
             const base = context.payload.pull_request.base.sha;
-
-            const changed = execSync(`git diff --name-only ${base} -- 'packages/*/package.json'`)
-              .toString().trim().split('\n').filter(Boolean);
-
-            const rows = [];
-            for (const file of changed) {
-              let oldPkg;
-              try {
-                oldPkg = JSON.parse(execSync(`git show ${base}:${file}`, { encoding: 'utf8' }));
-              } catch {
-                continue; // new package
-              }
-
-              const newPkg = JSON.parse(fs.readFileSync(file, 'utf8'));
-              if (newPkg.private) continue;
-
-              if (oldPkg.version !== newPkg.version) {
-                rows.push(`| ${newPkg.name} | ${oldPkg.version} | ${newPkg.version} |`);
-              }
-            }
-
-            const header = '**npm Package Versions**';
-            const prNumber = context.payload.pull_request.number;
-
-            if (rows.length) {
-              const body = `### ${header}\n\nMerging this PR will publish the following packages to npm:\n\n| Package | Current | New |\n|-|-|-|\n${rows.join('\n')}`;
-              await utils.upsertComment(github, context, prNumber, header, body);
-            } else {
-              const commentId = await utils.findComment(github, context, prNumber, header);
-              if (commentId) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: commentId,
-                });
-              }
-            }
+            const body = utils.generateNpmVersionReport(base);
+            fs.mkdirSync('npm_version_report', { recursive: true });
+            fs.writeFileSync('npm_version_report/pr_number', String(context.payload.pull_request.number));
+            fs.writeFileSync('npm_version_report/body', body || '');
+      - uses: actions/upload-artifact@v7
+        with:
+          name: npm_version_report
+          path: npm_version_report/

--- a/.github/workflows/npm_version_comment.yml
+++ b/.github/workflows/npm_version_comment.yml
@@ -1,0 +1,48 @@
+name: npm Package Version Comment
+
+on:
+  workflow_run:
+    workflows: [npm Package Version Check]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download report artifact
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const match = artifacts.data.artifacts.find(a => a.name === 'npm_version_report');
+            if (!match) {
+              core.setFailed('No npm_version_report artifact found');
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: match.id,
+              archive_format: 'zip',
+            });
+            require('fs').writeFileSync('npm_version_report.zip', Buffer.from(download.data));
+      - name: Unzip report
+        run: unzip npm_version_report.zip
+      - name: Post or update comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const utils = require('./.github/githubUtils.js');
+            const prNumber = Number(fs.readFileSync('pr_number', 'utf8').trim());
+            const body = fs.readFileSync('body', 'utf8').trim();
+            await utils.postNpmVersionComment(github, context, prNumber, body || null);

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.18.0",
+  "version": "1.0.0",
   "description": "Custom linting rules for kolibri",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-format",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A module for formatting frontend code to Kolibri standards",
   "repository": {
     "type": "git",

--- a/packages/kolibri-plugin-data/package.json
+++ b/packages/kolibri-plugin-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-plugin-data",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Kolibri plugin data module",
   "main": "src/index.js",
   "author": "Learning Equality",

--- a/scripts/npm_check_published.sh
+++ b/scripts/npm_check_published.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check which non-private packages have changes since their last npm publish.
+#
+# Uses the gitHead field from the npm registry to determine the commit
+# each package was last published from, then diffs against HEAD.
+# Falls back to SLSA provenance attestations when gitHead is missing.
+#
+# Usage:
+#   ./scripts/npm_check_published.sh              # check all packages
+#   ./scripts/npm_check_published.sh kolibri-tools # check a specific package
+
+has_changes=0
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+check_package() {
+  local pkg_dir="$1"
+  local name version private git_head npm_version changed_files
+
+  [ -f "$pkg_dir/package.json" ] || return 0
+
+  name=$(node -e "console.log(require('./$pkg_dir/package.json').name)")
+  private=$(node -e "console.log(require('./$pkg_dir/package.json').private || false)")
+  version=$(node -e "console.log(require('./$pkg_dir/package.json').version)")
+
+  if [ "$private" = "true" ]; then
+    return 0
+  fi
+
+  npm_version=$(npm view "$name" version 2>/dev/null) || {
+    echo "⚠️  $name — not found on npm (local version: $version)"
+    return 0
+  }
+
+  git_head=$(npm view "$name" gitHead 2>/dev/null)
+
+  if [ -z "$git_head" ]; then
+    # Fall back to SLSA provenance attestation
+    git_head=$("$SCRIPTS_DIR/npm_provenance.sh" "$name" "$npm_version" 2>/dev/null | grep 'Commit:' | awk '{print $2}') || true
+    if [ -z "$git_head" ]; then
+      echo "⚠️  $name — no gitHead or provenance for ${name}@${npm_version}"
+      return 0
+    fi
+  fi
+
+  if ! git cat-file -e "$git_head" 2>/dev/null; then
+    echo "⚠️  $name — published commit $git_head not found in repo"
+    return 0
+  fi
+
+  changed_files=$(git diff --name-only "$git_head"..HEAD -- "$pkg_dir")
+
+  if [ -n "$changed_files" ]; then
+    local count
+    count=$(echo "$changed_files" | wc -l)
+    echo "📦 $name (published: $npm_version, local: $version) — $count file(s) changed since $git_head"
+    echo "$changed_files" | sed 's/^/    /'
+    echo
+    has_changes=1
+  fi
+}
+
+if [ $# -ge 1 ]; then
+  # Find the directory for the named package
+  found=0
+  for pkg_dir in packages/*/; do
+    [ -f "$pkg_dir/package.json" ] || continue
+    name=$(node -e "console.log(require('./$pkg_dir/package.json').name)")
+    if [ "$name" = "$1" ]; then
+      check_package "$pkg_dir"
+      found=1
+      break
+    fi
+  done
+  if [ "$found" = "0" ]; then
+    echo "Error: package '$1' not found in packages/"
+    exit 1
+  fi
+else
+  for pkg_dir in packages/*/; do
+    check_package "$pkg_dir"
+  done
+fi
+
+if [ "$has_changes" = "0" ]; then
+  echo "✅ All packages are up-to-date with npm"
+fi
+
+exit "$has_changes"


### PR DESCRIPTION
## Summary

Add tooling to detect npm packages with unpublished changes:
- `scripts/npm_check_published.sh` compares each package against its last npm publish commit (via `gitHead`, falling back to SLSA provenance attestations)
- Expand the `npm_version_check` GitHub Action to trigger on any `packages/**` change and warn when files changed but the version wasn't bumped
- Bump eslint-plugin-kolibri (1.0.0), kolibri-format (2.0.0), kolibri-plugin-data (1.0.1)

## References

- kolibri-format and eslint-plugin-kolibri version bumps needed for learningequality/kolibri-design-system#1149

## Reviewer guidance

- Run `./scripts/npm_check_published.sh` to see the check script in action
- The version bumps are straightforward — review the changed file lists in each package to confirm the bump level is appropriate

## AI usage

Used Claude Code to write the check script and GitHub Action changes. Reviewed output and directed version bump decisions per-package.