### PR TITLE
Fix npm publish workflow permissions for provenance

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -34,6 +34,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read   # Required for npm provenance attestation
       id-token: write  # Required for npm OIDC trusted publishing
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

npm publish workflow fails with 404 because the job only has `id-token: write` — npm provenance attestation also requires `contents: read`.

## References

- Follow-up to learningequality/kolibri#14576

## Reviewer guidance

One-line change — re-run the publish workflow after merge to verify.

## AI usage

Diagnosed from CI logs with Claude Code.