### PR TITLE
Drop --provenance and --access public from npm publish

### DIFF
--- a/scripts/npm_publish.sh
+++ b/scripts/npm_publish.sh
@@ -62,10 +62,5 @@ fi
 
 echo "Filter: $FILTER"
 
-PUBLISH_ARGS="--access public --no-git-checks"
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-  PUBLISH_ARGS="$PUBLISH_ARGS --provenance"
-fi
-
 # shellcheck disable=SC2086
-pnpm $FILTER -r publish $PUBLISH_ARGS
+pnpm $FILTER -r publish --no-git-checks


### PR DESCRIPTION
## Summary

npm publish fails with 404 using OIDC trusted publishing. The `--provenance` and `--access public` flags are not used by the working [KDS publish workflow](https://github.com/learningequality/kolibri-design-system/blob/develop/.github/workflows/npm-publish.yml) and may interfere with the OIDC token exchange.

## References

- Follow-up to learningequality/kolibri#14577

## Reviewer guidance

Merge and re-run the publish workflow to verify.

## AI usage

Diagnosed with Claude Code by comparing against the working KDS workflow.