### PR TITLE
Add new guidance and linter rules for Testing Library tests

### DIFF
--- a/docs/frontend_architecture/unit_testing.rst
+++ b/docs/frontend_architecture/unit_testing.rst
@@ -103,10 +103,10 @@ Each folder is expected to have a ``__tests__`` folder, which would contain all 
 Use of ``renderComponent`` function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To avoid repeating boilerplate code while testing Vue components, define a ``renderComponent`` function to set up all the necessary mocks, stubs, and default props values to render the component to test. It can also revieve an optional argument ``props``, which can be used to overwrite:
+To avoid repeating boilerplate code while testing Vue components, define a ``renderComponent`` function to set up all the necessary mocks and default props values to render the component to test. It can also revieve an optional argument ``props``, which can be used to overwrite:
 
 -  The default props passed to the component being rendered
--  Configuration passed to other mocks/stubs (like the values the getters for store mock should return, arguments to Vue Router etc.) according to the test case. This is especially useful when you have a lot of tests that need to render the same component with the same configuration. Here is an example of how you can define a ``renderComponent`` function:
+-  Configuration passed to other mocks (like the values the getters for store mock should return, arguments to Vue Router etc.) according to the test case. This is especially useful when you have a lot of tests that need to render the same component with the same configuration. Here is an example of how you can define a ``renderComponent`` function:
 
 .. code:: javascript
 
@@ -154,6 +154,82 @@ Avoid long and complex unit tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A unit test should be kept simple and test a single execution flow, so that it is easy for someone else to read the test and understand the functionality of the component. You can always group related execution flows together using a ``describe`` block so that the test suite is organized.
+
+Reference translation keys, not hardcoded strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When querying the DOM in tests, never use hardcoded strings or regex patterns to match translated text. Such strings duplicate the translation and are hard to maintain. Instead, reference the translation keys directly. This way, if the translation changes, the test will still be valid and will not require updates.
+
+.. code-block:: javascript
+
+  // ❌
+  getByRole('button', { name: /toggle/i });
+  findAllByText('This field is required')
+  getByText('You have reached the learner limit');
+
+  // ✅
+  // core strings
+  import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+  const { deleteAction$ } = coreStrings;
+
+  getByRole('button', { name: deleteAction$() });
+
+  // feature strings
+  import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
+  const { noTestDataLabel$, sparklineDistributionLabel$ } = coursesStrings;
+
+  getByText(noTestDataLabel$());
+  getByText(sparklineDistributionLabel$({ lowCount: 1, midCount: 0, highCount: 4 }));
+
+  // when strings defined as in-component `$trs` (obsolete pattern),
+  // have to use `createTranslator` in the test
+  import { createTranslator } from 'kolibri/utils/i18n';
+  import TimeDuration from 'kolibri-common/components/TimeDuration';
+
+  const { minutes$ } = createTranslator(TimeDuration.name, TimeDuration.$trs);
+
+  getByText(minutes$({ value: 2 }));
+
+For strings that appear in the test itself (e.g. test data), assign the value to a named constant and reference it in both the setup and the assertion. This makes the relationship between input and expected output explicit and avoids the risk of typos or mismatches between the two.
+
+.. code-block:: javascript
+
+  // ❌
+  renderTopBar({ title: 'Test book title' });
+  expect(screen.getByRole('heading', { name: 'Test book title' })).toBeInTheDocument();
+
+  // ✅
+  const BOOK_TITLE = 'Test book title';
+  renderTopBar({ title: BOOK_TITLE });
+  expect(screen.getByRole('heading', { name: BOOK_TITLE })).toBeInTheDocument();
+
+The only exceptions are hardcoded strings used as ``data-testid`` values for ``*ByTestId`` queries, and standalone characters that are not typically translated, such as dashes, digits, or percentages:
+
+.. code-block:: javascript
+
+  // ✅
+  screen.getByTestId('summary-table');
+
+  screen.getAllByText('—');
+  screen.getByText('52');
+  screen.findByText('90%');
+
+Avoid using stubs
+~~~~~~~~~~~~~~~~~
+
+Except in very rare cases where stubbing is absolutely unavoidable (e.g. content renderers), avoid using stubs. Stubs replace real child components with simplified stand-ins, which means the test no longer exercises real rendering, slot wiring, event propagation, or accessibility attributes. Tests that rely on stubs can pass while hiding bugs that only surface in production, and their frequent use undermines the purpose of Testing Library: tests should interact with the UI the way a real user would, and stubs make that impossible by removing the very elements users interact with.
+
+.. code-block:: javascript
+
+  // ❌
+  render(LearningObjectivesReport, {
+    stubs: {
+      KTable: { template: '<div />' },
+    },
+  });
+
+  // ✅
+  render(LearningObjectivesReport);
 
 Use default props
 ~~~~~~~~~~~~~~~~~

--- a/kolibri/plugins/coach/frontend/composables/__mocks__/useCourses.js
+++ b/kolibri/plugins/coach/frontend/composables/__mocks__/useCourses.js
@@ -1,0 +1,52 @@
+/**
+ * `useCourses` composable function mock.
+ *
+ * If default values are sufficient for tests,
+ * you only need to call `jest.mock('<useCourses file path>')`
+ * at the top of a test file.
+ *
+ * If you need to override some default values for some tests,
+ * or if you need to inspect the state of the refs during tests,
+ * you can import a helper function `useCoursesMock` that accepts
+ * an object with values to be overridden and use it together
+ * with `mockImplementation` as follows:
+ *
+ * ```
+ * // eslint-disable-next-line import-x/named
+ * import useCourses, { useCoursesMock } from '<useCourses file path>';
+ *
+ * jest.mock('<useCourses file path>')
+ * describe('describe test', function () {
+ *   let courses = { courses: ref([]) }
+ *
+ *   beforeAll(() => {
+ *     useCourses.mockImplementation(() => useCoursesMock(courses))
+ *   })
+ *
+ *   it('the test', () => {
+ *     expect(courses.courses.value).toEqual([]);
+ *   })
+ * })
+ * ```
+ */
+import { ref } from 'vue';
+
+const MOCK_DEFAULTS = {
+  classId: ref(null),
+  courses: ref([]),
+  coursesAreLoading: ref(false),
+  setCourses: jest.fn(),
+  updateCourse: jest.fn(),
+  removeCourse: jest.fn(),
+  refreshClassCourses: jest.fn().mockResolvedValue([]),
+};
+
+export function useCoursesMock(overrides = {}) {
+  return {
+    ...MOCK_DEFAULTS,
+    ...overrides,
+  };
+}
+
+export const useCourses = jest.fn(() => useCoursesMock());
+export default useCourses;

--- a/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
+++ b/kolibri/plugins/coach/frontend/views/attendance/__tests__/AttendancePages.spec.js
@@ -1,8 +1,10 @@
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
-import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/vue';
 import { createLocalVue } from '@vue/test-utils';
 import store from 'kolibri/store';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { attendanceStrings } from 'kolibri-common/strings/attendanceStrings';
 // eslint-disable-next-line import-x/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar';
 import classSummaryModule from '../../../modules/classSummary';
@@ -11,6 +13,17 @@ import { useAttendance, useAttendanceMock } from '../../../composables/useAttend
 /* eslint-enable import-x/named */
 import AttendanceNewPage from '../AttendanceNewPage.vue';
 import AttendanceEditPage from '../AttendanceEditPage.vue';
+
+const { saveAction$ } = coreStrings;
+const {
+  searchPlaceholder$,
+  presentCount$,
+  absentCount$,
+  markAllPresentAction$,
+  submitAttendanceAction$,
+  noLearnersInClassMessage$,
+  previouslyEnrolledLabel$,
+} = attendanceStrings;
 
 jest.mock('../../../composables/useAttendance');
 jest.mock('kolibri/composables/useSnackbar');
@@ -35,23 +48,13 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(VueRouter);
 
-const MOCK_LEARNERS = [
-  { id: 'learner-c', name: 'Charlie', username: 'charlie' },
-  { id: 'learner-a', name: 'Alice', username: 'alice' },
-  { id: 'learner-b', name: 'Bob', username: 'bob' },
-];
-
-const COMPONENT_STUBS = {
-  CoachImmersivePage: {
-    template: '<div><slot /></div>',
-    props: ['appBarTitle', 'route'],
-  },
-  BottomAppBar: {
-    template: '<div data-testid="bottom-bar"><slot /></div>',
-  },
+const LEARNERS = {
+  charlie: { id: 'learner-c', name: 'Charlie', username: 'charlie' },
+  alice: { id: 'learner-a', name: 'Alice', username: 'alice' },
+  bob: { id: 'learner-b', name: 'Bob', username: 'bob' },
 };
 
-function setupTestStore(learners = MOCK_LEARNERS) {
+function setupTestStore(learners = Object.values(LEARNERS)) {
   const testStore = new Vuex.Store({
     state: {
       core: {},
@@ -84,7 +87,7 @@ function setupTestStore(learners = MOCK_LEARNERS) {
 }
 
 function renderNewPage({
-  learners = MOCK_LEARNERS,
+  learners = Object.values(LEARNERS),
   createSessionResult = Promise.resolve({ id: 'new-session' }),
 } = {}) {
   const createSession = jest.fn(() =>
@@ -110,9 +113,6 @@ function renderNewPage({
     localVue,
     router,
     store: testStore,
-    global: {
-      stubs: COMPONENT_STUBS,
-    },
   });
 
   return { ...result, createSession, createSnackbar, router };
@@ -131,7 +131,7 @@ const MOCK_RECORDS = [
 ];
 
 function renderEditPage({
-  learners = MOCK_LEARNERS,
+  learners = Object.values(LEARNERS),
   session = MOCK_SESSION,
   records = MOCK_RECORDS,
   bulkUpdateResult = Promise.resolve({}),
@@ -166,9 +166,6 @@ function renderEditPage({
     localVue,
     router,
     store: testStore,
-    global: {
-      stubs: COMPONENT_STUBS,
-    },
   });
 
   return { ...result, fetchSession, fetchRecords, bulkUpdateRecords, createSnackbar, router };
@@ -208,9 +205,13 @@ describe('AttendanceNewPage', () => {
   it('renders learners sorted alphabetically', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.getByText('Bob')).toBeInTheDocument();
-      expect(screen.getByText('Charlie')).toBeInTheDocument();
+      const rows = screen.getAllByRole('row').slice(1); // skip header row
+      const names = rows.map(row => within(row).getAllByRole('gridcell')[0].textContent.trim());
+      expect(names).toEqual(
+        Object.values(LEARNERS)
+          .map(l => l.name)
+          .sort(),
+      );
     });
   });
 
@@ -225,38 +226,38 @@ describe('AttendanceNewPage', () => {
   it('filters learners by search input', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
-    const filterInput = screen.getByPlaceholderText(/search/i);
+    const filterInput = screen.getByPlaceholderText(searchPlaceholder$());
     await fireEvent.update(filterInput, 'ali');
 
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.queryByText('Bob')).not.toBeInTheDocument();
-      expect(screen.queryByText('Charlie')).not.toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS['bob'].name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS['charlie'].name)).not.toBeInTheDocument();
     });
   });
 
   it('updates present/absent counts when toggling a learner', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('0 present')).toBeInTheDocument();
-      expect(screen.getByText('3 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 0 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 3 }))).toBeInTheDocument();
     });
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
 
     await waitFor(() => {
-      expect(screen.getByText('1 present')).toBeInTheDocument();
-      expect(screen.getByText('2 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 1 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 2 }))).toBeInTheDocument();
     });
   });
 
   it('shows confirmation modal when marking all present', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     await fireEvent.click(getMarkAllSwitch());
@@ -264,37 +265,12 @@ describe('AttendanceNewPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-  });
-
-  it('wraps mark-all modal action buttons in KButtonGroup', async () => {
-    renderNewPage();
-    await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-    });
-
-    await fireEvent.click(getMarkAllSwitch());
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    const dialog = screen.getByRole('dialog');
-
-    // KButtonGroup renders as <div class="button-group">. Without KButtonGroup,
-    // no such wrapper exists inside the dialog's actions area.
-    const buttonGroup = dialog.querySelector('.button-group');
-    expect(buttonGroup).not.toBeNull();
-
-    // Verify both buttons are inside the KButtonGroup wrapper
-    const confirmBtn = buttonGroup.querySelector('[data-testid="mark-all-confirm"]');
-    expect(confirmBtn).not.toBeNull();
-    const buttons = buttonGroup.querySelectorAll('button');
-    expect(buttons.length).toBe(2);
   });
 
   it('marks all learners present after confirming modal', async () => {
     renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     await fireEvent.click(getMarkAllSwitch());
@@ -302,22 +278,22 @@ describe('AttendanceNewPage', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByText('Mark all present'));
+    await fireEvent.click(screen.getByText(markAllPresentAction$()));
 
     await waitFor(() => {
-      expect(screen.getByText('3 present')).toBeInTheDocument();
-      expect(screen.getByText('0 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 3 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 0 }))).toBeInTheDocument();
     });
   });
 
   it('calls createSession and redirects with a success snackbar query on submit', async () => {
     const { createSession, createSnackbar } = renderNewPage();
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
-    await fireEvent.click(screen.getByRole('button', { name: 'Submit attendance' }));
+    await fireEvent.click(screen.getByRole('button', { name: submitAttendanceAction$() }));
     await global.flushPromises();
 
     expect(createSession).toHaveBeenCalledWith(
@@ -336,13 +312,13 @@ describe('AttendanceNewPage', () => {
       createSessionResult: () => Promise.reject(new Error('API error')),
     });
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     const initialRoute = router.currentRoute.name;
 
     await fireEvent.click(getLearnerSwitch('learner-a'));
-    await fireEvent.click(screen.getByRole('button', { name: 'Submit attendance' }));
+    await fireEvent.click(screen.getByRole('button', { name: submitAttendanceAction$() }));
     await global.flushPromises();
 
     expect(createSnackbar).toHaveBeenCalled();
@@ -372,7 +348,7 @@ describe('AttendanceEditPage', () => {
     await waitFor(() => {
       expect(fetchSession).toHaveBeenCalledWith('session-1');
       expect(fetchRecords).toHaveBeenCalledWith('session-1');
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     // Sorted: Alice (present), Bob (absent), Charlie (present)
@@ -388,7 +364,7 @@ describe('AttendanceEditPage', () => {
     });
 
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
-    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    expect(screen.queryByText(LEARNERS['alice'].name)).not.toBeInTheDocument();
   });
 
   it('displays the session date and time in the heading', async () => {
@@ -407,16 +383,16 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('2 present')).toBeInTheDocument();
-      expect(screen.getByText('1 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 2 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 1 }))).toBeInTheDocument();
     });
 
     // Toggle Bob from absent to present — 1 change
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     await waitFor(() => {
-      expect(screen.getByText('3 present')).toBeInTheDocument();
-      expect(screen.getByText('0 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 3 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 0 }))).toBeInTheDocument();
     });
   });
 
@@ -425,7 +401,7 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: saveAction$() })).toBeDisabled();
     });
   });
 
@@ -434,21 +410,21 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].name)).toBeInTheDocument();
     });
 
     // Toggle Bob from absent to present (1 change)
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: saveAction$() }));
 
     await waitFor(() => {
       const modal = screen.getByRole('dialog');
       expect(modal).toBeInTheDocument();
       expect(modal).toHaveTextContent('1');
-      expect(modal).toHaveTextContent('3 present');
-      expect(modal).toHaveTextContent('0 absent');
+      expect(modal).toHaveTextContent(presentCount$({ count: 3 }));
+      expect(modal).toHaveTextContent(absentCount$({ count: 0 }));
     });
   });
 
@@ -457,14 +433,14 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].name)).toBeInTheDocument();
     });
 
     // Toggle Bob from absent to present
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save to open modal
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: saveAction$() }));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -490,7 +466,7 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].name)).toBeInTheDocument();
     });
     const initialRoute = router.currentRoute.name;
 
@@ -498,7 +474,7 @@ describe('AttendanceEditPage', () => {
     await fireEvent.click(getLearnerSwitch('learner-b'));
 
     // Click save
-    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await fireEvent.click(screen.getByRole('button', { name: saveAction$() }));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -518,10 +494,10 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('There are no learners in this class')).toBeInTheDocument();
+      expect(screen.getByText(noLearnersInClassMessage$())).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: saveAction$() })).not.toBeInTheDocument();
   });
 
   it('shows previously enrolled section (no save button) when all learners are removed but records exist', async () => {
@@ -532,11 +508,13 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['alice'].name })),
+      ).toBeInTheDocument();
     });
 
-    expect(screen.queryByText('There are no learners in this class')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByText(noLearnersInClassMessage$())).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: saveAction$() })).not.toBeInTheDocument();
   });
 
   it('does not show learners added after the session was created', async () => {
@@ -556,12 +534,14 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     // Bob joined after this session — should not appear at all
-    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
-    expect(screen.queryByText('Bob (Previously enrolled)')).not.toBeInTheDocument();
+    expect(screen.queryByText(LEARNERS['bob'].name)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(previouslyEnrolledLabel$({ name: LEARNERS['bob'].name })),
+    ).not.toBeInTheDocument();
   });
 
   it('shows searchable list for previously enrolled when no current learners exist', async () => {
@@ -575,12 +555,16 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice (Previously enrolled)')).toBeInTheDocument();
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['alice'].name })),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['bob'].name })),
+      ).toBeInTheDocument();
     });
 
     // Search box should be present for filtering previously enrolled learners
-    expect(screen.getByPlaceholderText('Search for a learner')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(searchPlaceholder$())).toBeInTheDocument();
 
     // Both previously enrolled toggles should be disabled
     const aliceSwitch = document.querySelector('input[name="attendance-removed-learner-a"]');
@@ -603,9 +587,13 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
-      expect(screen.getByText('Charlie (Previously enrolled)')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['bob'].name })),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['charlie'].name })),
+      ).toBeInTheDocument();
     });
   });
 
@@ -621,7 +609,9 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Bob (Previously enrolled)')).toBeInTheDocument();
+      expect(
+        screen.getByText(previouslyEnrolledLabel$({ name: LEARNERS['bob'].name })),
+      ).toBeInTheDocument();
     });
 
     const removedSwitch = document.querySelector('input[name="attendance-removed-learner-b"]');
@@ -643,8 +633,8 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('2 present')).toBeInTheDocument();
-      expect(screen.getByText('1 absent')).toBeInTheDocument();
+      expect(screen.getByText(presentCount$({ count: 2 }))).toBeInTheDocument();
+      expect(screen.getByText(absentCount$({ count: 1 }))).toBeInTheDocument();
     });
   });
 
@@ -660,11 +650,11 @@ describe('AttendanceEditPage', () => {
     await global.flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
     });
 
     // 3 total present (Alice current + Bob and Charlie previously enrolled), 0 absent.
-    expect(screen.getByText('3 present')).toBeInTheDocument();
-    expect(screen.getByText('0 absent')).toBeInTheDocument();
+    expect(screen.getByText(presentCount$({ count: 3 }))).toBeInTheDocument();
+    expect(screen.getByText(absentCount$({ count: 0 }))).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
+++ b/kolibri/plugins/coach/frontend/views/common/__tests__/SparklineBar.spec.js
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import SparklineBar, { MIN_SEGMENT_WIDTH_PX } from '../SparklineBar.vue';
+
+const { sparklineDistributionLabel$ } = coursesStrings;
 
 function renderSparkline(overrides = {}) {
   return render(SparklineBar, {
@@ -15,19 +18,28 @@ function renderSparkline(overrides = {}) {
 
 describe('SparklineBar', () => {
   it('renders all three segments and keeps zero-count segments visible', () => {
-    const { container } = renderSparkline({ lowCount: 0, midCount: 0, highCount: 0 });
+    const COUNTS = { lowCount: 0, midCount: 0, highCount: 0 };
+    const { container } = renderSparkline(COUNTS);
 
     const segments = container.querySelectorAll('.segment');
     expect(segments).toHaveLength(3);
-    expect(screen.getByText('0', { selector: '.segment-low .count-text' })).toBeInTheDocument();
-    expect(screen.getByText('0', { selector: '.segment-mid .count-text' })).toBeInTheDocument();
-    expect(screen.getByText('0', { selector: '.segment-high .count-text' })).toBeInTheDocument();
+    expect(
+      screen.getByText(COUNTS.lowCount, { selector: '.segment-low .count-text' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(COUNTS.midCount, { selector: '.segment-mid .count-text' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(COUNTS.highCount, { selector: '.segment-high .count-text' }),
+    ).toBeInTheDocument();
   });
 
   it('provides a visually hidden textual summary for screen readers', () => {
     renderSparkline({ lowCount: 1, midCount: 0, highCount: 4 });
 
-    const hiddenSummary = screen.getByText(/1 low, 0 medium, 4 high/i);
+    const hiddenSummary = screen.getByText(
+      sparklineDistributionLabel$({ lowCount: 1, midCount: 0, highCount: 4 }),
+    );
     expect(hiddenSummary).toHaveClass('visuallyhidden');
     expect(hiddenSummary).not.toHaveAttribute('aria-hidden');
   });

--- a/kolibri/plugins/coach/frontend/views/courses/LearnerSidePanel.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/LearnerSidePanel.vue
@@ -98,7 +98,10 @@
         </div>
 
         <!-- LO section -->
-        <div class="lo-section">
+        <div
+          class="lo-section"
+          data-testid="lo-section"
+        >
           <div class="lo-section-heading">
             {{ individualLoPerformanceLabel$() }}
           </div>

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
@@ -1,269 +1,138 @@
-import { render, screen } from '@testing-library/vue';
+import { render, screen, fireEvent, within } from '@testing-library/vue';
+import { ref } from 'vue';
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
-import { ref } from 'vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import CoursesRootPage from '../CoursesRootPage.vue';
+// eslint-disable-next-line import-x/named
+import useCourses, { useCoursesMock } from '../../../composables/useCourses';
 
-// Stub all heavy dependencies
-jest.mock('kolibri-common/apiResources/CourseSessionResource');
-jest.mock('kolibri-common/apiResources/ContentNodeResource');
-jest.mock('kolibri/composables/useSnackbar', () => ({
-  __esModule: true,
-  default: () => ({ createSnackbar: jest.fn() }),
-}));
+const { courseDetailsAction$, editRecipientsAction$ } = coursesStrings;
+const { deleteAction$ } = coreStrings;
 
-const mockCoursesRef = ref([]);
-const mockCoursesAreLoading = ref(false);
-const mockCourses = {
-  courses: mockCoursesRef,
-  coursesAreLoading: mockCoursesAreLoading,
-  setCourses: jest.fn(),
-  updateCourse: jest.fn(),
-  removeCourse: jest.fn(),
-  refreshClassCourses: jest.fn().mockResolvedValue([]),
-  classId: ref('class-123'),
-};
-
-jest.mock('../../../composables/useCourses', () => ({
-  useCourses: () => mockCourses,
-}));
-
-jest.mock('../composables/useAssignCourse', () => ({
-  __esModule: true,
-  default: () => ({
-    resetAssignment: jest.fn(),
-    selectCourse: jest.fn(),
-    setCourseVisibility: jest.fn(),
-    setExistingAssignment: jest.fn(),
-  }),
-}));
-
-jest.mock('kolibri-common/strings/coursesStrings', () => ({
-  coursesStrings: new Proxy(
-    {},
-    {
-      get: (_, key) => {
-        if (key === '$tr') return jest.fn(key => key);
-        return jest.fn(() => key);
-      },
-    },
-  ),
-}));
-
-jest.mock('kolibri/uiText/commonCoreStrings', () => {
-  const coreString = jest.fn(key => key);
-  return {
-    coreString,
-    coreStrings: new Proxy(
-      {},
-      {
-        get: (_, key) => {
-          if (key === '$tr') return coreString;
-          return jest.fn(() => key);
-        },
-      },
-    ),
-  };
-});
-
-jest.mock('vue-router/composables', () => ({
-  useRoute: () => ({
-    params: { classId: 'class-123' },
-    query: {},
-    name: 'CoursesRoot',
-  }),
-  useRouter: () => ({
-    push: jest.fn(),
-  }),
-}));
-
-jest.mock('../../../views/common/commonCoachStrings', () => ({
-  coachStrings: new Proxy(
-    {},
-    {
-      get: (_, key) => {
-        if (key === '$tr') return jest.fn(key => key);
-        return jest.fn(() => key);
-      },
-    },
-  ),
-}));
+jest.mock('../../../composables/useCourses');
 
 function makeStore() {
   return new Vuex.Store({
     actions: {
       initClassInfo: jest.fn(),
-      notLoading: jest.fn(),
     },
     modules: {
       classSummary: {
         namespaced: true,
         state: { id: 'class-123' },
-        getters: {
-          groups: () => [],
-        },
       },
     },
   });
 }
 
-const STUBS = {
-  CoachAppBarPage: {
-    name: 'CoachAppBarPage',
-    template: '<div><slot /></div>',
-  },
-  CoachHeader: {
-    name: 'CoachHeader',
-    template: '<div><slot name="actions" /></div>',
-  },
-  CoreTable: {
-    name: 'CoreTable',
-    template: '<div data-testid="courses-table"><slot name="headers" /><slot name="tbody" /></div>',
-  },
-  FilterTextbox: {
-    name: 'FilterTextbox',
-    template: '<div />',
-  },
-  AssignCourseSuccessModal: {
-    name: 'AssignCourseSuccessModal',
-    template: '<div />',
-  },
-  DeleteCourseConfirmationModal: {
-    name: 'DeleteCourseConfirmationModal',
-    template: '<div />',
-  },
-  RouterView: {
-    name: 'RouterView',
-    template: '<div />',
-  },
-  KRouterLink: {
-    name: 'KRouterLink',
-    props: ['to', 'text'],
-    template: '<a>{{ text }}</a>',
-  },
-  MissingResourceAlert: {
-    name: 'MissingResourceAlert',
-    template: '<div data-testid="missing-resource-alert">Resources missing</div>',
-  },
-  KDropdownMenu: {
-    name: 'KDropdownMenu',
-    props: ['options'],
-    template:
-      '<ul data-testid="dropdown-menu"><li v-for="opt in options" :key="opt">{{ opt }}</li></ul>',
-  },
-  KSwitch: {
-    name: 'KSwitch',
-    props: ['disabled', 'checked', 'value', 'name'],
-    template:
-      '<button data-testid="visibility-toggle" role="switch" :disabled="disabled" :aria-checked="String(!!value)" />',
-  },
-};
+function renderComponent() {
+  return render(CoursesRootPage, {
+    store: makeStore(),
+    routes: new VueRouter({
+      routes: [
+        { path: '/', name: 'CoursesRoot' },
+        { path: '/course', name: 'COURSE_SUMMARY' },
+      ],
+    }),
+  });
+}
 
 describe('CoursesRootPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockCoursesRef.value = [];
-    mockCoursesAreLoading.value = false;
+    useCourses.mockImplementation(() => useCoursesMock());
   });
 
-  describe('MissingResourceAlert', () => {
-    it('should show MissingResourceAlert when any course has contentMissing', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
-        { id: 'session-2', title: 'Course 2', active: true, contentMissing: true },
-      ];
+  it('should show the missing resource alert when any course has missing content', () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([
+          { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+          { id: 'session-2', title: 'Course 2', active: true, contentMissing: true },
+        ]),
+      }),
+    );
 
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
+    renderComponent();
 
-      expect(screen.getByTestId('missing-resource-alert')).toBeInTheDocument();
-    });
-
-    it('should not show MissingResourceAlert when no courses have contentMissing', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
-        { id: 'session-2', title: 'Course 2', active: true, contentMissing: false },
-      ];
-
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
-
-      expect(screen.queryByTestId('missing-resource-alert')).not.toBeInTheDocument();
-    });
+    expect(screen.getByTestId('missing-resource-alert')).toBeInTheDocument();
   });
 
-  describe('course menu options when content is missing', () => {
-    it('should only show delete option for courses with missing content', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: true },
-      ];
+  it('should not show the missing resource alert when no courses have missing content', () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([
+          { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
+          { id: 'session-2', title: 'Course 2', active: true, contentMissing: false },
+        ]),
+      }),
+    );
 
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
+    renderComponent();
 
-      const menu = screen.getByTestId('dropdown-menu');
-      expect(menu).toHaveTextContent('deleteAction');
-      expect(menu).not.toHaveTextContent('courseDetailsAction$');
-      expect(menu).not.toHaveTextContent('editRecipientsAction$');
-    });
-
-    it('should show all options for courses with content present', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
-      ];
-
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
-
-      const menu = screen.getByTestId('dropdown-menu');
-      expect(menu).toHaveTextContent('courseDetailsAction$');
-      expect(menu).toHaveTextContent('editRecipientsAction$');
-      expect(menu).toHaveTextContent('deleteAction');
-    });
+    expect(screen.queryByTestId('missing-resource-alert')).not.toBeInTheDocument();
   });
 
-  describe('visibility toggle when content is missing', () => {
-    it('should disable visibility toggle for courses with missing content', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: true },
-      ];
+  it('should only show delete option for courses with missing content', async () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([{ id: 'session-1', title: 'Course 1', active: true, contentMissing: true }]),
+      }),
+    );
 
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
+    renderComponent();
+    await global.flushPromises();
+    await fireEvent.click(document.querySelector('[aria-haspopup="menu"]'));
 
-      const toggle = screen.getByRole('switch');
-      expect(toggle).toBeDisabled();
-    });
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText(deleteAction$())).toBeInTheDocument();
+    expect(within(menu).queryByText(courseDetailsAction$())).not.toBeInTheDocument();
+    expect(within(menu).queryByText(editRecipientsAction$())).not.toBeInTheDocument();
+  });
 
-    it('should enable visibility toggle for courses with content present', () => {
-      mockCoursesRef.value = [
-        { id: 'session-1', title: 'Course 1', active: true, contentMissing: false },
-      ];
+  it('should show all options for courses with content present', async () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([{ id: 'session-1', title: 'Course 1', active: true, contentMissing: false }]),
+      }),
+    );
 
-      render(CoursesRootPage, {
-        store: makeStore(),
-        routes: new VueRouter({ routes: [{ path: '/', name: 'CoursesRoot' }] }),
-        stubs: STUBS,
-      });
+    renderComponent();
+    await global.flushPromises();
+    await fireEvent.click(document.querySelector('[aria-haspopup="menu"]'));
 
-      const toggle = screen.getByRole('switch');
-      expect(toggle).toBeEnabled();
-    });
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText(deleteAction$())).toBeInTheDocument();
+    expect(within(menu).getByText(courseDetailsAction$())).toBeInTheDocument();
+    expect(within(menu).getByText(editRecipientsAction$())).toBeInTheDocument();
+  });
+
+  it('should disable visibility toggle for courses with missing content', () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([{ id: 'session-1', title: 'Course 1', active: true, contentMissing: true }]),
+      }),
+    );
+
+    renderComponent();
+
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeDisabled();
+  });
+
+  it('should enable visibility toggle for courses with content present', () => {
+    useCourses.mockImplementation(() =>
+      useCoursesMock({
+        courses: ref([{ id: 'session-1', title: 'Course 1', active: true, contentMissing: false }]),
+      }),
+    );
+
+    renderComponent();
+
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeEnabled();
   });
 });

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/LearnerSidePanel.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/LearnerSidePanel.spec.js
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, within } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import LearnerSidePanel from '../LearnerSidePanel.vue';
 
@@ -18,34 +19,14 @@ const {
   questionsCorrectLabel$,
 } = coursesStrings;
 
-const LEARNING_OBJECTIVES = [
-  { id: 'lo-1', text: 'Objective 1', num_questions: 4 },
-  { id: 'lo-2', text: 'Objective 2', num_questions: 4 },
-];
+const { closeAction$ } = coreStrings;
+
+const LEARNING_OBJECTIVES = {
+  'lo-1': { id: 'lo-1', text: 'Objective 1', num_questions: 4 },
+  'lo-2': { id: 'lo-2', text: 'Objective 2', num_questions: 4 },
+};
 
 const LEARNER = { id: 'user-1', name: 'Alice', username: 'alice', groups: [] };
-
-const STUBS = {
-  SidePanelModal: {
-    name: 'SidePanelModal',
-    template: '<div data-testid="side-panel"><slot /></div>',
-  },
-  SidePanelLayout: {
-    name: 'SidePanelLayout',
-    props: ['title', 'subtitle', 'closePanel'],
-    template: `
-      <div>
-        <slot name="title" />
-        <button data-testid="close-btn" @click="closePanel">close</button>
-        <slot />
-      </div>
-    `,
-  },
-  KIcon: {
-    name: 'KIcon',
-    template: '<span />',
-  },
-};
 
 function makePrefetchedData({ scores = {}, activeTestType = 'pre' } = {}) {
   return {
@@ -53,7 +34,7 @@ function makePrefetchedData({ scores = {}, activeTestType = 'pre' } = {}) {
     activeTestStatus: 'closed',
     learnersWithGroups: [],
     reportData: {
-      learning_objectives: LEARNING_OBJECTIVES,
+      learning_objectives: Object.values(LEARNING_OBJECTIVES),
       pre_test: {
         status: activeTestType === 'pre' ? 'closed' : 'not_activated',
         scores: activeTestType === 'pre' ? scores : {},
@@ -69,7 +50,6 @@ function makePrefetchedData({ scores = {}, activeTestType = 'pre' } = {}) {
 function renderComponent(props = {}) {
   return render(LearnerSidePanel, {
     props: { learner: LEARNER, ...props },
-    stubs: STUBS,
   });
 }
 
@@ -92,7 +72,7 @@ describe('LearnerSidePanel', () => {
 
     it('does not show LO rows in empty state', () => {
       renderComponent({ prefetchedData: makePrefetchedData({ scores: {} }) });
-      expect(screen.queryByText('Objective 1')).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNING_OBJECTIVES['lo-1'].text)).not.toBeInTheDocument();
     });
 
     it('does not show PROGRESS row in empty state', () => {
@@ -212,7 +192,7 @@ describe('LearnerSidePanel', () => {
     it('shows section heading', () => {
       const scores = { 'user-1': { 'lo-1': 3, 'lo-2': 2 } };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      const loSection = document.querySelector('.lo-section');
+      const loSection = screen.getByTestId('lo-section');
       expect(within(loSection).getByText(individualLoPerformanceLabel$())).toBeInTheDocument();
     });
 
@@ -241,10 +221,13 @@ describe('LearnerSidePanel', () => {
       // lo-1: 4/4 = 100%, lo-2: 1/4 = 25% → lo-2 appears first
       const scores = { 'user-1': { 'lo-1': 4, 'lo-2': 1 } };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      const loTexts = screen.getAllByText(/Objective [12]/);
+
+      const loSection = screen.getByTestId('lo-section');
+      const allRows = within(loSection).getAllByRole('row');
+
       // lo-2 (25%) should appear before lo-1 (100%)
-      expect(loTexts[0]).toHaveTextContent('Objective 2');
-      expect(loTexts[1]).toHaveTextContent('Objective 1');
+      expect(within(allRows[1]).getByText(LEARNING_OBJECTIVES['lo-2'].text)).toBeInTheDocument();
+      expect(within(allRows[2]).getByText(LEARNING_OBJECTIVES['lo-1'].text)).toBeInTheDocument();
     });
 
     it('shows 0 correct for LOs the learner did not answer', () => {
@@ -263,7 +246,7 @@ describe('LearnerSidePanel', () => {
       const { emitted } = renderComponent({
         prefetchedData: makePrefetchedData({ scores }),
       });
-      await fireEvent.click(screen.getByTestId('close-btn'));
+      await fireEvent.click(screen.getByRole('button', { name: closeAction$() }));
       expect(emitted().close).toBeTruthy();
     });
   });

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/LearnersReport.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/LearnersReport.spec.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import LearnersReport from '../LearnersReport.vue';
 
+const { learnersLabel$ } = coreStrings;
 const {
   noTestDataLabel$,
   noLearnersAttemptedLabel$,
@@ -11,49 +13,15 @@ const {
   onTrackLabel$,
 } = coursesStrings;
 
-const LEARNERS = [
-  { id: 'user-1', name: 'Alice', username: 'alice', groups: ['Group A'] },
-  { id: 'user-2', name: 'Bob', username: 'bob', groups: ['Group B'] },
-  { id: 'user-3', name: 'Carol', username: 'carol', groups: [] },
-];
+const LEARNERS = {
+  alice: { id: 'user-1', name: 'Alice', username: 'alice', groups: ['Group A'] },
+  bob: { id: 'user-2', name: 'Bob', username: 'bob', groups: ['Group B'] },
+  carol: { id: 'user-3', name: 'Carol', username: 'carol', groups: [] },
+};
 
-const LEARNING_OBJECTIVES = [
-  { id: 'lo-1', text: 'Objective 1', num_questions: 4 },
-  { id: 'lo-2', text: 'Objective 2', num_questions: 4 },
-];
-
-const STUBS = {
-  KCircularLoader: {
-    name: 'KCircularLoader',
-    template: '<div data-testid="loader">Loading...</div>',
-  },
-  KTable: {
-    name: 'KTable',
-    props: ['headers', 'rows', 'caption'],
-    template: `
-      <div data-testid="k-table">
-        <template v-for="(row, rowIndex) in rows">
-          <div :key="rowIndex" :data-testid="'row-' + rowIndex">
-            <slot
-              v-for="(content, colIndex) in row"
-              name="cell"
-              v-bind="{ content, rowIndex, colIndex, row }"
-            />
-          </div>
-        </template>
-      </div>
-    `,
-  },
-  KIcon: {
-    name: 'KIcon',
-    props: ['icon', 'color'],
-    template: '<span />',
-  },
-  KRouterLink: {
-    name: 'KRouterLink',
-    props: ['text', 'to', 'icon'],
-    template: '<a role="link">{{ text }}</a>',
-  },
+const LEARNING_OBJECTIVES = {
+  'lo-1': { id: 'lo-1', text: 'Objective 1', num_questions: 4 },
+  'lo-2': { id: 'lo-2', text: 'Objective 2', num_questions: 4 },
 };
 
 function makePrefetchedData({
@@ -64,9 +32,9 @@ function makePrefetchedData({
   return {
     activeTestType,
     activeTestStatus,
-    learnersWithGroups: LEARNERS,
+    learnersWithGroups: Object.values(LEARNERS),
     reportData: {
-      learning_objectives: LEARNING_OBJECTIVES,
+      learning_objectives: Object.values(LEARNING_OBJECTIVES),
       pre_test: {
         status: activeTestType === 'pre' ? activeTestStatus : 'not_activated',
         scores: activeTestType === 'pre' ? scores : {},
@@ -84,23 +52,23 @@ const defaultLearnerRoute = learner => ({ name: 'TestRoute', params: { learnerId
 function renderComponent(props = {}) {
   return render(LearnersReport, {
     props: { learnerRoute: defaultLearnerRoute, ...props },
-    stubs: STUBS,
+    routes: [{ name: 'TestRoute', path: '/' }],
   });
 }
 
 describe('LearnersReport', () => {
   describe('loading and empty states', () => {
-    it('shows KCircularLoader when prefetchedData is null', () => {
+    it('shows loader when prefetchedData is null', () => {
       renderComponent({ prefetchedData: null });
-      expect(screen.getByTestId('loader')).toBeInTheDocument();
-      expect(screen.queryByTestId('k-table')).not.toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByRole('grid', { name: learnersLabel$() })).not.toBeInTheDocument();
     });
 
     it('shows no-test empty state when activeTestStatus is not_activated', () => {
       renderComponent({
         prefetchedData: makePrefetchedData({ activeTestStatus: 'not_activated' }),
       });
-      expect(screen.queryByTestId('k-table')).not.toBeInTheDocument();
+      expect(screen.queryByRole('grid', { name: learnersLabel$() })).not.toBeInTheDocument();
       expect(screen.getByText(noTestDataLabel$())).toBeInTheDocument();
     });
 
@@ -108,7 +76,7 @@ describe('LearnersReport', () => {
       renderComponent({
         prefetchedData: makePrefetchedData({ activeTestStatus: 'closed', scores: {} }),
       });
-      expect(screen.queryByTestId('k-table')).not.toBeInTheDocument();
+      expect(screen.queryByRole('grid', { name: learnersLabel$() })).not.toBeInTheDocument();
       expect(screen.getByText(noLearnersAttemptedLabel$())).toBeInTheDocument();
     });
   });
@@ -120,25 +88,24 @@ describe('LearnersReport', () => {
         'user-2': { 'lo-1': 1, 'lo-2': 1 }, // 2/8 = 25% → support_needed
       };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      expect(screen.getByTestId('k-table')).toBeInTheDocument();
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.getByText('Bob')).toBeInTheDocument();
-      expect(screen.getByText('Carol')).toBeInTheDocument();
+      expect(screen.getByRole('grid', { name: learnersLabel$() })).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['carol'].name)).toBeInTheDocument();
     });
 
     it('shows group name in each row', () => {
       const scores = { 'user-1': { 'lo-1': 4, 'lo-2': 4 } };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      expect(screen.getByText('Group A')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].groups[0])).toBeInTheDocument();
     });
 
     it('joins multiple group names with a comma', () => {
       const prefetchedData = makePrefetchedData({ scores: { 'user-1': { 'lo-1': 1 } } });
-      prefetchedData.learnersWithGroups = [
-        { id: 'user-1', name: 'Alice', username: 'alice', groups: ['Group A', 'Group B'] },
-      ];
+      const multiGroupLearner = { ...LEARNERS['alice'], groups: ['Group A', 'Group B'] };
+      prefetchedData.learnersWithGroups = [multiGroupLearner];
       renderComponent({ prefetchedData });
-      expect(screen.getByText('Group A, Group B')).toBeInTheDocument();
+      expect(screen.getByText(multiGroupLearner.groups.join(', '))).toBeInTheDocument();
     });
   });
 
@@ -196,7 +163,6 @@ describe('LearnersReport', () => {
       // user-2 and user-3 have no scores entry → no attempt
       const scores = { 'user-1': { 'lo-1': 4, 'lo-2': 4 } };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      // Intentional Unicode U+2014 (em dash), matching the &mdash; rendered by Vue
       expect(screen.getAllByText('—').length).toBeGreaterThan(0);
     });
   });
@@ -209,7 +175,7 @@ describe('LearnersReport', () => {
         'user-3': { 'lo-1': 2, 'lo-2': 2 }, // 50% → middle
       };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      const rows = screen.getAllByTestId(/^row-/);
+      const rows = screen.getAllByRole('row').slice(1); // skip header row
       // row-0 should be the lowest scorer (Bob = 12.5%)
       expect(rows[0]).toHaveTextContent('Bob');
       // row-1 should be Carol (50%)
@@ -226,7 +192,7 @@ describe('LearnersReport', () => {
         // user-3 absent
       };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      const rows = screen.getAllByTestId(/^row-/);
+      const rows = screen.getAllByRole('row').slice(1); // skip header row
       expect(rows[rows.length - 1]).toHaveTextContent('Carol');
     });
   });
@@ -270,7 +236,7 @@ describe('LearnersReport', () => {
     it('renders learner names as links with person icon', () => {
       const scores = { 'user-1': { 'lo-1': 4, 'lo-2': 4 } };
       renderComponent({ prefetchedData: makePrefetchedData({ scores }) });
-      expect(screen.getByRole('link', { name: 'Alice' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: LEARNERS['alice'].name })).toBeInTheDocument();
     });
 
     it('calls learnerRoute with the learner object for each name link', () => {
@@ -281,7 +247,7 @@ describe('LearnersReport', () => {
       }));
       renderComponent({ prefetchedData: makePrefetchedData({ scores }), learnerRoute });
       expect(learnerRoute).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'user-1', name: 'Alice' }),
+        expect.objectContaining({ id: LEARNERS['alice'].id, name: LEARNERS['alice'].name }),
       );
     });
   });

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/LearningObjectiveSidePanel.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/LearningObjectiveSidePanel.spec.js
@@ -1,30 +1,9 @@
-import { render, screen, within } from '@testing-library/vue';
+import { render, screen, fireEvent, within } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import LearningObjectiveSidePanel from '../LearningObjectiveSidePanel.vue';
 
-const STUBS = {
-  SidePanelModal: {
-    name: 'SidePanelModal',
-    template: '<div data-testid="side-panel-modal"><slot /></div>',
-  },
-  SidePanelLayout: {
-    name: 'SidePanelLayout',
-    props: ['title', 'subtitle', 'closePanel', 'contentContainerStyleOverrides'],
-    template: `
-      <div data-testid="side-panel-layout">
-        <div data-testid="panel-title">{{ title }}</div>
-        <div data-testid="panel-subtitle">{{ subtitle }}</div>
-        <button data-testid="close-button" @click="closePanel">Close</button>
-        <slot />
-      </div>
-    `,
-  },
-  KIcon: {
-    name: 'KIcon',
-    props: ['icon', 'color'],
-    template: '<span :data-testid="\'icon-\' + icon" />',
-  },
-};
+const { closeAction$ } = coreStrings;
 
 const OBJECTIVE = {
   id: 'lo-1',
@@ -66,15 +45,14 @@ function renderPanel(propsOverrides = {}) {
       reportData: REPORT_DATA,
       ...propsOverrides,
     },
-    stubs: STUBS,
   });
 }
 
 describe('LearningObjectiveSidePanel', () => {
   it('renders LO title and unit name in header', () => {
     renderPanel();
-    expect(screen.getByTestId('panel-title')).toHaveTextContent('Capital letters');
-    expect(screen.getByTestId('panel-subtitle')).toHaveTextContent('Unit 1: Letters');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Capital letters');
+    expect(screen.getByText(REPORT_DATA.unit_title)).toBeInTheDocument();
   });
 
   it('shows completion count based on active test takers', () => {
@@ -120,7 +98,6 @@ describe('LearningObjectiveSidePanel', () => {
     // user-2 scored 1/4=25% (low); user-3 has no scores and is excluded
     const banner = screen.getByTestId('warning-banner');
     expect(banner).toBeInTheDocument();
-    expect(within(banner).getByTestId('icon-error')).toBeInTheDocument();
   });
 
   it('hides warning banner when no learners are struggling', () => {
@@ -161,8 +138,7 @@ describe('LearningObjectiveSidePanel', () => {
 
   it('emits closePanel when close button is clicked', async () => {
     const { emitted } = renderPanel();
-    const closeButton = screen.getByTestId('close-button');
-    await closeButton.click();
+    await fireEvent.click(screen.getByRole('button', { name: closeAction$() }));
     expect(emitted().closePanel).toBeTruthy();
   });
 

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/LearningObjectivesReport.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/LearningObjectivesReport.spec.js
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/vue';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import LearningObjectivesReport from '../LearningObjectivesReport.vue';
 
-const { noTestDataLabel$ } = coursesStrings;
+const { noTestDataLabel$, sparklineDistributionLabel$ } = coursesStrings;
 
 const MOCK_OBJECTIVES = [
   {
@@ -24,61 +24,17 @@ const MOCK_OBJECTIVES = [
   },
 ];
 
-const STUBS = {
-  KCircularLoader: {
-    name: 'KCircularLoader',
-    template: '<div data-testid="loader">Loading...</div>',
-  },
-  KTable: {
-    name: 'KTable',
-    props: ['headers', 'rows', 'caption', 'emptyMessage', 'dataLoading'],
-    template: `
-      <div data-testid="k-table">
-        <caption>{{ caption }}</caption>
-        <template v-for="(row, rowIndex) in rows">
-          <div :key="rowIndex" :data-testid="'row-' + rowIndex">
-            <slot
-              v-for="(content, colIndex) in row"
-              name="cell"
-              v-bind="{ content, rowIndex, colIndex, row }"
-            />
-          </div>
-        </template>
-      </div>
-    `,
-  },
-  KRouterLink: {
-    name: 'KRouterLink',
-    props: ['text', 'to'],
-    template: '<a data-testid="router-link">{{ text }}</a>',
-  },
-  KButton: {
-    name: 'KButton',
-    props: ['text', 'appearance'],
-    template: '<button data-testid="k-button" @click="$emit(\'click\')">{{ text }}</button>',
-  },
-  SparklineBar: {
-    name: 'SparklineBar',
-    props: ['lowCount', 'midCount', 'highCount'],
-    template:
-      '<div data-testid="sparkline-bar" :data-low="lowCount" :data-mid="midCount" :data-high="highCount" />',
-  },
-};
-
 function renderComponent(props = {}) {
   return render(LearningObjectivesReport, {
-    props: {
-      ...props,
-    },
-    stubs: STUBS,
+    props: { ...props },
   });
 }
 
 describe('LearningObjectivesReport', () => {
   it('shows KCircularLoader when prefetchedData is null', () => {
     renderComponent({ prefetchedData: null });
-    expect(screen.getByTestId('loader')).toBeInTheDocument();
-    expect(screen.queryByTestId('k-table')).not.toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
   });
 
   it('shows empty state when activeTestStatus is not_activated', () => {
@@ -88,8 +44,8 @@ describe('LearningObjectivesReport', () => {
         bucketedObjectives: [],
       },
     });
-    expect(screen.queryByTestId('k-table')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     expect(screen.getByText(noTestDataLabel$())).toBeInTheDocument();
   });
 
@@ -101,16 +57,28 @@ describe('LearningObjectivesReport', () => {
       },
     });
 
-    expect(screen.getByTestId('k-table')).toBeInTheDocument();
-    expect(screen.getByText('Understand fractions')).toBeInTheDocument();
-    expect(screen.getByText('Apply division')).toBeInTheDocument();
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(screen.getByText(MOCK_OBJECTIVES[0].text)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_OBJECTIVES[1].text)).toBeInTheDocument();
 
-    const sparklines = screen.getAllByTestId('sparkline-bar');
-    expect(sparklines).toHaveLength(2);
-
-    expect(sparklines[0]).toHaveAttribute('data-low', '8');
-    expect(sparklines[0]).toHaveAttribute('data-mid', '4');
-    expect(sparklines[0]).toHaveAttribute('data-high', '3');
+    expect(
+      screen.getByText(
+        sparklineDistributionLabel$({
+          lowCount: MOCK_OBJECTIVES[0].lowCount,
+          midCount: MOCK_OBJECTIVES[0].midCount,
+          highCount: MOCK_OBJECTIVES[0].highCount,
+        }),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        sparklineDistributionLabel$({
+          lowCount: MOCK_OBJECTIVES[1].lowCount,
+          midCount: MOCK_OBJECTIVES[1].midCount,
+          highCount: MOCK_OBJECTIVES[1].highCount,
+        }),
+      ),
+    ).toBeInTheDocument();
   });
 
   it('emits select-objective with objective and reportData when LO row is clicked', async () => {
@@ -128,8 +96,7 @@ describe('LearningObjectivesReport', () => {
       },
     });
 
-    const buttons = screen.getAllByTestId('k-button');
-    await buttons[0].click();
+    await fireEvent.click(screen.getByText(MOCK_OBJECTIVES[0].text));
 
     expect(emitted()['select-objective']).toBeTruthy();
     expect(emitted()['select-objective'][0][0]).toEqual({

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/OverviewBlock.spec.js
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/OverviewBlock.spec.js
@@ -28,13 +28,8 @@ VueRouter.prototype.getRoute = jest.fn((name, params = {}, query = {}) => ({
 const routes = [
   { path: '/test', name: 'test' },
   { path: '/passwords', name: 'LEARNER_PASSWORDS' },
+  { path: '/class-list', name: 'CoachClassListPage' },
 ];
-
-// Stub BackLink to avoid VueRouter warnings about unregistered named routes
-// used by the back-navigation links (CoachClassListPage, AllFacilitiesPage).
-const stubs = {
-  BackLink: { template: '<div />' },
-};
 
 const MOCK_LEARNER = { id: 'learner-1', name: 'Learner One', username: 'learner1' };
 
@@ -50,7 +45,7 @@ function renderComponent({ picturePasswordSettings, learners = [] } = {}) {
     learnerMap[l.id] = l;
   });
   store.state.classSummary.learnerMap = learnerMap;
-  return render(OverviewBlock, { store, routes, stubs });
+  return render(OverviewBlock, { store, routes });
 }
 
 describe('OverviewBlock', () => {

--- a/kolibri/plugins/coach/frontend/views/learners/__tests__/LearnersRootPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/__tests__/LearnersRootPage.spec.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import { ref } from 'vue';
-import VueRouter from 'vue-router';
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
+import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import makeStore from '../../../__tests__/utils/makeStore';
 import LearnersRootPage from '../LearnersRootPage.vue';
@@ -12,35 +12,18 @@ const { viewPasswordsAction$ } = picturePasswordStrings;
 jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri-common/composables/usePageLoading');
 jest.mock('kolibri/composables/useUser');
+jest.mock('../../../composables/fetchClassSyncStatus');
+jest.mock('kolibri/urls');
 jest.mock('kolibri/router', () => ({
   getRoute: jest.fn((name, params) => ({ name, params })),
+  getReactiveRoute: jest.fn(() => ({ params: {} })),
 }));
 
-VueRouter.prototype.getRoute = jest.fn((name, params = {}, query = {}) => ({
-  name,
-  params,
-  query,
-}));
-
-// Include LEARNER_PASSWORDS so KRouterLink does not warn about an unknown route
-// when picture_password_settings is non-null and the button is rendered.
 const routes = [
   { path: '/test', name: 'test' },
   { path: '/passwords', name: 'LEARNER_PASSWORDS' },
+  { path: '/learner', name: 'LEARNER_SUMMARY' },
 ];
-
-// Stub CoachAppBarPage to avoid useCoreCoach's route.params access.
-// Stub ReportsControls to prevent its created() hook from calling
-// fetchClassSyncStatus, which would trigger an unregistered resource URL.
-const stubs = {
-  CoachAppBarPage: { template: '<div><slot /></div>' },
-  // Prevent ReportsControls.created() from calling fetchClassSyncStatus,
-  // which would trigger an unregistered resource URL and crash the worker.
-  ReportsControls: { template: '<div />' },
-  // Prevent table rows from rendering KRouterLink elements that reference
-  // routes (LEARNER_SUMMARY) not registered in the test router.
-  CoreTable: { template: '<div />' },
-};
 
 const MOCK_LEARNER = { id: 'learner-1', name: 'Learner One', username: 'learner1' };
 
@@ -56,12 +39,13 @@ function renderComponent({ picturePasswordSettings, learners = [] } = {}) {
     learnerMap[l.id] = l;
   });
   store.state.classSummary.learnerMap = learnerMap;
-  return render(LearnersRootPage, { store, routes, stubs });
+  return render(LearnersRootPage, { store, routes });
 }
 
 describe('LearnersRootPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useUser.mockImplementation(() => useUserMock({ isCoach: true }));
   });
 
   describe('"View Passwords" button conditional rendering', () => {

--- a/kolibri/plugins/device/frontend/views/DeviceSettingsPage/__tests__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/DeviceSettingsPage/__tests__/DeviceSettingsPage.spec.js
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import { Store } from 'vuex';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import DeviceSettingsPage from '../index.vue';
 import usePlugins, {
   // eslint-disable-next-line import-x/named
@@ -10,10 +12,18 @@ import usePlugins, {
 import * as api from '../api';
 import { getFreeSpaceOnServer } from '../../AvailableChannelsPage/api';
 
-jest.mock('../../../composables/usePlugins');
-jest.mock('kolibri-common/composables/usePageLoading');
-jest.mock('kolibri/urls');
+const { saveChangesAction$ } = coreStrings;
 
+const {
+  allowGuestAccess$,
+  disallowGuestAccess$,
+  lockedContent$,
+  signInPageChoice$,
+  learnerAppPageChoice$,
+  unlistedChannels$,
+} = createTranslator(DeviceSettingsPage.name, DeviceSettingsPage.$trs);
+
+jest.mock('../../../composables/usePlugins');
 jest.mock('kolibri-plugin-data', () => {
   return {
     __esModule: true,
@@ -74,7 +84,6 @@ async function makeWrapper() {
   render(DeviceSettingsPage, {
     store,
     routes,
-    stubs: ['AppBarPage'],
   });
 
   // Need to wait for beforeMount to finish
@@ -82,22 +91,13 @@ async function makeWrapper() {
 }
 
 function getButtons() {
-  const saveButton = screen.getByRole('button', { name: /save changes/i });
-  const learnPage = screen.getByRole('radio', { name: /Learn page/i });
-  const signInPage = screen.getByRole('radio', { name: /Sign-in page/i });
-  const allowGuestAccess = screen.getByRole('radio', {
-    name: /Allow users to explore resources without signing in/i,
-  });
-  const disallowGuestAccess = screen.getByRole('radio', {
-    name: /Learners must sign in to explore resources/i,
-  });
-  const unlistedChannels = screen.getByRole('checkbox', {
-    name: /Allow other devices on this network to view and import my unlisted channels/i,
-  });
-
-  const lockedContent = screen.getByRole('radio', {
-    name: /Signed in learners should only see resources assigned to them in classes/i,
-  });
+  const saveButton = screen.getByRole('button', { name: saveChangesAction$() });
+  const learnPage = screen.getByRole('radio', { name: learnerAppPageChoice$() });
+  const signInPage = screen.getByRole('radio', { name: signInPageChoice$() });
+  const allowGuestAccess = screen.getByRole('radio', { name: allowGuestAccess$() });
+  const disallowGuestAccess = screen.getByRole('radio', { name: disallowGuestAccess$() });
+  const unlistedChannels = screen.getByRole('checkbox', { name: unlistedChannels$() });
+  const lockedContent = screen.getByRole('radio', { name: lockedContent$() });
 
   return {
     learnPage,

--- a/kolibri/plugins/device/frontend/views/ManageTasksPage/__tests__/TaskPanel.spec.js
+++ b/kolibri/plugins/device/frontend/views/ManageTasksPage/__tests__/TaskPanel.spec.js
@@ -1,6 +1,29 @@
 import { render, screen } from '@testing-library/vue';
 import { TaskTypes } from 'kolibri-common/utils/syncTaskUtils';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { deviceStrings } from '../../commonDeviceStrings';
+
 import TaskPanel from '../TaskPanel';
+
+const { clearAction$ } = coreStrings;
+const { statusCanceled$ } = deviceStrings;
+
+const { exportChannelPartial$, exportChannelWhole$, startedByUser$, numResourcesAndSize$ } =
+  createTranslator(TaskPanel.name, TaskPanel.$trs);
+
+const EXPORT_TASK = {
+  type: TaskTypes.DISKCONTENTEXPORT,
+  status: 'CANCELED',
+  clearable: true,
+  extra_metadata: {
+    channel_name: 'Canceled disk export channel test',
+    started_by_username: 'Tester',
+    file_size: 5000,
+    total_resources: 500,
+  },
+};
+const FILE_SIZE = '5 KB';
 
 function renderComponent(task) {
   return render(TaskPanel, {
@@ -11,44 +34,37 @@ function renderComponent(task) {
 }
 
 describe('TaskPanel', () => {
-  const exportTask = {
-    type: TaskTypes.DISKCONTENTEXPORT,
-    status: 'CANCELED',
-    clearable: true,
-    extra_metadata: {
-      channel_name: 'Canceled disk export channel test',
-      started_by_username: 'Tester',
-      file_size: 5000,
-      total_resources: 500,
-    },
-  };
-
   it('shows canceled partial export details including resource totals for a canceled disk content export task', () => {
-    renderComponent(exportTask);
+    const { channel_name, started_by_username, total_resources } = EXPORT_TASK.extra_metadata;
+    renderComponent(EXPORT_TASK);
 
-    expect(screen.getByText('Canceled')).toBeInTheDocument();
+    expect(screen.getByText(statusCanceled$())).toBeInTheDocument();
     expect(
-      screen.getByText(/export resources from 'canceled disk export channel test'/i),
+      screen.getByText(exportChannelPartial$({ channelName: channel_name })),
     ).toBeInTheDocument();
-    expect(screen.getByText(/started by 'tester'/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
-
-    expect(screen.getByText(/500 resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/\(5 KB\)/i)).toBeInTheDocument();
+    expect(screen.getByText(startedByUser$({ user: started_by_username }))).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: clearAction$() })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        numResourcesAndSize$({ numResources: total_resources, bytesText: FILE_SIZE }),
+      ),
+    ).toBeInTheDocument();
   });
 
   it('shows canceled bulk export details including resource totals for a canceled disk export task', () => {
-    renderComponent({
-      ...exportTask,
-      type: TaskTypes.DISKEXPORT,
-    });
+    const { channel_name, started_by_username, total_resources } = EXPORT_TASK.extra_metadata;
+    renderComponent({ ...EXPORT_TASK, type: TaskTypes.DISKEXPORT });
 
-    expect(screen.getByText('Canceled')).toBeInTheDocument();
-    expect(screen.getByText(/export 'canceled disk export channel test'/i)).toBeInTheDocument();
-    expect(screen.getByText(/started by 'tester'/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
-
-    expect(screen.getByText(/500 resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/\(5 KB\)/i)).toBeInTheDocument();
+    expect(screen.getByText(statusCanceled$())).toBeInTheDocument();
+    expect(
+      screen.getByText(exportChannelWhole$({ channelName: channel_name })),
+    ).toBeInTheDocument();
+    expect(screen.getByText(startedByUser$({ user: started_by_username }))).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: clearAction$() })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        numResourcesAndSize$({ numResources: total_resources, bytesText: FILE_SIZE }),
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/device/frontend/views/PinAuthenticationModal.vue
+++ b/kolibri/plugins/device/frontend/views/PinAuthenticationModal.vue
@@ -31,7 +31,7 @@
   import { createTranslator } from 'kolibri/utils/i18n';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
 
-  const strings = createTranslator('PinAuthenticationModal', {
+  export const strings = createTranslator('PinAuthenticationModal', {
     incorrectPin: {
       message: 'Incorrect PIN, please try again',
       context: 'Error message displayed when an incorrect PIN is input',

--- a/kolibri/plugins/device/frontend/views/__tests__/PinAuthenticationModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/PinAuthenticationModal.spec.js
@@ -2,7 +2,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
-import PinAuthenticationModal from '../PinAuthenticationModal.vue';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import PinAuthenticationModal, { strings as pinModalStrings } from '../PinAuthenticationModal';
+
+const { cancelAction$, continueAction$, requiredFieldError$, numbersOnly$ } = coreStrings;
+const { incorrectPin$, pinPlaceholder$ } = pinModalStrings;
 
 jest.mock('kolibri/client');
 jest.mock('kolibri/urls');
@@ -29,7 +33,7 @@ describe('PinAuthenticationModal', () => {
   it('emits cancel when the user clicks Cancel', async () => {
     const { emitted } = renderComponent();
 
-    await fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    await fireEvent.click(screen.getByRole('button', { name: cancelAction$() }));
 
     expect(emitted()).toHaveProperty('cancel');
     expect(emitted().cancel).toHaveLength(1);
@@ -39,16 +43,16 @@ describe('PinAuthenticationModal', () => {
     it('does not show validation messages before the user submits the form', () => {
       renderComponent();
 
-      expect(screen.queryByText('Incorrect PIN, please try again')).not.toBeInTheDocument();
-      expect(screen.queryByText('This field is required')).not.toBeInTheDocument();
-      expect(screen.queryByText('Enter numbers only')).not.toBeInTheDocument();
+      expect(screen.queryByText(incorrectPin$())).not.toBeInTheDocument();
+      expect(screen.queryByText(requiredFieldError$())).not.toBeInTheDocument();
+      expect(screen.queryByText(numbersOnly$())).not.toBeInTheDocument();
     });
 
     it('emits submit when the user enters a valid PIN and submits', async () => {
       const { emitted } = renderComponent();
 
-      await userEvent.type(screen.getByLabelText('PIN'), '1234');
-      await fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      await userEvent.type(screen.getByLabelText(pinPlaceholder$()), '1234');
+      await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
       await waitFor(() => {
         expect(emitted()).toHaveProperty('submit');
@@ -67,29 +71,29 @@ describe('PinAuthenticationModal', () => {
 
       renderComponent();
 
-      await userEvent.type(screen.getByLabelText('PIN'), '1234');
-      await fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      await userEvent.type(screen.getByLabelText(pinPlaceholder$()), '1234');
+      await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
       await waitFor(() => {
-        expect(screen.getByText('Incorrect PIN, please try again')).toBeInTheDocument();
+        expect(screen.getByText(incorrectPin$())).toBeInTheDocument();
       });
     });
 
     it('shows a numbers-only validation message when the PIN contains letters', async () => {
       renderComponent();
 
-      await userEvent.type(screen.getByLabelText('PIN'), 'abcd');
-      await fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      await userEvent.type(screen.getByLabelText(pinPlaceholder$()), 'abcd');
+      await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
-      expect(screen.getByText('Enter numbers only')).toBeInTheDocument();
+      expect(screen.getByText(numbersOnly$())).toBeInTheDocument();
     });
 
     it('shows a required-field validation message when the PIN is empty', async () => {
       renderComponent();
 
-      await fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
-      expect(screen.getByText('This field is required')).toBeInTheDocument();
+      expect(screen.getByText(requiredFieldError$())).toBeInTheDocument();
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/WelcomeModel.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/WelcomeModel.spec.js
@@ -1,6 +1,9 @@
 import { render, fireEvent, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import WelcomeModal from '../WelcomeModal';
+
+const { continueAction$ } = coreStrings;
 
 describe('WelcomeModal', () => {
   it('emits submit event when continue button is clicked', async () => {
@@ -12,7 +15,7 @@ describe('WelcomeModal', () => {
       },
     });
 
-    const submitButton = screen.getByRole('button', { name: /continue/i });
+    const submitButton = screen.getByRole('button', { name: continueAction$() });
     await fireEvent.click(submitButton);
     expect(submitListener).toHaveBeenCalledTimes(1);
   });

--- a/kolibri/plugins/device/frontend/views/commonDeviceStrings.js
+++ b/kolibri/plugins/device/frontend/views/commonDeviceStrings.js
@@ -1,6 +1,6 @@
 import { createTranslator } from 'kolibri/utils/i18n';
 
-const deviceStrings = createTranslator('CommonDeviceStrings', {
+export const deviceStrings = createTranslator('CommonDeviceStrings', {
   deviceManagementTitle: {
     message: 'Device',
     context:

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/NextButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/NextButton.spec.js
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { createTranslator } from 'kolibri/utils/i18n';
 import NextButton from '../NextButton';
+
+const { goToNextPage$ } = createTranslator(NextButton.name, NextButton.$trs);
 
 const renderComponent = () => {
   return render(NextButton, {
@@ -11,11 +14,11 @@ const renderComponent = () => {
 describe('Next button', () => {
   it('renders a button accessible as go to next page', () => {
     renderComponent();
-    expect(screen.getByRole('button', { name: 'Go to next page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: goToNextPage$() })).toBeInTheDocument();
   });
   it('emits goToNextPage when clicked', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+    await fireEvent.click(screen.getByRole('button', { name: goToNextPage$() }));
     expect(emitted()).toHaveProperty('goToNextPage');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/PreviousButton.spec.js
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { createTranslator } from 'kolibri/utils/i18n';
 import PreviousButton from '../PreviousButton';
+
+const { goToPreviousPage$ } = createTranslator(PreviousButton.name, PreviousButton.$trs);
 
 const renderComponent = () => {
   return render(PreviousButton, {
@@ -11,11 +14,11 @@ const renderComponent = () => {
 describe('Previous button', () => {
   it('renders a button accessible as go to previous page', () => {
     renderComponent();
-    expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: goToPreviousPage$() })).toBeInTheDocument();
   });
   it('emits goToPreviousPage when clicked', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button', { name: 'Go to previous page' }));
+    await fireEvent.click(screen.getByRole('button', { name: goToPreviousPage$() }));
     expect(emitted()).toHaveProperty('goToPreviousPage');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SearchSideBar.spec.js
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/vue';
 import { defineComponent, ref } from 'vue';
 import SearchSideBar from '../SearchSideBar';
 
+const FOCUS_BUTTON_TEXT = 'Focus';
+
 describe('Search side bar', () => {
   function renderComponent() {
     return render(SearchSideBar, {
@@ -36,13 +38,13 @@ describe('Search side bar', () => {
       },
       template: ` <div>
         <SearchSideBar ref="sidebarRef" :book="{}" />
-        <button @click="focusInput">Focus</button>
+        <button @click="focusInput">${FOCUS_BUTTON_TEXT}</button>
       </div> `,
     });
 
     render(Parent, { attachTo: document.body });
 
-    const button = screen.getByRole('button', { name: 'Focus' });
+    const button = screen.getByRole('button', { name: FOCUS_BUTTON_TEXT });
     button.click();
 
     const input = screen.getByRole('searchbox');

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
@@ -1,6 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
 import SettingsSideBar from '../SettingsSideBar';
 import { THEMES } from '../EpubConstants';
+
+const { decrease$, increase$, setWhiteTheme$, setBeigeTheme$, setGreyTheme$, setBlackTheme$ } =
+  createTranslator(SettingsSideBar.name, SettingsSideBar.$trs);
 
 function renderSettingsSideBar(props = {}) {
   return render(SettingsSideBar, {
@@ -16,18 +20,18 @@ describe('Settings side bar', () => {
     renderSettingsSideBar();
 
     // Font buttons
-    expect(screen.getByText('Decrease')).toBeInTheDocument();
-    expect(screen.getByText('Increase')).toBeInTheDocument();
+    expect(screen.getByText(decrease$())).toBeInTheDocument();
+    expect(screen.getByText(increase$())).toBeInTheDocument();
 
     // Theme buttons (check a few representative ones)
-    expect(screen.getByLabelText('Set white theme')).toBeInTheDocument();
-    expect(screen.getByLabelText('Set beige theme')).toBeInTheDocument();
+    expect(screen.getByLabelText(setWhiteTheme$())).toBeInTheDocument();
+    expect(screen.getByLabelText(setBeigeTheme$())).toBeInTheDocument();
   });
 
   it('emits event when decrease font size button is clicked', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByText('Decrease'));
+    await fireEvent.click(screen.getByText(decrease$()));
 
     expect(emitted().decreaseFontSize).toBeTruthy();
   });
@@ -35,7 +39,7 @@ describe('Settings side bar', () => {
   it('emits event when increase font size button is clicked', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByText('Increase'));
+    await fireEvent.click(screen.getByText(increase$()));
 
     expect(emitted().increaseFontSize).toBeTruthy();
   });
@@ -43,7 +47,7 @@ describe('Settings side bar', () => {
   it('renders expected theme options', () => {
     renderSettingsSideBar();
 
-    const themeLabels = ['Set white theme', 'Set beige theme', 'Set grey theme', 'Set black theme'];
+    const themeLabels = [setWhiteTheme$(), setBeigeTheme$(), setGreyTheme$(), setBlackTheme$()];
 
     const renderedThemes = themeLabels.filter(label => screen.queryByLabelText(label));
 
@@ -53,7 +57,7 @@ describe('Settings side bar', () => {
   it('emits event when a theme is selected', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByLabelText('Set white theme'));
+    await fireEvent.click(screen.getByLabelText(setWhiteTheme$()));
 
     expect(emitted().setTheme).toBeTruthy();
     expect(emitted().setTheme[0][0]).toBe(THEMES.WHITE);

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSection.spec.js
@@ -42,36 +42,36 @@ function renderComponent({ section, depth, currentSection } = {}) {
 describe('Table of Contents Section', () => {
   it('renders a section label correctly', () => {
     renderComponent({ section, depth: 0 });
-    expect(screen.getByText('Top level section')).toBeInTheDocument();
+    expect(screen.getByText(section.label)).toBeInTheDocument();
   });
 
   it('renders nested sub-items when a section has subitems', () => {
     renderComponent({ section: sectionWithSubItems, depth: 0 });
-    expect(screen.getByText('Top level section')).toBeInTheDocument();
-    expect(screen.getByText('Second level section')).toBeInTheDocument();
-    expect(screen.getByText('Third level section')).toBeInTheDocument();
+    expect(screen.getByText(sectionWithSubItems.label)).toBeInTheDocument();
+    expect(screen.getByText(sectionWithSubItems.subitems[0].label)).toBeInTheDocument();
+    expect(screen.getByText(sectionWithSubItems.subitems[0].subitems[0].label)).toBeInTheDocument();
   });
 
   it('displays the href as fallback text if the label is empty', () => {
     renderComponent({ section: sectionWithEmptyLabel, depth: 0 });
-    expect(screen.getByText('href1')).toBeInTheDocument();
+    expect(screen.getByText(sectionWithEmptyLabel.href)).toBeInTheDocument();
   });
 
   it('applies the appropriate top-level styling class for root level sections', () => {
     renderComponent({ section, depth: 0 });
-    const listItem = screen.getByText('Top level section').closest('li');
+    const listItem = screen.getByText(section.label).closest('li');
     expect(listItem).toHaveClass('toc-list-item-top-level');
   });
 
   it('does not apply the top-level styling class for nested sections', () => {
     renderComponent({ section, depth: 1 });
-    const listItem = screen.getByText('Top level section').closest('li');
+    const listItem = screen.getByText(section.label).closest('li');
     expect(listItem).not.toHaveClass('toc-list-item-top-level');
   });
 
   it('visually highlights the section if it is the current section', () => {
     renderComponent({ section, depth: 0, currentSection: section });
-    const button = screen.getByText('Top level section').closest('.toc-list-item-button');
+    const button = screen.getByText(section.label).closest('.toc-list-item-button');
     expect(button).toHaveClass('toc-list-item-button-current');
   });
 
@@ -81,13 +81,13 @@ describe('Table of Contents Section', () => {
       depth: 0,
       currentSection: { label: 'Random section', href: 'href' },
     });
-    const button = screen.getByText('Top level section').closest('.toc-list-item-button');
+    const button = screen.getByText(section.label).closest('.toc-list-item-button');
     expect(button).not.toHaveClass('toc-list-item-button-current');
   });
 
   it('emits a navigation event when the section is clicked', async () => {
     const { emitted } = renderComponent({ section, depth: 0 });
-    await fireEvent.click(screen.getByText('Top level section'));
+    await fireEvent.click(screen.getByText(section.label));
     expect(emitted()).toHaveProperty('tocNavigation');
     expect(emitted().tocNavigation[0][0]).toEqual(section);
   });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSectionSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TableOfContentsSectionSideBar.spec.js
@@ -38,9 +38,9 @@ function renderComponent({ toc, currentSection } = {}) {
 describe('Table of Contents Side Bar', () => {
   it('renders the sidebar with all sections', () => {
     renderComponent({ toc });
-    expect(screen.getByText('Top level section')).toBeInTheDocument();
-    expect(screen.getByText('Second level section')).toBeInTheDocument();
-    expect(screen.getByText('Third level section')).toBeInTheDocument();
+    expect(screen.getByText(toc[0].label)).toBeInTheDocument();
+    expect(screen.getByText(toc[0].subitems[0].label)).toBeInTheDocument();
+    expect(screen.getByText(toc[0].subitems[0].subitems[0].label)).toBeInTheDocument();
   });
 
   it('renders the correct nested list structure for the given toc', () => {
@@ -50,17 +50,17 @@ describe('Table of Contents Side Bar', () => {
 
   it('emits a tocNavigation event when a specific section is clicked', async () => {
     const { emitted } = renderComponent({ toc });
-    await fireEvent.click(screen.getByText('Third level section'));
+    await fireEvent.click(screen.getByText(currentSection.label));
     expect(emitted()).toHaveProperty('tocNavigation');
     expect(emitted().tocNavigation[0][0]).toEqual({
-      label: 'Third level section',
-      href: 'href3',
+      label: currentSection.label,
+      href: currentSection.href,
     });
   });
 
   it('visually highlights the currently active section', () => {
     renderComponent({ toc, currentSection });
-    const activeButton = screen.getByText('Third level section').closest('.toc-list-item-button');
+    const activeButton = screen.getByText(currentSection.label).closest('.toc-list-item-button');
     expect(activeButton).toHaveClass('toc-list-item-button-current');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TocButton.spec.js
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { createTranslator } from 'kolibri/utils/i18n';
 import TocButton from '../TocButton';
+
+const { toggleTocSideBar$ } = createTranslator(TocButton.name, TocButton.$trs);
 
 function renderComponent() {
   return render(TocButton);
@@ -9,12 +12,12 @@ function renderComponent() {
 describe('Table of contents button', () => {
   it('renders the table of contents button', () => {
     renderComponent();
-    expect(screen.getByRole('button', { name: /toggle table of contents/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: toggleTocSideBar$() })).toBeInTheDocument();
   });
 
   it('emits a click event when the button is interacted with', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button', { name: /toggle table of contents/i }));
+    await fireEvent.click(screen.getByRole('button', { name: toggleTocSideBar$() }));
     expect(emitted()).toHaveProperty('click');
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/TopBar.spec.js
@@ -1,5 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
 import TopBar from '../TopBar';
+import TocButton from '../TocButton';
+import SettingsButton from '../SettingsButton';
+import SearchButton from '../SearchButton';
+
+const { toggleTocSideBar$ } = createTranslator(TocButton.name, TocButton.$trs);
+const { toggleSettingsSideBar$ } = createTranslator(SettingsButton.name, SettingsButton.$trs);
+const { toggleSearchSideBar$ } = createTranslator(SearchButton.name, SearchButton.$trs);
+const { toggleFullscreen$ } = createTranslator(TopBar.name, TopBar.$trs);
 
 function renderTopBar(props = {}) {
   return render(TopBar, {
@@ -26,7 +35,7 @@ describe('Top bar', () => {
 
   it('allows parent to focus on table of contents button', () => {
     renderTopBar();
-    const tocButton = screen.getByRole('button', { name: /toggle table of contents/i });
+    const tocButton = screen.getByRole('button', { name: toggleTocSideBar$() });
     tocButton.focus();
     expect(tocButton).toHaveFocus();
   });
@@ -34,7 +43,7 @@ describe('Top bar', () => {
   it('allows parent to focus on settings button', () => {
     renderTopBar();
 
-    const settingsButton = screen.getByRole('button', { name: /toggle settings/i });
+    const settingsButton = screen.getByRole('button', { name: toggleSettingsSideBar$() });
     settingsButton.focus();
 
     expect(settingsButton).toHaveFocus();
@@ -43,7 +52,7 @@ describe('Top bar', () => {
   it('allows parent to focus on search button', () => {
     renderTopBar();
 
-    const searchButton = screen.getByRole('button', { name: /toggle search/i });
+    const searchButton = screen.getByRole('button', { name: toggleSearchSideBar$() });
     searchButton.focus();
 
     expect(searchButton).toHaveFocus();
@@ -52,7 +61,7 @@ describe('Top bar', () => {
   it('emits event when table of contents button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getByRole('button', { name: /toggle table of contents/i }));
+    await fireEvent.click(screen.getByRole('button', { name: toggleTocSideBar$() }));
 
     expect(emitted().tableOfContentsButtonClicked).toBeTruthy();
   });
@@ -60,7 +69,7 @@ describe('Top bar', () => {
   it('emits event when settings button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getByRole('button', { name: /toggle settings/i }));
+    await fireEvent.click(screen.getByRole('button', { name: toggleSettingsSideBar$() }));
 
     expect(emitted().settingsButtonClicked).toBeTruthy();
   });
@@ -68,7 +77,7 @@ describe('Top bar', () => {
   it('emits event when search button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getByRole('button', { name: /toggle search/i }));
+    await fireEvent.click(screen.getByRole('button', { name: toggleSearchSideBar$() }));
 
     expect(emitted().searchButtonClicked).toBeTruthy();
   });
@@ -76,7 +85,7 @@ describe('Top bar', () => {
   it('emits event when fullscreen button is clicked', async () => {
     const { emitted } = renderTopBar();
 
-    await fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
+    await fireEvent.click(screen.getByRole('button', { name: toggleFullscreen$() }));
 
     expect(emitted().fullscreenButtonClicked).toBeTruthy();
   });

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-app-bar-page.spec.js
@@ -4,7 +4,13 @@ import { ref } from 'vue';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import FacilityAppBarPage from '../FacilityAppBarPage';
+
+const { facilityLabel$ } = coreStrings;
+
+const APP_BAR_TITLE = 'Facility settings';
+const FACILITY_NAME = 'Sunrise School';
 
 jest.mock('kolibri/urls');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
@@ -40,16 +46,17 @@ describe('FacilityAppBarPage', function () {
   it('shows the page title passed by the parent page', () => {
     useFacilities.mockReturnValue(useFacilitiesMock({ userIsMultiFacilityAdmin: ref(false) }));
     useFacility.mockReturnValue(useFacilityMock({ currentFacilityName: ref('') }));
-    renderPage({ appBarTitle: 'Facility settings' });
-    expect(screen.getByRole('heading', { name: 'Facility settings' })).toBeInTheDocument();
+    renderPage({ appBarTitle: APP_BAR_TITLE });
+    expect(screen.getByRole('heading', { name: APP_BAR_TITLE })).toBeInTheDocument();
   });
 
   it('shows the current facility name for multi-facility admins', () => {
     useFacilities.mockReturnValue(useFacilitiesMock({ userIsMultiFacilityAdmin: ref(true) }));
-    useFacility.mockReturnValue(useFacilityMock({ currentFacilityName: ref('Sunrise School') }));
+    useFacility.mockReturnValue(useFacilityMock({ currentFacilityName: ref(FACILITY_NAME) }));
     renderPage();
 
-    expect(screen.getByRole('heading', { name: 'Facility – Sunrise School' })).toBeInTheDocument();
+    const expectedHeading = `${facilityLabel$()} – ${FACILITY_NAME}`;
+    expect(screen.getByRole('heading', { name: expectedHeading })).toBeInTheDocument();
   });
 
   it('shows the default facility title for single-facility admins', () => {
@@ -57,6 +64,6 @@ describe('FacilityAppBarPage', function () {
     useFacility.mockReturnValue(useFacilityMock({ currentFacilityName: ref('') }));
     renderPage();
 
-    expect(screen.getByRole('heading', { name: 'Facility' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: facilityLabel$() })).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -3,10 +3,16 @@ import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
 import useUserManagement from '../../../../composables/useUserManagement';
 import { useUserManagementMock } from '../../../../composables/__mocks__/useUserManagement';
 import makeStore from '../../../../__tests__/utils/makeStore';
 import UserPage from '../index';
+
+const { usersLabel$, searchForUser$, filter$, optionsLabel$ } = coreStrings;
+const { noUsersMatchSearch$, noUsersMatchFilter$, noUsersMatchFiltersAndSearch$ } =
+  bulkUserManagementStrings;
 
 jest.mock('kolibri/urls');
 jest.mock('lockr');
@@ -65,10 +71,10 @@ describe('UserPage component', () => {
   it('shows the main users management controls', async () => {
     await renderPage();
 
-    expect(screen.getByRole('heading', { name: 'Users' })).toBeInTheDocument();
-    expect(screen.getByRole('searchbox', { name: 'Search for a user...' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Filter' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Options' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: usersLabel$() })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: searchForUser$() })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: filter$() })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: optionsLabel$() })).toBeInTheDocument();
   });
 
   it('shows a search-specific empty state when no users match the search term', async () => {
@@ -102,7 +108,7 @@ describe('UserPage component', () => {
 
     expect(usersInFacility).toHaveLength(2);
     expect(searchResults).toHaveLength(0);
-    expect(screen.getByText('No users match this search')).toBeInTheDocument();
+    expect(screen.getByText(noUsersMatchSearch$())).toBeInTheDocument();
   });
 
   it('shows a filter-specific empty state when filters are applied', async () => {
@@ -113,7 +119,7 @@ describe('UserPage component', () => {
       },
     });
 
-    expect(screen.getByText('No users match this filter')).toBeInTheDocument();
+    expect(screen.getByText(noUsersMatchFilter$({ filtersCount: 1 }))).toBeInTheDocument();
   });
 
   it('shows combined empty-state messaging when both search and filters are applied', async () => {
@@ -125,6 +131,8 @@ describe('UserPage component', () => {
       },
     });
 
-    expect(screen.getByText('No users match this search and these filters')).toBeInTheDocument();
+    expect(
+      screen.getByText(noUsersMatchFiltersAndSearch$({ filtersCount: 2 })),
+    ).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
@@ -30,6 +30,7 @@
       />
       <ContentViewer
         v-else-if="!contentNode.assessmentmetadata"
+        data-testid="content-viewer"
         class="content-viewer"
         :lang="contentNode.lang"
         :files="contentNode.files"

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/__tests__/CourseUnitView.spec.js
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/__tests__/CourseUnitView.spec.js
@@ -3,9 +3,12 @@ import { useRouter, useRoute } from 'vue-router/composables';
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
 import LearningActivities from 'kolibri-constants/labels/LearningActivities';
 import Modalities from 'kolibri-constants/Modalities';
+import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import { LearnerCourseResource } from '../../../apiResources';
 import CourseUnitView from '../index.vue';
 import { PageNames } from '../../../constants';
+
+const { nextLabel$, previousLabel$, courseNameLabel$ } = coursesStrings;
 
 jest.mock('vue-router/composables');
 jest.mock('kolibri-common/apiResources/ContentNodeResource');
@@ -15,31 +18,16 @@ jest.mock('../../../apiResources', () => ({
     fetchModel: jest.fn(),
   },
 }));
-
-jest.mock('../../../composables/useProgressTracking', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    progress: { value: 0 },
-    time_spent: { value: 0 },
-    extra_fields: { value: {} },
-    initContentSession: jest.fn().mockResolvedValue(),
-    updateContentSession: jest.fn().mockResolvedValue(),
-    startTrackingProgress: jest.fn(),
-    stopTrackingProgress: jest.fn(),
-  })),
-}));
-
 jest.mock('../../../composables/useContentNodeProgress');
-
 jest.mock('../../../composables/useBookmarks');
-
 jest.mock('../useCourseContentProgressTracking');
 
-const ContentViewerMock = {
-  name: 'ContentViewer',
-  template: '<div data-testid="content-viewer">{{ options && options.title }}</div>',
-  props: ['options'],
-};
+const LESSON_1_TITLE = 'Lesson 1';
+const LESSON_2_TITLE = 'Lesson 2';
+const RESOURCE_1_TITLE = 'Resource 1';
+const RESOURCE_2_TITLE = 'Resource 2';
+const UNIT_2_TITLE = 'Unit 2';
+const PHYSICS_101_TITLE = 'Physics 101';
 
 // Data helpers
 const createResource = (id, title, parent, lft = 1) => ({
@@ -67,19 +55,6 @@ const createUnit = (id, title, children = []) => ({
   modality: Modalities.UNIT,
   children: { results: children },
 });
-
-const AccordionItemStub = {
-  template: `
-    <div data-testid="accordion-item">
-      <div data-testid="accordion-header">
-        <slot name="title" />
-      </div>
-      <div data-testid="accordion-content">
-        <slot name="content" />
-      </div>
-    </div>
-  `,
-};
 
 describe('CourseUnitView', () => {
   let router;
@@ -111,19 +86,19 @@ describe('CourseUnitView', () => {
     });
 
     // Setup sample data for rendering/interaction tests
-    const r1 = createResource('r1', 'Resource 1', 'l1', 10);
-    const r2 = createResource('r2', 'Resource 2', 'l1', 20);
+    const r1 = createResource('r1', RESOURCE_1_TITLE, 'l1', 10);
+    const r2 = createResource('r2', RESOURCE_2_TITLE, 'l1', 20);
     const r3 = createResource('r3', 'Resource 3', 'l2', 30);
 
-    const l1 = createLesson('l1', 'Lesson 1', true, [r1, r2]);
-    const l2 = createLesson('l2', 'Lesson 2', false, [r3]);
+    const l1 = createLesson('l1', LESSON_1_TITLE, true, [r1, r2]);
+    const l2 = createLesson('l2', LESSON_2_TITLE, false, [r3]);
 
     sampleUnitTree = createUnit('unit-1', 'Unit 1', [l1, l2]);
 
     // For fetchModel results (course units list)
     sampleCourseUnits = [
       { id: 'unit-1', title: 'Unit 1', modality: 'UNIT' },
-      { id: 'unit-2', title: 'Unit 2', modality: 'UNIT' },
+      { id: 'unit-2', title: UNIT_2_TITLE, modality: 'UNIT' },
     ];
 
     ContentNodeResource.fetchTree.mockResolvedValue(sampleUnitTree);
@@ -139,10 +114,6 @@ describe('CourseUnitView', () => {
       props: {
         courseId: COURSE_ID,
         ...props,
-      },
-      stubs: {
-        ContentViewer: ContentViewerMock,
-        AccordionItem: AccordionItemStub,
       },
     });
   }
@@ -797,7 +768,7 @@ describe('CourseUnitView', () => {
 
     it('renders course title', async () => {
       LearnerCourseResource.fetchModel.mockResolvedValue({
-        title: 'Physics 101',
+        title: PHYSICS_101_TITLE,
         course_id: COURSE_CONTENT_ID,
       });
       LearnerCourseResource.getResumeData.mockResolvedValue({
@@ -818,7 +789,7 @@ describe('CourseUnitView', () => {
       });
 
       await waitFor(() => {
-        expect(wrapper.getByText('Course: Physics 101')).toBeVisible();
+        expect(wrapper.getByText(courseNameLabel$({ name: PHYSICS_101_TITLE }))).toBeVisible();
       });
     });
   });
@@ -842,7 +813,7 @@ describe('CourseUnitView', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('content-viewer')).toHaveTextContent('Resource 1');
+        expect(screen.getByTestId('content-viewer')).toHaveTextContent(RESOURCE_1_TITLE);
       });
     });
 
@@ -857,11 +828,11 @@ describe('CourseUnitView', () => {
       await fireEvent.click(sidePanelToggle);
 
       await waitFor(() => {
-        expect(screen.getByText('Lesson 1')).toBeVisible();
-        expect(screen.getByText('Lesson 2')).toBeVisible();
+        expect(screen.getByText(LESSON_1_TITLE)).toBeVisible();
+        expect(screen.getByText(LESSON_2_TITLE)).toBeVisible();
         // Resource 1 appears in both ContentViewer and side panel
-        expect(screen.getAllByText('Resource 1').length).toBeGreaterThanOrEqual(1);
-        expect(screen.getByText('Resource 2')).toBeVisible();
+        expect(screen.getAllByText(RESOURCE_1_TITLE).length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText(RESOURCE_2_TITLE)).toBeVisible();
       });
     });
 
@@ -876,10 +847,10 @@ describe('CourseUnitView', () => {
       await fireEvent.click(sidePanelToggle);
 
       await waitFor(() => {
-        expect(screen.getByText('Resource 2')).toBeVisible();
+        expect(screen.getByText(RESOURCE_2_TITLE)).toBeVisible();
       });
 
-      fireEvent.click(screen.getByText('Resource 2'));
+      fireEvent.click(screen.getByText(RESOURCE_2_TITLE));
 
       await waitFor(() => {
         expect(router.replace).toHaveBeenCalledWith(
@@ -902,13 +873,10 @@ describe('CourseUnitView', () => {
         resourceId: 'r1',
       });
 
-      // Wait for content render
       await waitFor(() => {
-        expect(screen.getByTestId('content-viewer')).toBeVisible();
+        expect(screen.getByRole('button', { name: nextLabel$() })).toBeEnabled();
       });
-
-      const nextButton = await screen.findByRole('button', { name: /next/i });
-      expect(nextButton).toBeEnabled();
+      const nextButton = screen.getByRole('button', { name: nextLabel$() });
 
       await fireEvent.click(nextButton);
 
@@ -932,12 +900,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r2',
       });
 
-      // Wait for content render
-      await waitFor(() => {
-        expect(screen.getByTestId('content-viewer')).toBeVisible();
-      });
-
-      const prevButton = await screen.findByRole('button', { name: /previous/i });
+      const prevButton = await screen.findByRole('button', { name: previousLabel$() });
       expect(prevButton).toBeEnabled();
 
       await fireEvent.click(prevButton);
@@ -962,7 +925,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r2',
       });
 
-      const nextButton = await screen.findByRole('button', { name: /next/i });
+      const nextButton = await screen.findByRole('button', { name: nextLabel$() });
       await waitFor(() => {
         expect(nextButton).toBeEnabled();
       });
@@ -991,12 +954,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r3',
       });
 
-      // Wait for content render
-      await waitFor(() => {
-        expect(screen.getByTestId('content-viewer')).toBeVisible();
-      });
-
-      const prevButton = await screen.findByRole('button', { name: /previous/i });
+      const prevButton = await screen.findByRole('button', { name: previousLabel$() });
       expect(prevButton).toBeEnabled();
 
       await fireEvent.click(prevButton);
@@ -1022,7 +980,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r1',
       });
 
-      const prevButton = await screen.findByRole('button', { name: /previous/i });
+      const prevButton = await screen.findByRole('button', { name: previousLabel$() });
       expect(prevButton).toBeDisabled();
     });
 
@@ -1042,7 +1000,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r2',
       });
 
-      const nextButton = await screen.findByRole('button', { name: /next/i });
+      const nextButton = await screen.findByRole('button', { name: nextLabel$() });
       await waitFor(() => {
         expect(nextButton).toBeEnabled();
       });
@@ -1069,7 +1027,7 @@ describe('CourseUnitView', () => {
         resourceId: 'r3',
       });
 
-      const nextButton = await screen.findByRole('button', { name: /next/i });
+      const nextButton = await screen.findByRole('button', { name: nextLabel$() });
       expect(nextButton).toBeDisabled();
     });
 
@@ -1093,7 +1051,7 @@ describe('CourseUnitView', () => {
 
       await waitFor(() => {
         // Check for Unit 2 title.
-        expect(screen.getByText('Unit 2')).toBeVisible();
+        expect(screen.getByText(UNIT_2_TITLE)).toBeVisible();
       });
     });
   });

--- a/kolibri/plugins/learn/frontend/views/__tests__/course-welcome-page.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/course-welcome-page.spec.js
@@ -1,21 +1,19 @@
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
 import { render, waitFor } from '@testing-library/vue';
-import { createLocalVue } from '@vue/test-utils';
+import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import { PageNames } from '../../constants';
 import CourseWelcomePage from '../CourseWelcomePage.vue';
 import useLearnerResources from '../../composables/useLearnerResources';
 
-jest.mock('../../composables/useLearnerResources');
-jest.mock('kolibri-common/composables/usePageLoading');
-jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow', () => ({
-  __esModule: true,
-  default: () => ({ windowIsLarge: true }),
-}));
+const { startCourseAction$, resumeCourseAction$ } = coursesStrings;
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-localVue.use(VueRouter);
+jest.mock('../../composables/useLearnerResources');
+
+const COURSE_DESCRIPTION = 'Learn the fundamentals of physics';
+const COURSE_SUBTITLE = '2 units · 12 lessons';
+const UNIT_1_TITLE = 'Unit 1: Motion';
+const UNIT_2_TITLE = 'Unit 2: Forces';
 
 describe('CourseWelcomePage', () => {
   let learnerResources;
@@ -26,14 +24,14 @@ describe('CourseWelcomePage', () => {
     id: 'course-session-1',
     course_id: 'course-1',
     title: 'Introduction to Physics',
-    description: 'Learn the fundamentals of physics',
+    description: COURSE_DESCRIPTION,
     lesson_count: 12,
   };
 
   const mockUnits = [
     {
       id: 'unit-1',
-      title: 'Unit 1: Motion',
+      title: UNIT_1_TITLE,
       sort_order: 0,
       options: {
         completion_criteria: {
@@ -65,7 +63,7 @@ describe('CourseWelcomePage', () => {
     },
     {
       id: 'unit-2',
-      title: 'Unit 2: Forces',
+      title: UNIT_2_TITLE,
       sort_order: 1,
       options: {
         completion_criteria: {
@@ -192,42 +190,11 @@ describe('CourseWelcomePage', () => {
 
   function renderComponent(props = {}) {
     return render(CourseWelcomePage, {
-      localVue,
       router,
       store,
       props: {
         courseSessionId: 'course-session-1',
         ...props,
-      },
-      global: {
-        stubs: {
-          ImmersivePage: {
-            template: '<div data-testid="immersive-page"><slot /></div>',
-          },
-          AccordionContainer: {
-            template: `
-              <div data-testid="accordion-container">
-                <slot name="header" v-bind="{
-                  expandAll: () => {},
-                  collapseAll: () => {},
-                  canExpandAll: true,
-                  canCollapseAll: true
-                }" />
-                <slot />
-              </div>
-            `,
-          },
-          AccordionItem: {
-            template: `
-              <div data-testid="accordion-item">
-                <div data-testid="accordion-title">{{ title }}</div>
-                <slot name="content" />
-                <slot name="trailing-actions" />
-              </div>
-            `,
-            props: ['title', 'disabled'],
-          },
-        },
       },
     });
   }
@@ -256,7 +223,7 @@ describe('CourseWelcomePage', () => {
 
       await waitFor(() => {
         expect(wrapper.getByTestId('header-title')).toHaveTextContent('Introduction to Physics');
-        expect(wrapper.getByText('2 units · 12 lessons')).toBeInTheDocument();
+        expect(wrapper.getByText(COURSE_SUBTITLE)).toBeInTheDocument();
       });
     });
 
@@ -264,7 +231,7 @@ describe('CourseWelcomePage', () => {
       const wrapper = renderComponent();
 
       await waitFor(() => {
-        expect(wrapper.getByText('Learn the fundamentals of physics')).toBeInTheDocument();
+        expect(wrapper.getByText(COURSE_DESCRIPTION)).toBeInTheDocument();
       });
     });
 
@@ -280,8 +247,8 @@ describe('CourseWelcomePage', () => {
       const wrapper = renderComponent();
 
       await waitFor(() => {
-        expect(wrapper.getByText('Unit 1: Motion')).toBeInTheDocument();
-        expect(wrapper.getByText('Unit 2: Forces')).toBeInTheDocument();
+        expect(wrapper.getByText(UNIT_1_TITLE)).toBeInTheDocument();
+        expect(wrapper.getByText(UNIT_2_TITLE)).toBeInTheDocument();
       });
     });
   });
@@ -296,7 +263,7 @@ describe('CourseWelcomePage', () => {
       const wrapper = renderComponent();
 
       await waitFor(() => {
-        expect(wrapper.getByText(content => content.includes('Start Course'))).toBeInTheDocument();
+        expect(wrapper.getByText(startCourseAction$())).toBeInTheDocument();
       });
     });
   });
@@ -319,8 +286,8 @@ describe('CourseWelcomePage', () => {
       const wrapper = renderComponent();
 
       await waitFor(() => {
-        expect(wrapper.getByText(content => content.includes('Resume Course'))).toBeInTheDocument();
-        expect(wrapper.queryByText('Start Course')).not.toBeInTheDocument();
+        expect(wrapper.getByText(resumeCourseAction$())).toBeInTheDocument();
+        expect(wrapper.queryByText(startCourseAction$())).not.toBeInTheDocument();
       });
     });
   });

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
@@ -1,8 +1,24 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 
-import AssessmentWrapper from '../index.vue';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import AssessmentWrapper, { hintTranslator } from '../index.vue';
+
+const { completedLabel$ } = coreStrings;
 
 jest.mock('kolibri/composables/useUser');
+
+const {
+  goal$,
+  check$,
+  next$,
+  inputAnswer$,
+  correct$,
+  tryAgain$,
+  greatKeepGoing$,
+  itemError$,
+  tryDifferentQuestion$,
+} = createTranslator(AssessmentWrapper.name, AssessmentWrapper.$trs);
 
 const ASSESSMENT_IDS = ['item-1', 'item-2', 'item-3', 'item-4', 'item-5'];
 const DEFAULT_MASTERY_MODEL = { type: 'm_of_n', m: 3, n: 5 };
@@ -79,6 +95,10 @@ function renderComponent(props = {}, { stubs, ...restOptions } = {}) {
   const mergedProps = buildProps(props);
   return render(AssessmentWrapper, {
     props: mergedProps,
+    // ContentViewer is a complex renderer intentionally implemented as a stub
+    // to allow for testing AssessmentWrapper behavior in response to events
+    // emitted by ContentViewer
+    // eslint-disable-next-line kolibri/tests-no-stubs
     stubs: {
       ContentViewer: DefaultStub,
       ...stubs,
@@ -114,18 +134,18 @@ describe('AssessmentWrapper', () => {
     it('renders the mastery goal text', () => {
       renderComponent();
       // "Get 3 correct" appears in both the mastery bar and the bottom status bar
-      const elements = screen.getAllByText(/Get 3 correct/);
+      const elements = screen.getAllByText(goal$({ count: 3 }));
       expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders the Check button initially', () => {
       renderComponent();
-      expect(screen.getByText('Check')).toBeInTheDocument();
+      expect(screen.getByText(check$())).toBeInTheDocument();
     });
 
     it('does not render the Next button initially', () => {
       renderComponent();
-      expect(screen.queryByText('Next')).not.toBeInTheDocument();
+      expect(screen.queryByText(next$())).not.toBeInTheDocument();
     });
 
     it('renders the content viewer with the first item id', () => {
@@ -136,12 +156,12 @@ describe('AssessmentWrapper', () => {
 
     it('renders the completed label when mastered', () => {
       renderComponent({ mastered: true });
-      expect(screen.getByText('Completed')).toBeInTheDocument();
+      expect(screen.getByText(completedLabel$())).toBeInTheDocument();
     });
 
     it('does not render the completed label when not mastered', () => {
       renderComponent({ mastered: false });
-      expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+      expect(screen.queryByText(completedLabel$())).not.toBeInTheDocument();
     });
 
     it('shows additional button when hasNextResource is true', () => {
@@ -179,14 +199,14 @@ describe('AssessmentWrapper', () => {
   describe('checkAnswer with no answer', () => {
     it('shows "Please enter an answer above" when check is clicked but content viewer returns null', async () => {
       renderComponent();
-      await fireEvent.click(screen.getByText('Check'));
-      expect(getStatusText()).toBe('Please enter an answer above');
+      await fireEvent.click(screen.getByText(check$()));
+      expect(getStatusText()).toBe(inputAnswer$());
     });
 
     it('keeps the Check button visible when no answer is returned', async () => {
       renderComponent();
-      await fireEvent.click(screen.getByText('Check'));
-      expect(screen.getByText('Check')).toBeInTheDocument();
+      await fireEvent.click(screen.getByText(check$()));
+      expect(screen.getByText(check$())).toBeInTheDocument();
     });
   });
 
@@ -204,22 +224,22 @@ describe('AssessmentWrapper', () => {
 
     it('shows the Next button after a correct answer', async () => {
       renderWithCorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
-      expect(screen.getByText('Next')).toBeInTheDocument();
-      expect(screen.queryByText('Check')).not.toBeInTheDocument();
+      await fireEvent.click(screen.getByText(check$()));
+      expect(screen.getByText(next$())).toBeInTheDocument();
+      expect(screen.queryByText(check$())).not.toBeInTheDocument();
     });
 
     it('shows "Correct!" status when pastattempts contain a correct attempt', async () => {
       // currentStatus shows "Correct!" only when correct===1 AND
       // recentAttempts[last] === 'right'. The parent updates pastattempts.
       renderWithCorrectViewer({ pastattempts: [{ correct: 1 }] });
-      await fireEvent.click(screen.getByText('Check'));
-      expect(getStatusText()).toBe('Correct!');
+      await fireEvent.click(screen.getByText(check$()));
+      expect(getStatusText()).toBe(correct$());
     });
 
     it('emits updateInteraction with progress > 0 and correct=1 on the first attempt', async () => {
       const { emitted } = renderWithCorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const interactions = emitted().updateInteraction;
       expect(interactions).toHaveLength(1);
       const [{ progress, interaction }] = interactions[0];
@@ -230,7 +250,7 @@ describe('AssessmentWrapper', () => {
 
     it('includes answerState and simpleAnswer in the emitted interaction', async () => {
       const { emitted } = renderWithCorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ interaction }] = emitted().updateInteraction[0];
       expect(interaction.answer).toEqual({ answer: 42 });
       expect(interaction.simple_answer).toBe('42');
@@ -238,7 +258,7 @@ describe('AssessmentWrapper', () => {
 
     it('includes item id and time_spent in the emitted interaction', async () => {
       const { emitted } = renderWithCorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ interaction }] = emitted().updateInteraction[0];
       expect(interaction.item).toBe('item-1');
       expect(typeof interaction.time_spent).toBe('number');
@@ -259,26 +279,26 @@ describe('AssessmentWrapper', () => {
 
     it('shows "Try again" after an incorrect answer', async () => {
       renderWithIncorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
-      expect(getStatusText()).toBe('Try again');
+      await fireEvent.click(screen.getByText(check$()));
+      expect(getStatusText()).toBe(tryAgain$());
     });
 
     it('keeps the Check button after an incorrect answer', async () => {
       renderWithIncorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
-      expect(screen.getByText('Check')).toBeInTheDocument();
+      await fireEvent.click(screen.getByText(check$()));
+      expect(screen.getByText(check$())).toBeInTheDocument();
     });
 
     it('adds the shaking class on the Check button', async () => {
       renderWithIncorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
-      const checkButton = screen.getByText('Check').closest('button');
+      await fireEvent.click(screen.getByText(check$()));
+      const checkButton = screen.getByText(check$()).closest('button');
       expect(checkButton.className).toContain('shaking');
     });
 
     it('emits updateInteraction with correct=0 on first attempt', async () => {
       const { emitted } = renderWithIncorrectViewer();
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ interaction, progress }] = emitted().updateInteraction[0];
       expect(interaction.correct).toBe(0);
       expect(interaction.complete).toBe(false);
@@ -308,12 +328,12 @@ describe('AssessmentWrapper', () => {
       );
 
       // First click: incorrect
-      await fireEvent.click(screen.getByText('Check'));
-      expect(getStatusText()).toBe('Try again');
+      await fireEvent.click(screen.getByText(check$()));
+      expect(getStatusText()).toBe(tryAgain$());
 
       // Second click: correct (rectified)
-      await fireEvent.click(screen.getByText('Check'));
-      expect(getStatusText()).toBe('Great! Keep going');
+      await fireEvent.click(screen.getByText(check$()));
+      expect(getStatusText()).toBe(greatKeepGoing$());
     });
 
     it('does not send progress on the second attempt', async () => {
@@ -333,8 +353,8 @@ describe('AssessmentWrapper', () => {
         { stubs: { ContentViewer: stub } },
       );
 
-      await fireEvent.click(screen.getByText('Check')); // first attempt
-      await fireEvent.click(screen.getByText('Check')); // second attempt
+      await fireEvent.click(screen.getByText(check$())); // first attempt
+      await fireEvent.click(screen.getByText(check$())); // second attempt
 
       const secondInteraction = emitted().updateInteraction[1][0];
       expect(secondInteraction.progress).toBeUndefined();
@@ -349,12 +369,12 @@ describe('AssessmentWrapper', () => {
       });
       renderComponent({}, { stubs: { ContentViewer: stub } });
 
-      await fireEvent.click(screen.getByText('Check'));
-      expect(screen.getByText('Next')).toBeInTheDocument();
+      await fireEvent.click(screen.getByText(check$()));
+      expect(screen.getByText(next$())).toBeInTheDocument();
 
-      await fireEvent.click(screen.getByText('Next'));
-      expect(screen.getByText('Check')).toBeInTheDocument();
-      expect(screen.queryByText('Next')).not.toBeInTheDocument();
+      await fireEvent.click(screen.getByText(next$()));
+      expect(screen.getByText(check$())).toBeInTheDocument();
+      expect(screen.queryByText(next$())).not.toBeInTheDocument();
     });
   });
 
@@ -364,8 +384,8 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-item-error'));
 
       await waitFor(() => {
-        expect(screen.getByText('There was an error showing this question')).toBeInTheDocument();
-        expect(screen.getByText('Try a different question')).toBeInTheDocument();
+        expect(screen.getByText(itemError$())).toBeInTheDocument();
+        expect(screen.getByText(tryDifferentQuestion$())).toBeInTheDocument();
       });
     });
 
@@ -383,7 +403,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-item-error'));
 
       await waitFor(() => {
-        expect(screen.getByText('Next')).toBeInTheDocument();
+        expect(screen.getByText(next$())).toBeInTheDocument();
       });
     });
 
@@ -402,16 +422,14 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-item-error'));
 
       await waitFor(() => {
-        expect(screen.getByText('Try a different question')).toBeInTheDocument();
+        expect(screen.getByText(tryDifferentQuestion$())).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByText('Try a different question'));
+      await fireEvent.click(screen.getByText(tryDifferentQuestion$()));
 
       await waitFor(() => {
-        expect(
-          screen.queryByText('There was an error showing this question'),
-        ).not.toBeInTheDocument();
-        expect(screen.getByText('Check')).toBeInTheDocument();
+        expect(screen.queryByText(itemError$())).not.toBeInTheDocument();
+        expect(screen.getByText(check$())).toBeInTheDocument();
       });
     });
   });
@@ -428,7 +446,7 @@ describe('AssessmentWrapper', () => {
       );
 
       // First click: wrong → consumes first attempt at question
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
 
       // Now trigger hint taken via the stub button
       await fireEvent.click(screen.getByTestId('trigger-hint-taken'));
@@ -500,8 +518,10 @@ describe('AssessmentWrapper', () => {
   describe('hints UI', () => {
     it('does not show hint buttons when totalHints is 0', () => {
       renderComponent();
-      expect(screen.queryByText(/Use a hint/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/No more hints/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(hintTranslator.hint$({ hintsLeft: 1 }), { exact: false }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(hintTranslator.noMoreHint$())).not.toBeInTheDocument();
     });
 
     it('shows hint button with count after startTracking', async () => {
@@ -511,7 +531,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText(/3 left/)).toBeInTheDocument();
+        expect(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 }))).toBeInTheDocument();
       });
     });
 
@@ -522,7 +542,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText('No more hints')).toBeInTheDocument();
+        expect(screen.getByText(hintTranslator.noMoreHint$())).toBeInTheDocument();
       });
     });
 
@@ -533,10 +553,10 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText(/3 left/)).toBeInTheDocument();
+        expect(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 }))).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByText(/3 left/));
+      await fireEvent.click(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 })));
 
       await waitFor(() => {
         expect(emitted().updateInteraction).toBeTruthy();
@@ -552,26 +572,22 @@ describe('AssessmentWrapper', () => {
         assessmentIds: ['a', 'b'],
         masteryModel: { type: 'do_all' },
       });
-      const elements = screen.getAllByText(/Get 2 correct/);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(goal$({ count: 2 })).length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_2', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_2' } });
-      const elements = screen.getAllByText(/Get 2 correct/);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(goal$({ count: 2 })).length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_3', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_3' } });
-      const elements = screen.getAllByText(/Get 3 correct/);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(goal$({ count: 3 })).length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_10', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_10' } });
-      const elements = screen.getAllByText(/Get 10 correct/);
-      expect(elements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(goal$({ count: 10 })).length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders the correct number of attempt placeholder slots for do_all', () => {
@@ -611,14 +627,14 @@ describe('AssessmentWrapper', () => {
 
     it('emits progress > 0 with no past attempts and a correct answer', async () => {
       const { emitted } = renderAndCheck({});
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       expect(progress).toBeGreaterThan(0);
     });
 
     it('emits progress=1 when already mastered', async () => {
       const { emitted } = renderAndCheck({ mastered: true });
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       expect(progress).toBe(1);
     });
@@ -629,7 +645,7 @@ describe('AssessmentWrapper', () => {
         pastattempts: [{ correct: 1 }, { correct: 1 }],
         masteryModel: { type: 'm_of_n', m: 3, n: 5 },
       });
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       expect(progress).toBe(1);
     });
@@ -639,7 +655,7 @@ describe('AssessmentWrapper', () => {
         pastattempts: [{ correct: 1 }, { correct: 1 }, { correct: 1 }, { correct: 1 }],
         masteryModel: { type: 'm_of_n', m: 3, n: 5 },
       });
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       expect(progress).toBe(1);
     });
@@ -648,7 +664,7 @@ describe('AssessmentWrapper', () => {
       const { emitted } = renderAndCheckIncorrect({
         masteryModel: { type: 'm_of_n', m: 3, n: 5 },
       });
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       // exerciseProgress([{correct:0}]) → 0/3=0 → max(0, 0.001)=0.001
       expect(progress).toBe(0.001);
@@ -668,7 +684,7 @@ describe('AssessmentWrapper', () => {
         ],
         masteryModel: { type: 'm_of_n', m: 3, n: 5 },
       });
-      await fireEvent.click(screen.getByText('Check'));
+      await fireEvent.click(screen.getByText(check$()));
       const [{ progress }] = emitted().updateInteraction[0];
       expect(progress).toBe(1);
     });

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -179,7 +179,7 @@
   import LessonMasteryBar from './LessonMasteryBar';
   import ExerciseAttempts from './ExerciseAttempts';
 
-  const hintTranslator = createTranslator('PerseusRendererIndex', {
+  export const hintTranslator = createTranslator('PerseusRendererIndex', {
     hint: {
       message: 'Use a hint ({hintsLeft, number} left)',
       context:

--- a/kolibri/plugins/pdf_viewer/frontend/views/__tests__/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/frontend/views/__tests__/PdfRendererIndex.spec.js
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import PdfRendererIndex from '../PdfRendererIndex';
 import * as mockPDFJS from '../__mocks__/pdfjsMock';
+
+const { zoomIn$, zoomOut$ } = coreStrings;
 
 jest.mock('kolibri/urls');
 jest.mock('pdfjs-dist/legacy/build/pdf', () => require('../__mocks__/pdfjsMock'));
@@ -28,16 +31,6 @@ function makeWrapper(options = {}) {
         },
       },
     ],
-    stubs: {
-      KIconButton: {
-        props: ['ariaLabel'],
-        template:
-          '<button class="k-icon-button" :aria-label="ariaLabel" @click="$emit(\'click\')"></button>',
-      },
-      // We removed the RecycleList stub. The real component renders perfectly in the test
-      // environment, allowing us to test its real event wiring and behavior directly!
-      ...(options.stubs || {}),
-    },
   });
 }
 
@@ -237,7 +230,7 @@ describe('PdfRendererIndex', () => {
       vm.scale = 1;
       const initialScale = vm.scale;
 
-      const zoomInBtn = screen.getByRole('button', { name: /Zoom in/i });
+      const zoomInBtn = screen.getByRole('button', { name: zoomIn$() });
       await fireEvent.click(zoomInBtn);
       await global.flushPromises();
 
@@ -251,13 +244,13 @@ describe('PdfRendererIndex', () => {
       vm.scale = 1;
 
       // Click zoom in first to ensure we have room to zoom back out
-      const zoomInBtn = screen.getByRole('button', { name: /Zoom in/i });
+      const zoomInBtn = screen.getByRole('button', { name: zoomIn$() });
       await fireEvent.click(zoomInBtn);
       await global.flushPromises();
 
       const zoomedScale = vm.scale;
 
-      const zoomOutBtn = screen.getByRole('button', { name: /Zoom out/i });
+      const zoomOutBtn = screen.getByRole('button', { name: zoomOut$() });
       await fireEvent.click(zoomOutBtn);
       await global.flushPromises();
 

--- a/kolibri/plugins/safe_html5_viewer/frontend/views/__tests__/SafeHtml5RendererIndex.spec.js
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/__tests__/SafeHtml5RendererIndex.spec.js
@@ -1,18 +1,29 @@
 import { render, screen, waitFor } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
 import SafeHtml5RendererIndex from '../SafeHtml5RendererIndex.vue';
 
+const { articleContent$ } = createTranslator(
+  SafeHtml5RendererIndex.name,
+  SafeHtml5RendererIndex.$trs,
+);
+
 jest.mock('kolibri-common/components/SafeHTML/style.scss', () => ({}));
+
+const HEADING = 'Mocked HTML content';
+const TABLE_CAPTION = 'Mocked 3-column Table';
+const CELLS = ['Cell 1', 'Cell 2', 'Cell 3'];
+
 jest.mock('kolibri-zip', () => {
   return jest.fn().mockImplementation(() => ({
     file: jest.fn().mockResolvedValue({
       toString: () => `
-        <h1>Mocked HTML content</h1>
+        <h1>${HEADING}</h1>
         <table>
-          <caption>Mocked 3-column Table</caption>
+          <caption>${TABLE_CAPTION}</caption>
           <tr>
-            <td>Cell 1</td>
-            <td>Cell 2</td>
-            <td>Cell 3</td>
+            <td>${CELLS[0]}</td>
+            <td>${CELLS[1]}</td>
+            <td>${CELLS[2]}</td>
           </tr>
         </table>
         `,
@@ -67,10 +78,10 @@ describe('SafeHtml5RendererIndex', () => {
     it('renders safe-html-wrapper div and HTML content after loading finishes', async () => {
       renderComponent();
       await waitFor(() => {
-        expect(screen.getByLabelText('Article content')).toBeInTheDocument();
-        expect(screen.getByText('Mocked HTML content')).toBeInTheDocument();
-        expect(screen.getByText('Mocked 3-column Table')).toBeInTheDocument();
-        expect(screen.getByText('Cell 1')).toBeInTheDocument();
+        expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
+        expect(screen.getByText(HEADING)).toBeInTheDocument();
+        expect(screen.getByText(TABLE_CAPTION)).toBeInTheDocument();
+        CELLS.forEach(cell => expect(screen.getByText(cell)).toBeInTheDocument());
       });
     });
   });
@@ -105,7 +116,7 @@ describe('SafeHtml5RendererIndex', () => {
     it('emits stopTracking on destroy', async () => {
       const { emitted, unmount } = renderComponent();
       await waitFor(() => {
-        expect(screen.getByLabelText('Article content')).toBeInTheDocument();
+        expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
       });
       unmount();
 
@@ -121,7 +132,7 @@ describe('SafeHtml5RendererIndex', () => {
         scrollBasedProgress: 0.5,
       });
       await waitFor(() => {
-        expect(screen.getByLabelText('Article content')).toBeInTheDocument();
+        expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
       });
 
       jest.advanceTimersByTime(5000);
@@ -137,7 +148,7 @@ describe('SafeHtml5RendererIndex', () => {
         scrollBasedProgress: 1,
       });
       await waitFor(() => {
-        expect(screen.getByLabelText('Article content')).toBeInTheDocument();
+        expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
       });
 
       jest.advanceTimersByTime(5000);
@@ -152,7 +163,7 @@ describe('SafeHtml5RendererIndex', () => {
         debouncedHandleScroll: jest.fn(),
       });
       await waitFor(() => {
-        expect(screen.getByLabelText('Article content')).toBeInTheDocument();
+        expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
       });
 
       const wrapper = container.querySelector('[data-testid="safe-html-wrapper"]');

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { createTranslator } from 'kolibri/utils/i18n';
 import makeStore from '../../__tests__/utils/makeStore';
 import CreateLearnerAccountForm from '../onboarding-forms/CreateLearnerAccountForm';
+
+const { yesOptionLabel$, noOptionLabel$ } = createTranslator(
+  CreateLearnerAccountForm.name,
+  CreateLearnerAccountForm.$trs,
+);
 
 function renderComponent(options) {
   const store = makeStore();
@@ -25,22 +31,14 @@ describe('CreateLearnerAccountForm', () => {
   it('defaults to allowing learners to join for a nonformal facility', () => {
     renderComponent({ preset: 'nonformal' });
 
-    expect(screen.getByRole('radio', { name: /yes/i })).toBeChecked();
-    expect(
-      screen.getByRole('radio', {
-        name: /no\. admins must create an account for them to join this facility/i,
-      }),
-    ).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: yesOptionLabel$() })).toBeChecked();
+    expect(screen.getByRole('radio', { name: noOptionLabel$() })).not.toBeChecked();
   });
 
   it('defaults to requiring admins to create learner accounts for a formal facility', () => {
     renderComponent({ preset: 'formal' });
 
-    expect(screen.getByRole('radio', { name: /yes/i })).not.toBeChecked();
-    expect(
-      screen.getByRole('radio', {
-        name: /no\. admins must create an account for them to join this facility/i,
-      }),
-    ).toBeChecked();
+    expect(screen.getByRole('radio', { name: yesOptionLabel$() })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: noOptionLabel$() })).toBeChecked();
   });
 });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/FacilityPermissionsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/FacilityPermissionsForm.spec.js
@@ -1,7 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, within } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { createTranslator } from 'kolibri/utils/i18n';
 import makeStore from '../../__tests__/utils/makeStore';
 import FacilityPermissionsForm from '../onboarding-forms/FacilityPermissionsForm';
+import FacilityNameTextbox from '../onboarding-forms/FacilityNameTextbox';
+
+const { facilityNameFieldLabel$ } = createTranslator(
+  FacilityNameTextbox.name,
+  FacilityNameTextbox.$trs,
+);
 
 describe('FacilityPermissionsForm', () => {
   let focusSpy;
@@ -39,10 +46,10 @@ describe('FacilityPermissionsForm', () => {
 
     await global.flushPromises();
 
-    const nonFormalRadio = screen.getByRole('radio', { name: /non-formal/i });
+    const nonFormalRadio = within(screen.getByTestId('nonformal-radio')).getByRole('radio');
     expect(nonFormalRadio).toBeChecked();
 
-    const facilityInput = screen.getByRole('textbox', { name: /facility name/i });
+    const facilityInput = screen.getByRole('textbox', { name: facilityNameFieldLabel$() });
 
     await waitFor(() => {
       // 3. Assert that the component's internal logic successfully fired the focus command

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/LoadingTaskPage.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/LoadingTaskPage.spec.js
@@ -1,9 +1,16 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { syncStrings } from 'kolibri-common/mixins/commonSyncElements';
+import { TaskTypes } from 'kolibri-common/utils/syncTaskUtils';
 import TaskResource from 'kolibri/apiResources/TaskResource';
 import LoadingTaskPage from '../LoadingTaskPage';
 import makeStore from '../../__tests__/utils/makeStore';
+
+const { continueAction$, retryAction$, startOverAction$, cancelAction$ } = coreStrings;
+
+const { importFacilityAction$ } = syncStrings;
 
 jest.mock('kolibri/apiResources/TaskResource', () => ({
   cancel: jest.fn().mockResolvedValue({}),
@@ -22,11 +29,11 @@ const facilityMock = {
 const makeTask = status => ({
   id: 'task_1',
   status,
-  type: 'facility_import',
-  started_by: 'username',
+  type: TaskTypes.SYNCPEERPULL,
+  facility_id: 'facility_1',
   clearable: false,
   cancellable: true,
-  extra_metadata: { started_by: 'tester' },
+  extra_metadata: {},
 });
 
 const renderComponent = () => {
@@ -50,13 +57,6 @@ const renderComponent = () => {
     },
     props: {
       footerMessageType: 'IMPORT_FACILITY',
-    },
-    stubs: {
-      FacilityTaskPanel: {
-        name: 'FacilityTaskPanel',
-        template:
-          '<div data-testid="task-panel"><button data-testid="stub-cancel" @click="$emit(\'cancel\')">Cancel Task</button></div>',
-      },
     },
   });
 
@@ -105,7 +105,7 @@ describe('LoadingTaskPage', () => {
     await global.flushPromises();
     await global.flushPromises();
 
-    expect(screen.getByRole('heading', { name: /import learning facility/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: importFacilityAction$() })).toBeInTheDocument();
 
     const panel = screen.getByTestId('task-panel');
     expect(panel).toBeInTheDocument();
@@ -126,7 +126,9 @@ describe('LoadingTaskPage', () => {
 
     await global.flushPromises();
 
-    const continueButton = await screen.findByRole('button', { name: /continue/i });
+    const continueButton = await screen.findByRole('button', {
+      name: continueAction$(),
+    });
     expect(continueButton).toBeInTheDocument();
 
     await userEvent.click(continueButton);
@@ -141,7 +143,7 @@ describe('LoadingTaskPage', () => {
 
     await global.flushPromises();
 
-    const retryButton = await screen.findByRole('button', { name: /retry/i });
+    const retryButton = await screen.findByRole('button', { name: retryAction$() });
     expect(retryButton).toBeInTheDocument();
 
     await userEvent.click(retryButton);
@@ -155,7 +157,9 @@ describe('LoadingTaskPage', () => {
 
     await global.flushPromises();
 
-    const startOverButton = await screen.findByRole('button', { name: /start over/i });
+    const startOverButton = await screen.findByRole('button', {
+      name: startOverAction$(),
+    });
     expect(startOverButton).toBeInTheDocument();
 
     await userEvent.click(startOverButton);
@@ -169,8 +173,8 @@ describe('LoadingTaskPage', () => {
 
     await global.flushPromises();
 
-    const cancelButton = await screen.findByTestId('stub-cancel');
-    await userEvent.click(cancelButton);
+    const cancelButton = await screen.findByRole('button', { name: cancelAction$() });
+    await fireEvent.click(cancelButton);
 
     await waitFor(() => {
       expect(TaskResource.cancel).toHaveBeenCalledTimes(1);

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
@@ -1,7 +1,10 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import PersonalDataConsentForm from '../onboarding-forms/PersonalDataConsentForm';
 import { FooterMessageTypes } from '../../constants';
+
+const { usageAndPrivacyLabel$, closeAction$ } = coreStrings;
 
 function renderComponent() {
   render(PersonalDataConsentForm, {
@@ -27,7 +30,7 @@ describe('PersonalDataConsentForm', () => {
 
   it('opens the privacy statement modal when the user clicks "Usage and privacy"', async () => {
     renderComponent();
-    fireEvent.click(screen.getByText(/usage and privacy/i));
+    fireEvent.click(screen.getByText(usageAndPrivacyLabel$()));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -35,12 +38,12 @@ describe('PersonalDataConsentForm', () => {
 
   it('closes the privacy statement modal when the user clicks "Close"', async () => {
     renderComponent();
-    fireEvent.click(screen.getByText(/usage and privacy/i));
+    fireEvent.click(screen.getByText(usageAndPrivacyLabel$()));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    fireEvent.click(screen.getByRole('button', { name: closeAction$() }));
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
@@ -1,8 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
 import makeStore from '../../__tests__/utils/makeStore';
 import UserCredentialsForm from '../onboarding-forms/UserCredentialsForm';
+
+const { fullNameLabel$, usernameLabel$, passwordLabel$, continueAction$ } = coreStrings;
+const { confirmPasswordLabel$ } = createTranslator(PasswordTextbox.name, PasswordTextbox.$trs);
 
 function renderComponent() {
   const store = makeStore();
@@ -27,12 +33,12 @@ describe('UserCredentialsForm', () => {
   it('saves the entered admin details when the user continues', async () => {
     const { send, store } = renderComponent();
 
-    await userEvent.type(screen.getByLabelText(/full name/i), 'Schoolhouse Rock');
-    await userEvent.type(screen.getByLabelText(/^username$/i), 'schoolhouse_rock');
-    await userEvent.type(screen.getByLabelText(/^password$/i), 'password');
-    await userEvent.type(screen.getByLabelText(/re-enter password/i), 'password');
+    await userEvent.type(screen.getByLabelText(fullNameLabel$()), 'Schoolhouse Rock');
+    await userEvent.type(screen.getByLabelText(usernameLabel$()), 'schoolhouse_rock');
+    await userEvent.type(screen.getByLabelText(passwordLabel$()), 'password');
+    await userEvent.type(screen.getByLabelText(confirmPasswordLabel$()), 'password');
 
-    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await userEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
     expect(store.state.onboardingData.user).toEqual({
       full_name: 'Schoolhouse Rock',

--- a/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -12,6 +12,7 @@
         ref="first-button"
         v-model="selected"
         class="permission-preset-radio-button"
+        data-testid="nonformal-radio"
         :buttonValue="Presets.NONFORMAL"
         :label="$tr('nonFormalLabel')"
         :description="$tr('nonFormalDescription')"

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/NewPasswordPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/NewPasswordPage.spec.js
@@ -1,10 +1,20 @@
 import { render, screen, waitFor } from '@testing-library/vue';
+import { ref } from 'vue';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import useUser from 'kolibri/composables/useUser';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { coreStoreFactory } from 'kolibri/store';
+import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
 import { setUnspecifiedPassword } from '../../../api';
 import NewPasswordPage from '../NewPasswordPage.vue';
+
+const { passwordLabel$ } = coreStrings;
+
+const { confirmPasswordLabel$ } = createTranslator(PasswordTextbox.name, PasswordTextbox.$trs);
+
+jest.mock('kolibri-plugin-data', () => ({ allowRemoteAccess: true }));
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../api');
@@ -15,6 +25,7 @@ function renderComponent() {
   const store = coreStoreFactory();
   useUser.mockImplementation(() => ({
     login: mockLogin,
+    userFacilityId: ref(null),
   }));
 
   return render(
@@ -26,10 +37,6 @@ function renderComponent() {
         facilityId: 'facility_1',
       },
       routes: [{ name: 'SignInPage', path: '/signin' }],
-      stubs: {
-        // inorder to bypass the loading wrapper
-        AuthBase: { template: '<div><slot></slot></div>' },
-      },
     },
     (_vue, _store, router) => {
       router.push = mockRouterPush;
@@ -49,7 +56,10 @@ describe('NewPasswordPage', () => {
     renderComponent();
     const user = userEvent.setup();
     const password = 'validpassword';
-    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const passwordInputs = [
+      screen.getByLabelText(passwordLabel$()),
+      screen.getByLabelText(confirmPasswordLabel$()),
+    ];
     const submitButton = screen.getByTestId('submit');
     await user.type(passwordInputs[0], password);
     await user.type(passwordInputs[1], password);
@@ -84,7 +94,10 @@ describe('NewPasswordPage', () => {
     renderComponent();
     const user = userEvent.setup();
     const password = 'password';
-    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const passwordInputs = [
+      screen.getByLabelText(passwordLabel$()),
+      screen.getByLabelText(confirmPasswordLabel$()),
+    ];
     const submitButton = screen.getByTestId('submit');
     await user.type(passwordInputs[0], password);
     await user.type(passwordInputs[1], password);
@@ -100,7 +113,10 @@ describe('NewPasswordPage', () => {
     renderComponent();
     const user = userEvent.setup();
     const password = 'validpassword';
-    const passwordInputs = screen.getAllByLabelText(/password/i);
+    const passwordInputs = [
+      screen.getByLabelText(passwordLabel$()),
+      screen.getByLabelText(confirmPasswordLabel$()),
+    ];
     const submitButton = screen.getByTestId('submit');
     await user.type(passwordInputs[0], password);
     await user.type(passwordInputs[1], password);

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/auth-base.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/auth-base.spec.js
@@ -4,8 +4,12 @@ import { ref } from 'vue';
 import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
-import AuthBase from '../AuthBase';
+import { createTranslator } from 'kolibri/utils/i18n';
+import AuthBase from '../AuthBase.vue';
+import { userString } from '../commonUserStrings';
 import makeStore from '../../__tests__/utils/makeStore';
+
+const { restrictedAccess$ } = createTranslator(AuthBase.name, AuthBase.$trs);
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri-common/composables/useFacility');
@@ -49,28 +53,22 @@ function renderComponent({ allowRemoteAccess = true, isAppContext = false } = {}
 describe('auth base component', () => {
   it('shows restricted access message when remote access is disallowed and not app context', () => {
     renderComponent({ allowRemoteAccess: false, isAppContext: false });
-    expect(
-      screen.getByText('Access to Kolibri has been restricted for external devices'),
-    ).toBeInTheDocument();
+    expect(screen.getByText(restrictedAccess$())).toBeInTheDocument();
   });
 
   it('does not show restricted access message when remote access is allowed', () => {
     renderComponent({ allowRemoteAccess: true, isAppContext: false });
-    expect(
-      screen.queryByText('Access to Kolibri has been restricted for external devices'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(restrictedAccess$())).not.toBeInTheDocument();
   });
 
   it('does not show restricted access message in app context even when remote access is disallowed', () => {
     renderComponent({ allowRemoteAccess: false, isAppContext: true });
-    expect(
-      screen.queryByText('Access to Kolibri has been restricted for external devices'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(restrictedAccess$())).not.toBeInTheDocument();
   });
 
   it('shows a create account link', () => {
     renderComponent();
-    const link = screen.getByRole('link', { name: 'Create an account' });
+    const link = screen.getByRole('link', { name: userString('createAccountAction') });
     expect(link).toHaveAttribute('href', '#/signup');
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/auth-select-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/auth-select-page.spec.js
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import VueRouter from 'vue-router';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import AuthSelect from '../AuthSelect';
+import { userString } from '../commonUserStrings';
 import makeStore from '../../__tests__/utils/makeStore';
+
+const { signInLabel$ } = coreStrings;
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri-common/composables/useFacility');
@@ -40,8 +44,8 @@ function renderComponent() {
 describe('user index page component', () => {
   it('shows sign in and create account options with facility selection', () => {
     renderComponent();
-    const signInLink = screen.getByRole('link', { name: 'Sign in' });
-    const createAccountLink = screen.getByRole('link', { name: 'Create an account' });
+    const signInLink = screen.getByRole('link', { name: signInLabel$() });
+    const createAccountLink = screen.getByRole('link', { name: userString('createAccountAction') });
     expect(signInLink).toHaveAttribute('href', '#/facilities');
     expect(createAccountLink).toHaveAttribute('href', '#/facilities');
   });

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-in-page.spec.js
@@ -3,11 +3,15 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { ref } from 'vue';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import SignInPage from '../SignInPage';
 import makeStore from '../../__tests__/utils/makeStore';
 
+const { usernameLabel$, usernameNotAlphaNumError$, requiredFieldError$ } = coreStrings;
+
 jest.mock('kolibri/urls');
 jest.mock('kolibri-common/composables/useFacilities');
+jest.mock('kolibri-plugin-data', () => ({ allowRemoteAccess: true }));
 
 function renderComponent() {
   const store = makeStore();
@@ -31,10 +35,6 @@ function renderComponent() {
     {
       store,
       routes: [{ name: 'SIGN_IN', path: '/signin' }],
-      stubs: {
-        // inorder to bypass the loading wrapper
-        AuthBase: { template: '<div><slot></slot></div>' },
-      },
     },
     (_vue, _store, router) => {
       router.getRoute = () => {
@@ -47,19 +47,19 @@ function renderComponent() {
 describe('signInPage component', () => {
   it('smoke test', async () => {
     renderComponent();
-    expect(await screen.findByRole('textbox', { name: /username/i })).toBeInTheDocument();
+    expect(await screen.findByRole('textbox', { name: usernameLabel$() })).toBeInTheDocument();
   });
 
   it('will set the username as invalid if it contains punctuation', async () => {
     renderComponent();
     const user = userEvent.setup();
 
-    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+    const usernameInput = await screen.findByRole('textbox', { name: usernameLabel$() });
 
     await user.type(usernameInput, '?');
 
     await waitFor(() => {
-      expect(screen.getByText(/Username can only contain/i)).toBeInTheDocument();
+      expect(screen.getByText(usernameNotAlphaNumError$())).toBeInTheDocument();
     });
   });
 
@@ -67,20 +67,20 @@ describe('signInPage component', () => {
     renderComponent();
     const user = userEvent.setup();
 
-    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+    const usernameInput = await screen.findByRole('textbox', { name: usernameLabel$() });
 
     await user.click(usernameInput);
     await user.type(usernameInput, 'a');
     await user.clear(usernameInput);
 
     await waitFor(() => {
-      expect(screen.getByText(/required/i)).toBeInTheDocument();
+      expect(screen.getByText(requiredFieldError$())).toBeInTheDocument();
     });
   });
 
   it('will not show validation text if username is empty and not blurred', async () => {
     renderComponent();
-    expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/alpha/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(requiredFieldError$())).not.toBeInTheDocument();
+    expect(screen.queryByText(usernameNotAlphaNumError$())).not.toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
@@ -52,11 +52,12 @@ describe('multiFacility signUpPage component', () => {
   it('right facility', async () => {
     renderComponent();
     expect(screen.getByTestId('facilityLabel')).toHaveTextContent('Facility 1');
+    const FACILITY_2_NAME = 'Facility 2';
     selectedFacility.value = {
       id: 2,
-      name: 'Facility 2',
+      name: FACILITY_2_NAME,
       dataset: { learner_can_login_with_no_password: false },
     };
-    expect(await screen.findByText(/Facility 2/)).toBeInTheDocument();
+    expect(await screen.findByText(FACILITY_2_NAME)).toBeInTheDocument();
   });
 });

--- a/packages/eslint-plugin-kolibri/lib/rules/tests-no-hardcoded-strings.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/tests-no-hardcoded-strings.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Don't allow hardcoded strings in Testing Library queries.
+ */
+
+'use strict';
+
+const utils = require('../utils');
+
+const TESTING_LIBRARY_IMPORT = '@testing-library/vue';
+
+// https://testing-library.com/docs/queries/about#types-of-queries
+const TESTING_LIBRARY_QUERY = /^(get|query|getAll|queryAll|find|findAll)By\w+/;
+
+// data-testid is a dev-defined literal in the template
+const SKIP_ENTIRELY = /^(get|query|getAll|queryAll|find|findAll)ByTestId$/;
+
+// role arg ('button', 'dialog') is a WAI-ARIA spec constant
+const SKIP_FIRST_ARG = /^(get|query|getAll|queryAll|find|findAll)ByRole$/;
+
+function isAllowed(node) {
+  // CallExpression - deleteAction$(),coreString('facilitiesLabel')
+  // MemberExpression - ReportsLearnerTable.$trs.allQuestionsAnswered.message
+  // Identifier - COURSE_TITLE
+  const ALLOWED_ARG_TYPES = new Set(['CallExpression', 'MemberExpression', 'Identifier']);
+
+  // Standalone dashes (hyphen, en dash, em dash), digits,
+  // and percentages are not typically translated => allow
+  const ALLOWED_CHARACTERS = /^[\d\-–—]+%?$/;
+
+  if (!node) return false;
+  if (ALLOWED_ARG_TYPES.has(node.type)) return true;
+  if (
+    node.type === 'Literal' &&
+    typeof node.value === 'string' &&
+    ALLOWED_CHARACTERS.test(node.value)
+  )
+    return true;
+  return false;
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Don't allow hardcoded strings in Testing Library queries.",
+    },
+    fixable: null,
+  },
+  create(context) {
+    let usesTestingLibrary = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === TESTING_LIBRARY_IMPORT) {
+          usesTestingLibrary = true;
+        }
+      },
+
+      CallExpression(node) {
+        if (!usesTestingLibrary) return;
+
+        const method = utils.getCallMethodName(node);
+        if (!method) return;
+
+        if (!TESTING_LIBRARY_QUERY.test(method)) return;
+        if (SKIP_ENTIRELY.test(method)) return;
+
+        // Allow hardcoded string in the first 'role' argument,
+        // but don't allow it in the second 'name' argument
+        if (SKIP_FIRST_ARG.test(method)) {
+          const optionsArg = node.arguments[1];
+          if (optionsArg && optionsArg.type === 'ObjectExpression') {
+            const nameProp = optionsArg.properties.find(p => p.key && p.key.name === 'name');
+            if (nameProp && !isAllowed(nameProp.value)) {
+              context.report({
+                node: nameProp.value,
+                message: `Avoid hardcoded values in the name option of ${method}(). Use a translation key instead. See https://kolibri-dev.readthedocs.io/en/develop/frontend_architecture/unit_testing.html#reference-translation-keys-not-hardcoded-strings.`,
+              });
+            }
+          }
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!isAllowed(firstArg)) {
+          context.report({
+            node: firstArg,
+            message: `Avoid hardcoded values in ${method}(). Use a translation key instead. See https://kolibri-dev.readthedocs.io/en/develop/frontend_architecture/unit_testing.html#reference-translation-keys-not-hardcoded-strings.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-kolibri/lib/rules/tests-no-stubs.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/tests-no-stubs.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Don't allow stubs in Testing Library tests.
+ */
+
+'use strict';
+
+const utils = require('../utils');
+
+const TESTING_LIBRARY_IMPORT = '@testing-library/vue';
+
+const TESTING_LIBRARY_RENDER = /^render(ToString)?$/;
+
+const ERROR_MESSAGE =
+  'Avoid using stubs. See https://kolibri-dev.readthedocs.io/en/develop/frontend_architecture/unit_testing.html#avoid-using-stubs.';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Don't allow stubs in Testing Library tests.",
+    },
+    fixable: null,
+  },
+  create(context) {
+    let usesTestingLibrary = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === TESTING_LIBRARY_IMPORT) {
+          usesTestingLibrary = true;
+        }
+      },
+
+      CallExpression(node) {
+        if (!usesTestingLibrary) return;
+
+        const method = utils.getCallMethodName(node);
+        if (!method) return;
+
+        if (!TESTING_LIBRARY_RENDER.test(method)) return;
+
+        for (const arg of node.arguments) {
+          if (arg.type !== 'ObjectExpression') continue;
+
+          // render(Component, { stubs: ... })
+          const stubsProp = arg.properties.find(
+            p => p.type === 'Property' && p.key && p.key.name === 'stubs',
+          );
+          if (stubsProp) {
+            context.report({ node: stubsProp, message: ERROR_MESSAGE });
+          }
+
+          // render(Component, { global: { stubs: ... } })
+          const globalProp = arg.properties.find(
+            p => p.type === 'Property' && p.key && p.key.name === 'global',
+          );
+          if (globalProp && globalProp.value && globalProp.value.type === 'ObjectExpression') {
+            const nestedStubs = globalProp.value.properties.find(
+              p => p.type === 'Property' && p.key && p.key.name === 'stubs',
+            );
+            if (nestedStubs) {
+              context.report({ node: nestedStubs, message: ERROR_MESSAGE });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -6,6 +6,24 @@ const { GROUP_WATCH, GROUP_METHODS, PROPERTY_LABEL } = require('./constants');
 
 module.exports = {
   /**
+   * Extract the called method name from a CallExpression node, such as:
+   *   screen.getByText(...) => 'getByText'
+   *   getByText(...) => 'getByText'
+   *
+   * @param {ASTNode} node - A CallExpression node
+   * @returns {string|null}
+   */
+  getCallMethodName(node) {
+    if (node.callee.type === 'MemberExpression') {
+      return node.callee.property.name || null;
+    }
+    if (node.callee.type === 'Identifier') {
+      return node.callee.name || null;
+    }
+    return null;
+  },
+
+  /**
    * Safely access parserServices from the ESLint rule context.
    * In ESLint 9 flat config, parserServices moved to context.sourceCode.parserServices.
    */

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom linting rules for kolibri",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-hardcoded-strings.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-hardcoded-strings.spec.js
@@ -64,6 +64,9 @@ tester.run('tests-no-hardcoded-strings', rule, {
     { code: withTestingLibrary(`findAllByText('-');`) },
     { code: withTestingLibrary(`queryByText('52');`) },
     { code: withTestingLibrary(`findByText('90%');`) },
+
+    // check that the rule is not active in obsolete Vue Test Utils files
+    { code: `toContain('Enroll learners to mark attendance')` },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-hardcoded-strings.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-hardcoded-strings.spec.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/tests-no-hardcoded-strings');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+});
+
+// The rule is active only in files that import from Testing Library, so wrap code in a TL import
+function withTestingLibrary(code) {
+  return `import { screen } from '@testing-library/vue';\n${code}`;
+}
+
+const DOCS_URL =
+  'https://kolibri-dev.readthedocs.io/en/develop/frontend_architecture/unit_testing.html#reference-translation-keys-not-hardcoded-strings';
+
+function assertRoleMessage(method) {
+  return `Avoid hardcoded values in the name option of ${method}(). Use a translation key instead. See ${DOCS_URL}.`;
+}
+
+function assertMessage(method) {
+  return `Avoid hardcoded values in ${method}(). Use a translation key instead. See ${DOCS_URL}.`;
+}
+
+tester.run('tests-no-hardcoded-strings', rule, {
+  valid: [
+    // by test ID
+    { code: withTestingLibrary(`getByTestId('users-table');`) },
+    { code: withTestingLibrary(`queryByTestId('users-table');`) },
+
+    // by role
+    { code: withTestingLibrary(`getByRole('button');`) },
+    { code: withTestingLibrary(`findByRole('button', { name: coreString('closeLabel') });`) },
+    { code: withTestingLibrary(`getAllByRole('button', { name: closeLabel$() });`) },
+
+    // by text
+    { code: withTestingLibrary(`getByText(closeLabel$());`) },
+    { code: withTestingLibrary(`queryByText(coreString('closeLabel'));`) },
+    { code: withTestingLibrary(`findAllByText(UsersTable.$trs.title.message);`) },
+    { code: withTestingLibrary(`getAllByText(COURSE_TITLE);`) },
+
+    // other
+    { code: withTestingLibrary(`getAllByLabelText(closeLabel$());`) },
+    { code: withTestingLibrary(`findByPlaceholderText(InputComponent.$trs.placeholder.message);`) },
+    { code: withTestingLibrary(`queryByAltText(ALT_TEXT);`) },
+    { code: withTestingLibrary(`queryAllByTitle(title$());`) },
+    { code: withTestingLibrary(`getByDisplayValue(valueVariable);`) },
+
+    // method accessed as a property
+    { code: withTestingLibrary(`screen.getByTestId('users-table');`) },
+    { code: withTestingLibrary(`screen.getByText(closeLabel$());`) },
+    {
+      code: withTestingLibrary(
+        `within(modal).findByRole('button', { name: coreString('closeLabel') });`,
+      ),
+    },
+
+    // allowed characters (standalone dashes, digits, and percentages)
+    { code: withTestingLibrary(`getByText('—');`) },
+    { code: withTestingLibrary(`findAllByText('-');`) },
+    { code: withTestingLibrary(`queryByText('52');`) },
+    { code: withTestingLibrary(`findByText('90%');`) },
+  ],
+
+  invalid: [
+    // by role
+    {
+      code: withTestingLibrary(`getByRole('button', { name: 'Close' });`),
+      errors: [
+        {
+          message: assertRoleMessage('getByRole'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`findAllByRole('button', { name: /close/i });`),
+      errors: [
+        {
+          message: assertRoleMessage('findAllByRole'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`queryByRole('button', { name: /close/i });`),
+      errors: [
+        {
+          message: assertRoleMessage('queryByRole'),
+        },
+      ],
+    },
+    // by text
+    {
+      code: withTestingLibrary(`getByText('Close');`),
+      errors: [
+        {
+          message: assertMessage('getByText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`findAllByText(/close/i);`),
+      errors: [
+        {
+          message: assertMessage('findAllByText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`queryByText('52 items');`),
+      errors: [
+        {
+          message: assertMessage('queryByText'),
+        },
+      ],
+    },
+    // other
+    {
+      code: withTestingLibrary(`getByLabelText('First name');`),
+      errors: [
+        {
+          message: assertMessage('getByLabelText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`getByPlaceholderText('Enter text');`),
+      errors: [
+        {
+          message: assertMessage('getByPlaceholderText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`getByAltText('Profile photo');`),
+      errors: [
+        {
+          message: assertMessage('getByAltText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`getByTitle('Users table');`),
+      errors: [
+        {
+          message: assertMessage('getByTitle'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`getByDisplayValue('Option - A');`),
+      errors: [
+        {
+          message: assertMessage('getByDisplayValue'),
+        },
+      ],
+    },
+    // template literals
+    {
+      code: withTestingLibrary('getByText(`Get ${count} correct`);'),
+      errors: [
+        {
+          message: assertMessage('getByText'),
+        },
+      ],
+    },
+    // method accessed as a property
+    {
+      code: withTestingLibrary(`screen.getByText('Close');`),
+      errors: [
+        {
+          message: assertMessage('getByText'),
+        },
+      ],
+    },
+    {
+      code: withTestingLibrary(`within(modal).findByRole('button', { name: /close/i });`),
+      errors: [
+        {
+          message: assertRoleMessage('findByRole'),
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-stubs.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-stubs.spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/tests-no-stubs');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+});
+
+// The rule is active only in files that import from Testing Library, so wrap code in a TL import
+function withTestingLibrary(code) {
+  return `import { render } from '@testing-library/vue';\n${code}`;
+}
+
+const STUBS_MESSAGE =
+  'Avoid using stubs. See https://kolibri-dev.readthedocs.io/en/develop/frontend_architecture/unit_testing.html#avoid-using-stubs.';
+
+tester.run('tests-no-stubs', rule, {
+  valid: [
+    { code: withTestingLibrary(`render(UsersTable);`) },
+    { code: withTestingLibrary(`render(UsersTable, { props: { title: 'Title' } });`) },
+    { code: withTestingLibrary(`render(UsersTable, { listeners: { close: closeHandler } });`) },
+    { code: withTestingLibrary(`render(UsersTable, { store, routes });`) },
+  ],
+
+  invalid: [
+    {
+      code: withTestingLibrary(`render(UsersTable, { stubs: { SomeStub: true } });`),
+      errors: [{ message: STUBS_MESSAGE }],
+    },
+    {
+      code: withTestingLibrary(`render(UsersTable, { stubs: ['SomeStub'] });`),
+      errors: [{ message: STUBS_MESSAGE }],
+    },
+    {
+      code: withTestingLibrary(
+        `render(UsersTable, { props: { title: 'Title' }, stubs: { SomeStub: true } });`,
+      ),
+      errors: [{ message: STUBS_MESSAGE }],
+    },
+    {
+      code: withTestingLibrary(`render(UsersTable, { store, routes, stubs });`),
+      errors: [{ message: STUBS_MESSAGE }],
+    },
+    {
+      code: withTestingLibrary(`render(UsersTable, { store, routes, global: { stubs }});`),
+      errors: [{ message: STUBS_MESSAGE }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-stubs.spec.js
+++ b/packages/eslint-plugin-kolibri/tests/lib/rules/tests-no-stubs.spec.js
@@ -24,6 +24,10 @@ tester.run('tests-no-stubs', rule, {
     { code: withTestingLibrary(`render(UsersTable, { props: { title: 'Title' } });`) },
     { code: withTestingLibrary(`render(UsersTable, { listeners: { close: closeHandler } });`) },
     { code: withTestingLibrary(`render(UsersTable, { store, routes });`) },
+    // check that the rule is not active in obsolete Vue Test Utils files
+    {
+      code: `mount(UsersTable, { stubs: { SomeStub: true } });`,
+    },
   ],
 
   invalid: [

--- a/packages/kolibri-common/components/SafeHTML/__tests__/Lightbox.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/Lightbox.spec.js
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import Lightbox from '../Lightbox.vue';
+
+const { zoomOut$, zoomIn$, closeAction$ } = coreStrings;
 
 const sampleOpen = true;
 const sampleSrc = 'test_img.jpg';
@@ -35,9 +38,9 @@ describe('Lightbox', () => {
 
     lightboxDialog = screen.getByTestId('lightbox-dialog');
     img = screen.getByAltText(sampleAlt);
-    zoomOut = screen.getByLabelText('Zoom out');
-    zoomIn = screen.getByLabelText('Zoom in');
-    close = screen.getByLabelText('Close');
+    zoomOut = screen.getByLabelText(zoomOut$());
+    zoomIn = screen.getByLabelText(zoomIn$());
+    close = screen.getByLabelText(closeAction$());
 
     mockNaturalDimensions(img);
     img.dispatchEvent(new Event('load')); // Trigger load event so calculateSize is called

--- a/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlImage.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlImage.spec.js
@@ -1,6 +1,12 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import SafeHtmlImage from '../SafeHtmlImage.vue';
+
+const { closeAction$ } = coreStrings;
+
+const { expandImage$ } = createTranslator(SafeHtmlImage.name, SafeHtmlImage.$trs);
 
 const sampleSrc = 'test_img.jpg';
 const sampleAlt = 'Test img alt text';
@@ -28,7 +34,7 @@ describe('SafeHtmlImage', () => {
     user = userEvent.setup();
     renderComponent();
     img = screen.getByAltText(sampleAlt);
-    expandButton = screen.getByLabelText('Expand image');
+    expandButton = screen.getByLabelText(expandImage$());
   });
 
   describe('first render', () => {
@@ -65,7 +71,7 @@ describe('SafeHtmlImage', () => {
       await user.keyboard('{enter}');
       expect(screen.getByTestId('lightbox-dialog')).toBeInTheDocument();
 
-      await user.click(screen.getByLabelText('Close'));
+      await user.click(screen.getByLabelText(closeAction$()));
       expect(screen.queryByTestId('lightbox-dialog')).not.toBeInTheDocument();
 
       expandButton.focus();
@@ -78,7 +84,7 @@ describe('SafeHtmlImage', () => {
     await user.click(expandButton); // Open Lightbox first
     expect(screen.getByTestId('lightbox-dialog')).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText('Close'));
+    await user.click(screen.getByLabelText(closeAction$()));
     expect(screen.queryByTestId('lightbox-dialog')).not.toBeInTheDocument();
   });
 });

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -3,49 +3,35 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import AllPasswordsPage from '../AllPasswordsPage.vue';
 
+const { noPicturePasswordDescription$, printAction$, noLearnersInClass$ } = picturePasswordStrings;
+
 jest.mock('kolibri-common/apiResources/FacilityUserResource', () => ({
   fetchCollection: jest.fn(),
 }));
 
+const CLASS_ID = 'class-abc';
+const LEARNERS = {
+  alice: { id: 'u1', full_name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
+  bob: { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
+};
+const ICON_LABELS = ['testIcon1', 'testIcon2', 'testIcon3'];
+
 jest.mock('kolibri-common/utils/picturePassword', () => ({
   getPicturePasswordIcons: jest.fn(pw => {
-    if (pw === '3.7.12')
-      return [{ label: 'testIcon1' }, { label: 'testIcon2' }, { label: 'testIcon3' }];
+    if (pw === '3.7.12') return ICON_LABELS.map(label => ({ label }));
     return [];
   }),
 }));
-
-const LEARNERS = [
-  {
-    id: 'u1',
-    full_name: 'Alice Smith',
-    username: 'alice',
-    picture_password: '3.7.12',
-  },
-  {
-    id: 'u2',
-    full_name: 'Bob Jones',
-    username: 'bob',
-    picture_password: null,
-  },
-];
-
-const CLASS_ID = 'class-abc';
-
 function renderComponent(props = {}) {
   return render(AllPasswordsPage, {
     props: { classId: CLASS_ID, ...props },
-    stubs: {
-      ImmersivePage: {
-        template: '<div><slot /></div>',
-      },
-    },
+    routes: [],
   });
 }
 
 describe('AllPasswordsPage', () => {
   beforeEach(() => {
-    FacilityUserResource.fetchCollection.mockResolvedValue(LEARNERS);
+    FacilityUserResource.fetchCollection.mockResolvedValue(Object.values(LEARNERS));
   });
 
   afterEach(() => {
@@ -81,29 +67,27 @@ describe('AllPasswordsPage', () => {
     it('renders the full name of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-      expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].full_name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].full_name)).toBeInTheDocument();
     });
 
     it('renders the username of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText('alice')).toBeInTheDocument();
-      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['alice'].username)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS['bob'].username)).toBeInTheDocument();
     });
 
     it('renders resolved icon labels for a learner with a picture_password', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText('testIcon1, testIcon2, testIcon3')).toBeInTheDocument();
+      expect(screen.getByText(ICON_LABELS.join(', '))).toBeInTheDocument();
     });
 
     it('renders the "no password" description for a learner with picture_password=null', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(
-        screen.getByText(picturePasswordStrings.noPicturePasswordDescription$()),
-      ).toBeInTheDocument();
+      expect(screen.getByText(noPicturePasswordDescription$())).toBeInTheDocument();
     });
 
     it('renders one row per learner', async () => {
@@ -120,9 +104,7 @@ describe('AllPasswordsPage', () => {
     it('renders a Print button', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(
-        screen.getByRole('button', { name: picturePasswordStrings.printAction$() }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: printAction$() })).toBeInTheDocument();
     });
   });
 
@@ -140,7 +122,7 @@ describe('AllPasswordsPage', () => {
       FacilityUserResource.fetchCollection.mockResolvedValue([]);
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(picturePasswordStrings.noLearnersInClass$())).toBeInTheDocument();
+      expect(screen.getByText(noLearnersInClass$())).toBeInTheDocument();
     });
   });
 });

--- a/packages/kolibri-common/components/__tests__/TimeDuration.spec.js
+++ b/packages/kolibri-common/components/__tests__/TimeDuration.spec.js
@@ -46,7 +46,7 @@ describe('TimeDuration', () => {
     expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
-  it('should render empty string if seconds are not provided as props', () => {
+  it('should render dash if seconds are not provided as props', () => {
     renderComponent();
     expect(screen.getByText('—')).toBeInTheDocument();
   });

--- a/packages/kolibri-common/components/quizzes/InteractionList/__tests__/index.spec.js
+++ b/packages/kolibri-common/components/quizzes/InteractionList/__tests__/index.spec.js
@@ -1,5 +1,11 @@
 import { render, fireEvent, screen } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
 import InteractionList from '..';
+
+const { currAnswer$, noInteractions$ } = createTranslator(
+  InteractionList.name,
+  InteractionList.$trs,
+);
 
 const renderComponent = props => {
   const defaultProps = {
@@ -54,7 +60,9 @@ describe('InteractionList', () => {
         expect(isSelected(interactionItems[i])).toBe(selectedInteractionIndex === i);
 
       // Check if the correct attempt label is rendered
-      expect(screen.getByText(`Attempt ${selectedInteractionIndex + 1}`)).toBeInTheDocument();
+      expect(
+        screen.getByText(currAnswer$({ value: selectedInteractionIndex + 1 })),
+      ).toBeInTheDocument();
     });
 
     it("no event is emitted when the user clicks on the same interaction that's already selected", async () => {
@@ -89,6 +97,6 @@ describe('InteractionList', () => {
 
   it('renders the correct label when they are no interactions', () => {
     renderComponent({ interactions: [] });
-    expect(screen.getByText('No attempts made on this question')).toBeInTheDocument();
+    expect(screen.getByText(noInteractions$())).toBeInTheDocument();
   });
 });

--- a/packages/kolibri-common/components/quizzes/QuizReport/__tests__/TriesOverview.spec.js
+++ b/packages/kolibri-common/components/quizzes/QuizReport/__tests__/TriesOverview.spec.js
@@ -1,6 +1,24 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
+import TimeDuration from 'kolibri-common/components/TimeDuration.vue';
 import TriesOverview from '../TriesOverview.vue';
+
+const {
+  completedLabel$,
+  inProgressLabel$,
+  notStartedLabel$,
+  questionsCorrectLabel$,
+  questionsCorrectValue$,
+} = coreStrings;
+const {
+  bestScoreLabel$,
+  bestScoreTimeLabel$,
+  practiceQuizReportFasterSuggestedLabel$,
+  practiceQuizReportSlowerSuggestedLabel$,
+} = createTranslator(TriesOverview.name, TriesOverview.$trs);
+const { seconds$, minutes$ } = createTranslator(TimeDuration.name, TimeDuration.$trs);
 
 // Mock the tryValidator namespace as the same is used in the component
 jest.mock('../utils', () => {
@@ -11,20 +29,7 @@ jest.mock('../utils', () => {
   };
 });
 
-// Helper function to render the component with some default props
 const renderComponent = props => {
-  const commonCoreStrings = {
-    methods: {
-      coreString: (x, options) =>
-        !options
-          ? x
-          : // Add comma seperated options as key value pairs at the end of the label
-            `${x} ${Object.keys(options)
-              .map(key => `${key}=${options[key]}`)
-              .join(', ')}`,
-    },
-  };
-
   const defaultProps = {
     pastTries: [],
     totalQuestions: 20,
@@ -36,7 +41,6 @@ const renderComponent = props => {
       ...defaultProps,
       ...props,
     },
-    mixins: [commonCoreStrings],
   });
 };
 
@@ -55,7 +59,7 @@ describe('TriesOverview', () => {
       });
 
       expect(screen.getByTestId('progress-icon-1')).toBeInTheDocument();
-      expect(screen.getByText('completedLabel')).toBeInTheDocument();
+      expect(screen.getByText(completedLabel$())).toBeInTheDocument();
     });
 
     it('renders progress icon and in-progress label when there is an in-progress try', () => {
@@ -70,7 +74,7 @@ describe('TriesOverview', () => {
       });
 
       expect(screen.getByTestId('progress-icon-0.5')).toBeInTheDocument();
-      expect(screen.getByText('inProgressLabel')).toBeInTheDocument();
+      expect(screen.getByText(inProgressLabel$())).toBeInTheDocument();
     });
 
     it('renders progress icon and not started label when there are no past tries', () => {
@@ -80,7 +84,7 @@ describe('TriesOverview', () => {
       });
 
       expect(screen.getByTestId('progress-icon-0')).toBeInTheDocument();
-      expect(screen.getByText('notStartedLabel')).toBeInTheDocument();
+      expect(screen.getByText(notStartedLabel$())).toBeInTheDocument();
     });
   });
 
@@ -102,21 +106,25 @@ describe('TriesOverview', () => {
         totalQuestions: 10,
       });
 
-      expect(screen.getByText('Best score')).toBeInTheDocument();
+      expect(screen.getByText(bestScoreLabel$())).toBeInTheDocument();
       expect(screen.getByText('90%')).toBeInTheDocument();
 
-      expect(screen.getByText('questionsCorrectLabel')).toBeInTheDocument();
-      expect(screen.getByText('questionsCorrectValue correct=9, total=10')).toBeInTheDocument();
+      expect(screen.getByText(questionsCorrectLabel$())).toBeInTheDocument();
+      expect(
+        screen.getByText(questionsCorrectValue$({ correct: 9, total: 10 })),
+      ).toBeInTheDocument();
     });
 
     it('renders the best score as 0 when there are no past tries', () => {
       renderComponent();
 
-      expect(screen.getByText('Best score')).toBeInTheDocument();
+      expect(screen.getByText(bestScoreLabel$())).toBeInTheDocument();
       expect(screen.getByText('0%')).toBeInTheDocument();
 
-      expect(screen.getByText('questionsCorrectLabel')).toBeInTheDocument();
-      expect(screen.getByText('questionsCorrectValue correct=0, total=20')).toBeInTheDocument();
+      expect(screen.getByText(questionsCorrectLabel$())).toBeInTheDocument();
+      expect(
+        screen.getByText(questionsCorrectValue$({ correct: 0, total: 20 })),
+      ).toBeInTheDocument();
     });
   });
 
@@ -138,9 +146,11 @@ describe('TriesOverview', () => {
         suggestedTime: 100,
       });
 
-      expect(screen.getByText('Best score time')).toBeInTheDocument();
-      expect(screen.getByText('20 seconds')).toBeInTheDocument();
-      expect(screen.getByText('2 minutes faster than the suggested time')).toBeInTheDocument();
+      expect(screen.getByText(bestScoreTimeLabel$())).toBeInTheDocument();
+      expect(screen.getByText(seconds$({ value: 20 }))).toBeInTheDocument();
+      expect(
+        screen.getByText(practiceQuizReportFasterSuggestedLabel$({ value: 2 })),
+      ).toBeInTheDocument();
     });
 
     it('shows the time spent when there are past tries [Slower Quiz Report]', () => {
@@ -160,9 +170,11 @@ describe('TriesOverview', () => {
         suggestedTime: 100,
       });
 
-      expect(screen.getByText('Best score time')).toBeInTheDocument();
-      expect(screen.getByText('2 minutes')).toBeInTheDocument();
-      expect(screen.getByText('1 minute slower than the suggested time')).toBeInTheDocument();
+      expect(screen.getByText(bestScoreTimeLabel$())).toBeInTheDocument();
+      expect(screen.getByText(minutes$({ value: 2 }))).toBeInTheDocument();
+      expect(
+        screen.getByText(practiceQuizReportSlowerSuggestedLabel$({ value: 1 })),
+      ).toBeInTheDocument();
     });
 
     it('shows the time spent when there are past tries but no suggested time [No Quiz Report]', () => {
@@ -181,13 +193,13 @@ describe('TriesOverview', () => {
         ],
       });
 
-      expect(screen.getByText('Best score time')).toBeInTheDocument();
-      expect(screen.getByText('20 seconds')).toBeInTheDocument();
+      expect(screen.getByText(bestScoreTimeLabel$())).toBeInTheDocument();
+      expect(screen.getByText(seconds$({ value: 20 }))).toBeInTheDocument();
     });
 
     it('does not render the row if there are no past tries', () => {
       renderComponent({ pastTries: [] });
-      expect(screen.queryByText('Best score time')).not.toBeInTheDocument();
+      expect(screen.queryByText(bestScoreTimeLabel$())).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/kolibri-common/components/syncComponentSet/FacilityTaskPanelDetails.vue
+++ b/packages/kolibri-common/components/syncComponentSet/FacilityTaskPanelDetails.vue
@@ -2,6 +2,7 @@
 
   <div
     class="task-panel"
+    data-testid="task-panel"
     :class="{ 'task-panel-sm': windowIsSmall }"
   >
     <div class="icon">

--- a/packages/kolibri-common/components/syncComponentSet/__tests__/ConfirmationRegisterModal.spec.js
+++ b/packages/kolibri-common/components/syncComponentSet/__tests__/ConfirmationRegisterModal.spec.js
@@ -2,7 +2,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import PortalResource from 'kolibri-common/apiResources/PortalResource';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import { ERROR_CONSTANTS } from 'kolibri/constants';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import ConfirmationRegisterModal from '../ConfirmationRegisterModal.vue';
+
+const { registerAction$, cancelAction$, closeAction$ } = coreStrings;
+
+const { registerWith$, dataSaved$, alreadyRegistered$ } = createTranslator(
+  ConfirmationRegisterModal.name,
+  ConfirmationRegisterModal.$trs,
+);
 
 const sampleProjectName = 'Test Project';
 const sampleFacility = {
@@ -23,7 +32,6 @@ const renderComponent = props => {
   });
 };
 
-// Mock necessary resources and modules
 jest.mock('kolibri-common/apiResources/PortalResource', () => ({
   registerFacility: jest.fn(() => Promise.resolve()),
 }));
@@ -37,19 +45,18 @@ describe('ConfirmationRegisterModal', () => {
     renderComponent({ projectName: sampleProjectName });
 
     // Checking the text content of the modal
-    expect(screen.getByText(`Register with '${sampleProjectName}'?`)).toBeInTheDocument();
-    expect(screen.getByText('Data will be saved to the cloud')).toBeInTheDocument();
+    expect(screen.getByText(registerWith$({ name: sampleProjectName }))).toBeInTheDocument();
+    expect(screen.getByText(dataSaved$())).toBeInTheDocument();
 
     // Checking the content on the buttons
-    expect(screen.getByRole('button', { name: 'Register' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: registerAction$() })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: cancelAction$() })).toBeInTheDocument();
   });
 
   it("emits the cancel event when 'Cancel' button is clicked without registering", async () => {
     const { emitted } = renderComponent();
 
-    // Clicking the 'Cancel' button
-    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.click(screen.getByRole('button', { name: cancelAction$() }));
     expect(emitted()).toHaveProperty('cancel');
     expect(emitted().cancel).toHaveLength(1);
   });
@@ -60,7 +67,7 @@ describe('ConfirmationRegisterModal', () => {
         projectName: sampleProjectName,
         targetFacility: sampleFacility,
       });
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       expect(emitted()).toHaveProperty('success');
       expect(emitted().success).toHaveLength(1);
@@ -73,7 +80,7 @@ describe('ConfirmationRegisterModal', () => {
         targetFacility: sampleFacility,
         token: sampleToken,
       });
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       expect(PortalResource.registerFacility).toHaveBeenCalledWith({
         facility_id: sampleFacility.id,
@@ -101,22 +108,22 @@ describe('ConfirmationRegisterModal', () => {
 
     it('renders with correct text in the body of the modal', async () => {
       renderComponent({ projectName: sampleProjectName });
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       await waitFor(() =>
         expect(
-          screen.getByText(`Already registered with '${sampleProjectName}'`),
+          screen.getByText(alreadyRegistered$({ name: sampleProjectName })),
         ).toBeInTheDocument(),
       );
     });
 
     it('the buttons show the appropiate texts', async () => {
       renderComponent({ projectName: sampleProjectName });
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Register' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: closeAction$() })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: registerAction$() })).not.toBeInTheDocument();
       });
     });
 
@@ -125,10 +132,10 @@ describe('ConfirmationRegisterModal', () => {
         successOnAlreadyRegistered: true,
         targetFacility: sampleFacility,
       });
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       await waitFor(async () => {
-        await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        await fireEvent.click(screen.getByRole('button', { name: closeAction$() }));
 
         expect(emitted()).toHaveProperty('success');
         expect(emitted().success).toHaveLength(1);
@@ -138,10 +145,10 @@ describe('ConfirmationRegisterModal', () => {
 
     it("does not emit success event when 'Close' button is clicked if successOnAlreadyRegistered is not set", async () => {
       const { emitted } = renderComponent();
-      await fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+      await fireEvent.click(screen.getByRole('button', { name: registerAction$() }));
 
       await waitFor(async () => {
-        await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        await fireEvent.click(screen.getByRole('button', { name: closeAction$() }));
 
         expect(emitted()).not.toHaveProperty('success');
       });

--- a/packages/kolibri-common/components/syncComponentSet/__tests__/SelectSourceModal.spec.js
+++ b/packages/kolibri-common/components/syncComponentSet/__tests__/SelectSourceModal.spec.js
@@ -1,5 +1,14 @@
 import { render, fireEvent, screen } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { syncStrings } from 'kolibri-common/mixins/commonSyncElements';
 import SelectSourceModal from '../SelectSourceModal.vue';
+
+const { continueAction$, cancelAction$ } = coreStrings;
+
+const { selectSourceTitle$ } = syncStrings;
+
+const { loadingMessage$ } = createTranslator(SelectSourceModal.name, SelectSourceModal.$trs);
 
 const renderComponent = props => {
   return render(SelectSourceModal, {
@@ -11,14 +20,14 @@ describe('SelectSourceModal', () => {
   it('renders the correct default body and button labels', async () => {
     renderComponent();
 
-    expect(screen.getByText('Select a source')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByText(selectSourceTitle$())).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: continueAction$() })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: cancelAction$() })).toBeInTheDocument();
   });
 
   it('clicking the Continue button emits the submit event', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
 
     expect(emitted()).toHaveProperty('submit');
     expect(emitted().submit).toHaveLength(1);
@@ -26,7 +35,7 @@ describe('SelectSourceModal', () => {
 
   it('clicking the Cancel button emits the cancel event', async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await fireEvent.click(screen.getByRole('button', { name: cancelAction$() }));
 
     expect(emitted()).toHaveProperty('cancel');
     expect(emitted().cancel).toHaveLength(1);
@@ -34,11 +43,11 @@ describe('SelectSourceModal', () => {
 
   it('displays the loading message when showLoadingMessage is true', async () => {
     renderComponent({ showLoadingMessage: true });
-    expect(screen.getByText('Loading connections…')).toBeInTheDocument();
+    expect(screen.getByText(loadingMessage$())).toBeInTheDocument();
   });
 
   it('the submit button is disabled when the submitDisabled prop is true', async () => {
     renderComponent({ submitDisabled: true });
-    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: continueAction$() })).toBeDisabled();
   });
 });

--- a/packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js
+++ b/packages/kolibri-common/components/userAccounts/__tests__/GenderSelect.spec.js
@@ -1,18 +1,22 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import GenderSelect from '../GenderSelect';
 import '@testing-library/jest-dom';
+
+const { genderOptionMale$, genderOptionFemale$, genderOptionNotSpecified$, genderLabel$ } =
+  coreStrings;
 
 const renderComponent = () => {
   return render(GenderSelect);
 };
 
 describe('GenderSelect', () => {
-  const labelOptions = ['Male', 'Female', 'Not specified'];
+  const labelOptions = [genderOptionMale$(), genderOptionFemale$(), genderOptionNotSpecified$()];
 
   it('renders correctly with label placeholder and options', async () => {
     renderComponent();
-    await fireEvent.click(screen.getByText('Gender'));
-    expect(screen.getByText('Gender')).toBeInTheDocument();
+    await fireEvent.click(screen.getByText(genderLabel$()));
+    expect(screen.getByText(genderLabel$())).toBeInTheDocument();
     labelOptions.forEach(option => {
       expect(screen.getByText(option)).toBeInTheDocument();
     });
@@ -20,7 +24,7 @@ describe('GenderSelect', () => {
 
   it("emits 'update:value' event when an option is selected", async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByText('Gender'));
+    await fireEvent.click(screen.getByText(genderLabel$()));
 
     const selectedOption = labelOptions[0];
     await fireEvent.click(screen.getByText(selectedOption));
@@ -32,7 +36,7 @@ describe('GenderSelect', () => {
 
   it("the value of 'update:value' event is changed when a different option is selected", async () => {
     const { emitted } = renderComponent();
-    await fireEvent.click(screen.getByText('Gender'));
+    await fireEvent.click(screen.getByText(genderLabel$()));
     const selectedOption = labelOptions[0];
     await fireEvent.click(screen.getByText(selectedOption));
     const newSelectedOption = labelOptions[1];

--- a/packages/kolibri-common/mixins/commonSyncElements.js
+++ b/packages/kolibri-common/mixins/commonSyncElements.js
@@ -5,7 +5,7 @@ import { createTranslator } from 'kolibri/utils/i18n';
 
 // Strings that might be shared among syncing-related UIs across plugins.
 // See taskStrings mixin for strings relating to the Facility-Syncing Async Task.
-const syncStrings = createTranslator('CommonSyncStrings', {
+export const syncStrings = createTranslator('CommonSyncStrings', {
   selectSourceTitle: {
     message: 'Select a source',
     context: 'Title of menu where the user selects the source from where to import a facility',

--- a/packages/kolibri-format/eslint.config.mjs
+++ b/packages/kolibri-format/eslint.config.mjs
@@ -352,6 +352,10 @@ export default [
         ...globals.jest,
       },
     },
+    rules: {
+      'kolibri/tests-no-hardcoded-strings': ERROR,
+      'kolibri/tests-no-stubs': ERROR,
+    },
   },
   // Override: __mocks__ files get jest globals
   {

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-format",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A module for formatting frontend code to Kolibri standards",
   "repository": {
     "type": "git",

--- a/packages/kolibri-jest-config/jest.conf/setup.js
+++ b/packages/kolibri-jest-config/jest.conf/setup.js
@@ -77,8 +77,9 @@ Vue.use(VueMeta);
 Vue.use(KThemePlugin);
 
 Vue.component('ContentViewer', {
+  props: ['options'],
   render(h) {
-    return h('p', 'ContentViewer');
+    return h('p', this.options && this.options.title);
   },
 });
 

--- a/packages/kolibri/components/CoreMenu/__tests__/CoreMenuOption.spec.js
+++ b/packages/kolibri/components/CoreMenu/__tests__/CoreMenuOption.spec.js
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 import CoreMenuOption from '../CoreMenuOption.vue';
 
+const OPTION_LABEL = 'Sample Option';
+const SECONDARY_TEXT = 'Secondary Text';
+
 const sampleSubRoutes = [
   { name: 'subRoute1', label: 'Sub Route 1' },
   { name: 'subRoute2', label: 'Sub Route 2' },
@@ -104,13 +107,13 @@ describe('CoreMenuOption', () => {
       });
 
       it('should display the label of the option when provided', () => {
-        renderComponent({ label: 'Sample Option', subRoutes: sampleSubRoutes });
-        expect(screen.getByText('Sample Option')).toBeInTheDocument();
+        renderComponent({ label: OPTION_LABEL, subRoutes: sampleSubRoutes });
+        expect(screen.getByText(OPTION_LABEL)).toBeInTheDocument();
       });
 
       it('should display the secondary text of the option when provided', () => {
-        renderComponent({ secondaryText: 'Secondary Text', subRoutes: sampleSubRoutes });
-        expect(screen.getByText('Secondary Text')).toBeInTheDocument();
+        renderComponent({ secondaryText: SECONDARY_TEXT, subRoutes: sampleSubRoutes });
+        expect(screen.getByText(SECONDARY_TEXT)).toBeInTheDocument();
       });
 
       it('should display the icon of the option when provided', () => {
@@ -137,8 +140,8 @@ describe('CoreMenuOption', () => {
       });
 
       it('should display the label of the option when provided', () => {
-        renderComponent({ label: 'Sample Option', subRoutes: [] });
-        expect(screen.getByText('Sample Option')).toBeInTheDocument();
+        renderComponent({ label: OPTION_LABEL, subRoutes: [] });
+        expect(screen.getByText(OPTION_LABEL)).toBeInTheDocument();
       });
 
       it('pressing tab from keyboard should focus the menuitem', async () => {

--- a/packages/kolibri/components/error/__tests__/AppError.spec.js
+++ b/packages/kolibri/components/error/__tests__/AppError.spec.js
@@ -1,6 +1,15 @@
 import { render, screen } from '@testing-library/vue';
 import { error } from 'kolibri/utils/appError';
+import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import AppError from '../AppError';
+
+const { refresh$ } = coreStrings;
+
+const { resourceNotFoundHeader$, defaultErrorExitPrompt$, defaultErrorHeader$ } = createTranslator(
+  AppError.name,
+  AppError.$trs,
+);
 
 jest.mock('kolibri/utils/appError');
 
@@ -18,8 +27,8 @@ describe('AppError component', () => {
     };
     error.value = JSON.stringify(errorObj);
     render(AppError);
-    expect(screen.getByText('Resource not found')).toBeInTheDocument();
-    expect(screen.getByText('Back to home')).toBeInTheDocument();
+    expect(screen.getByText(resourceNotFoundHeader$())).toBeInTheDocument();
+    expect(screen.getByText(defaultErrorExitPrompt$())).toBeInTheDocument();
   });
 
   it('shows default errors and buttons if the error does not have status code 404', async () => {
@@ -31,8 +40,8 @@ describe('AppError component', () => {
     };
     error.value = JSON.stringify(errorObj);
     render(AppError);
-    expect(screen.getByText('Sorry! Something went wrong!')).toBeInTheDocument();
+    expect(screen.getByText(defaultErrorHeader$())).toBeInTheDocument();
     // First button should be Refresh
-    expect(screen.getByText('Refresh')).toBeInTheDocument();
+    expect(screen.getByText(refresh$())).toBeInTheDocument();
   });
 });

--- a/packages/kolibri/components/internal/ContentViewer/__tests__/ContentViewerError.spec.js
+++ b/packages/kolibri/components/internal/ContentViewer/__tests__/ContentViewerError.spec.js
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import ContentViewerError from '../ContentViewerError.vue';
+
+const { closeAction$ } = coreStrings;
 
 // Helper function to render the component with given props and a router
 const renderComponent = props => {
@@ -41,7 +44,7 @@ describe('ContentViewerError', () => {
     await userEvent.click(reportErrorButton);
 
     // Close the Report Error Modal
-    const closeButton = screen.getByRole('button', { name: /close/i });
+    const closeButton = screen.getByRole('button', { name: closeAction$() });
     await userEvent.click(closeButton);
     expect(screen.queryByText(sampleError.message)).not.toBeInTheDocument();
   });

--- a/packages/kolibri/components/pages/AppBarPage/internal/__tests__/TotalPoints.spec.js
+++ b/packages/kolibri/components/pages/AppBarPage/internal/__tests__/TotalPoints.spec.js
@@ -4,7 +4,10 @@ import useTotalProgress, { useTotalProgressMock } from 'kolibri/composables/useT
 import '@testing-library/jest-dom';
 import { ref } from 'vue';
 import { get, set } from '@vueuse/core';
+import { createTranslator } from 'kolibri/utils/i18n';
 import TotalPoints from '../TotalPoints.vue';
+
+const { pointsTooltip$ } = createTranslator(TotalPoints.name, TotalPoints.$trs);
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useTotalProgress');
@@ -50,7 +53,7 @@ describe('TotalPoints', () => {
 
     await fireEvent.mouseOver(screen.getByRole('presentation'));
     expect(
-      screen.getByText(`You earned ${get(totalPointsMock.totalPoints)} points`),
+      screen.getByText(pointsTooltip$({ points: get(totalPointsMock.totalPoints) })),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Adds two new conventions for Testing Library tests:

- [Reference translation keys, not hardcoded strings](https://kolibri-dev--14579.org.readthedocs.build/en/14579/frontend_architecture/unit_testing.html#reference-translation-keys-not-hardcoded-strings)
- [Avoid using stubs](https://kolibri-dev--14579.org.readthedocs.build/en/14579/frontend_architecture/unit_testing.html#avoid-using-stubs)

including related linting rules & codebase fixes to align with them.

Also has few rather random updates to improve tests readability, remove unnecessary test cases or `jest.mock`s.

## References

Discussed in meetings and on [Slack](https://learningequality.slack.com/archives/C0LE9NLCE/p1775708441792809).

## Reviewer guidance

- Read the new developer documentation sections (linked above)
- Preview the diff

## AI usage

I used Claude for drafting & then further iteration. There's no place I wouldn't touch or see myself. Finally, I self-reviewed the final diff fully.