### PR TITLE
Revert pnpm pack change, use Node 24 for npm publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/scripts/npm_publish.sh
+++ b/scripts/npm_publish.sh
@@ -7,11 +7,11 @@ set -euo pipefail
 #   ./scripts/npm_publish.sh              # auto-detect and publish all changed packages
 #   ./scripts/npm_publish.sh kolibri-format  # publish a specific package
 
-PACKAGES=()
+FILTER=""
 
 if [ $# -ge 1 ]; then
   # Specific package requested
-  PACKAGES+=("$1")
+  FILTER="--filter $1"
   echo "Publishing $1"
 else
   # Auto-detect packages with newer versions than npm
@@ -33,7 +33,7 @@ else
         continue
       else
         echo "Will publish $name: first publish ($repo_version)"
-        PACKAGES+=("$name")
+        FILTER="$FILTER --filter $name"
         continue
       fi
     }
@@ -48,25 +48,19 @@ else
 
     if [ "$is_newer" = "true" ]; then
       echo "Will publish $name: $npm_version → $repo_version"
-      PACKAGES+=("$name")
+      FILTER="$FILTER --filter $name"
     else
       echo "Skipping $name ($repo_version is not newer than $npm_version)"
     fi
   done
 fi
 
-if [ ${#PACKAGES[@]} -eq 0 ]; then
+if [ -z "$FILTER" ]; then
   echo "No packages need publishing"
   exit 0
 fi
 
-# Use pnpm pack to resolve workspace:* references, then npm publish the tarball.
-# pnpm publish doesn't support OIDC trusted publishing, so we pack with pnpm
-# (to rewrite workspace:* deps) and publish with npm (which handles OIDC).
-for name in "${PACKAGES[@]}"; do
-  echo "Publishing $name..."
-  pack_dir=$(mktemp -d)
-  pnpm --filter "$name" pack --pack-destination "$pack_dir"
-  npm publish "$pack_dir"/*.tgz
-  rm -rf "$pack_dir"
-done
+echo "Filter: $FILTER"
+
+# shellcheck disable=SC2086
+pnpm $FILTER -r publish --no-git-checks


### PR DESCRIPTION
## Summary

Revert the pnpm pack + npm publish change (didn't fix the 404). Try Node 24 instead — the working KDS publish workflow uses Node 24 (npm 11), while we were using Node 20 (npm 10).

## References

- Follow-up to learningequality/kolibri#14581

## Reviewer guidance

Merge and re-run the publish workflow.

## AI usage

Identified remaining difference with Claude Code by comparing against the KDS workflow.