### PR TITLE
Remove pnpm install from npm publish workflow

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -44,8 +44,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install pnpm
         uses: pnpm/action-setup@v5
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Publish to npm
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.npm_package }}" != "all" ]; then


### PR DESCRIPTION
## Summary

Dependencies don't need to be installed to publish packages, and Node 24 causes install failures for some dependencies. Removing this step speeds up the workflow significantly.

## References

- Follow-up to learningequality/kolibri#14582

## Reviewer guidance

Merge and re-run the publish workflow.

## AI usage

Identified with Claude Code.