### PR TITLE
Use lightweight install for npm publish workflow

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -44,6 +44,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install pnpm
         uses: pnpm/action-setup@v5
+      - name: Link workspace packages
+        run: pnpm install --ignore-scripts --no-optional
       - name: Publish to npm
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.npm_package }}" != "all" ]; then


### PR DESCRIPTION
## Summary

pnpm needs workspace packages linked to resolve `workspace:*` references during publish, but native module compilation fails on Node 24 and isn't needed. Use `--ignore-scripts --no-optional` to skip the expensive/broken parts.

## References

- Follow-up to learningequality/kolibri#14583

## Reviewer guidance

Merge and re-run the publish workflow.

## AI usage

Identified with Claude Code.