### PR TITLE
Add published packages summary for Slack notifications

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -53,3 +53,4 @@ jobs:
           else
             ./scripts/npm_publish.sh
           fi
+          cat publish_summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/npm_publish.sh
+++ b/scripts/npm_publish.sh
@@ -64,3 +64,22 @@ echo "Filter: $FILTER"
 
 # shellcheck disable=SC2086
 pnpm $FILTER -r publish --no-git-checks
+
+# Write a markdown summary of published packages to a file
+SUMMARY_FILE="${PUBLISH_SUMMARY:-publish_summary.md}"
+{
+  echo "### Published npm packages"
+  echo ""
+  echo "| Package | Version |"
+  echo "|-|-|"
+  for filter_arg in $FILTER; do
+    [ "$filter_arg" = "--filter" ] && continue
+    pkg_dir=$(find packages -maxdepth 1 -name "$filter_arg" -type d | head -1)
+    if [ -n "$pkg_dir" ] && [ -f "$pkg_dir/package.json" ]; then
+      name=$(node -e "console.log(require('./$pkg_dir/package.json').name)")
+      version=$(node -e "console.log(require('./$pkg_dir/package.json').version)")
+      echo "| [$name](https://www.npmjs.com/package/$name) | $version |"
+    fi
+  done
+} > "$SUMMARY_FILE"
+cat "$SUMMARY_FILE"


### PR DESCRIPTION
## Summary

Add a job summary showing which packages were published and their versions. This shows up in the GitHub Actions UI and in Slack notifications when subscribed to the workflow.

## Reviewer guidance

The summary file is written by the publish script and appended to `GITHUB_STEP_SUMMARY` by the workflow. Can be tested locally — the script writes to `publish_summary.md` by default (overridable via `PUBLISH_SUMMARY` env var).

## AI usage

Implemented with Claude Code.