### PR TITLE
Automigrate allow_other_browsers_to_connect to True as it was previously always wrong

### DIFF
--- a/kolibri/core/device/upgrade.py
+++ b/kolibri/core/device/upgrade.py
@@ -22,3 +22,10 @@ def migrate_nyn_to_ny():
 
     if get_device_setting("language_id") == "nyn":
         set_device_settings(language_id="ny")
+
+
+@version_upgrade(old_version="<0.20.0")
+def allow_other_browsers_to_connect_true():
+    from kolibri.core.device.utils import set_device_settings
+
+    set_device_settings(allow_other_browsers_to_connect=True)


### PR DESCRIPTION
## Summary
* Create an upgrade migration to ensure allow_other_browsers_to_connect is True - it defaulted to False in non-app mode but got obscured by the logic for activating it

## Reviewer guidance
I can't think of an effective way to determine whether this has been set deliberately or not - so I think this is the only way to prevent a regression.

## AI usage
None