### PR TITLE
Do early resolution of language redirect for redirect views to prevent multihop redirects.

### DIFF
--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -7,6 +7,7 @@ from django.urls import is_valid_path
 from django.urls import resolve
 from django.urls import Resolver404
 from django.utils import translation
+from django.views.generic.base import RedirectView
 
 from .translation import get_language_from_request_and_is_from_path
 from kolibri.core.device.hooks import SetupHook
@@ -31,6 +32,35 @@ class KolibriLocaleMiddleware:
         # Standard boilerplate for a new style Django middleware.
         self.get_response = get_response
 
+    def _language_url(self, request, language):
+        # Maybe the language code is missing in the URL? Try adding the
+        # language prefix and redirecting to that URL.
+        # First get any global prefix that is being used.
+        script_prefix = OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+        # Replace the global prefix with the global prefix and the language prefix.
+        language_path = request.path_info.replace(
+            script_prefix, "%s%s/" % (script_prefix, language), 1
+        )
+
+        # Get the urlconf from the request, default to the global settings ROOT_URLCONF
+        urlconf = getattr(request, "urlconf", settings.ROOT_URLCONF)
+        # Check if this is a valid path
+        path_valid = is_valid_path(language_path, urlconf)
+        # Check if the path is only invalid because it is missing a trailing slash
+        path_needs_slash = not path_valid and (
+            settings.APPEND_SLASH
+            and not language_path.endswith("/")
+            and is_valid_path("%s/" % language_path, urlconf)
+        )
+        # If the constructed path is valid, or it would be valid with a trailing slash
+        # then redirect to the prefixed path, with a trailing slash added if needed.
+        if path_valid or path_needs_slash:
+            # Insert language after the script prefix and before the
+            # rest of the URL
+            return request.get_full_path(force_append_slash=path_needs_slash).replace(
+                script_prefix, "%s%s/" % (script_prefix, language), 1
+            )
+
     def __call__(self, request):
         # First get the language code, and whether this was calculated from the path
         # i.e. was this a language-prefixed URL.
@@ -45,39 +75,28 @@ class KolibriLocaleMiddleware:
             translation.activate(language)
             request.LANGUAGE_CODE = translation.get_language()
 
+        # If the URL is missing a language prefix, check whether the language-prefixed
+        # path resolves to a RedirectView subclass. If so, rewrite the path before
+        # dispatching so that auth and other downstream middleware run once with the
+        # correct path, collapsing the two-hop chain into a single redirect response.
+        if language is not None and not language_from_path:
+            language_url = self._language_url(request, language)
+            try:
+                inner_match = resolve(language_url)
+                view_class = getattr(inner_match.func, "view_class", None)
+                if view_class is not None and issubclass(view_class, RedirectView):
+                    request.path_info = language_url
+            except Resolver404:
+                pass
+
         response = self.get_response(request)
 
         if language is not None:
             language = translation.get_language()
 
             if response.status_code == 404 and not language_from_path:
-                # Maybe the language code is missing in the URL? Try adding the
-                # language prefix and redirecting to that URL.
-                # First get any global prefix that is being used.
-                script_prefix = OPTIONS["Deployment"]["URL_PATH_PREFIX"]
-                # Replace the global prefix with the global prefix and the language prefix.
-                language_path = request.path_info.replace(
-                    script_prefix, "%s%s/" % (script_prefix, language), 1
-                )
-
-                # Get the urlconf from the request, default to the global settings ROOT_URLCONF
-                urlconf = getattr(request, "urlconf", settings.ROOT_URLCONF)
-                # Check if this is a valid path
-                path_valid = is_valid_path(language_path, urlconf)
-                # Check if the path is only invalid because it is missing a trailing slash
-                path_needs_slash = not path_valid and (
-                    settings.APPEND_SLASH
-                    and not language_path.endswith("/")
-                    and is_valid_path("%s/" % language_path, urlconf)
-                )
-                # If the constructed path is valid, or it would be valid with a trailing slash
-                # then redirect to the prefixed path, with a trailing slash added if needed.
-                if path_valid or path_needs_slash:
-                    # Insert language after the script prefix and before the
-                    # rest of the URL
-                    language_url = request.get_full_path(
-                        force_append_slash=path_needs_slash
-                    ).replace(script_prefix, "%s%s/" % (script_prefix, language), 1)
+                language_url = self._language_url(request, language)
+                if language_url is not None:
                     return HttpResponseRedirect(language_url)
 
             # Add a content language header to the response if not already present.

--- a/kolibri/core/device/test/locale_middleware_urls.py
+++ b/kolibri/core/device/test/locale_middleware_urls.py
@@ -2,6 +2,7 @@ from django.urls import include
 from django.urls import path
 from django.urls import re_path
 from django.views.generic import TemplateView
+from django.views.generic.base import RedirectView
 
 from kolibri.core.device.translation import i18n_patterns
 
@@ -20,6 +21,11 @@ patterns += i18n_patterns(
     [
         re_path(r"^prefixed/$", view, name="prefixed"),
         re_path(r"^prefixed\.xml$", view, name="prefixed_xml"),
+        re_path(
+            r"^prefixed-redirect/$",
+            RedirectView.as_view(pattern_name="not-prefixed"),
+            name="prefixed-redirect",
+        ),
     ]
 )
 

--- a/kolibri/core/device/test/test_locale_middleware.py
+++ b/kolibri/core/device/test/test_locale_middleware.py
@@ -216,3 +216,56 @@ class URLResponseTests(URLResponseTestsBase, URLTestCaseBase):
 @override_option("Deployment", "URL_PATH_PREFIX", "test/")
 class PrefixedURLResponseTests(URLResponseTestsBase, URLTestCaseBase):
     pass
+
+
+class OneShotRedirectTestsBase:
+    """
+    Tests that a language-less request to a RedirectView subclass produces
+    a single redirect to the final destination rather than a two-hop chain
+    (language-prefix redirect followed by the view's own redirect).
+    """
+
+    def test_redirect_view_one_shot(self):
+        # /prefixed-redirect/ resolves (with language prefix) to a RedirectView.
+        # The middleware should rewrite the path and return its redirect in one hop,
+        # going directly to the final target rather than first to /en/prefixed-redirect/.
+        response = self.client.get(
+            get_url("prefixed-redirect/"), HTTP_ACCEPT_LANGUAGE="en"
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], get_url("not-prefixed/"))
+
+    def test_template_view_still_redirects_to_language_prefix(self):
+        # /prefixed/ resolves (with language prefix) to a TemplateView, not a
+        # RedirectView. The middleware falls back to the normal language-prefix
+        # redirect so the browser ends up at the canonical URL.
+        response = self.client.get(get_url("prefixed/"), HTTP_ACCEPT_LANGUAGE="en")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], get_url("en/prefixed/"))
+
+    def test_redirect_view_one_shot_fr(self):
+        # Same as above but with French, confirming language detection still works.
+        response = self.client.get(
+            get_url("prefixed-redirect/"), HTTP_ACCEPT_LANGUAGE="fr-fr"
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], get_url("not-prefixed/"))
+
+    def test_redirect_view_one_shot_session_language(self):
+        session = self.client.session
+        session[translation.LANGUAGE_SESSION_KEY] = "fr-fr"
+        session.save()
+        response = self.client.get(get_url("prefixed-redirect/"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], get_url("not-prefixed/"))
+
+
+@override_settings(**settings_override_dict)
+class OneShotRedirectTests(OneShotRedirectTestsBase, URLTestCaseBase):
+    pass
+
+
+@override_settings(**prefixed_settings_override_dict)
+@override_option("Deployment", "URL_PATH_PREFIX", "test/")
+class PrefixedOneShotRedirectTests(OneShotRedirectTestsBase, URLTestCaseBase):
+    pass

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -5,7 +5,6 @@ from django.contrib.auth import logout
 from django.http import Http404
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
 from django.urls import is_valid_path
 from django.urls import reverse
 from django.urls import translate_url
@@ -15,6 +14,7 @@ from django.utils.translation import check_for_language
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.views.decorators.http import require_POST
+from django.views.generic.base import RedirectView
 from django.views.generic.base import TemplateView
 from django.views.generic.base import View
 from django.views.i18n import LANGUAGE_QUERY_PARAMETER
@@ -118,74 +118,80 @@ def get_url_by_role(role, full_facility_import=False, on_my_own_device=False):
         return obj.url
 
 
-class GuestRedirectView(View):
-    def get(self, request):
-        """
-        Redirects a guest user to a learner accessible page.
-        """
-        if allow_guest_access():
-            return HttpResponseRedirect(get_url_by_role(user_kinds.LEARNER))
-        return RootURLRedirectView.as_view()(request)
+class RootURLRedirectView(RedirectView):
+    permanent = False
 
-
-class RootURLRedirectView(View):
-    def get(self, request):
+    def get_redirect_url(self, *args, **kwargs):
         """
-        Redirects user based on the highest role they have for which a redirect is defined.
+        Returns the URL to redirect to based on the highest role the user has
+        for which a redirect is defined.
         """
         # If it has not been provisioned and we have something that can handle setup, redirect there.
         if not device_provisioned() and SetupHook.provision_url:
-            return redirect(SetupHook.provision_url())
+            return SetupHook.provision_url()
 
-        if request.user.is_authenticated:
+        if self.request.user.is_authenticated:
             url = None
-            if request.user.is_superuser:
+            if self.request.user.is_superuser:
                 url = url or get_url_by_role(
                     user_kinds.SUPERUSER,
-                    full_facility_import=request.user.full_facility_import,
-                    on_my_own_device=request.user.full_facility_on_my_own_setup,
+                    full_facility_import=self.request.user.full_facility_import,
+                    on_my_own_device=self.request.user.full_facility_on_my_own_setup,
                 )
             roles = set(
-                Role.objects.filter(user_id=request.user.id)
+                Role.objects.filter(user_id=self.request.user.id)
                 .values_list("kind", flat=True)
                 .distinct()
             )
             if user_kinds.ADMIN in roles:
                 url = url or get_url_by_role(
                     user_kinds.ADMIN,
-                    full_facility_import=request.user.full_facility_import,
-                    on_my_own_device=request.user.full_facility_on_my_own_setup,
+                    full_facility_import=self.request.user.full_facility_import,
+                    on_my_own_device=self.request.user.full_facility_on_my_own_setup,
                 )
             if user_kinds.COACH in roles or user_kinds.ASSIGNABLE_COACH in roles:
                 url = url or get_url_by_role(
                     user_kinds.COACH,
-                    full_facility_import=request.user.full_facility_import,
-                    on_my_own_device=request.user.full_facility_on_my_own_setup,
+                    full_facility_import=self.request.user.full_facility_import,
+                    on_my_own_device=self.request.user.full_facility_on_my_own_setup,
                 )
             url = url or get_url_by_role(
                 user_kinds.LEARNER,
-                full_facility_import=request.user.full_facility_import,
-                on_my_own_device=request.user.full_facility_on_my_own_setup,
+                full_facility_import=self.request.user.full_facility_import,
+                on_my_own_device=self.request.user.full_facility_on_my_own_setup,
             )
         else:
             url = get_url_by_role(user_kinds.ANONYMOUS)
         if url:
-            next_url = request.GET.get("next")
+            next_url = self.request.GET.get("next")
             if next_url:
                 # Step 2: Validate the next_url
                 if url_has_allowed_host_and_scheme(
                     next_url,
-                    allowed_hosts={request.get_host()},
-                    require_https=request.is_secure(),
+                    allowed_hosts={self.request.get_host()},
+                    require_https=self.request.is_secure(),
                 ):
                     # Step 3: Append next_url to the base url if it's valid
                     url = f"{url}?next={next_url}"
-            return HttpResponseRedirect(url)
+            return url
+
         raise Http404(
             _(
                 "No appropriate redirect pages found. It is likely that Kolibri is badly configured"
             )
         )
+
+
+class GuestRedirectView(RootURLRedirectView):
+    permanent = False
+
+    def get_redirect_url(self, *args, **kwargs):
+        """
+        Redirects a guest user to a learner accessible page.
+        """
+        if allow_guest_access():
+            return get_url_by_role(user_kinds.LEARNER)
+        return super().get_redirect_url(*args, **kwargs)
 
 
 @method_decorator(cache_no_user_data, name="dispatch")


### PR DESCRIPTION
## Summary
* Turns all our redirect views into Django RedirectViews
* Adds special handling of Django redirect views within the locale middleware to allow more immediate resolution of redirects to avoid two redirects in a row

## References
Fixes #14593

## Reviewer guidance
Go to the root of the server, see that it redirects in a single redirect, as here:

<img width="2484" height="976" alt="image" src="https://github.com/user-attachments/assets/16998832-0dd7-447e-8e84-26e2f9c78ed6" />

## AI usage

Claude Code web (Sonnet) did the initial implementation after some back and forth and discussion with me. I then copied the patch locally and reworked it to reduce code duplication, confirming that all the tests still passed, then manually tested to confirm the fix.