### PR TITLE
Update android installer version to v0.1.7.1

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -55,10 +55,10 @@ jobs:
   apk:
     name: Build APK file
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.7
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.7.1
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
-      ref: v0.1.7
+      ref: v0.1.7.1
   zip:
     name: Build Raspberry Pi Image
     needs: deb

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -119,11 +119,11 @@ jobs:
   apk:
     name: Build Android APK
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.7
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.7.1
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
       release: true
-      ref: v0.1.7
+      ref: v0.1.7.1
     secrets:
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE }}
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD }}
@@ -248,10 +248,10 @@ jobs:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}
     needs: [apk, block_release_step]
-    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.1.7
+    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.1.7.1
     with:
       version-code: ${{ needs.apk.outputs.version-code }}
-      ref: v0.1.7
+      ref: v0.1.7.1
     secrets:
       KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON: ${{ secrets.KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON }}
   container_image_publish:


### PR DESCRIPTION
## Summary

Update kolibri-installer-android references from v0.1.7 to v0.1.7.1 in CI workflows.

## Reviewer guidance

Straightforward version string replacement — verify the six references in `release_kolibri.yml` and `pr_build_kolibri.yml` all point to `v0.1.7.1`. Confirm the APK build succeeds in CI.

## AI usage

Used Claude Code to find and replace the version references across both workflow files.