### PR TITLE
Narrow npm publish triggers and add Slack notifications

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,7 +5,19 @@ on:
     branches:
       - develop
     paths:
-      - 'packages/**'
+      - 'packages/browserslist-config-kolibri/package.json'
+      - 'packages/eslint-plugin-kolibri/package.json'
+      - 'packages/kolibri/package.json'
+      - 'packages/kolibri-app/package.json'
+      - 'packages/kolibri-build/package.json'
+      - 'packages/kolibri-format/package.json'
+      - 'packages/kolibri-glob/package.json'
+      - 'packages/kolibri-i18n/package.json'
+      - 'packages/kolibri-jest-config/package.json'
+      - 'packages/kolibri-logging/package.json'
+      - 'packages/kolibri-module/package.json'
+      - 'packages/kolibri-plugin-data/package.json'
+      - 'packages/kolibri-viewer/package.json'
   workflow_dispatch:
     inputs:
       npm_package:
@@ -27,7 +39,6 @@ on:
           - 'kolibri-logging'
           - 'kolibri-module'
           - 'kolibri-plugin-data'
-          - 'kolibri-tools'
           - 'kolibri-viewer'
 
 jobs:
@@ -53,4 +64,8 @@ jobs:
           else
             ./scripts/npm_publish.sh
           fi
-          cat publish_summary.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f publish_summary.md ]; then
+            cat publish_summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No packages needed publishing — all versions match npm." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Link workspace packages
         run: pnpm install --ignore-scripts --no-optional
       - name: Publish to npm
+        id: publish
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.npm_package }}" != "all" ]; then
             ./scripts/npm_publish.sh "${{ github.event.inputs.npm_package }}"
@@ -66,6 +67,28 @@ jobs:
           fi
           if [ -f publish_summary.md ]; then
             cat publish_summary.md >> "$GITHUB_STEP_SUMMARY"
+            echo "published=true" >> "$GITHUB_OUTPUT"
           else
             echo "No packages needed publishing — all versions match npm." >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Build Slack message
+        if: steps.publish.outputs.published == 'true'
+        id: slack_message
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "text<<SLACKEOF"
+            echo ":package: *npm packages published* (<${run_url}|workflow run>)"
+            sed -n 's#^| *\[\([^]]*\)\](\([^)]*\)) *| *\([^ |]*\) *|$#• <\2|\1> v\3#p' publish_summary.md
+            echo "SLACKEOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Notify Slack
+        if: steps.publish.outputs.published == 'true'
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.SLACK_NPM_PACKAGES_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(steps.slack_message.outputs.text) }}
+            }


### PR DESCRIPTION
## Summary

Reduce noise from the npm publish workflow. The broad `packages/**` path filter was triggering on every file change under packages/, producing Slack notifications for no-op runs that then failed. Narrow the trigger to only `package.json` files of publishable (public, non-deprecated) packages, and add a Slack webhook notification that fires only on successful publishes with package/version details.

## References

- Slack notification pattern based on https://github.com/learningequality/.github/blob/main/.github/workflows/contributor-issue-comment.yml

## Reviewer guidance

- The `SLACK_NPM_PACKAGES_WEBHOOK` secret needs to be added to the repo before the Slack step will work
- Slack message parsing was tested locally against real and mock `publish_summary.md` output — links render as clickable package names

## AI usage

PR authored with Claude Code. Slack message parsing pipeline was tested locally against real and mock publish_summary.md output before committing.