### PR TITLE
Convert setup wizard step unit tests to Vue Testing Library

### DIFF
--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
@@ -5,9 +5,6 @@ import CreateLearnerAccountForm from '../onboarding-forms/CreateLearnerAccountFo
 
 function renderComponent(options) {
   const store = makeStore();
-  if (options.previousChoice !== undefined) {
-    store.commit('SET_LEARNER_CAN_SIGN_UP', options.previousChoice);
-  }
 
   render(CreateLearnerAccountForm, {
     store,

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js
@@ -1,13 +1,15 @@
-import { mount } from '@vue/test-utils';
+import { render, screen } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import makeStore from '../../__tests__/utils/makeStore';
 import CreateLearnerAccountForm from '../onboarding-forms/CreateLearnerAccountForm';
 
-function makeWrapper(options) {
+function renderComponent(options) {
   const store = makeStore();
   if (options.previousChoice !== undefined) {
     store.commit('SET_LEARNER_CAN_SIGN_UP', options.previousChoice);
   }
-  const wrapper = mount(CreateLearnerAccountForm, {
+
+  render(CreateLearnerAccountForm, {
     store,
     provide: {
       wizardService: {
@@ -20,19 +22,28 @@ function makeWrapper(options) {
       },
     },
   });
-  jest.spyOn(wrapper.vm, '$emit');
-
-  return { wrapper, store };
 }
 
 describe('CreateLearnerAccountForm', () => {
-  it('has the correct default with "nonformal" preset', () => {
-    const { wrapper } = makeWrapper({ preset: 'nonformal' });
-    expect(wrapper.vm.setting).toEqual(true);
+  it('defaults to allowing learners to join for a nonformal facility', () => {
+    renderComponent({ preset: 'nonformal' });
+
+    expect(screen.getByRole('radio', { name: /yes/i })).toBeChecked();
+    expect(
+      screen.getByRole('radio', {
+        name: /no\. admins must create an account for them to join this facility/i,
+      }),
+    ).not.toBeChecked();
   });
 
-  it('has the correct default with "formal" preset', () => {
-    const { wrapper } = makeWrapper({ preset: 'formal' });
-    expect(wrapper.vm.setting).toEqual(false);
+  it('defaults to requiring admins to create learner accounts for a formal facility', () => {
+    renderComponent({ preset: 'formal' });
+
+    expect(screen.getByRole('radio', { name: /yes/i })).not.toBeChecked();
+    expect(
+      screen.getByRole('radio', {
+        name: /no\. admins must create an account for them to join this facility/i,
+      }),
+    ).toBeChecked();
   });
 });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
@@ -1,22 +1,54 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
+import '@testing-library/jest-dom';
 import PersonalDataConsentForm from '../onboarding-forms/PersonalDataConsentForm';
 
-function makeWrapper() {
-  const wrapper = mount(PersonalDataConsentForm);
-  return { wrapper };
+function renderComponent() {
+  render(PersonalDataConsentForm, {
+    baseElement: document.body,
+    provide: {
+      wizardService: {
+        state: {
+          context: {},
+        },
+      },
+    },
+  });
 }
 
 describe('PersonalDataConsentForm', () => {
-  it('the PrivacyInfoModal is hidden by default', () => {
-    const { wrapper } = makeWrapper();
-    expect(wrapper.findComponent({ name: 'PrivacyInfoModal' }).exists()).toBeFalsy();
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
-  it('the "View statement" opens the statement', async () => {
-    const { wrapper } = makeWrapper();
-    await wrapper.find("[data-testid='modal-open-button']").vm.$emit('click');
-    expect(wrapper.findComponent({ name: 'PrivacyInfoModal' }).exists()).toBe(true);
 
-    await wrapper.findComponent({ name: 'PrivacyInfoModal' }).vm.$emit('cancel');
-    expect(wrapper.findComponent({ name: 'PrivacyInfoModal' }).exists()).toBeFalsy();
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not show the privacy statement modal on initial render', () => {
+    renderComponent();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the privacy statement modal when the user clicks "Usage and privacy"', async () => {
+    renderComponent();
+    fireEvent.click(screen.getByTestId('modal-open-button'));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('closes the privacy statement modal when the user clicks "Close"', async () => {
+    renderComponent();
+    fireEvent.click(screen.getByTestId('modal-open-button'));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    jest.runAllTimers();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js
@@ -1,10 +1,14 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import PersonalDataConsentForm from '../onboarding-forms/PersonalDataConsentForm';
+import { FooterMessageTypes } from '../../constants';
 
 function renderComponent() {
   render(PersonalDataConsentForm, {
     baseElement: document.body,
+    props: {
+      footerMessageType: FooterMessageTypes.NEW_FACILITY,
+    },
     provide: {
       wizardService: {
         state: {
@@ -16,15 +20,6 @@ function renderComponent() {
 }
 
 describe('PersonalDataConsentForm', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   it('does not show the privacy statement modal on initial render', () => {
     renderComponent();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -32,7 +27,7 @@ describe('PersonalDataConsentForm', () => {
 
   it('opens the privacy statement modal when the user clicks "Usage and privacy"', async () => {
     renderComponent();
-    fireEvent.click(screen.getByTestId('modal-open-button'));
+    fireEvent.click(screen.getByText(/usage and privacy/i));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
@@ -40,13 +35,12 @@ describe('PersonalDataConsentForm', () => {
 
   it('closes the privacy statement modal when the user clicks "Close"', async () => {
     renderComponent();
-    fireEvent.click(screen.getByTestId('modal-open-button'));
+    fireEvent.click(screen.getByText(/usage and privacy/i));
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
-    jest.runAllTimers();
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
@@ -1,43 +1,49 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/vue';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import makeStore from '../../__tests__/utils/makeStore';
 import UserCredentialsForm from '../onboarding-forms/UserCredentialsForm';
 
-function makeWrapper() {
+function renderComponent() {
   const store = makeStore();
-  const wrapper = mount(UserCredentialsForm, {
+  const send = jest.fn();
+
+  render(UserCredentialsForm, {
     store,
-    // These need to be stubbed because of some mysterious errors
-    stubs: ['FullNameTextbox', 'UsernameTextbox'],
+    provide: {
+      wizardService: {
+        send,
+        state: {
+          context: {},
+        },
+      },
+    },
   });
-  jest.spyOn(wrapper.vm, '$emit');
-  const actions = {
-    simulateSubmit: () => wrapper.findComponent({ name: 'OnboardingForm' }).vm.$emit('submit'),
-  };
-  return { store, wrapper, actions };
+
+  return { send, store };
 }
 
-describe.skip('UserCredentialsForm', () => {
-  it('clicking submit updates vuex with correct data', async () => {
-    const { store, wrapper, actions } = makeWrapper();
-    wrapper.setData({
-      fullName: 'Schoolhouse Rock',
-      fullNameValid: true,
-      username: 'schoolhouse_rock',
-      usernameValid: true,
-      password: 'password',
-      passwordValid: true,
-    });
-    actions.simulateSubmit();
-    await wrapper.vm.$nextTick();
+describe('UserCredentialsForm', () => {
+  it('saves the entered super admin details when the user continues', async () => {
+    const { send, store } = renderComponent();
+
+    await userEvent.type(screen.getByLabelText(/full name/i), 'Schoolhouse Rock');
+    await userEvent.type(screen.getByLabelText(/^username$/i), 'schoolhouse_rock');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password');
+    await userEvent.type(screen.getByLabelText(/re-enter password/i), 'password');
+
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+
     expect(store.state.onboardingData.user).toEqual({
       full_name: 'Schoolhouse Rock',
       username: 'schoolhouse_rock',
       password: 'password',
     });
-    expect(wrapper.vm.$emit).toHaveBeenCalledWith('click_next', {
-      full_name: 'Schoolhouse Rock',
-      username: 'schoolhouse_rock',
-      password: 'password',
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledWith({
+        type: 'CONTINUE',
+        value: store.state.onboardingData.user,
+      });
     });
   });
 });

--- a/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js
@@ -24,7 +24,7 @@ function renderComponent() {
 }
 
 describe('UserCredentialsForm', () => {
-  it('saves the entered super admin details when the user continues', async () => {
+  it('saves the entered admin details when the user continues', async () => {
     const { send, store } = renderComponent();
 
     await userEvent.type(screen.getByLabelText(/full name/i), 'Schoolhouse Rock');


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
The current test suites for individual setup wizard form components (`CreateLearnerAccountForm.spec.js`, `PersonalDataConsentForm.spec.js`, `UserCredentialsForm.spec.js`) currently use `@vue/test-utils`. I have refactored  these test files to use Vue Testing Library (VTL) and write tests in a way that reflect how a user interacts.

#### Verification
<img width="820" height="231" alt="image" src="https://github.com/user-attachments/assets/0095ee55-9f4f-4ad4-ac86-cc0f138db1a3" />

## References
<!--
 * references to related issues and PRs
-->
closes #14193 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
The changes are reflected in the locations:
- `kolibri/plugins/setup_wizard/frontend/views/__tests__/CreateLearnerAccountForm.spec.js`
- `kolibri/plugins/setup_wizard/frontend/views/__tests__/PersonalDataConsentForm.spec.js`
- `kolibri/plugins/setup_wizard/frontend/views/__tests__/UserCredentialsForm.spec.js`

The `setup_wizard` test suites can be executed using the command ( `pnpm run test-jest -- --testPathPattern setup_wizard` )
<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."
-->

## AI usage
- I hand coded the `CreateLearnerAccountForm` and `UserCredentialsForm` test files during the migration. I did manual verification, and to ensure the code is consistent, I used Claude but no significant changes were made.
- I used Claude to implement the `PersonalDataConsentForm` test migration, prompting it to resolve the error I was encountering. I reviewed the generated code, removed unnecessary error handling, and verified the tests pass.