### PR TITLE
Implement full icon display and print functionality for AllPasswordsPage

### DIFF
--- a/kolibri/plugins/coach/frontend/views/learners/LearnerSummaryPage/__tests__/LearnerHeader.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/LearnerSummaryPage/__tests__/LearnerHeader.spec.js
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
 import VueRouter from 'vue-router';
 import router from 'kolibri/router';
-import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import { coreString } from 'kolibri/uiText/commonCoreStrings';
 import makeStore from '../../../../__tests__/utils/makeStore';
 import LearnerHeader from '../LearnerHeader.vue';
@@ -10,8 +9,6 @@ import LearnerHeader from '../LearnerHeader.vue';
 jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../../composables/fetchClassSyncStatus');
-
-const { picturePassword$ } = picturePasswordStrings;
 
 const LEARNER_ID = 'learner-1';
 const PICTURE_PASSWORD = '3.7.12';
@@ -60,30 +57,29 @@ describe('LearnerHeader', () => {
     });
 
     it('renders the password row with an empty placeholder when the learner has no picture_password', () => {
-      renderComponent({
+      const { container } = renderComponent({
         picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
         picturePassword: null,
       });
       expect(screen.getByText(coreString('passwordLabel'))).toBeInTheDocument();
-      expect(screen.queryByRole('list', { name: picturePassword$() })).not.toBeInTheDocument();
+      expect(container.querySelector('.picture-password-wrapper')).not.toBeInTheDocument();
     });
 
     it('renders the password row with icons when both picture_password_settings and picture_password are set', () => {
-      renderComponent({
+      const { container } = renderComponent({
         picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
         picturePassword: PICTURE_PASSWORD,
       });
       expect(screen.getByText(coreString('passwordLabel'))).toBeInTheDocument();
-      expect(screen.getByRole('list', { name: picturePassword$() })).toBeInTheDocument();
+      expect(container.querySelector('.picture-password-wrapper')).toBeInTheDocument();
     });
 
     it('renders colorful icon names when icon_style is colorful', () => {
-      renderComponent({
+      const { container } = renderComponent({
         picturePasswordSettings: { icon_style: 'colorful', show_icon_text: false },
         picturePassword: PICTURE_PASSWORD,
       });
-      const passwordList = screen.getByRole('list', { name: picturePassword$() });
-      const icons = [...passwordList.querySelectorAll('[data-testid^="picture-password-icon-"]')];
+      const icons = [...container.querySelectorAll('[data-testid^="picture-password-icon-"]')];
       expect(icons.map(el => el.getAttribute('data-testid'))).toEqual([
         'picture-password-icon-moonColorful',
         'picture-password-icon-waterColorful',
@@ -92,12 +88,11 @@ describe('LearnerHeader', () => {
     });
 
     it('renders standard icon names when icon_style is standard', () => {
-      renderComponent({
+      const { container } = renderComponent({
         picturePasswordSettings: { icon_style: 'standard', show_icon_text: false },
         picturePassword: PICTURE_PASSWORD,
       });
-      const passwordList = screen.getByRole('list', { name: picturePassword$() });
-      const icons = [...passwordList.querySelectorAll('[data-testid^="picture-password-icon-"]')];
+      const icons = [...container.querySelectorAll('[data-testid^="picture-password-icon-"]')];
       expect(icons.map(el => el.getAttribute('data-testid'))).toEqual([
         'picture-password-icon-moonStandard',
         'picture-password-icon-waterStandard',

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -111,7 +111,7 @@
     <!-- Print format selection dialog -->
     <KModal
       v-if="showPrintDialog"
-      :title="printFormatDialogHeader$()"
+      :title="printPasswordsDialogHeader$()"
       :submitText="continueAction$()"
       :cancelText="cancelAction$()"
       @submit="handlePrintSubmit"
@@ -211,7 +211,7 @@
         allPasswordsHeader$,
         printWithImages$,
         printWithTextOnly$,
-        printFormatDialogHeader$,
+        printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
       } = picturePasswordStrings;
 
@@ -295,7 +295,7 @@
         allPasswordsHeader$,
         printWithImages$,
         printWithTextOnly$,
-        printFormatDialogHeader$,
+        printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
       };
     },
@@ -372,6 +372,7 @@
   }
 
   .learner-name {
+    padding-bottom: 4px;
     font-size: 16px;
   }
 

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -167,6 +167,7 @@
               <UserPicturePassword
                 v-else
                 :picturePassword="previewLearner.picture_password"
+                :showCounts="true"
               />
             </div>
           </div>
@@ -378,7 +379,7 @@
   .no-password-info {
     display: flex;
     flex-direction: column;
-    max-width: 196px;
+    max-width: 165px;
     padding-left: 8px;
   }
 

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -226,8 +226,7 @@
       const sortOrder = ref(null);
 
       const sortedLearners = computed(() => {
-        if (!sortOrder.value) return learners.value;
-        return orderBy(learners.value, ['full_name'], [sortOrder.value]);
+        return orderBy(learners.value, ['full_name'], [sortOrder.value || 'asc']);
       });
 
       const tableHeaders = computed(() => [

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -1,12 +1,13 @@
 <template>
 
   <ImmersivePage
-    :appBarTitle="allPasswordsHeader$()"
+    :appBarTitle="!$isPrint ? allPasswordsHeader$() : ''"
     :route="route"
     :primary="false"
   >
     <KPageContainer>
-      <KGrid>
+      <!-- Screen-only header with Print button -->
+      <KGrid v-show="!$isPrint">
         <KGridItem
           :layout12="{ span: 6, alignment: 'left' }"
           :layout8="{ span: 4, alignment: 'left' }"
@@ -16,21 +17,35 @@
           <h1 class="header-title">{{ allPasswordsHeader$() }}</h1>
         </KGridItem>
         <KGridItem
+          v-if="!isAppContext"
           :layout12="{ span: 6, alignment: 'right' }"
           :layout8="{ span: 4, alignment: 'right' }"
           :layout4="{ span: 2, alignment: 'right' }"
           class="header-row print-button"
         >
-          <KButton :text="printAction$()" />
+          <KButton
+            :text="printAction$()"
+            :disabled="!hasPicturePasswords"
+            @click="openPrintDialog"
+          />
         </KGridItem>
       </KGrid>
+
+      <!-- Print-only header with facility and class name -->
+      <div
+        v-if="$isPrint"
+        class="print-header"
+      >
+        <h4 class="print-facility-class">{{ currentFacilityName }} - {{ className }}</h4>
+      </div>
+
       <CoreTable
         :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
-        :selectable="true"
       >
         <template #headers>
           <th
+            v-show="!$isPrint"
             class="table-header"
             :style="{ color: $themeTokens.text }"
           >
@@ -43,8 +58,11 @@
               v-for="learner in learners"
               :key="learner.id"
             >
-              <td :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }">
-                <div class="learner-row">
+              <td :style="tdStyle">
+                <div
+                  class="learner-row"
+                  :style="learnerRowStyle"
+                >
                   <div class="learner-info">
                     <span
                       dir="auto"
@@ -59,7 +77,34 @@
                   </div>
                   <div class="learner-password">
                     <template v-if="learner.picture_password">
-                      {{ resolvePicturePassword(learner.picture_password) }}
+                      <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
+                      <div
+                        v-if="$isPrint && printFormat === 'text'"
+                        class="password-text-sequence"
+                      >
+                        {{ getPasswordTextLabels(learner.picture_password) }}
+                      </div>
+                      <!-- Images: icon sequence with labels -->
+                      <div
+                        v-else
+                        class="password-icon-sequence"
+                      >
+                        <div
+                          v-for="(icon, index) in getPasswordIcons(learner.picture_password)"
+                          :key="index"
+                          class="password-icon-item"
+                        >
+                          <KIcon
+                            :icon="icon.iconName"
+                            :aria-label="icon.label"
+                            class="password-icon"
+                          />
+                          <span
+                            class="password-icon-label"
+                            :style="{ color: $themeTokens.annotation }"
+                          >{{ icon.label }}</span>
+                        </div>
+                      </div>
                     </template>
                     <div
                       v-else
@@ -68,15 +113,11 @@
                       <span
                         class="no-password-title"
                         :style="{ color: $themeTokens.text }"
-                      >
-                        {{ noPicturePasswordDescription$() }}
-                      </span>
+                      >{{ noPicturePasswordDescription$() }}</span>
                       <span
                         class="no-password-subtitle"
                         :style="{ color: $themeTokens.annotation }"
-                      >
-                        {{ noPasswordSignInDescription$() }}
-                      </span>
+                      >{{ noPasswordSignInDescription$() }}</span>
                     </div>
                   </div>
                 </div>
@@ -86,6 +127,88 @@
         </template>
       </CoreTable>
     </KPageContainer>
+
+    <!-- Print format selection dialog -->
+    <KModal
+      v-if="showPrintDialog"
+      :title="printFormatDialogHeader$()"
+      :submitText="continueAction$()"
+      :cancelText="cancelAction$()"
+      @submit="handlePrintSubmit"
+      @cancel="closePrintDialog"
+    >
+      <KRadioButtonGroup>
+        <KRadioButton
+          v-model="printFormat"
+          :label="printWithImages$()"
+          buttonValue="images"
+        />
+        <KRadioButton
+          v-model="printFormat"
+          :label="printWithTextOnly$()"
+          buttonValue="text"
+        />
+      </KRadioButtonGroup>
+
+      <!-- Live preview for example learner -->
+      <div
+        v-if="previewLearner"
+        class="preview-section"
+      >
+        <div class="preview-label">{{ printFormatPreviewLabel$() }}</div>
+        <div
+          class="preview-content"
+          :style="previewContentStyle"
+        >
+          <div class="preview-row">
+            <div class="learner-info">
+              <span
+                dir="auto"
+                class="learner-name"
+                :style="{ color: $themeTokens.text }"
+              >{{ previewLearner.full_name }}</span>
+              <span
+                dir="auto"
+                class="learner-username"
+                :style="{ color: $themeTokens.annotation }"
+              >{{ previewLearner.username }}</span>
+            </div>
+            <div class="learner-password">
+              <div
+                v-if="printFormat === 'text'"
+                class="password-text-sequence"
+              >
+                {{ getPasswordTextLabels(previewLearner.picture_password) }}
+              </div>
+              <div
+                v-else
+                class="password-icon-sequence"
+              >
+                <div
+                  v-for="(icon, index) in getPasswordIcons(previewLearner.picture_password)"
+                  :key="index"
+                  class="password-icon-item"
+                >
+                  <KIcon
+                    :icon="icon.iconName"
+                    :aria-label="icon.label"
+                    class="password-icon"
+                  />
+                  <span
+                    class="password-icon-label"
+                    :style="{ color: $themeTokens.annotation }"
+                  >{{ icon.label }}</span>
+                  <span
+                    class="password-icon-number"
+                    :style="{ color: $themeTokens.annotation }"
+                  >{{ index + 1 }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </KModal>
   </ImmersivePage>
 
 </template>
@@ -93,13 +216,16 @@
 
 <script>
 
-  import { ref, onMounted } from 'vue';
+  import { ref, computed, onMounted } from 'vue';
   import CoreTable from 'kolibri/components/CoreTable';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+  import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
   import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
+  import useUser from 'kolibri/composables/useUser';
+  import useFacility from 'kolibri-common/composables/useFacility';
 
   export default {
     name: 'AllPasswordsPage',
@@ -107,45 +233,101 @@
     setup(props) {
       const learners = ref([]);
       const loading = ref(true);
+      const showPrintDialog = ref(false);
+      const printFormat = ref('images');
+      const className = ref('');
 
-      const { nameLabel$ } = coreStrings;
+      const { isAppContext } = useUser();
+      const { currentFacilityName, facilityConfig } = useFacility();
+
+      const { nameLabel$, cancelAction$, continueAction$ } = coreStrings;
       const {
+        noLearnersInClass$,
         noPicturePasswordDescription$,
         noPasswordSignInDescription$,
-        noLearnersInClass$,
         printAction$,
         allPasswordsHeader$,
+        printWithImages$,
+        printWithTextOnly$,
+        printFormatDialogHeader$,
+        printFormatPreviewLabel$,
       } = picturePasswordStrings;
 
+      const iconStyle = computed(() => facilityConfig.value.picture_password_settings.icon_style);
+
+      const previewLearner = computed(() => {
+        return learners.value.find(learner => learner.picture_password) || null;
+      });
+
+      const hasPicturePasswords = computed(() => {
+        return Boolean(previewLearner.value);
+      });
+
       onMounted(() => {
-        FacilityUserResource.fetchCollection({
-          getParams: { member_of: props.classId },
-          force: true,
-        })
-          .then(data => {
-            learners.value = data;
+        Promise.all([
+          FacilityUserResource.fetchCollection({
+            getParams: { member_of: props.classId },
+            force: true,
+          }),
+          ClassroomResource.fetchModel({ id: props.classId }),
+        ])
+          .then(([users, classroom]) => {
+            learners.value = users;
+            className.value = classroom.name;
           })
           .finally(() => {
             loading.value = false;
           });
       });
 
-      function resolvePicturePassword(picturePassword) {
+      function getPasswordIcons(picturePassword) {
+        const style = iconStyle.value;
+        return getPicturePasswordIcons(picturePassword, style).map(icon => ({
+          label: icon.label,
+          iconName: style === 'colorful' ? icon.iconColorful : icon.iconStandard,
+        }));
+      }
+
+      function getPasswordTextLabels(picturePassword) {
         return getPicturePasswordIcons(picturePassword)
           .map(icon => icon.label)
-          .join(', ');
+          .join(' - ');
+      }
+
+      function openPrintDialog() {
+        showPrintDialog.value = true;
+      }
+
+      function closePrintDialog() {
+        showPrintDialog.value = false;
       }
 
       return {
         learners,
         loading,
-        resolvePicturePassword,
+        showPrintDialog,
+        printFormat,
+        className,
+        isAppContext,
+        currentFacilityName,
+        previewLearner,
+        hasPicturePasswords,
+        getPasswordIcons,
+        getPasswordTextLabels,
+        openPrintDialog,
+        closePrintDialog,
         nameLabel$,
+        cancelAction$,
+        continueAction$,
+        noLearnersInClass$,
         noPicturePasswordDescription$,
         noPasswordSignInDescription$,
-        noLearnersInClass$,
         printAction$,
         allPasswordsHeader$,
+        printWithImages$,
+        printWithTextOnly$,
+        printFormatDialogHeader$,
+        printFormatPreviewLabel$,
       };
     },
     props: {
@@ -156,6 +338,36 @@
       route: {
         type: Object,
         default: null,
+      },
+    },
+    computed: {
+      tdStyle() {
+        if (this.$isPrint && this.printFormat === 'images') return {};
+        if (this.$isPrint) return { borderBottom: `2px solid ${this.$themeTokens.fineLine}` };
+        return { borderTop: `2px solid ${this.$themeTokens.fineLine}` };
+      },
+      learnerRowStyle() {
+        if (!(this.$isPrint && this.printFormat === 'images')) return {};
+        return {
+          backgroundColor: this.$themePalette.grey.v_100,
+          border: `3px solid ${this.$themeTokens.fineLine}`,
+          borderRadius: '8px',
+          padding: '8px',
+          WebkitPrintColorAdjust: 'exact',
+          printColorAdjust: 'exact',
+        };
+      },
+      previewContentStyle() {
+        return {
+          backgroundColor: this.$themePalette.grey.v_100,
+          borderColor: this.$themeTokens.fineLine,
+        };
+      },
+    },
+    methods: {
+      handlePrintSubmit() {
+        this.closePrintDialog();
+        this.$print();
       },
     },
   };
@@ -190,14 +402,11 @@
     align-items: center;
     justify-content: space-between;
     min-height: 48px;
-    padding: 8px 0;
   }
 
-  .learner-info,
-  .no-password-info {
+  .learner-info {
     display: flex;
     flex-direction: column;
-    padding: 4px;
   }
 
   .learner-name {
@@ -209,7 +418,14 @@
   }
 
   .learner-password {
-    text-align: right;
+    text-align: left;
+  }
+
+  .no-password-info {
+    display: flex;
+    flex-direction: column;
+    max-width: 196px;
+    padding-left: 8px;
   }
 
   .no-password-title {
@@ -218,6 +434,97 @@
 
   .no-password-subtitle {
     font-size: 12px;
+  }
+
+  .password-icon-sequence {
+    display: flex;
+    gap: 16px;
+  }
+
+  .password-text-sequence {
+    font-size: 16px;
+  }
+
+  .password-icon-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .password-icon {
+    font-size: 48px;
+  }
+
+  .password-icon-label {
+    font-size: 12px;
+    text-align: center;
+  }
+
+  .password-icon-number {
+    font-size: 11px;
+    text-align: center;
+  }
+
+  .preview-section {
+    margin-top: 16px;
+  }
+
+  .preview-label {
+    margin-bottom: 8px;
+    font-size: 14px;
+    font-weight: bold;
+  }
+
+  .preview-content {
+    padding: 12px;
+    border: 2px solid;
+    border-radius: 8px;
+  }
+
+  .preview-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .print-header {
+    display: none;
+    padding: 2px;
+  }
+
+  @media print {
+    .print-header {
+      display: block;
+    }
+
+    .print-facility-class {
+      margin: 0 0 16px;
+      font-size: 20px;
+    }
+
+    table {
+      width: 100%;
+
+      thead th:first-child,
+      tr td:first-child {
+        padding-left: 0;
+      }
+
+      thead th:last-child,
+      tr td:last-child {
+        padding-right: 0;
+      }
+
+      tr td {
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+
+      tr {
+        page-break-inside: avoid;
+      }
+    }
   }
 
 </style>

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -85,26 +85,10 @@
                         {{ getPasswordTextLabels(learner.picture_password) }}
                       </div>
                       <!-- Images: icon sequence with labels -->
-                      <div
+                      <UserPicturePassword
                         v-else
-                        class="password-icon-sequence"
-                      >
-                        <div
-                          v-for="(icon, index) in getPasswordIcons(learner.picture_password)"
-                          :key="index"
-                          class="password-icon-item"
-                        >
-                          <KIcon
-                            :icon="icon.iconName"
-                            :aria-label="icon.label"
-                            class="password-icon"
-                          />
-                          <span
-                            class="password-icon-label"
-                            :style="{ color: $themeTokens.annotation }"
-                          >{{ icon.label }}</span>
-                        </div>
-                      </div>
+                        :picturePassword="learner.picture_password"
+                      />
                     </template>
                     <div
                       v-else
@@ -180,30 +164,10 @@
               >
                 {{ getPasswordTextLabels(previewLearner.picture_password) }}
               </div>
-              <div
+              <UserPicturePassword
                 v-else
-                class="password-icon-sequence"
-              >
-                <div
-                  v-for="(icon, index) in getPasswordIcons(previewLearner.picture_password)"
-                  :key="index"
-                  class="password-icon-item"
-                >
-                  <KIcon
-                    :icon="icon.iconName"
-                    :aria-label="icon.label"
-                    class="password-icon"
-                  />
-                  <span
-                    class="password-icon-label"
-                    :style="{ color: $themeTokens.annotation }"
-                  >{{ icon.label }}</span>
-                  <span
-                    class="password-icon-number"
-                    :style="{ color: $themeTokens.annotation }"
-                  >{{ index + 1 }}</span>
-                </div>
-              </div>
+                :picturePassword="previewLearner.picture_password"
+              />
             </div>
           </div>
         </div>
@@ -224,12 +188,13 @@
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
+  import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
   import useUser from 'kolibri/composables/useUser';
   import useFacility from 'kolibri-common/composables/useFacility';
 
   export default {
     name: 'AllPasswordsPage',
-    components: { CoreTable, ImmersivePage },
+    components: { CoreTable, ImmersivePage, UserPicturePassword },
     setup(props) {
       const learners = ref([]);
       const loading = ref(true);
@@ -238,7 +203,7 @@
       const className = ref('');
 
       const { isAppContext } = useUser();
-      const { currentFacilityName, facilityConfig } = useFacility();
+      const { currentFacilityName } = useFacility();
 
       const { nameLabel$, cancelAction$, continueAction$ } = coreStrings;
       const {
@@ -252,8 +217,6 @@
         printFormatDialogHeader$,
         printFormatPreviewLabel$,
       } = picturePasswordStrings;
-
-      const iconStyle = computed(() => facilityConfig.value.picture_password_settings.icon_style);
 
       const previewLearner = computed(() => {
         return learners.value.find(learner => learner.picture_password) || null;
@@ -280,14 +243,6 @@
           });
       });
 
-      function getPasswordIcons(picturePassword) {
-        const style = iconStyle.value;
-        return getPicturePasswordIcons(picturePassword, style).map(icon => ({
-          label: icon.label,
-          iconName: style === 'colorful' ? icon.iconColorful : icon.iconStandard,
-        }));
-      }
-
       function getPasswordTextLabels(picturePassword) {
         return getPicturePasswordIcons(picturePassword)
           .map(icon => icon.label)
@@ -312,7 +267,6 @@
         currentFacilityName,
         previewLearner,
         hasPicturePasswords,
-        getPasswordIcons,
         getPasswordTextLabels,
         openPrintDialog,
         closePrintDialog,
@@ -436,34 +390,8 @@
     font-size: 12px;
   }
 
-  .password-icon-sequence {
-    display: flex;
-    gap: 16px;
-  }
-
   .password-text-sequence {
     font-size: 16px;
-  }
-
-  .password-icon-item {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    align-items: center;
-  }
-
-  .password-icon {
-    font-size: 48px;
-  }
-
-  .password-icon-label {
-    font-size: 12px;
-    text-align: center;
-  }
-
-  .password-icon-number {
-    font-size: 11px;
-    text-align: center;
   }
 
   .preview-section {

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -1,11 +1,12 @@
 <template>
 
   <ImmersivePage
-    :appBarTitle="!$isPrint ? allPasswordsHeader$() : ''"
+    :appBarTitle="allPasswordsHeader$()"
     :route="route"
     :primary="false"
+    :showHeader="!$isPrint"
   >
-    <KPageContainer>
+    <KPageContainer :class="{ 'passwords-page-container': !$isPrint }">
       <!-- Screen-only header with Print button -->
       <KGrid v-show="!$isPrint">
         <KGridItem
@@ -85,6 +86,7 @@
                 <UserPicturePassword
                   v-else
                   :picturePassword="content.picture_password"
+                  :showSequenceNumbers="$isPrint"
                 />
               </template>
               <div
@@ -311,7 +313,7 @@
           backgroundColor: this.$themePalette.grey.v_100,
           border: `3px solid ${this.$themeTokens.fineLine}`,
           borderRadius: '8px',
-          padding: '8px',
+          padding: '8px 16px',
         };
       },
       previewContentStyle() {
@@ -333,6 +335,10 @@
 
 
 <style lang="scss" scoped>
+
+  .passwords-page-container {
+    margin: 80px 175px 72px;
+  }
 
   .header-row {
     display: flex;

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -6,7 +6,7 @@
     :primary="false"
     :showHeader="!$isPrint"
   >
-    <KPageContainer :class="{ 'passwords-page-container': !$isPrint }">
+    <KPageContainer :class="{ 'passwords-page-container': !$isPrint && windowBreakpoint > 4 }">
       <!-- Screen-only header with Print button -->
       <KGrid v-show="!$isPrint">
         <KGridItem
@@ -187,6 +187,7 @@
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
   import useFacility from 'kolibri-common/composables/useFacility';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   export default {
     name: 'AllPasswordsPage',
@@ -199,6 +200,7 @@
       const className = ref('');
 
       const { currentFacilityName } = useFacility();
+      const { windowBreakpoint } = useKResponsiveWindow();
 
       const { nameLabel$, cancelAction$, continueAction$ } = coreStrings;
       const {
@@ -275,6 +277,7 @@
         printFormat,
         className,
         currentFacilityName,
+        windowBreakpoint,
         previewLearner,
         hasPicturePasswords,
         tableHeaders,

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -167,7 +167,7 @@
               <UserPicturePassword
                 v-else
                 :picturePassword="previewLearner.picture_password"
-                :showCounts="true"
+                :showSequenceNumbers="true"
               />
             </div>
           </div>

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -78,6 +78,7 @@
                 <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
                 <div
                   v-if="$isPrint && printFormat === 'text'"
+                  dir="ltr"
                   class="password-text-sequence"
                 >
                   {{ getPasswordTextLabels(content.picture_password) }}
@@ -155,6 +156,7 @@
           <div class="learner-password">
             <div
               v-if="printFormat === 'text'"
+              dir="ltr"
               class="password-text-sequence"
             >
               {{ getPasswordTextLabels(previewLearner.picture_password) }}

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -161,6 +161,18 @@
 
   export default {
     name: 'AllPasswordsPage',
+    metaInfo() {
+      return {
+        title: [
+          this.allPasswordsHeader$(),
+          this.className,
+          this.currentFacilityName,
+          this.kolibriLabel$(),
+        ]
+          .filter(Boolean)
+          .join(' - '),
+      };
+    },
     components: { ImmersivePage, UserPicturePassword, NoPasswordInfo, LearnerPasswordCard },
     setup(props) {
       const learners = ref([]);
@@ -172,8 +184,14 @@
       const { currentFacilityName } = useFacility();
       const { windowBreakpoint } = useKResponsiveWindow();
 
-      const { nameLabel$, usernameLabel$, passwordLabel$, cancelAction$, continueAction$ } =
-        coreStrings;
+      const {
+        nameLabel$,
+        usernameLabel$,
+        passwordLabel$,
+        cancelAction$,
+        continueAction$,
+        kolibriLabel$,
+      } = coreStrings;
       const {
         noLearnersInClass$,
         printAction$,
@@ -272,6 +290,7 @@
         printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
         picturePasswordSequenceForLearner$,
+        kolibriLabel$,
       };
     },
     props: {

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -329,7 +329,7 @@
     methods: {
       handlePrintSubmit() {
         this.closePrintDialog();
-        this.$print();
+        this.$nextTick(() => this.$print());
       },
     },
   };

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -42,9 +42,8 @@
         :caption="allPasswordsHeader$()"
         :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
+        :defaultSort="{ columnId: 'full_name', direction: 'asc' }"
         sortable
-        disableBuiltinSorting
-        @changeSort="handleSortChange"
       >
         <template #header="{ header }">
           <span>
@@ -53,19 +52,7 @@
         </template>
         <template #cell="{ content, colIndex }">
           <span
-            v-if="colIndex === 0"
-            dir="auto"
-            :style="{ color: $themeTokens.text }"
-          >{{ content.full_name }}</span>
-
-          <span
-            v-else-if="colIndex === 1"
-            dir="auto"
-            :style="{ color: $themeTokens.annotation }"
-          >{{ content.username }}</span>
-
-          <div
-            v-else
+            v-if="colIndex === 2"
             dir="ltr"
           >
             <!-- Offsets icon's internal left padding to align with cell edge -->
@@ -76,7 +63,8 @@
               :style="{ marginLeft: '-6px' }"
             />
             <NoPasswordInfo v-else />
-          </div>
+          </span>
+          <span v-else>{{ content }}</span>
         </template>
       </KTable>
 
@@ -87,11 +75,11 @@
       >
         <!-- Print-only header with facility and class name -->
         <div class="print-header">
-          <h4 class="print-facility-class">{{ currentFacilityName }} - {{ className }}</h4>
+          <h4 class="print-facility-class">{{ pageTitle }}</h4>
         </div>
 
         <LearnerPasswordCard
-          v-for="learner in sortedLearners"
+          v-for="learner in printLearners"
           :key="learner.id"
           :learner="learner"
           :cardStyle="printListCardStyle"
@@ -162,16 +150,7 @@
   export default {
     name: 'AllPasswordsPage',
     metaInfo() {
-      return {
-        title: [
-          this.allPasswordsHeader$(),
-          this.className,
-          this.currentFacilityName,
-          this.kolibriLabel$(),
-        ]
-          .filter(Boolean)
-          .join(' - '),
-      };
+      return { title: this.pageTitle };
     },
     components: { ImmersivePage, UserPicturePassword, NoPasswordInfo, LearnerPasswordCard },
     setup(props) {
@@ -211,9 +190,6 @@
         return Boolean(previewLearner.value);
       });
 
-      const sortKey = ref(0);
-      const sortOrder = ref(null);
-
       const tableHeaders = computed(() => [
         { label: nameLabel$(), dataType: 'string', columnId: 'full_name', width: '45%' },
         { label: usernameLabel$(), dataType: 'string', columnId: 'username', width: '45%' },
@@ -225,20 +201,9 @@
         },
       ]);
 
-      const sortedLearners = computed(() => {
-        const header = tableHeaders.value[sortKey.value];
-        const column = header && header.dataType !== 'undefined' ? header.columnId : 'full_name';
-        return orderBy(learners.value, [column], [sortOrder.value || 'asc']);
-      });
+      const printLearners = computed(() => orderBy(learners.value, ['full_name'], ['asc']));
 
-      const tableRows = computed(() =>
-        sortedLearners.value.map(learner => [learner, learner, learner]),
-      );
-
-      function handleSortChange({ sortKey: key, sortOrder: order }) {
-        sortKey.value = key;
-        sortOrder.value = order;
-      }
+      const tableRows = computed(() => learners.value.map(l => [l.full_name, l.username, l]));
 
       onMounted(() => {
         Promise.all([
@@ -276,8 +241,7 @@
         hasPicturePasswords,
         tableHeaders,
         tableRows,
-        sortedLearners,
-        handleSortChange,
+        printLearners,
         openPrintDialog,
         closePrintDialog,
         cancelAction$,
@@ -304,6 +268,16 @@
       },
     },
     computed: {
+      pageTitle() {
+        return [
+          this.allPasswordsHeader$(),
+          this.className,
+          this.currentFacilityName,
+          this.kolibriLabel$(),
+        ]
+          .filter(Boolean)
+          .join(' - ');
+      },
       cardStyle() {
         return {
           backgroundColor: this.$themePalette.grey.v_100,

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -47,7 +47,7 @@
         @changeSort="handleSortChange"
       >
         <template #header="{ header }">
-          <span :class="{ visuallyhidden: header.columnId === 'picture_password' }">
+          <span>
             {{ header.label }}
           </span>
         </template>
@@ -68,10 +68,12 @@
             v-else
             dir="ltr"
           >
+            <!-- Offsets icon's internal left padding to align with cell edge -->
             <UserPicturePassword
               v-if="content.picture_password"
               :picturePassword="content.picture_password"
               :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: content.full_name })"
+              :style="{ marginLeft: '-6px' }"
             />
             <NoPasswordInfo v-else />
           </div>

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -6,7 +6,11 @@
     :primary="false"
     :showHeader="!$isPrint"
   >
-    <KPageContainer :class="{ 'passwords-page-container': !$isPrint && windowBreakpoint > 4 }">
+    <KPageContainer
+      :class="{ 'passwords-page-container': !$isPrint && windowBreakpoint > 4 }"
+      :topMargin="$isPrint ? 0 : 24"
+      :noPadding="$isPrint"
+    >
       <!-- Screen-only header with Print button -->
       <KGrid v-show="!$isPrint">
         <KGridItem

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -59,7 +59,7 @@
             <UserPicturePassword
               v-if="content.picture_password"
               :picturePassword="content.picture_password"
-              :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: content.full_name })"
+              :learnerName="content.full_name"
               :style="{ marginLeft: '-6px' }"
             />
             <NoPasswordInfo v-else />
@@ -85,7 +85,7 @@
           :cardStyle="printListCardStyle"
           :printFormat="printFormat"
           :showSequenceNumbers="true"
-          :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: learner.full_name })"
+          :learnerName="learner.full_name"
         />
       </section>
     </KPageContainer>
@@ -123,7 +123,7 @@
           :cardStyle="cardStyle"
           :printFormat="printFormat"
           :showSequenceNumbers="true"
-          :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: previewLearner.full_name })"
+          :learnerName="previewLearner.full_name"
         />
       </section>
     </KModal>
@@ -179,7 +179,6 @@
         printWithTextOnly$,
         printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
-        picturePasswordSequenceForLearner$,
       } = picturePasswordStrings;
 
       const previewLearner = computed(() => {
@@ -253,7 +252,6 @@
         printWithTextOnly$,
         printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
-        picturePasswordSequenceForLearner$,
         kolibriLabel$,
       };
     },

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -54,55 +54,56 @@
         @changeSort="handleSortChange"
       >
         <template #header="{ header }">
-          <span v-show="!$isPrint">{{ header.label }}</span>
+          <span
+            v-show="!$isPrint"
+            :class="{ visuallyhidden: header.columnId === 'picture_password' }"
+          >{{ header.label }}</span>
         </template>
-        <template #cell="{ content }">
+        <template #cell="{ content, colIndex }">
+          <span
+            v-if="colIndex === 0"
+            dir="auto"
+            :style="{ color: $themeTokens.text }"
+          >{{ content.full_name }}</span>
+
+          <span
+            v-else-if="colIndex === 1"
+            dir="auto"
+            :style="{ color: $themeTokens.annotation }"
+          >{{ content.username }}</span>
+
           <div
-            class="learner-row"
-            :style="learnerRowStyle"
+            v-else
+            dir="ltr"
           >
-            <div class="learner-info">
-              <span
-                dir="auto"
-                class="learner-name"
-                :style="{ color: $themeTokens.text }"
-              >{{ content.full_name }}</span>
-              <span
-                dir="auto"
-                class="learner-username"
-                :style="{ color: $themeTokens.annotation }"
-              >{{ content.username }}</span>
-            </div>
-            <div class="learner-password">
-              <template v-if="content.picture_password">
-                <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
-                <div
-                  v-if="$isPrint && printFormat === 'text'"
-                  dir="ltr"
-                  class="password-text-sequence"
-                >
-                  {{ getPasswordTextLabels(content.picture_password) }}
-                </div>
-                <!-- Images: icon sequence with labels -->
-                <UserPicturePassword
-                  v-else
-                  :picturePassword="content.picture_password"
-                  :showSequenceNumbers="$isPrint"
-                />
-              </template>
+            <template v-if="content.picture_password">
+              <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
               <div
-                v-else
-                class="no-password-info"
+                v-if="$isPrint && printFormat === 'text'"
+                class="password-text-sequence"
               >
-                <span
-                  class="no-password-title"
-                  :style="{ color: $themeTokens.text }"
-                >{{ noPicturePasswordDescription$() }}</span>
-                <span
-                  class="no-password-subtitle"
-                  :style="{ color: $themeTokens.annotation }"
-                >{{ noPasswordSignInDescription$() }}</span>
+                {{ getPasswordTextLabels(content.picture_password) }}
               </div>
+              <!-- Images: icon sequence with labels -->
+              <UserPicturePassword
+                v-else
+                :picturePassword="content.picture_password"
+                :showSequenceNumbers="$isPrint"
+                :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: content.full_name })"
+              />
+            </template>
+            <div
+              v-else
+              class="no-password-info"
+            >
+              <span
+                class="no-password-title"
+                :style="{ color: $themeTokens.text }"
+              >{{ noPicturePasswordDescription$() }}</span>
+              <span
+                class="no-password-subtitle"
+                :style="{ color: $themeTokens.annotation }"
+              >{{ noPasswordSignInDescription$() }}</span>
             </div>
           </div>
         </template>
@@ -153,10 +154,9 @@
               :style="{ color: $themeTokens.annotation }"
             >{{ previewLearner.username }}</span>
           </div>
-          <div class="learner-password">
+          <div dir="ltr">
             <div
               v-if="printFormat === 'text'"
-              dir="ltr"
               class="password-text-sequence"
             >
               {{ getPasswordTextLabels(previewLearner.picture_password) }}
@@ -165,6 +165,9 @@
               v-else
               :picturePassword="previewLearner.picture_password"
               :showSequenceNumbers="true"
+              :ariaLabel="
+                picturePasswordSequenceForLearner$({ learnerName: previewLearner.full_name })
+              "
             />
           </div>
         </div>
@@ -202,7 +205,8 @@
       const { currentFacilityName } = useFacility();
       const { windowBreakpoint } = useKResponsiveWindow();
 
-      const { nameLabel$, cancelAction$, continueAction$ } = coreStrings;
+      const { nameLabel$, usernameLabel$, passwordLabel$, cancelAction$, continueAction$ } =
+        coreStrings;
       const {
         noLearnersInClass$,
         noPicturePasswordDescription$,
@@ -213,6 +217,7 @@
         printWithTextOnly$,
         printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
+        picturePasswordSequenceForLearner$,
       } = picturePasswordStrings;
 
       const previewLearner = computed(() => {
@@ -223,19 +228,32 @@
         return Boolean(previewLearner.value);
       });
 
+      const sortKey = ref(0);
       const sortOrder = ref(null);
 
-      const sortedLearners = computed(() => {
-        return orderBy(learners.value, ['full_name'], [sortOrder.value || 'asc']);
-      });
-
       const tableHeaders = computed(() => [
-        { label: nameLabel$(), dataType: 'string', columnId: 'full_name' },
+        { label: nameLabel$(), dataType: 'string', columnId: 'full_name', width: '45%' },
+        { label: usernameLabel$(), dataType: 'string', columnId: 'username', width: '45%' },
+        {
+          label: passwordLabel$(),
+          dataType: 'undefined',
+          columnId: 'picture_password',
+          width: '10%',
+        },
       ]);
 
-      const tableRows = computed(() => sortedLearners.value.map(learner => [learner]));
+      const sortedLearners = computed(() => {
+        const header = tableHeaders.value[sortKey.value];
+        const column = header && header.dataType !== 'undefined' ? header.columnId : 'full_name';
+        return orderBy(learners.value, [column], [sortOrder.value || 'asc']);
+      });
 
-      function handleSortChange({ sortOrder: order }) {
+      const tableRows = computed(() =>
+        sortedLearners.value.map(learner => [learner, learner, learner]),
+      );
+
+      function handleSortChange({ sortKey: key, sortOrder: order }) {
+        sortKey.value = key;
         sortOrder.value = order;
       }
 
@@ -296,6 +314,7 @@
         printWithTextOnly$,
         printPasswordsDialogHeader$,
         printFormatPreviewLabel$,
+        picturePasswordSequenceForLearner$,
       };
     },
     props: {
@@ -309,15 +328,6 @@
       },
     },
     computed: {
-      learnerRowStyle() {
-        if (!(this.$isPrint && this.printFormat === 'images')) return {};
-        return {
-          backgroundColor: this.$themePalette.grey.v_100,
-          border: `3px solid ${this.$themeTokens.fineLine}`,
-          borderRadius: '8px',
-          padding: '8px 16px',
-        };
-      },
       previewContentStyle() {
         return {
           backgroundColor: this.$themePalette.grey.v_100,
@@ -358,13 +368,6 @@
     justify-content: flex-end;
   }
 
-  .learner-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 48px;
-  }
-
   .learner-info {
     display: flex;
     flex-direction: column;
@@ -400,12 +403,6 @@
     font-size: 16px;
   }
 
-  .learner-row .password-text-sequence {
-    width: 165px;
-    padding-left: 8px;
-    text-align: start;
-  }
-
   .preview-section {
     margin-top: 16px;
   }
@@ -436,7 +433,7 @@
   }
 
   @media print {
-    .learner-row {
+    .passwords-table-print /deep/ td {
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
     }

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -39,77 +39,68 @@
         <h4 class="print-facility-class">{{ currentFacilityName }} - {{ className }}</h4>
       </div>
 
-      <CoreTable
+      <KTable
+        :headers="tableHeaders"
+        :rows="tableRows"
+        :caption="allPasswordsHeader$()"
         :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
+        :sortable="!$isPrint"
+        disableBuiltinSorting
+        @changeSort="handleSortChange"
       >
-        <template #headers>
-          <th
-            v-show="!$isPrint"
-            class="table-header"
-            :style="{ color: $themeTokens.text }"
+        <template #header="{ header }">
+          <span v-show="!$isPrint">{{ header.label }}</span>
+        </template>
+        <template #cell="{ content }">
+          <div
+            class="learner-row"
+            :style="learnerRowStyle"
           >
-            {{ nameLabel$() }}
-          </th>
-        </template>
-        <template #tbody>
-          <tbody>
-            <tr
-              v-for="learner in learners"
-              :key="learner.id"
-            >
-              <td :style="tdStyle">
+            <div class="learner-info">
+              <span
+                dir="auto"
+                class="learner-name"
+                :style="{ color: $themeTokens.text }"
+              >{{ content.full_name }}</span>
+              <span
+                dir="auto"
+                class="learner-username"
+                :style="{ color: $themeTokens.annotation }"
+              >{{ content.username }}</span>
+            </div>
+            <div class="learner-password">
+              <template v-if="content.picture_password">
+                <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
                 <div
-                  class="learner-row"
-                  :style="learnerRowStyle"
+                  v-if="$isPrint && printFormat === 'text'"
+                  class="password-text-sequence"
                 >
-                  <div class="learner-info">
-                    <span
-                      dir="auto"
-                      class="learner-name"
-                      :style="{ color: $themeTokens.text }"
-                    >{{ learner.full_name }}</span>
-                    <span
-                      dir="auto"
-                      class="learner-username"
-                      :style="{ color: $themeTokens.annotation }"
-                    >{{ learner.username }}</span>
-                  </div>
-                  <div class="learner-password">
-                    <template v-if="learner.picture_password">
-                      <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
-                      <div
-                        v-if="$isPrint && printFormat === 'text'"
-                        class="password-text-sequence"
-                      >
-                        {{ getPasswordTextLabels(learner.picture_password) }}
-                      </div>
-                      <!-- Images: icon sequence with labels -->
-                      <UserPicturePassword
-                        v-else
-                        :picturePassword="learner.picture_password"
-                      />
-                    </template>
-                    <div
-                      v-else
-                      class="no-password-info"
-                    >
-                      <span
-                        class="no-password-title"
-                        :style="{ color: $themeTokens.text }"
-                      >{{ noPicturePasswordDescription$() }}</span>
-                      <span
-                        class="no-password-subtitle"
-                        :style="{ color: $themeTokens.annotation }"
-                      >{{ noPasswordSignInDescription$() }}</span>
-                    </div>
-                  </div>
+                  {{ getPasswordTextLabels(content.picture_password) }}
                 </div>
-              </td>
-            </tr>
-          </tbody>
+                <!-- Images: icon sequence with labels -->
+                <UserPicturePassword
+                  v-else
+                  :picturePassword="content.picture_password"
+                />
+              </template>
+              <div
+                v-else
+                class="no-password-info"
+              >
+                <span
+                  class="no-password-title"
+                  :style="{ color: $themeTokens.text }"
+                >{{ noPicturePasswordDescription$() }}</span>
+                <span
+                  class="no-password-subtitle"
+                  :style="{ color: $themeTokens.annotation }"
+                >{{ noPasswordSignInDescription$() }}</span>
+              </div>
+            </div>
+          </div>
         </template>
-      </CoreTable>
+      </KTable>
     </KPageContainer>
 
     <!-- Print format selection dialog -->
@@ -182,7 +173,7 @@
 <script>
 
   import { ref, computed, onMounted } from 'vue';
-  import CoreTable from 'kolibri/components/CoreTable';
+  import orderBy from 'lodash/orderBy';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
   import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
@@ -195,7 +186,7 @@
 
   export default {
     name: 'AllPasswordsPage',
-    components: { CoreTable, ImmersivePage, UserPicturePassword },
+    components: { ImmersivePage, UserPicturePassword },
     setup(props) {
       const learners = ref([]);
       const loading = ref(true);
@@ -226,6 +217,23 @@
       const hasPicturePasswords = computed(() => {
         return Boolean(previewLearner.value);
       });
+
+      const sortOrder = ref(null);
+
+      const sortedLearners = computed(() => {
+        if (!sortOrder.value) return learners.value;
+        return orderBy(learners.value, ['full_name'], [sortOrder.value]);
+      });
+
+      const tableHeaders = computed(() => [
+        { label: nameLabel$(), dataType: 'string', columnId: 'full_name' },
+      ]);
+
+      const tableRows = computed(() => sortedLearners.value.map(learner => [learner]));
+
+      function handleSortChange({ sortOrder: order }) {
+        sortOrder.value = order;
+      }
 
       onMounted(() => {
         Promise.all([
@@ -259,7 +267,6 @@
       }
 
       return {
-        learners,
         loading,
         showPrintDialog,
         printFormat,
@@ -268,10 +275,12 @@
         currentFacilityName,
         previewLearner,
         hasPicturePasswords,
+        tableHeaders,
+        tableRows,
+        handleSortChange,
         getPasswordTextLabels,
         openPrintDialog,
         closePrintDialog,
-        nameLabel$,
         cancelAction$,
         continueAction$,
         noLearnersInClass$,
@@ -296,11 +305,6 @@
       },
     },
     computed: {
-      tdStyle() {
-        if (this.$isPrint && this.printFormat === 'images') return {};
-        if (this.$isPrint) return { borderBottom: `2px solid ${this.$themeTokens.fineLine}` };
-        return { borderTop: `2px solid ${this.$themeTokens.fineLine}` };
-      },
       learnerRowStyle() {
         if (!(this.$isPrint && this.printFormat === 'images')) return {};
         return {
@@ -348,10 +352,6 @@
     justify-content: flex-end;
   }
 
-  .table-header {
-    font-size: 14px;
-  }
-
   .learner-row {
     display: flex;
     align-items: center;
@@ -372,14 +372,10 @@
     font-size: 14px;
   }
 
-  .learner-password {
-    text-align: left;
-  }
-
   .no-password-info {
     display: flex;
     flex-direction: column;
-    max-width: 165px;
+    width: 165px;
     padding-left: 8px;
   }
 
@@ -393,6 +389,12 @@
 
   .password-text-sequence {
     font-size: 16px;
+  }
+
+  .learner-row .password-text-sequence {
+    width: 165px;
+    padding-left: 8px;
+    text-align: start;
   }
 
   .preview-section {
@@ -430,29 +432,6 @@
     .print-facility-class {
       margin: 0 0 16px;
       font-size: 20px;
-    }
-
-    table {
-      width: 100%;
-
-      thead th:first-child,
-      tr td:first-child {
-        padding-left: 0;
-      }
-
-      thead th:last-child,
-      tr td:last-child {
-        padding-right: 0;
-      }
-
-      tr td {
-        padding-top: 4px;
-        padding-bottom: 4px;
-      }
-
-      tr {
-        page-break-inside: avoid;
-      }
     }
   }
 

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -17,7 +17,6 @@
           <h1 class="header-title">{{ allPasswordsHeader$() }}</h1>
         </KGridItem>
         <KGridItem
-          v-if="!isAppContext"
           :layout12="{ span: 6, alignment: 'right' }"
           :layout8="{ span: 4, alignment: 'right' }"
           :layout4="{ span: 2, alignment: 'right' }"
@@ -181,7 +180,6 @@
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
-  import useUser from 'kolibri/composables/useUser';
   import useFacility from 'kolibri-common/composables/useFacility';
 
   export default {
@@ -194,7 +192,6 @@
       const printFormat = ref('images');
       const className = ref('');
 
-      const { isAppContext } = useUser();
       const { currentFacilityName } = useFacility();
 
       const { nameLabel$, cancelAction$, continueAction$ } = coreStrings;
@@ -271,7 +268,6 @@
         showPrintDialog,
         printFormat,
         className,
-        isAppContext,
         currentFacilityName,
         previewLearner,
         hasPicturePasswords,

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -31,33 +31,21 @@
         </KGridItem>
       </KGrid>
 
-      <!-- Print-only header with facility and class name -->
-      <div
-        v-if="$isPrint"
-        class="print-header"
-      >
-        <h4 class="print-facility-class">{{ currentFacilityName }} - {{ className }}</h4>
-      </div>
-
       <KTable
+        v-if="!$isPrint"
         :headers="tableHeaders"
         :rows="tableRows"
         :caption="allPasswordsHeader$()"
         :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
-        :sortable="!$isPrint"
-        :class="{
-          'passwords-table-print-images': $isPrint && printFormat === 'images',
-          'passwords-table-print': $isPrint,
-        }"
+        sortable
         disableBuiltinSorting
         @changeSort="handleSortChange"
       >
         <template #header="{ header }">
-          <span
-            v-show="!$isPrint"
-            :class="{ visuallyhidden: header.columnId === 'picture_password' }"
-          >{{ header.label }}</span>
+          <span :class="{ visuallyhidden: header.columnId === 'picture_password' }">
+            {{ header.label }}
+          </span>
         </template>
         <template #cell="{ content, colIndex }">
           <span
@@ -76,38 +64,36 @@
             v-else
             dir="ltr"
           >
-            <template v-if="content.picture_password">
-              <!-- Text-only: hyphenated labels e.g. "cat - dog - rat" -->
-              <div
-                v-if="$isPrint && printFormat === 'text'"
-                class="password-text-sequence"
-              >
-                {{ getPasswordTextLabels(content.picture_password) }}
-              </div>
-              <!-- Images: icon sequence with labels -->
-              <UserPicturePassword
-                v-else
-                :picturePassword="content.picture_password"
-                :showSequenceNumbers="$isPrint"
-                :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: content.full_name })"
-              />
-            </template>
-            <div
-              v-else
-              class="no-password-info"
-            >
-              <span
-                class="no-password-title"
-                :style="{ color: $themeTokens.text }"
-              >{{ noPicturePasswordDescription$() }}</span>
-              <span
-                class="no-password-subtitle"
-                :style="{ color: $themeTokens.annotation }"
-              >{{ noPasswordSignInDescription$() }}</span>
-            </div>
+            <UserPicturePassword
+              v-if="content.picture_password"
+              :picturePassword="content.picture_password"
+              :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: content.full_name })"
+            />
+            <NoPasswordInfo v-else />
           </div>
         </template>
       </KTable>
+
+      <!-- Print-only list: one card per learner, stacked vertically -->
+      <section
+        v-else
+        class="print-list"
+      >
+        <!-- Print-only header with facility and class name -->
+        <div class="print-header">
+          <h4 class="print-facility-class">{{ currentFacilityName }} - {{ className }}</h4>
+        </div>
+
+        <LearnerPasswordCard
+          v-for="learner in sortedLearners"
+          :key="learner.id"
+          :learner="learner"
+          :cardStyle="printListCardStyle"
+          :printFormat="printFormat"
+          :showSequenceNumbers="true"
+          :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: learner.full_name })"
+        />
+      </section>
     </KPageContainer>
 
     <!-- Print format selection dialog -->
@@ -138,39 +124,13 @@
         class="preview-section"
       >
         <h6 class="preview-label">{{ printFormatPreviewLabel$() }}</h6>
-        <div
-          class="preview-content"
-          :style="previewContentStyle"
-        >
-          <div class="learner-info">
-            <span
-              dir="auto"
-              class="learner-name"
-              :style="{ color: $themeTokens.text }"
-            >{{ previewLearner.full_name }}</span>
-            <span
-              dir="auto"
-              class="learner-username"
-              :style="{ color: $themeTokens.annotation }"
-            >{{ previewLearner.username }}</span>
-          </div>
-          <div dir="ltr">
-            <div
-              v-if="printFormat === 'text'"
-              class="password-text-sequence"
-            >
-              {{ getPasswordTextLabels(previewLearner.picture_password) }}
-            </div>
-            <UserPicturePassword
-              v-else
-              :picturePassword="previewLearner.picture_password"
-              :showSequenceNumbers="true"
-              :ariaLabel="
-                picturePasswordSequenceForLearner$({ learnerName: previewLearner.full_name })
-              "
-            />
-          </div>
-        </div>
+        <LearnerPasswordCard
+          :learner="previewLearner"
+          :cardStyle="cardStyle"
+          :printFormat="printFormat"
+          :showSequenceNumbers="true"
+          :ariaLabel="picturePasswordSequenceForLearner$({ learnerName: previewLearner.full_name })"
+        />
       </section>
     </KModal>
   </ImmersivePage>
@@ -184,17 +144,18 @@
   import orderBy from 'lodash/orderBy';
   import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
   import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
-  import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
+  import NoPasswordInfo from 'kolibri-common/components/NoPasswordInfo';
+  import LearnerPasswordCard from 'kolibri-common/components/LearnerPasswordCard';
   import useFacility from 'kolibri-common/composables/useFacility';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   export default {
     name: 'AllPasswordsPage',
-    components: { ImmersivePage, UserPicturePassword },
+    components: { ImmersivePage, UserPicturePassword, NoPasswordInfo, LearnerPasswordCard },
     setup(props) {
       const learners = ref([]);
       const loading = ref(true);
@@ -209,8 +170,6 @@
         coreStrings;
       const {
         noLearnersInClass$,
-        noPicturePasswordDescription$,
-        noPasswordSignInDescription$,
         printAction$,
         allPasswordsHeader$,
         printWithImages$,
@@ -274,12 +233,6 @@
           });
       });
 
-      function getPasswordTextLabels(picturePassword) {
-        return getPicturePasswordIcons(picturePassword)
-          .map(icon => icon.label)
-          .join(' - ');
-      }
-
       function openPrintDialog() {
         showPrintDialog.value = true;
       }
@@ -299,15 +252,13 @@
         hasPicturePasswords,
         tableHeaders,
         tableRows,
+        sortedLearners,
         handleSortChange,
-        getPasswordTextLabels,
         openPrintDialog,
         closePrintDialog,
         cancelAction$,
         continueAction$,
         noLearnersInClass$,
-        noPicturePasswordDescription$,
-        noPasswordSignInDescription$,
         printAction$,
         allPasswordsHeader$,
         printWithImages$,
@@ -328,11 +279,24 @@
       },
     },
     computed: {
-      previewContentStyle() {
+      cardStyle() {
         return {
           backgroundColor: this.$themePalette.grey.v_100,
           borderColor: this.$themeTokens.fineLine,
         };
+      },
+      printListCardStyle() {
+        if (this.printFormat === 'text') {
+          return {
+            ...this.cardStyle,
+            border: 'none',
+            borderBottom: `2px solid ${this.$themeTokens.fineLine}`,
+            borderRadius: 0,
+            paddingTop: '0px',
+            paddingBottom: '16px',
+          };
+        }
+        return this.cardStyle;
       },
     },
     methods: {
@@ -368,41 +332,6 @@
     justify-content: flex-end;
   }
 
-  .learner-info {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .learner-name {
-    padding-bottom: 4px;
-    font-size: 16px;
-  }
-
-  .learner-username {
-    font-size: 14px;
-  }
-
-  .no-password-info {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: 165px;
-    min-height: 64px;
-    padding-left: 8px;
-  }
-
-  .no-password-title {
-    font-size: 14px;
-  }
-
-  .no-password-subtitle {
-    font-size: 12px;
-  }
-
-  .password-text-sequence {
-    font-size: 16px;
-  }
-
   .preview-section {
     margin-top: 16px;
   }
@@ -413,13 +342,15 @@
     font-weight: bold;
   }
 
-  .preview-content {
+  .print-list {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px;
-    border: 2px solid;
-    border-radius: 8px;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .print-list /deep/ .password-text-sequence {
+    width: 165px;
+    padding-left: 8px;
   }
 
   .print-header {
@@ -427,17 +358,7 @@
     padding: 2px 8px;
   }
 
-  .passwords-table-print /deep/ th,
-  .passwords-table-print-images /deep/ td {
-    border-bottom-width: 0 !important;
-  }
-
   @media print {
-    .passwords-table-print /deep/ td {
-      -webkit-print-color-adjust: exact;
-      print-color-adjust: exact;
-    }
-
     .print-header {
       display: block;
     }

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -117,7 +117,7 @@
         v-if="previewLearner"
         class="preview-section"
       >
-        <h6 class="preview-label">{{ printFormatPreviewLabel$() }}</h6>
+        <p class="preview-label">{{ printFormatPreviewLabel$() }}</p>
         <LearnerPasswordCard
           :learner="previewLearner"
           :cardStyle="cardStyle"

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -14,14 +14,15 @@
       <!-- Screen-only header with Print button -->
       <KGrid v-show="!$isPrint">
         <KGridItem
-          :layout12="{ span: 6, alignment: 'left' }"
-          :layout8="{ span: 4, alignment: 'left' }"
-          :layout4="{ span: 2, alignment: 'left' }"
+          :layout12="{ span: isAppContext ? 12 : 6, alignment: 'left' }"
+          :layout8="{ span: isAppContext ? 8 : 4, alignment: 'left' }"
+          :layout4="{ span: isAppContext ? 4 : 2, alignment: 'left' }"
           class="header-row"
         >
           <h1 class="header-title">{{ allPasswordsHeader$() }}</h1>
         </KGridItem>
         <KGridItem
+          v-if="!isAppContext"
           :layout12="{ span: 6, alignment: 'right' }"
           :layout8="{ span: 4, alignment: 'right' }"
           :layout4="{ span: 2, alignment: 'right' }"
@@ -150,6 +151,7 @@
   import NoPasswordInfo from 'kolibri-common/components/NoPasswordInfo';
   import LearnerPasswordCard from 'kolibri-common/components/LearnerPasswordCard';
   import useFacility from 'kolibri-common/composables/useFacility';
+  import useUser from 'kolibri/composables/useUser';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
   export default {
@@ -166,6 +168,7 @@
       const className = ref('');
 
       const { currentFacilityName } = useFacility();
+      const { isAppContext } = useUser();
       const { windowBreakpoint } = useKResponsiveWindow();
 
       const {
@@ -236,6 +239,7 @@
 
       return {
         loading,
+        isAppContext,
         showPrintDialog,
         printFormat,
         className,

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -439,6 +439,11 @@
   }
 
   @media print {
+    .learner-row {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+
     .print-header {
       display: block;
     }

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -117,7 +117,12 @@
         v-if="previewLearner"
         class="preview-section"
       >
-        <p class="preview-label">{{ printFormatPreviewLabel$() }}</p>
+        <p
+          class="preview-label"
+          :style="{ color: $themeTokens.annotation }"
+        >
+          {{ printFormatPreviewLabel$() }}
+        </p>
         <LearnerPasswordCard
           :learner="previewLearner"
           :cardStyle="cardStyle"
@@ -334,9 +339,9 @@
   }
 
   .preview-label {
+    margin-top: 32px;
     margin-bottom: 8px;
     font-size: 14px;
-    font-weight: bold;
   }
 
   .print-list {

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -131,44 +131,42 @@
       </KRadioButtonGroup>
 
       <!-- Live preview for example learner -->
-      <div
+      <section
         v-if="previewLearner"
         class="preview-section"
       >
-        <div class="preview-label">{{ printFormatPreviewLabel$() }}</div>
+        <h6 class="preview-label">{{ printFormatPreviewLabel$() }}</h6>
         <div
           class="preview-content"
           :style="previewContentStyle"
         >
-          <div class="preview-row">
-            <div class="learner-info">
-              <span
-                dir="auto"
-                class="learner-name"
-                :style="{ color: $themeTokens.text }"
-              >{{ previewLearner.full_name }}</span>
-              <span
-                dir="auto"
-                class="learner-username"
-                :style="{ color: $themeTokens.annotation }"
-              >{{ previewLearner.username }}</span>
+          <div class="learner-info">
+            <span
+              dir="auto"
+              class="learner-name"
+              :style="{ color: $themeTokens.text }"
+            >{{ previewLearner.full_name }}</span>
+            <span
+              dir="auto"
+              class="learner-username"
+              :style="{ color: $themeTokens.annotation }"
+            >{{ previewLearner.username }}</span>
+          </div>
+          <div class="learner-password">
+            <div
+              v-if="printFormat === 'text'"
+              class="password-text-sequence"
+            >
+              {{ getPasswordTextLabels(previewLearner.picture_password) }}
             </div>
-            <div class="learner-password">
-              <div
-                v-if="printFormat === 'text'"
-                class="password-text-sequence"
-              >
-                {{ getPasswordTextLabels(previewLearner.picture_password) }}
-              </div>
-              <UserPicturePassword
-                v-else
-                :picturePassword="previewLearner.picture_password"
-                :showSequenceNumbers="true"
-              />
-            </div>
+            <UserPicturePassword
+              v-else
+              :picturePassword="previewLearner.picture_password"
+              :showSequenceNumbers="true"
+            />
           </div>
         </div>
-      </div>
+      </section>
     </KModal>
   </ImmersivePage>
 
@@ -418,15 +416,12 @@
   }
 
   .preview-content {
-    padding: 12px;
-    border: 2px solid;
-    border-radius: 8px;
-  }
-
-  .preview-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding: 12px;
+    border: 2px solid;
+    border-radius: 8px;
   }
 
   .print-header {

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -373,7 +373,9 @@
   .no-password-info {
     display: flex;
     flex-direction: column;
+    justify-content: center;
     width: 165px;
+    min-height: 64px;
     padding-left: 8px;
   }
 
@@ -435,11 +437,6 @@
     .print-facility-class {
       margin: 0 0 16px;
       font-size: 20px;
-    }
-
-    .learner-row {
-      -webkit-print-color-adjust: exact;
-      print-color-adjust: exact;
     }
   }
 

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -45,6 +45,8 @@
         :emptyMessage="noLearnersInClass$()"
         :defaultSort="{ columnId: 'full_name', direction: 'asc' }"
         sortable
+        disableBuiltinSorting
+        @changeSort="handleSortChange"
       >
         <template #header="{ header }">
           <span>
@@ -208,9 +210,15 @@
         },
       ]);
 
-      const printLearners = computed(() => orderBy(learners.value, ['full_name'], ['asc']));
+      const sortConfig = ref({ columnId: 'full_name', direction: 'asc' });
 
-      const tableRows = computed(() => learners.value.map(l => [l.full_name, l.username, l]));
+      const sortedLearners = computed(() =>
+        orderBy(learners.value, [sortConfig.value.columnId], [sortConfig.value.direction]),
+      );
+
+      const printLearners = computed(() => sortedLearners.value);
+
+      const tableRows = computed(() => sortedLearners.value.map(l => [l.full_name, l.username, l]));
 
       onMounted(() => {
         Promise.all([
@@ -229,6 +237,15 @@
           });
       });
 
+      function handleSortChange({ sortKey, sortOrder }) {
+        const columnId = tableHeaders.value[sortKey]?.columnId;
+        if (!sortOrder || !columnId || columnId === 'picture_password') {
+          sortConfig.value = { columnId: 'full_name', direction: 'asc' };
+        } else {
+          sortConfig.value = { columnId, direction: sortOrder };
+        }
+      }
+
       function openPrintDialog() {
         showPrintDialog.value = true;
       }
@@ -240,6 +257,7 @@
       return {
         loading,
         isAppContext,
+        handleSortChange,
         showPrintDialog,
         printFormat,
         className,
@@ -319,7 +337,8 @@
 <style lang="scss" scoped>
 
   .passwords-page-container {
-    margin: 80px 175px 72px;
+    max-width: 1000px;
+    margin: 80px auto 72px;
   }
 
   .header-row {

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -45,6 +45,10 @@
         :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
         :sortable="!$isPrint"
+        :class="{
+          'passwords-table-print-images': $isPrint && printFormat === 'images',
+          'passwords-table-print': $isPrint,
+        }"
         disableBuiltinSorting
         @changeSort="handleSortChange"
       >
@@ -308,8 +312,6 @@
           border: `3px solid ${this.$themeTokens.fineLine}`,
           borderRadius: '8px',
           padding: '8px',
-          WebkitPrintColorAdjust: 'exact',
-          printColorAdjust: 'exact',
         };
       },
       previewContentStyle() {
@@ -417,7 +419,12 @@
 
   .print-header {
     display: none;
-    padding: 2px;
+    padding: 2px 8px;
+  }
+
+  .passwords-table-print /deep/ th,
+  .passwords-table-print-images /deep/ td {
+    border-bottom-width: 0 !important;
   }
 
   @media print {
@@ -428,6 +435,11 @@
     .print-facility-class {
       margin: 0 0 16px;
       font-size: 20px;
+    }
+
+    .learner-row {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
     }
   }
 

--- a/packages/kolibri-common/components/LearnerPasswordCard.vue
+++ b/packages/kolibri-common/components/LearnerPasswordCard.vue
@@ -28,7 +28,7 @@
           v-else
           :picturePassword="learner.picture_password"
           :showSequenceNumbers="showSequenceNumbers"
-          :ariaLabel="ariaLabel"
+          :learnerName="learnerName"
         />
       </template>
       <NoPasswordInfo
@@ -77,7 +77,7 @@
         type: Boolean,
         default: false,
       },
-      ariaLabel: {
+      learnerName: {
         type: String,
         default: null,
       },

--- a/packages/kolibri-common/components/LearnerPasswordCard.vue
+++ b/packages/kolibri-common/components/LearnerPasswordCard.vue
@@ -1,0 +1,125 @@
+<template>
+
+  <div
+    class="learner-password-card"
+    :style="cardStyle"
+  >
+    <div class="learner-info">
+      <span
+        dir="auto"
+        class="learner-name"
+        :style="{ color: $themeTokens.text }"
+      >{{ learner.full_name }}</span>
+      <span
+        dir="auto"
+        class="learner-username"
+        :style="{ color: $themeTokens.annotation }"
+      >{{ learner.username }}</span>
+    </div>
+    <div dir="ltr">
+      <template v-if="learner.picture_password">
+        <div
+          v-if="printFormat === 'text'"
+          class="password-text-sequence"
+        >
+          {{ passwordTextLabels }}
+        </div>
+        <UserPicturePassword
+          v-else
+          :picturePassword="learner.picture_password"
+          :showSequenceNumbers="showSequenceNumbers"
+          :ariaLabel="ariaLabel"
+        />
+      </template>
+      <NoPasswordInfo v-else />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed } from 'vue';
+  import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
+  import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
+  import NoPasswordInfo from 'kolibri-common/components/NoPasswordInfo';
+
+  export default {
+    name: 'LearnerPasswordCard',
+    components: { UserPicturePassword, NoPasswordInfo },
+    setup(props) {
+      const passwordTextLabels = computed(() => {
+        if (!props.learner.picture_password) return '';
+        return getPicturePasswordIcons(props.learner.picture_password)
+          .map(icon => icon.label)
+          .join(' - ');
+      });
+      return { passwordTextLabels };
+    },
+    props: {
+      learner: {
+        type: Object,
+        required: true,
+      },
+      cardStyle: {
+        type: Object,
+        default: () => ({}),
+      },
+      printFormat: {
+        type: String,
+        default: 'images',
+      },
+      showSequenceNumbers: {
+        type: Boolean,
+        default: false,
+      },
+      ariaLabel: {
+        type: String,
+        default: '',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .learner-password-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px;
+    border: 2px solid;
+    border-radius: 8px;
+  }
+
+  .learner-info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .learner-name {
+    padding-bottom: 4px;
+    font-size: 16px;
+  }
+
+  .learner-username {
+    font-size: 14px;
+  }
+
+  .password-text-sequence {
+    font-size: 16px;
+  }
+
+  @media print {
+    .learner-password-card {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
+  }
+
+</style>

--- a/packages/kolibri-common/components/LearnerPasswordCard.vue
+++ b/packages/kolibri-common/components/LearnerPasswordCard.vue
@@ -31,7 +31,10 @@
           :ariaLabel="ariaLabel"
         />
       </template>
-      <NoPasswordInfo v-else />
+      <NoPasswordInfo
+        v-else
+        :style="{ paddingLeft: '8px' }"
+      />
     </div>
   </div>
 

--- a/packages/kolibri-common/components/LearnerPasswordCard.vue
+++ b/packages/kolibri-common/components/LearnerPasswordCard.vue
@@ -76,7 +76,7 @@
       },
       ariaLabel: {
         type: String,
-        default: '',
+        default: null,
       },
     },
   };

--- a/packages/kolibri-common/components/NoPasswordInfo.vue
+++ b/packages/kolibri-common/components/NoPasswordInfo.vue
@@ -1,0 +1,52 @@
+<template>
+
+  <div class="no-password-info">
+    <span
+      class="no-password-title"
+      :style="{ color: $themeTokens.text }"
+    >{{ noPicturePasswordDescription$() }}</span>
+    <span
+      class="no-password-subtitle"
+      :style="{ color: $themeTokens.annotation }"
+    >{{ noPasswordSignInDescription$() }}</span>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+
+  export default {
+    name: 'NoPasswordInfo',
+    setup() {
+      const { noPicturePasswordDescription$, noPasswordSignInDescription$ } =
+        picturePasswordStrings;
+      return { noPicturePasswordDescription$, noPasswordSignInDescription$ };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .no-password-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 165px;
+    min-height: 64px;
+    padding-left: 8px;
+  }
+
+  .no-password-title {
+    font-size: 14px;
+  }
+
+  .no-password-subtitle {
+    font-size: 12px;
+  }
+
+</style>

--- a/packages/kolibri-common/components/NoPasswordInfo.vue
+++ b/packages/kolibri-common/components/NoPasswordInfo.vue
@@ -38,7 +38,6 @@
     justify-content: center;
     width: 165px;
     min-height: 64px;
-    padding-left: 8px;
   }
 
   .no-password-title {

--- a/packages/kolibri-common/components/NoPasswordInfo.vue
+++ b/packages/kolibri-common/components/NoPasswordInfo.vue
@@ -42,6 +42,7 @@
   }
 
   .no-password-title {
+    padding-bottom: 4px;
     font-size: 14px;
   }
 

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -4,6 +4,7 @@
     class="picture-password-icons"
     :class="{ 'show-sequence-numbers': showSequenceNumbers }"
     :aria-label="ariaLabel"
+    :aria-description="picturePasswordSequenceDescription$()"
   >
     <li
       v-for="(icon, index) in picturePasswordIcons"
@@ -36,7 +37,7 @@
     name: 'UserPicturePassword',
     setup(props) {
       const { facilityConfig } = useFacility();
-      const { picturePasswordSequence$ } = picturePasswordStrings;
+      const { picturePasswordSequenceDescription$ } = picturePasswordStrings;
 
       const picturePasswordIcons = computed(() =>
         getPicturePasswordIcons(
@@ -56,17 +57,11 @@
           : (facilityConfig.value.picture_password_settings?.show_icon_text ?? false),
       );
 
-      const ariaLabel = computed(() =>
-        picturePasswordSequence$({
-          sequence: picturePasswordIcons.value.map(icon => icon.label).join(', '),
-        }),
-      );
-
       return {
         picturePasswordIcons,
         iconStyles,
         effectiveShowIconText,
-        ariaLabel,
+        picturePasswordSequenceDescription$,
       };
     },
     props: {
@@ -92,6 +87,14 @@
       showSequenceNumbers: {
         type: Boolean,
         default: false,
+      },
+      // Optional accessible name for the list. Callers that render this in a
+      // context where multiple picture passwords appear together (e.g. the All
+      // Passwords page) should pass a label that identifies whose sequence it
+      // is. Omit when a surrounding semantic heading already provides context.
+      ariaLabel: {
+        type: String,
+        default: null,
       },
     },
   };

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -8,11 +8,9 @@
     <li
       v-for="(icon, index) in picturePasswordIcons"
       :key="`${icon.label}-${index}`"
+      :class="$computedClass({ color: $themeTokens.annotation })"
     >
-      <figure
-        :data-testid="`picture-password-icon-${icon.iconName}`"
-        :class="$computedClass({ color: $themeTokens.annotation })"
-      >
+      <figure :data-testid="`picture-password-icon-${icon.iconName}`">
         <KIcon
           :icon="icon.iconName"
           :style="iconStyles"
@@ -112,6 +110,9 @@
     margin: 0;
 
     li {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       margin: 0;
       list-style: none;
     }

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -12,12 +12,12 @@
         :key="`${icon.label}-${index}`"
         :class="$computedClass({ color: $themeTokens.annotation })"
       >
-        <figure>
+        <figure :data-testid="`picture-password-icon-${icon.iconName}`">
           <KIcon
-            class="icon"
             :icon="icon.iconName"
+            :style="iconStyles"
           />
-          <figcaption>
+          <figcaption :class="{ visuallyhidden: !effectiveShowIconText }">
             {{ icon.label }}
           </figcaption>
         </figure>
@@ -48,6 +48,17 @@
         ),
       );
 
+      const iconStyles = computed(() => ({
+        width: props.iconSize,
+        height: props.iconSize,
+      }));
+
+      const effectiveShowIconText = computed(() =>
+        props.showIconText !== null
+          ? props.showIconText
+          : (facilityConfig.value.picture_password_settings?.show_icon_text ?? false),
+      );
+
       const ariaLabel = computed(() => {
         const labels = picturePasswordIcons.value.map(icon => icon.label).join(', ');
         const count = picturePasswordIcons.value.length;
@@ -58,6 +69,8 @@
 
       return {
         picturePasswordIcons,
+        iconStyles,
+        effectiveShowIconText,
         ariaLabel,
       };
     },

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -106,6 +106,7 @@
     display: flex;
     gap: 12px;
     align-items: flex-start;
+    width: 100%;
     padding: 0;
     margin: 0;
 

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -19,6 +19,11 @@
         >
           {{ icon.label }}
         </figcaption>
+        <span
+          v-if="showCounts"
+          class="icon-count"
+          :style="{ color: $themeTokens.annotation }"
+        >{{ index + 1 }}</span>
       </figure>
     </li>
   </ol>
@@ -85,6 +90,10 @@
         type: String,
         default: '46px',
       },
+      showCounts: {
+        type: Boolean,
+        default: false,
+      },
     },
   };
 
@@ -114,6 +123,11 @@
 
     figcaption {
       margin-top: 4px;
+      font-size: 12px;
+    }
+
+    .icon-count {
+      margin-top: 2px;
       font-size: 12px;
     }
   }

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -115,6 +115,7 @@
       align-items: center;
       margin: 0;
       list-style: none;
+      counter-increment: list-item;
     }
 
     figure {

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -1,27 +1,29 @@
 <template>
 
-  <ol
-    class="picture-password-icons"
-    :class="{ 'show-sequence-numbers': showSequenceNumbers }"
-    :aria-label="ariaLabel"
-    :aria-description="picturePasswordSequenceDescription$()"
-  >
-    <li
-      v-for="(icon, index) in picturePasswordIcons"
-      :key="`${icon.label}-${index}`"
-      :class="$computedClass({ color: $themeTokens.annotation })"
+  <div class="picture-password-wrapper">
+    <span class="visuallyhidden">{{ ariaLabel }}</span>
+    <ol
+      class="picture-password-icons"
+      :class="{ 'show-sequence-numbers': showSequenceNumbers }"
+      aria-hidden="true"
     >
-      <figure :data-testid="`picture-password-icon-${icon.iconName}`">
-        <KIcon
-          :icon="icon.iconName"
-          :style="iconStyles"
-        />
-        <figcaption :class="{ visuallyhidden: !effectiveShowIconText }">
-          {{ icon.label }}
-        </figcaption>
-      </figure>
-    </li>
-  </ol>
+      <li
+        v-for="(icon, index) in picturePasswordIcons"
+        :key="`${icon.label}-${index}`"
+        :class="$computedClass({ color: $themeTokens.annotation })"
+      >
+        <figure>
+          <KIcon
+            class="icon"
+            :icon="icon.iconName"
+          />
+          <figcaption>
+            {{ icon.label }}
+          </figcaption>
+        </figure>
+      </li>
+    </ol>
+  </div>
 
 </template>
 
@@ -37,7 +39,7 @@
     name: 'UserPicturePassword',
     setup(props) {
       const { facilityConfig } = useFacility();
-      const { picturePasswordSequenceDescription$ } = picturePasswordStrings;
+      const { picturePasswordForLearner$, picturePasswordList$ } = picturePasswordStrings;
 
       const picturePasswordIcons = computed(() =>
         getPicturePasswordIcons(
@@ -46,22 +48,17 @@
         ),
       );
 
-      const iconStyles = computed(() => ({
-        width: props.iconSize,
-        height: props.iconSize,
-      }));
-
-      const effectiveShowIconText = computed(() =>
-        props.showIconText !== null
-          ? props.showIconText
-          : (facilityConfig.value.picture_password_settings?.show_icon_text ?? false),
-      );
+      const ariaLabel = computed(() => {
+        const labels = picturePasswordIcons.value.map(icon => icon.label).join(', ');
+        const count = picturePasswordIcons.value.length;
+        return props.learnerName
+          ? picturePasswordForLearner$({ learnerName: props.learnerName, count, labels })
+          : picturePasswordList$({ count, labels });
+      });
 
       return {
         picturePasswordIcons,
-        iconStyles,
-        effectiveShowIconText,
-        picturePasswordSequenceDescription$,
+        ariaLabel,
       };
     },
     props: {
@@ -88,11 +85,7 @@
         type: Boolean,
         default: false,
       },
-      // Optional accessible name for the list. Callers that render this in a
-      // context where multiple picture passwords appear together (e.g. the All
-      // Passwords page) should pass a label that identifies whose sequence it
-      // is. Omit when a surrounding semantic heading already provides context.
-      ariaLabel: {
+      learnerName: {
         type: String,
         default: null,
       },
@@ -103,6 +96,10 @@
 
 
 <style lang="scss" scoped>
+
+  .picture-password-wrapper {
+    position: relative;
+  }
 
   .picture-password-icons {
     display: flex;

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -20,8 +20,8 @@
           {{ icon.label }}
         </figcaption>
         <span
-          v-if="showCounts"
-          class="icon-count"
+          v-if="showSequenceNumbers"
+          class="icon-sequence-number"
           :style="{ color: $themeTokens.annotation }"
         >{{ index + 1 }}</span>
       </figure>
@@ -90,7 +90,7 @@
         type: String,
         default: '46px',
       },
-      showCounts: {
+      showSequenceNumbers: {
         type: Boolean,
         default: false,
       },
@@ -126,7 +126,7 @@
       font-size: 12px;
     }
 
-    .icon-count {
+    .icon-sequence-number {
       margin-top: 2px;
       font-size: 12px;
     }

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -129,11 +129,13 @@
       color: inherit;
     }
 
-    &.show-sequence-numbers figure::after {
-      margin-top: 2px;
-      font-size: 12px;
-      color: inherit;
-      content: counter(list-item);
+    &.show-sequence-numbers {
+      li::after {
+        margin-top: 2px;
+        font-size: 12px;
+        color: inherit;
+        content: counter(list-item);
+      }
     }
   }
 

--- a/packages/kolibri-common/components/UserPicturePassword.vue
+++ b/packages/kolibri-common/components/UserPicturePassword.vue
@@ -2,28 +2,24 @@
 
   <ol
     class="picture-password-icons"
-    :aria-label="picturePassword$()"
+    :class="{ 'show-sequence-numbers': showSequenceNumbers }"
+    :aria-label="ariaLabel"
   >
     <li
       v-for="(icon, index) in picturePasswordIcons"
       :key="`${icon.label}-${index}`"
     >
-      <figure :data-testid="`picture-password-icon-${icon.iconName}`">
+      <figure
+        :data-testid="`picture-password-icon-${icon.iconName}`"
+        :class="$computedClass({ color: $themeTokens.annotation })"
+      >
         <KIcon
           :icon="icon.iconName"
           :style="iconStyles"
         />
-        <figcaption
-          :style="{ color: $themeTokens.annotation }"
-          :class="{ visuallyhidden: !effectiveShowIconText }"
-        >
+        <figcaption :class="{ visuallyhidden: !effectiveShowIconText }">
           {{ icon.label }}
         </figcaption>
-        <span
-          v-if="showSequenceNumbers"
-          class="icon-sequence-number"
-          :style="{ color: $themeTokens.annotation }"
-        >{{ index + 1 }}</span>
       </figure>
     </li>
   </ol>
@@ -42,7 +38,7 @@
     name: 'UserPicturePassword',
     setup(props) {
       const { facilityConfig } = useFacility();
-      const { picturePassword$ } = picturePasswordStrings;
+      const { picturePasswordSequence$ } = picturePasswordStrings;
 
       const picturePasswordIcons = computed(() =>
         getPicturePasswordIcons(
@@ -62,12 +58,17 @@
           : (facilityConfig.value.picture_password_settings?.show_icon_text ?? false),
       );
 
+      const ariaLabel = computed(() =>
+        picturePasswordSequence$({
+          sequence: picturePasswordIcons.value.map(icon => icon.label).join(', '),
+        }),
+      );
+
       return {
-        // state
         picturePasswordIcons,
         iconStyles,
         effectiveShowIconText,
-        picturePassword$,
+        ariaLabel,
       };
     },
     props: {
@@ -125,11 +126,14 @@
     figcaption {
       margin-top: 4px;
       font-size: 12px;
+      color: inherit;
     }
 
-    .icon-sequence-number {
+    &.show-sequence-numbers figure::after {
       margin-top: 2px;
       font-size: 12px;
+      color: inherit;
+      content: counter(list-item);
     }
   }
 

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { render, screen } from '@testing-library/vue';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import AllPasswordsPage from '../AllPasswordsPage.vue';
 
@@ -22,14 +23,7 @@ jest.mock('kolibri-common/apiResources/ClassroomResource', () => ({
   fetchModel: jest.fn(),
 }));
 
-jest.mock('kolibri-common/composables/useFacility', () => ({
-  default: jest.fn(() => ({
-    currentFacilityName: ref('Test Facility'),
-    facilityConfig: ref({
-      picture_password_settings: { icon_style: 'colorful' },
-    }),
-  })),
-}));
+jest.mock('kolibri-common/composables/useFacility');
 
 jest.mock('kolibri-common/utils/picturePassword', () => ({
   getPicturePasswordIcons: jest.fn(pw => {
@@ -48,6 +42,9 @@ describe('AllPasswordsPage', () => {
   beforeEach(() => {
     FacilityUserResource.fetchCollection.mockResolvedValue(Object.values(LEARNERS));
     ClassroomResource.fetchModel.mockResolvedValue({ name: 'Test Class' });
+    useFacility.mockImplementation(() =>
+      useFacilityMock({ currentFacilityName: ref('Test Facility') }),
+    );
   });
 
   afterEach(() => {
@@ -56,7 +53,6 @@ describe('AllPasswordsPage', () => {
 
   describe('loading state', () => {
     it('shows a loading indicator before the fetch resolves', () => {
-      // Do not resolve the promise so we can inspect the loading state
       FacilityUserResource.fetchCollection.mockImplementation(() => new Promise(() => {}));
       renderComponent();
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
@@ -109,7 +105,6 @@ describe('AllPasswordsPage', () => {
     it('renders one row per learner', async () => {
       renderComponent();
       await global.flushPromises();
-      // One row per learner in tbody
       const rows = screen.getAllByRole('row');
       // 1 header row + 2 learner rows
       expect(rows).toHaveLength(3);
@@ -129,7 +124,6 @@ describe('AllPasswordsPage', () => {
       FacilityUserResource.fetchCollection.mockResolvedValue([]);
       renderComponent();
       await global.flushPromises();
-      // Only the header row
       const rows = screen.getAllByRole('row');
       expect(rows).toHaveLength(1);
     });

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -53,8 +53,7 @@ describe('AllPasswordsPage', () => {
       useFacilityMock({ currentFacilityName: ref('Test Facility') }),
     );
     useKResponsiveWindow.mockImplementation(() => ({
-      windowHeight: ref(768),
-      windowIsSmall: ref(false),
+      windowBreakpoint: ref(4),
     }));
   });
 

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -2,7 +2,8 @@ import { ref } from 'vue';
 import { render, screen } from '@testing-library/vue';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
-import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
+import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import AllPasswordsPage from '../AllPasswordsPage.vue';
 
@@ -24,6 +25,12 @@ jest.mock('kolibri-common/apiResources/ClassroomResource', () => ({
 }));
 
 jest.mock('kolibri-common/composables/useFacility');
+jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('vue-router/composables', () => ({
+  useRoute: jest.fn(() => ({ params: {}, query: {}, name: null })),
+  useRouter: jest.fn(() => ({ push: jest.fn(), currentRoute: {} })),
+}));
 
 jest.mock('kolibri-common/utils/picturePassword', () => ({
   getPicturePasswordIcons: jest.fn(pw => {
@@ -45,6 +52,10 @@ describe('AllPasswordsPage', () => {
     useFacility.mockImplementation(() =>
       useFacilityMock({ currentFacilityName: ref('Test Facility') }),
     );
+    useKResponsiveWindow.mockImplementation(() => ({
+      windowHeight: ref(768),
+      windowIsSmall: ref(false),
+    }));
   });
 
   afterEach(() => {
@@ -55,8 +66,8 @@ describe('AllPasswordsPage', () => {
     it('does not show learner data while the fetch is pending', () => {
       FacilityUserResource.fetchCollection.mockImplementation(() => new Promise(() => {}));
       renderComponent();
-      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
-      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS[1].full_name)).not.toBeInTheDocument();
     });
 
     it('hides the loading indicator after the fetch resolves', async () => {
@@ -80,15 +91,15 @@ describe('AllPasswordsPage', () => {
     it('renders the full name of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(LEARNERS['alice'].full_name)).toBeInTheDocument();
-      expect(screen.getByText(LEARNERS['bob'].full_name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
     });
 
     it('renders the username of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(LEARNERS['alice'].username)).toBeInTheDocument();
-      expect(screen.getByText(LEARNERS['bob'].username)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS[0].username)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS[1].username)).toBeInTheDocument();
     });
 
     it('renders resolved icon labels for a learner with a picture_password', async () => {
@@ -126,8 +137,8 @@ describe('AllPasswordsPage', () => {
       renderComponent();
       await global.flushPromises();
       // KTable hides the table element entirely when rows are empty
-      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
-      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS[1].full_name)).not.toBeInTheDocument();
     });
 
     it('renders the empty class message', async () => {

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -52,10 +52,11 @@ describe('AllPasswordsPage', () => {
   });
 
   describe('loading state', () => {
-    it('shows a loading indicator before the fetch resolves', () => {
+    it('does not show learner data while the fetch is pending', () => {
       FacilityUserResource.fetchCollection.mockImplementation(() => new Promise(() => {}));
       renderComponent();
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
     });
 
     it('hides the loading indicator after the fetch resolves', async () => {
@@ -120,12 +121,13 @@ describe('AllPasswordsPage', () => {
   });
 
   describe('when the fetch returns an empty list', () => {
-    it('renders no learner rows', async () => {
+    it('renders no learner content', async () => {
       FacilityUserResource.fetchCollection.mockResolvedValue([]);
       renderComponent();
       await global.flushPromises();
-      const rows = screen.getAllByRole('row');
-      expect(rows).toHaveLength(1);
+      // KTable hides the table element entirely when rows are empty
+      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
     });
 
     it('renders the empty class message', async () => {

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -65,8 +65,8 @@ describe('AllPasswordsPage', () => {
     it('does not show learner data while the fetch is pending', () => {
       FacilityUserResource.fetchCollection.mockImplementation(() => new Promise(() => {}));
       renderComponent();
-      expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
-      expect(screen.queryByText(LEARNERS[1].full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS.alice.full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS.bob.full_name)).not.toBeInTheDocument();
     });
 
     it('hides the loading indicator after the fetch resolves', async () => {
@@ -90,21 +90,21 @@ describe('AllPasswordsPage', () => {
     it('renders the full name of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
-      expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS.alice.full_name)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS.bob.full_name)).toBeInTheDocument();
     });
 
     it('renders the username of each learner', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(LEARNERS[0].username)).toBeInTheDocument();
-      expect(screen.getByText(LEARNERS[1].username)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS.alice.username)).toBeInTheDocument();
+      expect(screen.getByText(LEARNERS.bob.username)).toBeInTheDocument();
     });
 
     it('renders resolved icon labels for a learner with a picture_password', async () => {
       renderComponent();
       await global.flushPromises();
-      expect(screen.getByText(ICON_LABELS.join(', '))).toBeInTheDocument();
+      ICON_LABELS.forEach(label => expect(screen.getByText(label)).toBeInTheDocument());
     });
 
     it('renders the "no password" description for a learner with picture_password=null', async () => {
@@ -150,7 +150,7 @@ describe('AllPasswordsPage', () => {
         screen.getByRole('radio', { name: picturePasswordStrings.printWithTextOnly$() }),
       );
       await global.flushPromises();
-      expect(screen.getByText('testIcon1 - testIcon2 - testIcon3')).toBeInTheDocument();
+      expect(screen.getByText(ICON_LABELS.join(' - '))).toBeInTheDocument();
     });
   });
 
@@ -160,8 +160,8 @@ describe('AllPasswordsPage', () => {
       renderComponent();
       await global.flushPromises();
       // KTable hides the table element entirely when rows are empty
-      expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
-      expect(screen.queryByText(LEARNERS[1].full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS.alice.full_name)).not.toBeInTheDocument();
+      expect(screen.queryByText(LEARNERS.bob.full_name)).not.toBeInTheDocument();
     });
 
     it('renders the empty class message', async () => {

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -1,13 +1,11 @@
+import { ref } from 'vue';
 import { render, screen } from '@testing-library/vue';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import AllPasswordsPage from '../AllPasswordsPage.vue';
 
 const { noPicturePasswordDescription$, printAction$, noLearnersInClass$ } = picturePasswordStrings;
-
-jest.mock('kolibri-common/apiResources/FacilityUserResource', () => ({
-  fetchCollection: jest.fn(),
-}));
 
 const CLASS_ID = 'class-abc';
 const LEARNERS = {
@@ -15,6 +13,23 @@ const LEARNERS = {
   bob: { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
 };
 const ICON_LABELS = ['testIcon1', 'testIcon2', 'testIcon3'];
+
+jest.mock('kolibri-common/apiResources/FacilityUserResource', () => ({
+  fetchCollection: jest.fn(),
+}));
+
+jest.mock('kolibri-common/apiResources/ClassroomResource', () => ({
+  fetchModel: jest.fn(),
+}));
+
+jest.mock('kolibri-common/composables/useFacility', () => ({
+  default: jest.fn(() => ({
+    currentFacilityName: ref('Test Facility'),
+    facilityConfig: ref({
+      picture_password_settings: { icon_style: 'colorful' },
+    }),
+  })),
+}));
 
 jest.mock('kolibri-common/utils/picturePassword', () => ({
   getPicturePasswordIcons: jest.fn(pw => {
@@ -32,6 +47,7 @@ function renderComponent(props = {}) {
 describe('AllPasswordsPage', () => {
   beforeEach(() => {
     FacilityUserResource.fetchCollection.mockResolvedValue(Object.values(LEARNERS));
+    ClassroomResource.fetchModel.mockResolvedValue({ name: 'Test Class' });
   });
 
   afterEach(() => {

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { render, screen } from '@testing-library/vue';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
@@ -127,6 +127,30 @@ describe('AllPasswordsPage', () => {
       renderComponent();
       await global.flushPromises();
       expect(screen.getByRole('button', { name: printAction$() })).toBeInTheDocument();
+    });
+  });
+
+  describe('print dialog', () => {
+    it('opens the print format dialog when the Print button is clicked', async () => {
+      renderComponent();
+      await global.flushPromises();
+      fireEvent.click(screen.getByRole('button', { name: picturePasswordStrings.printAction$() }));
+      await global.flushPromises();
+      expect(
+        screen.getByText(picturePasswordStrings.printFormatDialogHeader$()),
+      ).toBeInTheDocument();
+    });
+
+    it('shows hyphenated icon labels in the preview when text format is selected', async () => {
+      renderComponent();
+      await global.flushPromises();
+      fireEvent.click(screen.getByRole('button', { name: picturePasswordStrings.printAction$() }));
+      await global.flushPromises();
+      fireEvent.click(
+        screen.getByRole('radio', { name: picturePasswordStrings.printWithTextOnly$() }),
+      );
+      await global.flushPromises();
+      expect(screen.getByText('testIcon1 - testIcon2 - testIcon3')).toBeInTheDocument();
     });
   });
 

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -137,7 +137,7 @@ describe('AllPasswordsPage', () => {
       fireEvent.click(screen.getByRole('button', { name: picturePasswordStrings.printAction$() }));
       await global.flushPromises();
       expect(
-        screen.getByText(picturePasswordStrings.printFormatDialogHeader$()),
+        screen.getByText(picturePasswordStrings.printPasswordsDialogHeader$()),
       ).toBeInTheDocument();
     });
 

--- a/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
+++ b/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
@@ -1,0 +1,98 @@
+import { ref } from 'vue';
+import { render, screen } from '@testing-library/vue';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
+import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import LearnerPasswordCard from '../LearnerPasswordCard.vue';
+
+jest.mock('kolibri-common/composables/useFacility');
+jest.mock('kolibri-common/utils/picturePassword', () => ({
+  getPicturePasswordIcons: jest.fn(pw => {
+    if (pw === '3.7.12')
+      return [
+        { label: 'testIcon1', iconName: 'moonColorful' },
+        { label: 'testIcon2', iconName: 'waterColorful' },
+        { label: 'testIcon3', iconName: 'birdColorful' },
+      ];
+    return [];
+  }),
+}));
+
+const LEARNER_WITH_PASSWORD = {
+  id: 'u1',
+  full_name: 'Alice Smith',
+  username: 'alice',
+  picture_password: '3.7.12',
+};
+
+const LEARNER_WITHOUT_PASSWORD = {
+  id: 'u2',
+  full_name: 'Bob Jones',
+  username: 'bob',
+  picture_password: null,
+};
+
+function renderCard(props = {}) {
+  return render(LearnerPasswordCard, {
+    props: { learner: LEARNER_WITH_PASSWORD, ...props },
+  });
+}
+
+describe('LearnerPasswordCard', () => {
+  beforeEach(() => {
+    useFacility.mockImplementation(() =>
+      useFacilityMock({
+        facilityConfig: ref({
+          picture_password_settings: { icon_style: PicturePasswordIconStyle.COLORFUL },
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the learner full name', () => {
+    renderCard();
+    expect(screen.getByText(LEARNER_WITH_PASSWORD.full_name)).toBeInTheDocument();
+  });
+
+  it('renders the learner username', () => {
+    renderCard();
+    expect(screen.getByText(LEARNER_WITH_PASSWORD.username)).toBeInTheDocument();
+  });
+
+  describe('when the learner has no picture password', () => {
+    it('renders NoPasswordInfo', () => {
+      renderCard({ learner: LEARNER_WITHOUT_PASSWORD });
+      expect(
+        screen.getByText(picturePasswordStrings.noPicturePasswordDescription$()),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('when printFormat is "text"', () => {
+    it('renders icon labels joined by " - "', () => {
+      renderCard({ printFormat: 'text' });
+      expect(screen.getByText('testIcon1 - testIcon2 - testIcon3')).toBeInTheDocument();
+    });
+
+    it('does not render the icon image sequence', () => {
+      renderCard({ printFormat: 'text' });
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when printFormat is "images" (default)', () => {
+    it('renders the UserPicturePassword icon sequence', () => {
+      renderCard();
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('does not render the text sequence', () => {
+      renderCard();
+      expect(screen.queryByText('testIcon1 - testIcon2 - testIcon3')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
+++ b/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
@@ -6,14 +6,11 @@ import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords'
 import LearnerPasswordCard from '../LearnerPasswordCard.vue';
 
 jest.mock('kolibri-common/composables/useFacility');
+const ICON_LABELS = ['testIcon1', 'testIcon2', 'testIcon3'];
+
 jest.mock('kolibri-common/utils/picturePassword', () => ({
   getPicturePasswordIcons: jest.fn(pw => {
-    if (pw === '3.7.12')
-      return [
-        { label: 'testIcon1', iconName: 'moonColorful' },
-        { label: 'testIcon2', iconName: 'waterColorful' },
-        { label: 'testIcon3', iconName: 'birdColorful' },
-      ];
+    if (pw === '3.7.12') return ICON_LABELS.map(label => ({ label }));
     return [];
   }),
 }));
@@ -75,7 +72,7 @@ describe('LearnerPasswordCard', () => {
   describe('when printFormat is "text"', () => {
     it('renders icon labels joined by " - "', () => {
       renderCard({ printFormat: 'text' });
-      expect(screen.getByText('testIcon1 - testIcon2 - testIcon3')).toBeInTheDocument();
+      expect(screen.getByText(ICON_LABELS.join(' - '))).toBeInTheDocument();
     });
 
     it('does not render the icon image sequence', () => {
@@ -92,7 +89,7 @@ describe('LearnerPasswordCard', () => {
 
     it('does not render the text sequence', () => {
       renderCard();
-      expect(screen.queryByText('testIcon1 - testIcon2 - testIcon3')).not.toBeInTheDocument();
+      expect(screen.queryByText(ICON_LABELS.join(' - '))).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
+++ b/packages/kolibri-common/components/__tests__/LearnerPasswordCard.spec.js
@@ -76,15 +76,15 @@ describe('LearnerPasswordCard', () => {
     });
 
     it('does not render the icon image sequence', () => {
-      renderCard({ printFormat: 'text' });
-      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+      const { container } = renderCard({ printFormat: 'text' });
+      expect(container.querySelector('.picture-password-wrapper')).not.toBeInTheDocument();
     });
   });
 
   describe('when printFormat is "images" (default)', () => {
     it('renders the UserPicturePassword icon sequence', () => {
-      renderCard();
-      expect(screen.getByRole('list')).toBeInTheDocument();
+      const { container } = renderCard();
+      expect(container.querySelector('.picture-password-wrapper')).toBeInTheDocument();
     });
 
     it('does not render the text sequence', () => {

--- a/packages/kolibri-common/components/__tests__/NoPasswordInfo.spec.js
+++ b/packages/kolibri-common/components/__tests__/NoPasswordInfo.spec.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/vue';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import NoPasswordInfo from '../NoPasswordInfo.vue';
+
+describe('NoPasswordInfo', () => {
+  it('renders the "no picture password" title', () => {
+    render(NoPasswordInfo);
+    expect(
+      screen.getByText(picturePasswordStrings.noPicturePasswordDescription$()),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the "sign in with text password" subtitle', () => {
+    render(NoPasswordInfo);
+    expect(
+      screen.getByText(picturePasswordStrings.noPasswordSignInDescription$()),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import { ref } from 'vue';
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
 import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
@@ -18,14 +18,30 @@ function mockFacilityConfig(iconStyle, showIconText = false) {
   );
 }
 
-describe('UserPicturePassword', () => {
-  it('renders expected captions for picturePassword 3.7.12', () => {
-    mockFacilityConfig(PicturePasswordIconStyle.COLORFUL);
+const COLORFUL_FACILITY_CONFIG = ref({
+  picture_password_settings: {
+    icon_style: PicturePasswordIconStyle.COLORFUL,
+  },
+});
 
+function setupFacilityMock() {
+  useFacility.mockImplementation(() =>
+    useFacilityMock({ facilityConfig: COLORFUL_FACILITY_CONFIG }),
+  );
+}
+
+describe('UserPicturePassword', () => {
+  beforeEach(() => {
+    setupFacilityMock();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders expected captions for picturePassword 3.7.12', () => {
     const { container } = render(UserPicturePassword, {
-      props: {
-        picturePassword: '3.7.12',
-      },
+      props: { picturePassword: '3.7.12' },
     });
 
     const captions = Array.from(container.querySelectorAll('figcaption')).map(node =>
@@ -84,5 +100,27 @@ describe('UserPicturePassword', () => {
       'picture-password-icon-waterStandard',
       'picture-password-icon-birdStandard',
     ]);
+  });
+
+  describe('showCounts prop', () => {
+    it('does not render count numbers by default', () => {
+      render(UserPicturePassword, {
+        props: { picturePassword: '3.7.12' },
+      });
+
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+      expect(screen.queryByText('2')).not.toBeInTheDocument();
+      expect(screen.queryByText('3')).not.toBeInTheDocument();
+    });
+
+    it('renders count numbers when showCounts is true', () => {
+      render(UserPicturePassword, {
+        props: { picturePassword: '3.7.12', showCounts: true },
+      });
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -102,7 +102,7 @@ describe('UserPicturePassword', () => {
     ]);
   });
 
-  describe('showCounts prop', () => {
+  describe('showSequenceNumbers prop', () => {
     it('does not render count numbers by default', () => {
       render(UserPicturePassword, {
         props: { picturePassword: '3.7.12' },
@@ -113,9 +113,9 @@ describe('UserPicturePassword', () => {
       expect(screen.queryByText('3')).not.toBeInTheDocument();
     });
 
-    it('renders count numbers when showCounts is true', () => {
+    it('renders count numbers when showSequenceNumbers is true', () => {
       render(UserPicturePassword, {
-        props: { picturePassword: '3.7.12', showCounts: true },
+        props: { picturePassword: '3.7.12', showSequenceNumbers: true },
       });
 
       expect(screen.getByText('1')).toBeInTheDocument();

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -5,13 +5,8 @@ import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import UserPicturePassword from '../UserPicturePassword.vue';
 
-const {
-  moon$,
-  water$,
-  bird$,
-  picturePasswordSequenceDescription$,
-  picturePasswordSequenceForLearner$,
-} = picturePasswordStrings;
+const { moon$, water$, bird$, picturePasswordForLearner$, picturePasswordList$ } =
+  picturePasswordStrings;
 
 const LEARNER_NAME = 'Alice';
 const PICTURE_PASSWORD = '3.7.12';
@@ -51,33 +46,28 @@ describe('UserPicturePassword', () => {
     jest.clearAllMocks();
   });
 
-  it('does not set an aria-label by default (callers provide context-specific labels)', () => {
-    render(UserPicturePassword, {
-      props: { picturePassword: PICTURE_PASSWORD },
+  describe('aria-label', () => {
+    it('uses the list sentence when no learnerName is provided', () => {
+      render(UserPicturePassword, {
+        props: { picturePassword: PICTURE_PASSWORD },
+      });
+
+      const labels = [moon$(), water$(), bird$()].join(', ');
+      expect(screen.getByText(picturePasswordList$({ count: 3, labels }))).toBeInTheDocument();
     });
 
-    const list = screen.getByRole('list');
-    expect(list).not.toHaveAttribute('aria-label');
-  });
+    it('uses the learner sentence when learnerName is provided', () => {
+      render(UserPicturePassword, {
+        props: { picturePassword: PICTURE_PASSWORD, learnerName: LEARNER_NAME },
+      });
 
-  it('applies an aria-label when the ariaLabel prop is provided', () => {
-    const ariaLabel = picturePasswordSequenceForLearner$({ learnerName: LEARNER_NAME });
-    render(UserPicturePassword, {
-      props: { picturePassword: PICTURE_PASSWORD, ariaLabel },
+      const labels = [moon$(), water$(), bird$()].join(', ');
+      expect(
+        screen.getByText(
+          picturePasswordForLearner$({ learnerName: LEARNER_NAME, count: 3, labels }),
+        ),
+      ).toBeInTheDocument();
     });
-
-    expect(screen.getByRole('list', { name: ariaLabel })).toBeInTheDocument();
-  });
-
-  it('sets a static aria-description describing the sequence structure', () => {
-    render(UserPicturePassword, {
-      props: { picturePassword: PICTURE_PASSWORD },
-    });
-
-    expect(screen.getByRole('list')).toHaveAttribute(
-      'aria-description',
-      picturePasswordSequenceDescription$(),
-    );
   });
 
   it('renders expected captions for picturePassword 3.7.12', () => {

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -40,15 +40,34 @@ describe('UserPicturePassword', () => {
     jest.clearAllMocks();
   });
 
-  it('sets an aria-label on the list describing the icon sequence', () => {
+  it('does not set an aria-label by default (callers provide context-specific labels)', () => {
     render(UserPicturePassword, {
       props: { picturePassword: '3.7.12' },
     });
 
-    const expectedLabel = picturePasswordStrings.picturePasswordSequence$({
-      sequence: 'moon, water, bird',
+    const list = screen.getByRole('list');
+    expect(list).not.toHaveAttribute('aria-label');
+  });
+
+  it('applies an aria-label when the ariaLabel prop is provided', () => {
+    render(UserPicturePassword, {
+      props: { picturePassword: '3.7.12', ariaLabel: 'Picture password sequence for Alice' },
     });
-    expect(screen.getByRole('list', { name: expectedLabel })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('list', { name: 'Picture password sequence for Alice' }),
+    ).toBeInTheDocument();
+  });
+
+  it('sets a static aria-description describing the sequence structure', () => {
+    render(UserPicturePassword, {
+      props: { picturePassword: '3.7.12' },
+    });
+
+    expect(screen.getByRole('list')).toHaveAttribute(
+      'aria-description',
+      picturePasswordStrings.picturePasswordSequenceDescription$(),
+    );
   });
 
   it('renders expected captions for picturePassword 3.7.12', () => {

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -5,6 +5,17 @@ import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import UserPicturePassword from '../UserPicturePassword.vue';
 
+const {
+  moon$,
+  water$,
+  bird$,
+  picturePasswordSequenceDescription$,
+  picturePasswordSequenceForLearner$,
+} = picturePasswordStrings;
+
+const LEARNER_NAME = 'Alice';
+const PICTURE_PASSWORD = '3.7.12';
+
 jest.mock('kolibri-common/composables/useFacility');
 
 function mockFacilityConfig(iconStyle, showIconText = false) {
@@ -42,7 +53,7 @@ describe('UserPicturePassword', () => {
 
   it('does not set an aria-label by default (callers provide context-specific labels)', () => {
     render(UserPicturePassword, {
-      props: { picturePassword: '3.7.12' },
+      props: { picturePassword: PICTURE_PASSWORD },
     });
 
     const list = screen.getByRole('list');
@@ -50,36 +61,35 @@ describe('UserPicturePassword', () => {
   });
 
   it('applies an aria-label when the ariaLabel prop is provided', () => {
+    const ariaLabel = picturePasswordSequenceForLearner$({ learnerName: LEARNER_NAME });
     render(UserPicturePassword, {
-      props: { picturePassword: '3.7.12', ariaLabel: 'Picture password sequence for Alice' },
+      props: { picturePassword: PICTURE_PASSWORD, ariaLabel },
     });
 
-    expect(
-      screen.getByRole('list', { name: 'Picture password sequence for Alice' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: ariaLabel })).toBeInTheDocument();
   });
 
   it('sets a static aria-description describing the sequence structure', () => {
     render(UserPicturePassword, {
-      props: { picturePassword: '3.7.12' },
+      props: { picturePassword: PICTURE_PASSWORD },
     });
 
     expect(screen.getByRole('list')).toHaveAttribute(
       'aria-description',
-      picturePasswordStrings.picturePasswordSequenceDescription$(),
+      picturePasswordSequenceDescription$(),
     );
   });
 
   it('renders expected captions for picturePassword 3.7.12', () => {
     const { container } = render(UserPicturePassword, {
-      props: { picturePassword: '3.7.12' },
+      props: { picturePassword: PICTURE_PASSWORD },
     });
 
     const captions = Array.from(container.querySelectorAll('figcaption')).map(node =>
       node.textContent.trim(),
     );
 
-    expect(captions).toEqual(['moon', 'water', 'bird']);
+    expect(captions).toEqual([moon$(), water$(), bird$()]);
   });
 
   it('hides figcaption labels when showIconText is false via facilityConfig', () => {
@@ -136,7 +146,7 @@ describe('UserPicturePassword', () => {
   describe('showSequenceNumbers prop', () => {
     it('does not add show-sequence-numbers class by default', () => {
       const { container } = render(UserPicturePassword, {
-        props: { picturePassword: '3.7.12' },
+        props: { picturePassword: PICTURE_PASSWORD },
       });
 
       expect(container.querySelector('.show-sequence-numbers')).not.toBeInTheDocument();
@@ -144,7 +154,7 @@ describe('UserPicturePassword', () => {
 
     it('adds show-sequence-numbers class when showSequenceNumbers is true', () => {
       const { container } = render(UserPicturePassword, {
-        props: { picturePassword: '3.7.12', showSequenceNumbers: true },
+        props: { picturePassword: PICTURE_PASSWORD, showSequenceNumbers: true },
       });
 
       expect(container.querySelector('.show-sequence-numbers')).toBeInTheDocument();

--- a/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
+++ b/packages/kolibri-common/components/__tests__/UserPicturePassword.spec.js
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/vue';
 import { ref } from 'vue';
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
 import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import UserPicturePassword from '../UserPicturePassword.vue';
 
 jest.mock('kolibri-common/composables/useFacility');
@@ -37,6 +38,17 @@ describe('UserPicturePassword', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('sets an aria-label on the list describing the icon sequence', () => {
+    render(UserPicturePassword, {
+      props: { picturePassword: '3.7.12' },
+    });
+
+    const expectedLabel = picturePasswordStrings.picturePasswordSequence$({
+      sequence: 'moon, water, bird',
+    });
+    expect(screen.getByRole('list', { name: expectedLabel })).toBeInTheDocument();
   });
 
   it('renders expected captions for picturePassword 3.7.12', () => {
@@ -103,24 +115,20 @@ describe('UserPicturePassword', () => {
   });
 
   describe('showSequenceNumbers prop', () => {
-    it('does not render count numbers by default', () => {
-      render(UserPicturePassword, {
+    it('does not add show-sequence-numbers class by default', () => {
+      const { container } = render(UserPicturePassword, {
         props: { picturePassword: '3.7.12' },
       });
 
-      expect(screen.queryByText('1')).not.toBeInTheDocument();
-      expect(screen.queryByText('2')).not.toBeInTheDocument();
-      expect(screen.queryByText('3')).not.toBeInTheDocument();
+      expect(container.querySelector('.show-sequence-numbers')).not.toBeInTheDocument();
     });
 
-    it('renders count numbers when showSequenceNumbers is true', () => {
-      render(UserPicturePassword, {
+    it('adds show-sequence-numbers class when showSequenceNumbers is true', () => {
+      const { container } = render(UserPicturePassword, {
         props: { picturePassword: '3.7.12', showSequenceNumbers: true },
       });
 
-      expect(screen.getByText('1')).toBeInTheDocument();
-      expect(screen.getByText('2')).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(container.querySelector('.show-sequence-numbers')).toBeInTheDocument();
     });
   });
 });

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -173,7 +173,7 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     context: 'Button label that navigates to the page listing all learner picture passwords',
   },
   noPicturePasswordDescription: {
-    message: 'No picture password assigned',
+    message: 'No picture password',
     context: 'Shown in the learner password list when a learner has no picture password set',
   },
   printAction: {

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -209,16 +209,6 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'Preview',
     context: 'Label for the live preview section in the print format dialog',
   },
-  picturePasswordSequenceForLearner: {
-    message: 'Picture password sequence for {learnerName}',
-    context:
-      "Accessible label for a learner's picture password icon sequence when multiple learners are shown together (e.g. the All Passwords page). Lets screen readers distinguish one learner's sequence from another. The icons and their names are already announced as items of the ordered list, so this label intentionally does not repeat them.",
-  },
-  picturePasswordSequenceDescription: {
-    message: 'A sequence of 3 pictures and their names',
-    context:
-      'Accessible description of the picture password sequence list, explaining its structure to screen reader users. The number 3 is a fixed design constant (picture passwords are always 3 icons long).',
-  },
   picturePasswordForLearner: {
     message: 'Password for {learnerName} is a list of {count} pictures: {labels}',
     context:

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -193,4 +193,20 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'There are no learners in this class',
     context: 'Shown on the all passwords page when the class has no enrolled learners',
   },
+  printWithImages: {
+    message: 'Print with images',
+    context: 'Radio option label for printing the picture password list with icon images',
+  },
+  printWithTextOnly: {
+    message: 'Print with text only',
+    context: 'Radio option label for printing the picture password list using text labels only',
+  },
+  printFormatDialogHeader: {
+    message: 'Print format',
+    context: 'Title for the dialog where coaches choose how to print the picture password list',
+  },
+  printFormatPreviewLabel: {
+    message: 'Preview',
+    context: 'Label for the live preview section in the print format dialog',
+  },
 });

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -209,9 +209,14 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'Preview',
     context: 'Label for the live preview section in the print format dialog',
   },
-  picturePasswordSequence: {
-    message: 'Picture password: {sequence}',
+  picturePasswordSequenceForLearner: {
+    message: 'Picture password sequence for {learnerName}',
     context:
-      'Accessible label for a learner\'s picture password icon sequence, e.g. "Picture password: moon, water, bird". Read aloud by screen readers in place of the generic "list" announcement.',
+      "Accessible label for a learner's picture password icon sequence when multiple learners are shown together (e.g. the All Passwords page). Lets screen readers distinguish one learner's sequence from another. The icons and their names are already announced as items of the ordered list, so this label intentionally does not repeat them.",
+  },
+  picturePasswordSequenceDescription: {
+    message: 'A sequence of 3 pictures and their names',
+    context:
+      'Accessible description of the picture password sequence list, explaining its structure to screen reader users. The number 3 is a fixed design constant (picture passwords are always 3 icons long).',
   },
 });

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -201,8 +201,8 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'Print with text only',
     context: 'Radio option label for printing the picture password list using text labels only',
   },
-  printFormatDialogHeader: {
-    message: 'Print format',
+  printPasswordsDialogHeader: {
+    message: 'Print passwords',
     context: 'Title for the dialog where coaches choose how to print the picture password list',
   },
   printFormatPreviewLabel: {

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -209,4 +209,9 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'Preview',
     context: 'Label for the live preview section in the print format dialog',
   },
+  picturePasswordSequence: {
+    message: 'Picture password: {sequence}',
+    context:
+      'Accessible label for a learner\'s picture password icon sequence, e.g. "Picture password: moon, water, bird". Read aloud by screen readers in place of the generic "list" announcement.',
+  },
 });

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -219,4 +219,14 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     context:
       'Accessible description of the picture password sequence list, explaining its structure to screen reader users. The number 3 is a fixed design constant (picture passwords are always 3 icons long).',
   },
+  picturePasswordForLearner: {
+    message: 'Password for {learnerName} is a list of {count} pictures: {labels}',
+    context:
+      "Screen reader sentence describing a learner's picture password when the learner name is known. For example: 'Password for Alice is a list of 3 pictures: moon, water, bird'.",
+  },
+  picturePasswordList: {
+    message: 'A list of {count} pictures: {labels}',
+    context:
+      "Screen reader sentence describing a picture password when no learner name is available. For example: 'A list of 3 pictures: moon, water, bird'.",
+  },
 });

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -1,7 +1,10 @@
 <template>
 
   <div class="main">
-    <ScrollingHeader :scrollPosition="0">
+    <ScrollingHeader
+      v-if="showHeader"
+      :scrollPosition="0"
+    >
       <ImmersiveToolbar
         ref="appBar"
         :appBarTitle="!loading ? appBarTitle : ''"
@@ -90,6 +93,11 @@
         type: String,
         required: false,
         default: '',
+      },
+      showHeader: {
+        type: Boolean,
+        required: false,
+        default: true,
       },
     },
     data() {

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -137,3 +137,14 @@
   };
 
 </script>
+
+
+<style>
+
+  @media print {
+    .main-wrapper {
+      display: block !important;
+    }
+  }
+
+</style>

--- a/packages/kolibri/components/pages/ImmersivePage/index.vue
+++ b/packages/kolibri/components/pages/ImmersivePage/index.vue
@@ -111,7 +111,7 @@
           ? this.appearanceOverrides
           : {
             width: '100%',
-            display: 'inline-block',
+            display: this.$isPrint ? undefined : 'inline-block',
             backgroundColor: this.$themePalette.grey.v_100,
             paddingBottom: '72px',
             paddingLeft: this.paddingLeftRight,
@@ -137,14 +137,3 @@
   };
 
 </script>
-
-
-<style>
-
-  @media print {
-    .main-wrapper {
-      display: block !important;
-    }
-  }
-
-</style>


### PR DESCRIPTION
## Summary

Implements full icon display and print functionality for `AllPasswordsPage`, part of the picture password feature.

**Icon display**
- Delegates icon sequence rendering to the existing `UserPicturePassword` component
- Sequence numbers (1, 2, 3 under each icon) are shown on printed cards (`showSequenceNumbers` prop) and hidden on screen
- Sequence number rendering uses a CSS `::after` counter on the `ol`'s built-in `list-item` counter — no extra DOM node needed; the manual index `<span>` is removed
- Annotation color is applied via `$computedClass` on `<figure>` so both `figcaption` and `::after` inherit it, avoiding CSS custom properties

**Accessibility**
- `UserPicturePassword` now has a computed `aria-label` (e.g. "Picture password: moon, water, bird") so screen readers announce the full sequence instead of the generic "list"

**Table**
- Replaces `CoreTable` with `KTable` for a single sortable "Name" column
- Client-side sort via `lodash/orderBy`; sort controls and column header are hidden in print mode

**Print dialog & layout**
- On submit, user chooses between image layout (icon cards with sequence numbers) or text-only (hyphenated labels, e.g. "moon - water - bird")
- A live preview of the selected format is shown before confirming
- `ImmersivePage` gains a `showHeader` prop (default `true`) — `AllPasswordsPage` sets it to `!$isPrint` to hide the app bar on printed output
- Text-only print cards use a bottom-border-only style (no full border/radius) to improve visual separation without boxing each row
- `KPageContainer` uses `topMargin=0` and `noPadding` during print to remove excess spacing at the top of the printed page

**Component extraction**
- `LearnerPasswordCard` — owns the card layout (learner info + password content, text labels, and print color/page-break rules); replaces duplicated markup between the print list and modal preview
- `NoPasswordInfo` — owns the "no picture password" display; replaces duplicated markup between the table cell and the print cards
- `printListCardStyle` spreads from `cardStyle` to avoid the two computed props drifting out of sync

**Dynamic styles**
- Complex inline `:style` expressions extracted into Options API `computed` properties (required because `$isPrint`, `$themeTokens`, and `$themePalette` are Vue instance properties)

**Strings**
- New `picturePasswords.js` strings: `noLearnersInClass`, `noPicturePasswordDescription`, `noPasswordSignInDescription`, `printAction`, `allPasswordsHeader`, `printWithImages`, `printWithTextOnly`, `printFormatDialogHeader`, `printFormatPreviewLabel`, `picturePasswordSequence`

**Tests**
- `AllPasswordsPage.spec.js` drops component stubs and renders the real component tree, mocking only at hard boundaries: composables, vue-router, and API resources
- `UserPicturePassword.spec.js` tests the `show-sequence-numbers` class and the new aria-label
- `LearnerPasswordCard.spec.js` covers name/username rendering, text format vs image format switching, and the no-password fallback
- `NoPasswordInfo.spec.js` covers both translated strings

**Screenshots**

<img width="1799" height="1034" alt="Screenshot 2026-04-23 at 12 47 08" src="https://github.com/user-attachments/assets/21b41851-13f7-40f8-9190-7e4e5211e934" />
<img width="1799" height="1034" alt="Screenshot 2026-04-23 at 12 48 33" src="https://github.com/user-attachments/assets/57c52fcb-964c-45db-aa5a-8ae2e5df0654" />
<img width="1799" height="1034" alt="Screenshot 2026-04-23 at 12 48 43" src="https://github.com/user-attachments/assets/bf7e2be8-470b-4e31-8a92-5a6a9d1e12e6" />
<img width="1799" height="1034" alt="Screenshot 2026-04-23 at 13 09 43" src="https://github.com/user-attachments/assets/f53fd79d-45c0-43d3-9fdd-2df974ea7002" />
<img width="1799" height="1034" alt="Screenshot 2026-04-23 at 13 09 58" src="https://github.com/user-attachments/assets/2df37192-bda2-4c87-92bc-7a6cd8d75d16" />

## References
Closes #14371

## Reviewer guidance

- View passwords from the Coach Home and Learners Pages
- Print passwords in the different formats

## AI usage

I used Claude Code (claude-sonnet-4-6) throughout this implementation. I reviewed each change and directed several corrections along the way.