### PR TITLE
Remove leaked sqlite3 connection in sqlite_check_foreign_keys

### DIFF
--- a/kolibri/utils/database.py
+++ b/kolibri/utils/database.py
@@ -83,7 +83,6 @@ def sqlite_check_foreign_keys(database_paths):
         if not os.path.exists(name):
             continue
 
-        db_connection = sqlite3.connect(name)
         with sqlite3.connect(name) as db_connection:
             cursor = db_connection.cursor()
 


### PR DESCRIPTION
## Bug

`sqlite_check_foreign_keys` in `kolibri/utils/database.py` leaks one
SQLite connection per database path it inspects.

## Root cause

```python
db_connection = sqlite3.connect(name)
with sqlite3.connect(name) as db_connection:
    cursor = db_connection.cursor()
    ...
```

The first `sqlite3.connect(name)` is assigned to `db_connection`, then
immediately overwritten by the `with sqlite3.connect(name) as
db_connection:` on the next line. The `with` block manages its own
connection; the earlier one is never used, never closed, and gets
garbage-collected later (which may leave the file handle open until
GC runs — an issue under the "whoever allocates a resource releases
it" rule in `CLAUDE.md`).

This looks like a refactor leftover: the original code likely used
the bare `connect(...)` assignment, and when the block was wrapped
in a context manager the previous line was not removed.

## Why the fix is correct

- The `with sqlite3.connect(name) as db_connection:` block already
  binds `db_connection` and guarantees it will be closed.
- No other code in the function references the pre-`with` binding, so
  removing it is safe.
- Matches the rest of the file (`_backup_records`, which uses a
  single `with open(...):` to manage resources).

## Change

`kolibri/utils/database.py`: delete the dead
`db_connection = sqlite3.connect(name)` line in
`sqlite_check_foreign_keys`. One-line deletion.

## Test plan

- [ ] `pytest kolibri/utils/tests/test_database.py` still passes.
- [ ] `sqlite_check_foreign_keys` still detects and fixes foreign-key
  violations (exercised by existing coverage in `test_database.py`).