### PR TITLE
Fix TaskRegistry.update crashing on NoneType after {}.update()

### DIFF
--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -110,7 +110,7 @@ class _registry(dict):
 
     def update(self, other):
         # Coerce args to a dict and then set each key in that dict
-        other = {}.update(other)
+        other = dict(other)
         for key, value in other.items():
             self[key] = value
 


### PR DESCRIPTION
## Bug

`_registry.update` in `kolibri/core/tasks/registry.py` raises
`AttributeError: 'NoneType' object has no attribute 'items'` whenever
it is called with anything, because it coerces its argument through
an expression that evaluates to `None`.

## Root cause

```python
def update(self, other):
    # Coerce args to a dict and then set each key in that dict
    other = {}.update(other)
    for key, value in other.items():
        self[key] = value
```

`dict.update()` (here called on a throwaway `{}`) mutates the dict
in place and returns `None`. The line therefore rebinds `other` to
`None`, and the very next line calls `None.items()` — crash. The
code path has been dormant because no in-tree caller currently uses
`TaskRegistry.update(...)`, but the method is public and subclassed
behaviour requires it to work.

## Why the fix is correct

- `dict(other)` is the one-expression coercion that matches the
  comment's intent ("Coerce args to a dict"). It accepts the same
  argument shapes `dict.update` itself accepts — a mapping, or an
  iterable of key/value pairs — and returns a new dict.
- `self[key] = value` inside the loop still goes through the
  overridden `__setitem__` that enforces `RegisteredTask` instances,
  so the registry's type invariant is preserved.
- Only one expression changes; the surrounding method signature,
  comment, and loop are untouched.

## Change

`kolibri/core/tasks/registry.py`: `other = {}.update(other)` →
`other = dict(other)`. One-line fix.