### PR TITLE
A11y fixes

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/LearnersAndGroupsSelector.vue
@@ -6,9 +6,11 @@
         {{ classLabel$() }}
       </h2>
       <KRadioButton
-        v-model="isClassSelected"
+        :currentValue="isClassSelected"
         :buttonValue="SELECT_CLASS_OPTION"
         :disabled="disabled"
+        @change="selectEntireClass"
+        @keydown.space.prevent="selectEntireClass"
       >
         <KLabeledIcon
           :label="entireClassLabel$()"
@@ -103,25 +105,20 @@
         },
       });
 
-      const isClassSelected = computed({
-        get: () => {
-          if (!props.showSelectClassOption) {
-            return '';
-          }
-          if (workingSelectedGroupIds.value.find(group => group === props.classId)) {
-            return SELECT_CLASS_OPTION;
-          }
+      const isClassSelected = computed(() => {
+        if (!props.showSelectClassOption) {
           return '';
-        },
-        set: value => {
-          if (value === SELECT_CLASS_OPTION) {
-            workingSelectedGroupIds.value = [props.classId];
-            workingAdHocLearners.value = [];
-          } else {
-            workingSelectedGroupIds.value = [];
-          }
-        },
+        }
+        if (workingSelectedGroupIds.value.find(group => group === props.classId)) {
+          return SELECT_CLASS_OPTION;
+        }
+        return '';
       });
+
+      const selectEntireClass = () => {
+        workingSelectedGroupIds.value = [props.classId];
+        workingAdHocLearners.value = [];
+      };
 
       const groups = computed(() => {
         if (props.groups) {
@@ -190,6 +187,7 @@
         areAllUngroupedLearnersSelected,
 
         selectAllUngroupedLearners,
+        selectEntireClass,
 
         classLabel$,
         groupsLabel$,

--- a/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/CoursesRootPage.vue
@@ -39,7 +39,6 @@
         <FilterTextbox
           v-model="searchFilter"
           :placeholder="coreString('searchLabel')"
-          :aria-label="coreString('searchLabel')"
           :disabled="!hasCourses"
           class="filter-search"
         />
@@ -53,86 +52,85 @@
         />
       </div>
       <div v-if="showCoursesTable">
-        <CoreTable
+        <KTable
           :dataLoading="coursesAreLoading"
           :emptyMessage="hasActiveFilters ? coreString('noResultsLabel') : noCoursesAssigned$()"
+          :caption="tableCaption"
+          :headers="tableHeaders"
+          :rows="tableRows"
+          :stickyColumns="['first']"
         >
-          <template #headers>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coreString('statusLabel') }}</th>
-            <th>{{ coachString('learnersLabel') }}</th>
-            <th>{{ masteryLabel$() }}</th>
-            <th>{{ visibleLabel$() }}</th>
+          <template #header="{ header, colIndex }">
+            <span
+              v-if="colIndex === 5"
+              class="visuallyhidden"
+            >{{ header.label }}</span>
+            <span
+              v-else-if="colIndex === 4"
+              id="course-visibility-column-header"
+              class="table-header-label"
+              :style="{ color: $themeTokens.annotation }"
+            >{{ header.label }}</span>
+            <span
+              v-else
+              class="table-header-label"
+              :style="{ color: $themeTokens.annotation }"
+            >{{ header.label }}</span>
           </template>
-          <template #tbody>
-            <transition-group
-              tag="tbody"
-              name="list"
+          <template #cell="{ content, colIndex }">
+            <template v-if="colIndex === 0">
+              <div class="course-title">
+                <KRouterLink
+                  :to="courseSummaryLink(content)"
+                  :text="content.title"
+                  icon="course"
+                />
+              </div>
+            </template>
+            <template v-else-if="colIndex >= 1 && colIndex <= 3">
+              {{ content }}
+            </template>
+            <div
+              v-else-if="colIndex === 4"
+              class="visibility-toggle-container"
             >
-              <tr
-                v-for="course in sortedCourses"
-                :key="course.id"
-              >
-                <td>
-                  <div class="course-title">
-                    <KRouterLink
-                      :to="courseSummaryLink(course)"
-                      :text="course.title"
-                      icon="course"
-                    />
-                  </div>
-                  <KTextTruncator
-                    v-if="course.description"
-                    :text="course.description"
-                    :maxLines="1"
-                    class="course-description"
-                  />
-                </td>
-                <td>
-                  <span>—</span>
-                </td>
-                <td>
-                  <span>—</span>
-                </td>
-                <td>
-                  <span>
-                    {{ formatMastery(course.averageMastery) }}
-                  </span>
-                </td>
-                <td>
-                  <div class="visibility-toggle-container">
-                    <KTransition kind="component-fade-out-in">
-                      <KCircularLoader
-                        v-if="show(course.id, isUpdatingActive(course.id), 500)"
-                        :key="`loader-${course.id}`"
-                        disableDefaultTransition
-                      />
-                      <KSwitch
-                        v-else
-                        :key="`switch-${course.id}`"
-                        name="toggle-course-visibility"
-                        :checked="course.active"
-                        :value="course.active"
-                        :disabled="course.contentMissing || isUpdatingActive(course.id)"
-                        @change="toggleCourseActive(course)"
-                      />
-                    </KTransition>
-                  </div>
-                </td>
-                <td>
-                  <KIconButton icon="optionsVertical">
-                    <template #menu>
-                      <KDropdownMenu
-                        :options="courseMenuOptions(course)"
-                        @select="selection => handleCourseMenuSelect(selection, course)"
-                      />
-                    </template>
-                  </KIconButton>
-                </td>
-              </tr>
-            </transition-group>
+              <span
+                :id="`course-visibility-label-${content.id}`"
+                class="hidden"
+                aria-hidden="true"
+              >{{ `${content.title} - ${coachString('lessonVisibleLabel')}` }}</span>
+              <KTransition kind="component-fade-out-in">
+                <KCircularLoader
+                  v-if="show(content.id, isUpdatingActive(content.id), 500)"
+                  :key="`loader-${content.id}`"
+                  disableDefaultTransition
+                />
+                <KSwitch
+                  v-else
+                  :key="`switch-${content.id}`"
+                  name="toggle-course-visibility"
+                  :checked="content.active"
+                  :value="content.active"
+                  :disabled="content.contentMissing || isUpdatingActive(content.id)"
+                  :ariaLabelledBy="`course-visibility-label-${content.id}`"
+                  @change="toggleCourseActive(content)"
+                />
+              </KTransition>
+            </div>
+            <KIconButton
+              v-else-if="colIndex === 5"
+              icon="optionsVertical"
+              :aria-label="coreString('optionsLabel')"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="courseMenuOptions(content)"
+                  @select="selection => handleCourseMenuSelect(selection, content)"
+                />
+              </template>
+            </KIconButton>
           </template>
-        </CoreTable>
+        </KTable>
       </div>
       <div
         v-else
@@ -186,7 +184,6 @@
 
   import CourseSessionResource from 'kolibri-common/apiResources/CourseSessionResource';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert.vue';
-  import CoreTable from 'kolibri/components/CoreTable';
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import { coreString as translateCoreString } from 'kolibri/uiText/commonCoreStrings';
   import useKShow from 'kolibri-design-system/lib/composables/useKShow';
@@ -214,7 +211,6 @@
       CoachAppBarPage,
       AssignCourseSuccessModal,
       DeleteCourseConfirmationModal,
-      CoreTable,
       FilterTextbox,
       MissingResourceAlert,
     },
@@ -231,7 +227,6 @@
         noCoursesAssigned$,
         emptyCoursesDescription$,
         masteryLabel$,
-        visibleLabel$,
         courseVisibleToLearnersMessage$,
         courseNotVisibleToLearnersMessage$,
         courseUpdateError$,
@@ -243,6 +238,7 @@
         courseDeleteError$,
         courseDetailsAction$,
         editRecipientsAction$,
+        allCoursesForClass$,
       } = coursesStrings;
       const { entireClassLabel$ } = coachStrings;
       const { show } = useKShow();
@@ -447,7 +443,6 @@
         noCoursesAssigned$,
         emptyCoursesDescription$,
         masteryLabel$,
-        visibleLabel$,
         filterCourseStatus$,
         filterCourseVisible$,
         filterCourseNotVisible$,
@@ -466,6 +461,7 @@
         handleCourseMenuSelect,
         editRecipientsAction$,
         courseDetailsAction$,
+        allCoursesForClass$,
         coreString,
         coachString,
       };
@@ -478,6 +474,62 @@
       };
     },
     computed: {
+      className() {
+        return this.$store.state.classSummary.name;
+      },
+      tableCaption() {
+        return this.allCoursesForClass$({ className: this.className });
+      },
+      tableHeaders() {
+        return [
+          {
+            label: this.coachString('titleLabel'),
+            dataType: 'string',
+            minWidth: '200px',
+            columnId: 'title',
+          },
+          {
+            label: this.coreString('progressLabel'),
+            dataType: 'undefined',
+            minWidth: '100px',
+            columnId: 'status',
+          },
+          {
+            label: this.coachString('learnersLabel'),
+            dataType: 'undefined',
+            minWidth: '100px',
+            columnId: 'learners',
+          },
+          {
+            label: this.masteryLabel$(),
+            dataType: 'undefined',
+            minWidth: '100px',
+            columnId: 'mastery',
+          },
+          {
+            label: this.coachString('lessonVisibleLabel'),
+            dataType: 'undefined',
+            minWidth: '200px',
+            columnId: 'visible',
+          },
+          {
+            label: this.coreString('optionsLabel'),
+            dataType: 'undefined',
+            minWidth: '64px',
+            columnId: 'options',
+          },
+        ];
+      },
+      tableRows() {
+        return this.sortedCourses.map(course => [
+          course, // title
+          '—', // status
+          '—', // learners
+          '—', // mastery
+          course, // visible toggle
+          course, // options menu
+        ]);
+      },
       learnerGroups() {
         return this.$store.getters['classSummary/groups'] || [];
       },
@@ -603,10 +655,6 @@
         this.filterSelection = this.filterOptions[0];
         this.filterRecipients = this.recipientOptions[0];
       },
-      formatMastery() {
-        // TODO: Implement mastery formatting once we figured out mastery calculation
-        return '—';
-      },
     },
   };
 
@@ -655,6 +703,10 @@
     font-weight: 600;
   }
 
+  .table-header-label {
+    font-size: 12px;
+  }
+
   .course-title {
     display: flex;
     gap: 8px;
@@ -670,6 +722,10 @@
   .course-title-text {
     font-weight: 600;
   }
+
+  // .hidden {
+  //   display: none;
+  // }
 
   .empty-courses {
     display: flex;

--- a/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
+++ b/kolibri/plugins/coach/frontend/views/courses/sidePanels/AssignCourse/subpages/AssignCourseIndex.vue
@@ -27,6 +27,7 @@
         :loadingMore="loadingMore"
         :selectedResources="selectedResources"
         :getTopicLink="getCourseLink"
+        :cardsHeadingLevel="2"
         @setSelectedResources="setSelectedResourcesHandler"
       />
     </template>

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/TreeItem.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/UnitTreeAccordion/TreeItem.vue
@@ -6,6 +6,7 @@
   >
     <button
       class="tree-item"
+      :class="$computedClass({ ':focus': $coreOutline })"
       :disabled="disabled"
       @click="$emit('click')"
     >
@@ -107,6 +108,13 @@
 
 <style scoped lang="scss">
 
+  .tree-item-wrapper {
+    &:focus-within {
+      position: relative;
+      z-index: 1;
+    }
+  }
+
   .tree-item {
     display: flex;
     gap: 8px;
@@ -119,7 +127,6 @@
     user-select: text;
     background: unset;
     border: 0;
-    outline-offset: -3px;
 
     .item-content {
       display: flex;

--- a/packages/kolibri-common/components/accordion/AccordionItem.vue
+++ b/packages/kolibri-common/components/accordion/AccordionItem.vue
@@ -12,6 +12,7 @@
     <h3 class="header-wrapper">
       <button
         class="header"
+        :class="$computedClass({ ':focus': $coreOutline })"
         :style="headerAppearanceOverrides"
         :aria-expanded="isExpanded"
         :aria-controls="contentId"
@@ -148,6 +149,11 @@
 
   .accordion-item {
     border-bottom: 1px solid;
+
+    &:focus-within {
+      position: relative;
+      z-index: 1;
+    }
 
     &.disabled {
       pointer-events: none;

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -140,7 +140,7 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     context: 'Confirmation message when deleting a course from the course detail page',
   },
   filterCourseStatus: {
-    message: 'status',
+    message: 'Status',
     context: 'Label for filter dropdown to filter courses by visibility status',
   },
   filterCourseVisible: {
@@ -312,6 +312,10 @@ export const coursesStrings = createTranslator('CoursesStrings', {
   dateAssigned: {
     message: 'Date assigned',
     context: 'Label in course summary showing how long it has been since the course was assigned',
+  },
+  setCourseVisibilityLabel: {
+    message: 'Set course visibility',
+    context: 'Aria label for the toggle switch to set course visibility, read by screen readers',
   },
   courseVisible: {
     message: 'Course visible to learners',
@@ -569,5 +573,9 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Sorted by score (lowest first)',
     context:
       'Subtitle below the individual performance heading explaining the sort order of learner scores',
+  },
+  allCoursesForClass: {
+    message: "All courses for class '{className}'",
+    context: 'Accessible caption for the courses table, read by screen readers',
   },
 });

--- a/packages/kolibri/components/FilterTextbox.vue
+++ b/packages/kolibri/components/FilterTextbox.vue
@@ -4,7 +4,6 @@
     <UiIcon
       class="k-filter-icon"
       :style="{ color: $themeTokens.annotation }"
-      :ariaLabel="coreString('filter')"
     >
       <KIcon icon="search" />
     </UiIcon>


### PR DESCRIPTION
## Summary
Addresses in-scope a11y fixes for pre-post tests filed in 

## References
Fixes some of #14196 

## Reviewer guidance
Confirm the following points are fixed: 

1. aria label removed from "span" since it's not actually read out 
2. refactor to use KTable instead of CoreTable
3. Adds "Options" button label and associates the visible to learners kswitch properly with the header label 
4. updates course card heading to h2
5.  fixes space bar radio button selection
6. fixes focus outline on course accordions


## AI usage
Implemented collaboratively with Claude (specifically KTable refactor, and the debugging the space radio button/input bug)
