### PR TITLE
Migrates device content tree tests to VTL

### DIFF
--- a/kolibri/plugins/device/frontend/views/SelectContentPage/ContentNodeRow.vue
+++ b/kolibri/plugins/device/frontend/views/SelectContentPage/ContentNodeRow.vue
@@ -19,6 +19,7 @@
             v-if="isCourse"
             icon="course"
             style="top: 4px"
+            data-testid="icon-course"
           />
           <ContentIcon
             v-else

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
@@ -1,9 +1,9 @@
-import { mount } from '@vue/test-utils';
+import { queryByDisplayValue, render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import ContentNodeRow from '../SelectContentPage/ContentNodeRow';
 import { makeNode } from '../../__tests__/utils/data';
 import router from './testRouter';
 
-//
 const defaultProps = {
   node: {
     title: 'Awesome Content',
@@ -21,103 +21,85 @@ const defaultProps = {
   },
 };
 
-function makeWrapper(props = {}) {
-  return mount(ContentNodeRow, {
-    propsData: { ...defaultProps, ...props },
+function renderComponent(props = {}) {
+  return render(ContentNodeRow, {
+    props: { ...defaultProps, ...props },
     ...router,
   });
 }
 
-// prettier-ignore
-function getElements(wrapper) {
-  return {
-    titleText: () => wrapper.find('.title').text().trim(),
-    messageText: () => wrapper.find('.message').text().trim(),
-    goToTopicButton: () => wrapper.find('a[name="select-node"]'),
-    checkbox: () => wrapper.find('input[type="checkbox"]'),
-    KCheckbox: () => wrapper.findComponent({ name: 'KCheckbox' }),
-  };
-}
-
 describe('contentNodeRow component', () => {
   it('shows the correct title', () => {
-    const wrapper = makeWrapper();
-    const { titleText } = getElements(wrapper);
-    expect(titleText()).toEqual('Awesome Content');
+    renderComponent();
+    expect(screen.getByText('Awesome Content', { selector: 'span' })).toBeInTheDocument();
   });
 
-  it('shows the correct message', () => {
-    const wrapper = makeWrapper();
-    const { messageText } = getElements(wrapper);
-    expect(messageText()).toEqual('HELLO');
+  it('shows the correct message when checkbox is checked', async () => {
+    renderComponent();
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+    expect(screen.getByText('HELLO')).toBeInTheDocument();
   });
 
   it('when node is not a topic, title is just text', () => {
-    const wrapper = makeWrapper({
+    renderComponent({
       node: makeNode('1', {
         kind: 'video',
       }),
     });
-    const { goToTopicButton, titleText } = getElements(wrapper);
-    expect(goToTopicButton().exists()).toEqual(false);
-    expect(titleText()).toEqual('node_1');
+
+    expect(screen.queryByRole('link', { name: /node_1/i })).not.toBeInTheDocument();
+    expect(screen.getByText('node_1', { selector: 'span' })).toBeInTheDocument();
   });
 
   it('when node is disabled, title is just text', () => {
-    const wrapper = makeWrapper({ disabled: true });
-    const { goToTopicButton, titleText } = getElements(wrapper);
-    expect(goToTopicButton()[0]).toEqual(undefined);
-    expect(titleText()).toEqual('Awesome Content');
+    renderComponent({ disabled: true });
+
+    const link = screen.queryByRole('link', { name: 'Awesome Content' });
+    expect(link).toHaveAttribute('href', undefined);
   });
 
-  it('topic links have the correct route', () => {
-    const wrapper = makeWrapper();
-    const { goToTopicButton } = getElements(wrapper);
-    expect(goToTopicButton().props().to).toMatchObject({
-      name: 'SELECT_CONTENT',
-      query: {
-        node_id: 'awesome_content',
-      },
-    });
+  it('topic links have the correct route', async () => {
+    renderComponent();
+    const link = screen.getByRole('link', { name: 'Awesome Content' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('node_id=awesome_content'));
   });
 
-  it('when checkbox is changed, it emits a "changeselection" event', () => {
-    const wrapper = makeWrapper();
-    const { checkbox } = getElements(wrapper);
-    // have to "click" the inner checkbox to trigger "change" on whole component
-    checkbox().trigger('click');
-    expect(wrapper.emitted().changeselection).toEqual([[wrapper.vm.node]]);
+  it('checks the checkbox when clicked if initially unchecked', async () => {
+    renderComponent({ checked: false });
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  it('unchecks the checkbox when clicked if initially checked', async () => {
+    renderComponent({ checked: true });
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
   });
 
   it('when props.disabled, the checkbox is disabled', () => {
-    const wrapper = makeWrapper({ disabled: true });
-    const { checkbox } = getElements(wrapper);
-    expect(checkbox().attributes().disabled).toEqual('disabled');
+    renderComponent({ disabled: true });
+    expect(screen.getByRole('checkbox')).toBeDisabled();
   });
 
   it('when props.checked, the checkbox is checked', () => {
-    const wrapper = makeWrapper({
+    renderComponent({
       disabled: true,
       checked: true,
     });
-    // For some reason, the HTML for the actual checkbox does not have checked attribute
-    const { KCheckbox } = getElements(wrapper);
-    expect(KCheckbox().props().checked).toEqual(true);
+    expect(screen.getByRole('checkbox')).toBeChecked();
   });
 
-  it('when props.determinate, the checkbox is indeterminate', () => {
-    const wrapper = makeWrapper({
-      disabled: true,
-      checked: true,
-      indeterminate: true,
-    });
-    const { KCheckbox } = getElements(wrapper);
-    expect(KCheckbox().props().indeterminate).toEqual(true);
+  it('when props.indeterminate, the checkbox is indeterminate', () => {
+    renderComponent({ disabled: true, checked: true, indeterminate: true });
+    expect(screen.getByRole('checkbox')).toHaveProperty('indeterminate', true);
   });
 
   describe('course modality nodes', () => {
     it('does not render a link for course nodes even though they are topics', () => {
-      const wrapper = makeWrapper({
+      renderComponent({
         node: {
           title: 'My Course',
           kind: 'topic',
@@ -125,12 +107,12 @@ describe('contentNodeRow component', () => {
           id: 'course_1',
         },
       });
-      const { goToTopicButton } = getElements(wrapper);
-      expect(goToTopicButton().exists()).toEqual(false);
+
+      expect(screen.queryByRole('link', { name: 'My Course' })).not.toBeInTheDocument();
     });
 
     it('uses the course icon instead of topic icon for course nodes', () => {
-      const wrapper = makeWrapper({
+      renderComponent({
         node: {
           title: 'My Course',
           kind: 'topic',
@@ -138,14 +120,12 @@ describe('contentNodeRow component', () => {
           id: 'course_1',
         },
       });
-      const kIcons = wrapper.findAllComponents({ name: 'KIcon' });
-      const courseIcon = kIcons.wrappers.find(w => w.props('icon') === 'course');
-      expect(courseIcon).toBeTruthy();
-      expect(wrapper.findComponent({ name: 'ContentIcon' }).exists()).toBe(false);
+
+      expect(screen.getByTestId('icon-course')).toBeInTheDocument();
     });
 
     it('prepends "Course: " to the title for course nodes', () => {
-      const wrapper = makeWrapper({
+      renderComponent({
         node: {
           title: 'My Course',
           kind: 'topic',
@@ -153,9 +133,8 @@ describe('contentNodeRow component', () => {
           id: 'course_1',
         },
       });
-      const { titleText } = getElements(wrapper);
-      expect(titleText()).toContain('Course:');
-      expect(titleText()).toContain('My Course');
+
+      expect(screen.getByText(/Course:.*My Course/i)).toBeInTheDocument();
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { createTranslator } from 'kolibri/utils/i18n';
 import ContentNodeRow from '../SelectContentPage/ContentNodeRow';
 import { makeNode } from '../../__tests__/utils/data';
 import router from './testRouter';
+
+const tr = createTranslator('ContentNodeRow', ContentNodeRow.$trs);
 
 const defaultProps = {
   node: {
@@ -38,10 +41,8 @@ describe('contentNodeRow component', () => {
     expect(screen.getByText(NODE_TITLE, { selector: 'span' })).toBeInTheDocument();
   });
 
-  it('shows the correct message when checkbox is checked', async () => {
+  it('shows the correct message', async () => {
     renderComponent();
-    const checkbox = screen.getByRole('checkbox');
-    await userEvent.click(checkbox);
     expect(screen.getByText(NODE_MESSAGE)).toBeInTheDocument();
   });
 
@@ -56,10 +57,12 @@ describe('contentNodeRow component', () => {
     expect(screen.getByText(VIDEO_NODE_TITLE, { selector: 'span' })).toBeInTheDocument();
   });
 
-  it('when node is disabled, title is just text', () => {
+  it('when node is disabled, checkbox is disabled but link remains navigable', async () => {
     renderComponent({ disabled: true });
-    const link = screen.queryByRole('link', { name: NODE_TITLE });
-    expect(link).toHaveAttribute('href', undefined);
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+    const link = screen.getByRole('link', { name: NODE_TITLE });
+    const expectedSubstring = `node_id=${NODE_ID}`;
+    expect(link).toHaveAttribute('href', expect.stringContaining(expectedSubstring));
   });
 
   it('topic links have the correct route', async () => {
@@ -132,8 +135,9 @@ describe('contentNodeRow component', () => {
       renderComponent({
         node: NODE,
       });
-      const PREPENDED_TITLE = 'Course: My Course';
-      expect(screen.getByText(PREPENDED_TITLE)).toBeInTheDocument();
+      expect(
+        screen.getByText(tr.$tr('coursePrefixedTitle', { title: NODE_TITLE })),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
@@ -1,4 +1,4 @@
-import { queryByDisplayValue, render, screen } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import ContentNodeRow from '../SelectContentPage/ContentNodeRow';
 import { makeNode } from '../../__tests__/utils/data';
@@ -29,16 +29,20 @@ function renderComponent(props = {}) {
 }
 
 describe('contentNodeRow component', () => {
+  const NODE_TITLE = defaultProps.node.title;
+  const NODE_ID = defaultProps.node.id;
+  const NODE_MESSAGE = defaultProps.message;
+
   it('shows the correct title', () => {
     renderComponent();
-    expect(screen.getByText('Awesome Content', { selector: 'span' })).toBeInTheDocument();
+    expect(screen.getByText(NODE_TITLE, { selector: 'span' })).toBeInTheDocument();
   });
 
   it('shows the correct message when checkbox is checked', async () => {
     renderComponent();
     const checkbox = screen.getByRole('checkbox');
     await userEvent.click(checkbox);
-    expect(screen.getByText('HELLO')).toBeInTheDocument();
+    expect(screen.getByText(NODE_MESSAGE)).toBeInTheDocument();
   });
 
   it('when node is not a topic, title is just text', () => {
@@ -47,22 +51,22 @@ describe('contentNodeRow component', () => {
         kind: 'video',
       }),
     });
-
-    expect(screen.queryByRole('link', { name: /node_1/i })).not.toBeInTheDocument();
-    expect(screen.getByText('node_1', { selector: 'span' })).toBeInTheDocument();
+    const VIDEO_NODE_TITLE = 'node_1';
+    expect(screen.queryByRole('link', { name: VIDEO_NODE_TITLE })).not.toBeInTheDocument();
+    expect(screen.getByText(VIDEO_NODE_TITLE, { selector: 'span' })).toBeInTheDocument();
   });
 
   it('when node is disabled, title is just text', () => {
     renderComponent({ disabled: true });
-
-    const link = screen.queryByRole('link', { name: 'Awesome Content' });
+    const link = screen.queryByRole('link', { name: NODE_TITLE });
     expect(link).toHaveAttribute('href', undefined);
   });
 
   it('topic links have the correct route', async () => {
     renderComponent();
-    const link = screen.getByRole('link', { name: 'Awesome Content' });
-    expect(link).toHaveAttribute('href', expect.stringContaining('node_id=awesome_content'));
+    const link = screen.getByRole('link', { name: NODE_TITLE });
+    const expectedSubstring = `node_id=${NODE_ID}`;
+    expect(link).toHaveAttribute('href', expect.stringContaining(expectedSubstring));
   });
 
   it('checks the checkbox when clicked if initially unchecked', async () => {
@@ -98,43 +102,38 @@ describe('contentNodeRow component', () => {
   });
 
   describe('course modality nodes', () => {
+    const NODE_TITLE = 'My Course';
+    const NODE_KIND = 'topic';
+    const NODE_MODALITY = 'COURSE';
+    const NODE_ID = 'course_1';
+
+    const NODE = {
+      title: NODE_TITLE,
+      kind: NODE_KIND,
+      modality: NODE_MODALITY,
+      id: NODE_ID,
+    };
+
     it('does not render a link for course nodes even though they are topics', () => {
       renderComponent({
-        node: {
-          title: 'My Course',
-          kind: 'topic',
-          modality: 'COURSE',
-          id: 'course_1',
-        },
+        node: NODE,
       });
-
-      expect(screen.queryByRole('link', { name: 'My Course' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: NODE_TITLE })).not.toBeInTheDocument();
     });
 
     it('uses the course icon instead of topic icon for course nodes', () => {
       renderComponent({
-        node: {
-          title: 'My Course',
-          kind: 'topic',
-          modality: 'COURSE',
-          id: 'course_1',
-        },
+        node: NODE,
       });
-
       expect(screen.getByTestId('icon-course')).toBeInTheDocument();
     });
 
     it('prepends "Course: " to the title for course nodes', () => {
       renderComponent({
-        node: {
-          title: 'My Course',
-          kind: 'topic',
-          modality: 'COURSE',
-          id: 'course_1',
-        },
+        node: NODE,
       });
-
-      expect(screen.getByText(/Course:.*My Course/i)).toBeInTheDocument();
+      const PREPENDED_TITLE = 'Course: My Course';
+      expect(screen.getByText(PREPENDED_TITLE)).toBeInTheDocument();
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js
@@ -8,6 +8,9 @@ import router from './testRouter';
 
 const ContentTreeViewerStrings = createTranslator('ContentTreeViewer', ContentTreeViewer.$trs);
 
+jest.mock('kolibri/urls');
+jest.mock('kolibri/client');
+
 function simplePath(ids) {
   return ids.map(makeNode);
 }
@@ -113,15 +116,19 @@ describe('ContentTreeViewer component', () => {
   });
 
   it('checks child nodes are rendered at their correct full path', () => {
+    const CHANNEL_ID = 'channel_1';
+    const CHANNEL_TITLE = 'Channel 1';
+    const TOPIC_ID = 'topic_1';
+    const TOPIC_TITLE = 'Topic 1';
     store.state.manageContent.wizard.path = [
-      { id: 'channel_1', title: 'Channel 1' },
-      { id: 'topic_1', title: 'Topic 1' },
+      { id: CHANNEL_ID, title: CHANNEL_TITLE },
+      { id: TOPIC_ID, title: TOPIC_TITLE },
     ];
 
     renderComponent({ store });
     const navPath = screen.getByRole('list');
-    expect(within(navPath).getByRole('link', { name: 'Channel 1' })).toBeInTheDocument();
-    expect(within(navPath).getByText('Topic 1')).toBeInTheDocument();
+    expect(within(navPath).getByRole('link', { name: CHANNEL_TITLE })).toBeInTheDocument();
+    expect(within(navPath).getByText(TOPIC_TITLE)).toBeInTheDocument();
   });
 
   describe('"select all" checkbox state', () => {
@@ -171,8 +178,9 @@ describe('ContentTreeViewer component', () => {
 
     it('if unchecked, clicking the "Select All" for the topic triggers an "add node" action', async () => {
       // Selected w/ unselected child scenario
-      setIncludedNodes([makeNode('topic_1', { total_resources: 1000 })]);
-      setOmittedNodes([makeNode('subtopic_1', { path: [{ id: 'topic_1', title: '' }] })]);
+      const NODE_ID = 'topic_1';
+      setIncludedNodes([makeNode(NODE_ID, { total_resources: 1000 })]);
+      setOmittedNodes([makeNode('subtopic_1', { path: [{ id: NODE_ID, title: '' }] })]);
       renderComponent({ store });
       const selectAllCheckbox = screen.getByRole('checkbox', {
         name: ContentTreeViewerStrings.$tr('selectAll'),
@@ -181,12 +189,13 @@ describe('ContentTreeViewer component', () => {
       expect(store.dispatch).toHaveBeenCalledTimes(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         'manageContent/wizard/addNodeForTransfer',
-        expect.objectContaining({ id: 'topic_1' }),
+        expect.objectContaining({ id: NODE_ID }),
       );
     });
 
     it('if topic is checked, clicking the "Select All" for the topic triggers a "remove node" action ', async () => {
-      setIncludedNodes([makeNode('topic_1')]);
+      const NODE_ID = 'topic_1';
+      setIncludedNodes([makeNode(NODE_ID)]);
       renderComponent({ store });
       const selectAllCheckbox = screen.getByRole('checkbox', {
         name: ContentTreeViewerStrings.$tr('selectAll'),
@@ -195,51 +204,46 @@ describe('ContentTreeViewer component', () => {
       expect(store.dispatch).toHaveBeenCalledTimes(1);
       expect(store.dispatch).toHaveBeenCalledWith(
         'manageContent/wizard/removeNodeForTransfer',
-        expect.objectContaining({ id: 'topic_1' }),
+        expect.objectContaining({ id: NODE_ID }),
       );
     });
   });
 
   describe('selecting child nodes', () => {
-    beforeEach(() => {
-      jest.spyOn(store, 'dispatch').mockResolvedValue();
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
     it('unchecks a checked child node checkbox when clicked', async () => {
+      const SUB_TOPIC_ID = 'subtopic_1';
+      const SUB_TOPIC_TITLE = 'node_subtopic_1';
       const subTopic = makeNode('subtopic_1', {
-        path: [{ id: 'subtopic_1', title: 'node_subtopic_1' }],
+        path: [{ id: SUB_TOPIC_ID, title: SUB_TOPIC_TITLE }],
         total_resources: 100,
         on_device_resources: 50,
       });
       setChildren([subTopic]);
       setIncludedNodes([subTopic]);
       renderComponent({ store });
-
-      const checkbox = screen.getByRole('checkbox', { name: 'node_subtopic_1' });
+      const checkbox = screen.getByRole('checkbox', { name: SUB_TOPIC_TITLE });
       expect(checkbox).toBeChecked();
       await userEvent.click(checkbox);
       expect(checkbox).not.toBeChecked();
     });
 
     it('checks a unchecked child node checkbox when clicked', async () => {
+      const SUB_TOPIC_ID = 'subtopic_1';
+      const SUB_TOPIC_TITLE = 'node_subtopic_1';
       // Need to add at least two children, so clicking subtopic doesn't complete the topic
       const subTopic = makeNode('subtopic_1', {
-        path: [{ id: 'subtopic_1', title: 'node_subtopic_1' }],
+        path: [{ id: SUB_TOPIC_ID, title: SUB_TOPIC_TITLE }],
         total_resources: 100,
         on_device_resources: 50,
       });
       const subTopic2 = makeNode('subtopic_2', {
-        path: [{ id: 'subtopic_1', title: 'node_subtopic_1' }],
+        path: [{ id: SUB_TOPIC_ID, title: SUB_TOPIC_TITLE }],
         total_resources: 100,
         on_device_resources: 50,
       });
       setChildren([subTopic, subTopic2]);
       renderComponent({ store });
-      const checkbox = screen.getByRole('checkbox', { name: 'node_subtopic_1' });
+      const checkbox = screen.getByRole('checkbox', { name: SUB_TOPIC_TITLE });
       expect(checkbox).not.toBeChecked();
       await userEvent.click(checkbox);
       expect(checkbox).toBeChecked();
@@ -259,11 +263,13 @@ describe('ContentTreeViewer component', () => {
         total_resources: 1,
       });
 
+      const SUB_TOPIC_TITLE = 'node_subtopic';
+
       store.state.manageContent.wizard.path = simplePath(['channel_1']);
       setChildren([subTopic, subTopic2]);
       setIncludedNodes([subSubTopic]);
       renderComponent({ store });
-      const checkbox = screen.getAllByRole('checkbox', { name: /node_subtopic/i })[0];
+      const checkbox = screen.getAllByRole('checkbox', { name: SUB_TOPIC_TITLE })[0];
       expect(checkbox).not.toBeChecked();
       expect(checkbox).toHaveProperty('indeterminate', true);
       await userEvent.click(checkbox);

--- a/kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js
@@ -1,40 +1,24 @@
-import { mount } from '@vue/test-utils';
-import omit from 'lodash/fp/omit';
+import { render, screen, within } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { createTranslator } from 'kolibri/utils/i18n';
 import ContentTreeViewer from '../SelectContentPage/ContentTreeViewer';
 import { makeNode } from '../../__tests__/utils/data';
 import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
 import router from './testRouter';
 
+const ContentTreeViewerStrings = createTranslator('ContentTreeViewer', ContentTreeViewer.$trs);
+
 function simplePath(ids) {
   return ids.map(makeNode);
 }
 
-function makeWrapper(options = {}) {
+function renderComponent(options = {}) {
   const { props = {}, store } = options;
-  return mount(ContentTreeViewer, {
-    propsData: props,
+  return render(ContentTreeViewer, {
+    props,
     store: store || makeSelectContentPageStore(),
     ...router,
   });
-}
-
-// prettier-ignore
-function getElements(wrapper) {
-  return {
-    // Need to filter out checkboxes in content-node-rows
-    selectAllCheckbox: () => wrapper.findAllComponents({ name: 'KCheckbox' }).filter(el => el.props().label === 'Select all').at(0),
-    emptyState: () => wrapper.find('.no-contents'),
-    contentsSection: () => wrapper.findAll('.contents'),
-    contentNodeRows: () => wrapper.findAllComponents({ name: 'ContentNodeRow' }),
-    addNodeForTransferMock: () => {
-      const mock = wrapper.vm.addNodeForTransfer = jest.fn().mockResolvedValue();
-      return mock;
-    },
-    removeNodeForTransferMock: () => {
-      const mock = wrapper.vm.removeNodeForTransfer = jest.fn().mockResolvedValue();
-      return mock;
-    },
-  };
 }
 
 describe('ContentTreeViewer component', () => {
@@ -74,9 +58,9 @@ describe('ContentTreeViewer component', () => {
         },
       ],
     });
-    const wrapper = makeWrapper({ store });
-    const rows = wrapper.findAllComponents({ name: 'ContentNodeRow' });
-    expect(rows).toHaveLength(2);
+
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')).toHaveLength(3);
   });
 
   it('if in LOCALIMPORT, then non-importable nodes are filtered from the list', () => {
@@ -94,9 +78,8 @@ describe('ContentTreeViewer component', () => {
         },
       ],
     });
-    const wrapper = makeWrapper({ store });
-    const { contentNodeRows } = getElements(wrapper);
-    expect(contentNodeRows()).toHaveLength(1);
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')).toHaveLength(2);
   });
 
   it('in LOCALEXPORT, if a node has available: false, then it is not shown', () => {
@@ -116,99 +99,117 @@ describe('ContentTreeViewer component', () => {
         },
       ],
     });
-    const wrapper = makeWrapper({ store });
-    const { contentNodeRows } = getElements(wrapper);
-    expect(contentNodeRows()).toHaveLength(1);
+
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')).toHaveLength(2);
   });
 
   it('shows an empty state if the topic has no children', () => {
     setChildren([]);
-    const wrapper = makeWrapper({ store });
-    const { contentsSection, emptyState } = getElements(wrapper);
-    expect(contentsSection()).toHaveLength(0);
-    expect(emptyState().element.tagName).toBe('DIV');
+    renderComponent({ store });
+    expect(
+      screen.getByText(ContentTreeViewerStrings.$tr('topicHasNoContents')),
+    ).toBeInTheDocument();
   });
 
-  it('child nodes are annotated with their full path', () => {
+  it('checks child nodes are rendered at their correct full path', () => {
     store.state.manageContent.wizard.path = [
       { id: 'channel_1', title: 'Channel 1' },
       { id: 'topic_1', title: 'Topic 1' },
     ];
-    const wrapper = makeWrapper({ store });
-    wrapper.vm.annotatedChildNodes.forEach(n => {
-      const expectedPath = [
-        { id: 'channel_1', title: 'Channel 1' },
-        { id: 'topic_1', title: 'Topic 1' },
-        { id: n.id, title: n.title },
-      ];
-      expect(n.path).toEqual(expectedPath);
-    });
+
+    renderComponent({ store });
+    const navPath = screen.getByRole('list');
+    expect(within(navPath).getByRole('link', { name: 'Channel 1' })).toBeInTheDocument();
+    expect(within(navPath).getByText('Topic 1')).toBeInTheDocument();
   });
 
   describe('"select all" checkbox state', () => {
-    // These are integration tests with component and annotateNode utility
-    function checkboxIsChecked(wrapper) {
-      const { selectAllCheckbox } = getElements(wrapper);
-      return selectAllCheckbox().props().checked;
-    }
-
     it('if neither topic nor any ancestor is selected, then "Select All" is unchecked', () => {
-      const wrapper = makeWrapper({ store });
-      expect(checkboxIsChecked(wrapper)).toEqual(false);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('checkbox', { name: ContentTreeViewerStrings.$tr('selectAll') }),
+      ).not.toBeChecked();
     });
+
     it('if any ancestor of the topic is selected, then "Select All" is checked', () => {
       store.state.manageContent.wizard.path = [{ id: 'channel_1' }];
       setIncludedNodes([makeNode('channel_1')]);
-      const wrapper = makeWrapper({ store });
-      expect(checkboxIsChecked(wrapper)).toEqual(true);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('checkbox', { name: ContentTreeViewerStrings.$tr('selectAll') }),
+      ).toBeChecked();
     });
 
     it('if the topic itself is selected, then "Select All" is checked', () => {
       setIncludedNodes([makeNode('topic_1')]);
-      const wrapper = makeWrapper({ store });
-      expect(checkboxIsChecked(wrapper)).toEqual(true);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('checkbox', { name: ContentTreeViewerStrings.$tr('selectAll') }),
+      ).toBeChecked();
     });
 
-    it('if topic is selected, but one descendant is omitted', () => {
+    it('if topic is selected, but one descendant is omitted then "Select All" is unchecked', () => {
       // ...then "Select All" is unchecked
       setIncludedNodes([makeNode('topic_1')]);
       setOmittedNodes([makeNode('subtopic_1', { path: [{ id: 'topic_1' }] })]);
-      const wrapper = makeWrapper({ store });
-      expect(checkboxIsChecked(wrapper)).toEqual(false);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('checkbox', { name: ContentTreeViewerStrings.$tr('selectAll') }),
+      ).not.toBeChecked();
     });
   });
 
   describe('toggling "select all" checkbox', () => {
-    const sanitizeNode = omit(['message', 'checkboxType', 'disabled', 'children']);
-    it('if unchecked, clicking the "Select All" for the topic triggers an "add node" action', () => {
+    beforeEach(() => {
+      jest.spyOn(store, 'dispatch').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('if unchecked, clicking the "Select All" for the topic triggers an "add node" action', async () => {
       // Selected w/ unselected child scenario
       setIncludedNodes([makeNode('topic_1', { total_resources: 1000 })]);
       setOmittedNodes([makeNode('subtopic_1', { path: [{ id: 'topic_1', title: '' }] })]);
-      const wrapper = makeWrapper({ store });
-      const { selectAllCheckbox, addNodeForTransferMock } = getElements(wrapper);
-      const addNodeMock = addNodeForTransferMock();
-      selectAllCheckbox().trigger('click');
-      expect(addNodeMock).toHaveBeenCalledTimes(1);
-      expect(addNodeMock).toHaveBeenCalledWith(
-        expect.objectContaining(sanitizeNode(wrapper.vm.annotatedTopicNode)),
+      renderComponent({ store });
+      const selectAllCheckbox = screen.getByRole('checkbox', {
+        name: ContentTreeViewerStrings.$tr('selectAll'),
+      });
+      await userEvent.click(selectAllCheckbox);
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        'manageContent/wizard/addNodeForTransfer',
+        expect.objectContaining({ id: 'topic_1' }),
       );
     });
 
-    it('if topic is checked, clicking the "Select All" for the topic triggers a "remove node" action', () => {
+    it('if topic is checked, clicking the "Select All" for the topic triggers a "remove node" action ', async () => {
       setIncludedNodes([makeNode('topic_1')]);
-      const wrapper = makeWrapper({ store });
-      const { selectAllCheckbox, removeNodeForTransferMock } = getElements(wrapper);
-      const removeNodeMock = removeNodeForTransferMock();
-      selectAllCheckbox().trigger('click');
-      expect(removeNodeMock).toHaveBeenCalledTimes(1);
-      expect(removeNodeMock).toHaveBeenCalledWith(
-        expect.objectContaining(sanitizeNode(wrapper.vm.annotatedTopicNode)),
+      renderComponent({ store });
+      const selectAllCheckbox = screen.getByRole('checkbox', {
+        name: ContentTreeViewerStrings.$tr('selectAll'),
+      });
+      await userEvent.click(selectAllCheckbox);
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+      expect(store.dispatch).toHaveBeenCalledWith(
+        'manageContent/wizard/removeNodeForTransfer',
+        expect.objectContaining({ id: 'topic_1' }),
       );
     });
   });
 
   describe('selecting child nodes', () => {
-    it('clicking a checked child node triggers a "remove node" action', () => {
+    beforeEach(() => {
+      jest.spyOn(store, 'dispatch').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('unchecks a checked child node checkbox when clicked', async () => {
       const subTopic = makeNode('subtopic_1', {
         path: [{ id: 'subtopic_1', title: 'node_subtopic_1' }],
         total_resources: 100,
@@ -216,18 +217,15 @@ describe('ContentTreeViewer component', () => {
       });
       setChildren([subTopic]);
       setIncludedNodes([subTopic]);
-      const wrapper = makeWrapper({ store });
-      const { removeNodeForTransferMock } = getElements(wrapper);
-      const { mock } = removeNodeForTransferMock();
-      const topicRow = wrapper.findComponent({ name: 'ContentNodeRow' });
-      expect(topicRow.props().checked).toEqual(true);
-      expect(topicRow.props().disabled).toEqual(false);
-      topicRow.find('input[type="checkbox"]').trigger('click');
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0][0]).toMatchObject(subTopic);
+      renderComponent({ store });
+
+      const checkbox = screen.getByRole('checkbox', { name: 'node_subtopic_1' });
+      expect(checkbox).toBeChecked();
+      await userEvent.click(checkbox);
+      expect(checkbox).not.toBeChecked();
     });
 
-    it('clicking an unchecked child node triggers an "add node" action', () => {
+    it('checks a unchecked child node checkbox when clicked', async () => {
       // Need to add at least two children, so clicking subtopic doesn't complete the topic
       const subTopic = makeNode('subtopic_1', {
         path: [{ id: 'subtopic_1', title: 'node_subtopic_1' }],
@@ -240,17 +238,14 @@ describe('ContentTreeViewer component', () => {
         on_device_resources: 50,
       });
       setChildren([subTopic, subTopic2]);
-      const wrapper = makeWrapper({ store });
-      const { addNodeForTransferMock } = getElements(wrapper);
-      const { mock } = addNodeForTransferMock();
-      const topicRow = wrapper.findComponent({ name: 'ContentNodeRow' });
-      expect(topicRow.props().checked).toEqual(false);
-      topicRow.find('input[type="checkbox"]').trigger('click');
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0][0]).toMatchObject(subTopic);
+      renderComponent({ store });
+      const checkbox = screen.getByRole('checkbox', { name: 'node_subtopic_1' });
+      expect(checkbox).not.toBeChecked();
+      await userEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
     });
 
-    it('clicking an indeterminate child node triggers an "add node" action', () => {
+    it('selects an indeterminate child node when clicked', async () => {
       const subTopic = makeNode('subtopic', {
         path: simplePath(['channel_1', 'topic_1']),
         total_resources: 5,
@@ -267,15 +262,12 @@ describe('ContentTreeViewer component', () => {
       store.state.manageContent.wizard.path = simplePath(['channel_1']);
       setChildren([subTopic, subTopic2]);
       setIncludedNodes([subSubTopic]);
-      const wrapper = makeWrapper({ store });
-      const { addNodeForTransferMock } = getElements(wrapper);
-      const { mock } = addNodeForTransferMock();
-      const topicRow = wrapper.findComponent({ name: 'ContentNodeRow' });
-      expect(topicRow.props().checked).toEqual(false);
-      expect(topicRow.props().indeterminate).toEqual(true);
-      topicRow.find('input[type="checkbox"]').trigger('click');
-      expect(mock.calls).toHaveLength(1);
-      expect(mock.calls[0][0]).toMatchObject({ id: 'subtopic' });
+      renderComponent({ store });
+      const checkbox = screen.getAllByRole('checkbox', { name: /node_subtopic/i })[0];
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox).toHaveProperty('indeterminate', true);
+      await userEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -1,19 +1,21 @@
 import { render, screen } from '@testing-library/vue';
+import { createTranslator } from 'kolibri/utils/i18n';
 import SelectContentPage from '../SelectContentPage';
 import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
+import ChannelContentsSummary from '../SelectContentPage/ChannelContentsSummary';
+import NewChannelVersionBanner from '../ManageContentPage/NewChannelVersionBanner';
 import router from './testRouter';
 
-SelectContentPage.methods.getAvailableSpaceOnDrive = () => {};
+const summaryTr = createTranslator('ChannelContentsSummary', ChannelContentsSummary.$trs);
+const bannerTr = createTranslator('NewChannelVersionBanner', NewChannelVersionBanner.$trs);
 
 function renderComponent(options) {
   const { store, props = {} } = options;
-  const renderResult = render(SelectContentPage, {
+  return render(SelectContentPage, {
     props,
     store: store || makeSelectContentPageStore(),
     ...router,
   });
-  renderResult.container.refreshPage = () => {};
-  return renderResult;
 }
 
 function updateMetaChannel(store, updates) {
@@ -37,27 +39,29 @@ describe('SelectContentPage', () => {
 
   it('shows the thumbnail, title, descripton, and version of the channel', () => {
     const heading = 'Awesome Channel';
-    const version = 'Version 10';
+    const version = '10';
     const description = 'An awesome channel';
     const fakeImage = 'data:image/png;base64,abcd1234';
     updateMetaChannel(store, { thumbnail: fakeImage });
     renderComponent({ store });
     expect(screen.getByRole('img')).toHaveAttribute('src', fakeImage);
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(heading);
-    expect(screen.getByText(version)).toBeInTheDocument();
+    expect(screen.getByText(summaryTr.$tr('version', { version: version }))).toBeInTheDocument();
     expect(screen.getByText(description)).toBeInTheDocument();
   });
 
   it('shows the total size of the channel', () => {
     renderComponent({ store });
-    const TOTAL_SIZE_OF_CHANNEL = 'Total size 1,000 5 GB';
-    expect(screen.getAllByRole('row')[1]).toHaveTextContent(TOTAL_SIZE_OF_CHANNEL);
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent(
+      `${summaryTr.$tr('totalSizeRow')} 1,000 5 GB`,
+    );
   });
 
   it('shows the total size of any resources on the device', () => {
     renderComponent({ store });
-    const TOTAL_SIZE_OF_RESOURCES_ON_DEVICE = 'On your device 2,000 95 MB';
-    expect(screen.getAllByRole('row')[2]).toHaveTextContent(TOTAL_SIZE_OF_RESOURCES_ON_DEVICE);
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent(
+      `${summaryTr.$tr('onDeviceRow')} 2,000 95 MB`,
+    );
   });
 
   it('shows size and resources as 0 if channel is not on device', () => {
@@ -67,22 +71,27 @@ describe('SelectContentPage', () => {
       on_device_file_size: 0,
     });
     renderComponent({ store });
-    const TOTAL_SIZE_IF_CHANNEL_NOT_ON_DEVICE = 'On your device 0 0 B';
-    expect(screen.getAllByRole('row')[2]).toHaveTextContent(TOTAL_SIZE_IF_CHANNEL_NOT_ON_DEVICE);
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent(
+      `${summaryTr.$tr('onDeviceRow')} 0 0 B`,
+    );
   });
 
   it('shows a update notification if a new version is available', () => {
     updateMetaChannel(store, { version: 1000 });
     renderComponent({ store });
-    const NEW_VERSION_TEXT = 'Version 1000 is available';
-    expect(screen.getByText(NEW_VERSION_TEXT)).toBeInTheDocument();
+    const NEW_VERSION = '1000';
+    expect(
+      screen.getByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+    ).toBeInTheDocument();
   });
 
   it('if a new version is not available, then no notification/button appear', () => {
     updateMetaChannel(store, { version: 10 }); // same version
     renderComponent({ store });
-    const NEW_VERSION_TEXT = 'Version 1000 is available';
-    expect(screen.queryByText(NEW_VERSION_TEXT)).not.toBeInTheDocument();
+    const NEW_VERSION = '1000';
+    expect(
+      screen.queryByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+    ).not.toBeInTheDocument();
   });
 
   describe('draft channel (installed version = 0)', () => {

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -36,23 +36,28 @@ describe('SelectContentPage', () => {
   });
 
   it('shows the thumbnail, title, descripton, and version of the channel', () => {
+    const heading = 'Awesome Channel';
+    const version = 'Version 10';
+    const description = 'An awesome channel';
     const fakeImage = 'data:image/png;base64,abcd1234';
     updateMetaChannel(store, { thumbnail: fakeImage });
     renderComponent({ store });
     expect(screen.getByRole('img')).toHaveAttribute('src', fakeImage);
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Awesome Channel');
-    expect(screen.getByText('Version 10')).toBeInTheDocument();
-    expect(screen.getByText('An awesome channel')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(heading);
+    expect(screen.getByText(version)).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
   });
 
   it('shows the total size of the channel', () => {
     renderComponent({ store });
-    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Total size 1,000 5 GB');
+    const TOTAL_SIZE_OF_CHANNEL = 'Total size 1,000 5 GB';
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent(TOTAL_SIZE_OF_CHANNEL);
   });
 
   it('shows the total size of any resources on the device', () => {
     renderComponent({ store });
-    expect(screen.getAllByRole('row')[2]).toHaveTextContent('On your device 2,000 95 MB');
+    const TOTAL_SIZE_OF_RESOURCES_ON_DEVICE = 'On your device 2,000 95 MB';
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent(TOTAL_SIZE_OF_RESOURCES_ON_DEVICE);
   });
 
   it('shows size and resources as 0 if channel is not on device', () => {
@@ -62,19 +67,22 @@ describe('SelectContentPage', () => {
       on_device_file_size: 0,
     });
     renderComponent({ store });
-    expect(screen.getAllByRole('row')[2]).toHaveTextContent('On your device 0 0 B');
+    const TOTAL_SIZE_IF_CHANNEL_NOT_ON_DEVICE = 'On your device 0 0 B';
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent(TOTAL_SIZE_IF_CHANNEL_NOT_ON_DEVICE);
   });
 
   it('shows a update notification if a new version is available', () => {
     updateMetaChannel(store, { version: 1000 });
     renderComponent({ store });
-    expect(screen.getByText('Version 1000 is available')).toBeInTheDocument();
+    const NEW_VERSION_TEXT = 'Version 1000 is available';
+    expect(screen.getByText(NEW_VERSION_TEXT)).toBeInTheDocument();
   });
 
   it('if a new version is not available, then no notification/button appear', () => {
     updateMetaChannel(store, { version: 10 }); // same version
     renderComponent({ store });
-    expect(screen.queryByText('Version 1000 is available')).not.toBeInTheDocument();
+    const NEW_VERSION_TEXT = 'Version 1000 is available';
+    expect(screen.queryByText(NEW_VERSION_TEXT)).not.toBeInTheDocument();
   });
 
   describe('draft channel (installed version = 0)', () => {

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -1,23 +1,19 @@
-import { mount } from '@vue/test-utils';
-import { i18nSetup } from 'kolibri/utils/i18n';
+import { render, screen } from '@testing-library/vue';
 import SelectContentPage from '../SelectContentPage';
-import ChannelContentsSummary from '../SelectContentPage/ChannelContentsSummary';
 import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
 import router from './testRouter';
 
 SelectContentPage.methods.getAvailableSpaceOnDrive = () => {};
 
-function makeWrapper(options) {
+function renderComponent(options) {
   const { store, props = {} } = options;
-  const wrapper = mount(SelectContentPage, {
-    propsData: props,
+  const renderResult = render(SelectContentPage, {
+    props,
     store: store || makeSelectContentPageStore(),
-    stubs: ['content-tree-viewer'],
     ...router,
   });
-  // To avoid test failures
-  wrapper.vm.refreshPage = () => {};
-  return wrapper;
+  renderResult.container.refreshPage = () => {};
+  return renderResult;
 }
 
 function updateMetaChannel(store, updates) {
@@ -42,22 +38,21 @@ describe('SelectContentPage', () => {
   it('shows the thumbnail, title, descripton, and version of the channel', () => {
     const fakeImage = 'data:image/png;base64,abcd1234';
     updateMetaChannel(store, { thumbnail: fakeImage });
-    const summary = makeWrapper({ store }).findComponent(ChannelContentsSummary);
-    expect(summary.find('img').attributes().src).toEqual(fakeImage);
-    expect(summary.find('h1').text()).toEqual('Awesome Channel');
-    const pTags = summary.findAll('p');
-    expect(pTags.at(0).text()).toEqual('Version 10');
-    expect(pTags.at(2).text()).toEqual('An awesome channel');
+    renderComponent({ store });
+    expect(screen.getByRole('img')).toHaveAttribute('src', fakeImage);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Awesome Channel');
+    expect(screen.getByText('Version 10')).toBeInTheDocument();
+    expect(screen.getByText('An awesome channel')).toBeInTheDocument();
   });
 
   it('shows the total size of the channel', () => {
-    const rows = makeWrapper({ store }).findComponent(ChannelContentsSummary).findAll('tr');
-    expect(rows.at(1).text()).toEqual('Total size 1,000 5 GB');
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Total size 1,000 5 GB');
   });
 
   it('shows the total size of any resources on the device', () => {
-    const rows = makeWrapper({ store }).findComponent(ChannelContentsSummary).findAll('tr');
-    expect(rows.at(2).text()).toEqual('On your device 2,000 95 MB');
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent('On your device 2,000 95 MB');
   });
 
   it('shows size and resources as 0 if channel is not on device', () => {
@@ -66,20 +61,20 @@ describe('SelectContentPage', () => {
       on_device_resources: 0,
       on_device_file_size: 0,
     });
-    const rows = makeWrapper({ store }).findComponent(ChannelContentsSummary).findAll('tr');
-    expect(rows.at(2).text()).toEqual('On your device 0 0 B');
+    renderComponent({ store });
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent('On your device 0 0 B');
   });
 
   it('shows a update notification if a new version is available', () => {
     updateMetaChannel(store, { version: 1000 });
-    const wrapper = makeWrapper({ store });
-    expect(wrapper.findComponent({ name: 'NewChannelVersionBanner' }).exists()).toBe(true);
+    renderComponent({ store });
+    expect(screen.getByText('Version 1000 is available')).toBeInTheDocument();
   });
 
   it('if a new version is not available, then no notification/button appear', () => {
     updateMetaChannel(store, { version: 10 }); // same version
-    const wrapper = makeWrapper({ store });
-    expect(wrapper.text()).not.toMatch(/Version \S+ available/);
+    renderComponent({ store });
+    expect(screen.queryByText('Version 1000 is available')).not.toBeInTheDocument();
   });
 
   describe('draft channel (installed version = 0)', () => {

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -1,13 +1,17 @@
 import { render, screen } from '@testing-library/vue';
-import { createTranslator } from 'kolibri/utils/i18n';
+import { createTranslator, i18nSetup } from 'kolibri/utils/i18n';
 import SelectContentPage from '../SelectContentPage';
 import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
 import ChannelContentsSummary from '../SelectContentPage/ChannelContentsSummary';
+import ContentTreeViewer from '../SelectContentPage/ContentTreeViewer';
 import NewChannelVersionBanner from '../ManageContentPage/NewChannelVersionBanner';
+import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
 import router from './testRouter';
 
 const summaryTr = createTranslator('ChannelContentsSummary', ChannelContentsSummary.$trs);
 const bannerTr = createTranslator('NewChannelVersionBanner', NewChannelVersionBanner.$trs);
+const treeViewerTr = createTranslator('ContentTreeViewer', ContentTreeViewer.$trs);
+const bottomBarTr = createTranslator('SelectionBottomBar', SelectionBottomBar.$trs);
 
 function renderComponent(options) {
   const { store, props = {} } = options;
@@ -94,6 +98,7 @@ describe('SelectContentPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  //Add translations strings to these tests & test these & commit the changes.
   describe('draft channel (installed version = 0)', () => {
     function setInstalledVersion(store, version) {
       const existing = store.state.manageContent.channelList[0];
@@ -103,29 +108,42 @@ describe('SelectContentPage', () => {
     it('shows ContentTreeViewer when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
       updateMetaChannel(store, { version: 5 });
-      const wrapper = makeWrapper({ store });
-      expect(wrapper.findAllComponents({ name: 'ContentTreeViewer' }).length).toBeGreaterThan(0);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('checkbox', {
+          name: treeViewerTr.$tr('selectAll'),
+        }),
+      ).toBeInTheDocument();
     });
 
     it('shows NewChannelVersionBanner when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
       updateMetaChannel(store, { version: 5 });
-      const wrapper = makeWrapper({ store });
-      expect(wrapper.findComponent({ name: 'NewChannelVersionBanner' }).exists()).toBe(true);
+      renderComponent({ store });
+      const NEW_VERSION = 5;
+      expect(
+        screen.getByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+      ).toBeInTheDocument();
     });
 
     it('shows SelectionBottomBar when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
       updateMetaChannel(store, { version: 5 });
-      const wrapper = makeWrapper({ store });
-      expect(wrapper.findAllComponents({ name: 'SelectionBottomBar' }).length).toBeGreaterThan(0);
+      renderComponent({ store });
+      expect(
+        screen.getByRole('button', { name: bottomBarTr.$tr('importAction') }),
+      ).toBeInTheDocument();
     });
 
     it('hides ContentTreeViewer when installed version > 0 and newer version available on Studio', () => {
       // Preserve existing non-draft behavior
       updateMetaChannel(store, { version: 1000 });
-      const wrapper = makeWrapper({ store });
-      expect(wrapper.findAllComponents({ name: 'ContentTreeViewer' }).length).toBe(0);
+      renderComponent({ store });
+      expect(
+        screen.queryByRole('checkbox', {
+          name: treeViewerTr.$tr('selectAll'),
+        }),
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Converted the test suites for the device content tree tests to Vue Testing Library. The existing test suites and the testcases were migrated from `@vue/test-utils` to `@testing-library/vue`. The changes apply to the following files in the codebase:

- `kolibri/plugins/device/frontend/views/SelectContentPage/ContentNodeRow.vue`
- `kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js`
- `kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js`
- `kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js`

## References

Closes #14262 

## Reviewer guidance

Run these command to verify the tests pass properly.

```
pnpm run test-jest -- ./kolibri/plugins/device/frontend/views/__tests__/ContentNodeRow.spec.js
pnpm run test-jest -- ./kolibri/plugins/device/frontend/views/__tests__/ContentTreeViewer.spec.js
pnpm run test-jest -- ./kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js

## AI Usage

I have used AI only for researching about `@testing-library/vue`. No AI written code has been added to the files.
