### PR TITLE
Conditionalize webpack cache by hot/transpile to prevent errors.

### DIFF
--- a/packages/kolibri-build/package.json
+++ b/packages/kolibri-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-build",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Build tools and webpack configuration for Kolibri",
   "repository": {
     "type": "git",

--- a/packages/kolibri-build/src/webpack.config.base.js
+++ b/packages/kolibri-build/src/webpack.config.base.js
@@ -101,7 +101,7 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
     mode,
     cache: cache && {
       type: 'filesystem',
-      version: '1.0.0',
+      version: `1.0.0-${hot ? 'hot' : 'nothot'}-${transpile ? 'transpiled' : 'source'}`,
       buildDependencies: {
         config: [__filename],
       },


### PR DESCRIPTION
## Summary
Makes the "cache version" sensitive to the `hot` and `transpile` arguments to prevent cache collisions

Run `devserver-hot` then `devserver` make sure that the latter now runs without error.

## AI usage
None