### PR TITLE
Add picture password row to learner Profile page

### DIFF
--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
@@ -1,8 +1,13 @@
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import { mount, RouterLinkStub, createLocalVue } from '@vue/test-utils';
+import { render, screen } from '@testing-library/vue';
+import { ref } from 'vue';
 import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
+import { UserKinds } from 'kolibri/constants';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import ProfilePage from '../index';
 import makeStore from '../../../__tests__/utils/makeStore';
 import useOnMyOwnSetup, {
@@ -10,6 +15,7 @@ import useOnMyOwnSetup, {
   useOnMyOwnSetupMock,
 } from '../../../composables/useOnMyOwnSetup';
 import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
 
 jest.mock('kolibri-common/apiResources/FacilityUserResource');
 jest.mock('../../../composables/useOnMyOwnSetup');
@@ -17,6 +23,9 @@ jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/urls');
 jest.mock('kolibri-common/composables/useFacilities');
+jest.mock('kolibri-common/composables/useFacility');
+
+const { fullNameLabel$ } = coreStrings;
 
 FacilityUserResource.fetchModel = jest.fn().mockResolvedValue({});
 
@@ -59,5 +68,109 @@ describe('profilePage component', () => {
   it('smoke test', () => {
     const wrapper = makeWrapper();
     expect(wrapper.exists()).toEqual(true);
+  });
+});
+
+describe('picture password row', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useOnMyOwnSetup.mockImplementation(() => useOnMyOwnSetupMock({ onMyOwnSetup: false }));
+    useKResponsiveWindow.mockImplementation(() => ({ windowIsSmall: false }));
+    useFacilities.mockImplementation(() => useFacilitiesMock({ facilities: ref([]) }));
+  });
+
+  async function renderProfile({
+    userKind = UserKinds.LEARNER,
+    picturePasswordSettings = null,
+    picturePassword = null,
+  } = {}) {
+    useUser.mockImplementation(() =>
+      useUserMock({
+        userKind,
+        isLearner: userKind === UserKinds.LEARNER,
+        isCoach: userKind === UserKinds.COACH,
+        isAdmin: userKind === UserKinds.ADMIN || userKind === UserKinds.SUPERUSER,
+        isSuperuser: userKind === UserKinds.SUPERUSER,
+      }),
+    );
+    useFacility.mockImplementation(() =>
+      useFacilityMock({
+        facilityConfig: ref({
+          picture_password_settings: picturePasswordSettings,
+          learner_can_edit_password: false,
+        }),
+      }),
+    );
+    FacilityUserResource.fetchModel = jest
+      .fn()
+      .mockResolvedValue({ picture_password: picturePassword });
+
+    const localRouter = new VueRouter();
+    localRouter.getRoute = () => '/';
+
+    return render(ProfilePage, {
+      store: makeStore(),
+      routes: localRouter,
+    });
+  }
+
+  it('renders the picture password display for a learner with a picture_password', async () => {
+    await renderProfile({
+      userKind: UserKinds.LEARNER,
+      picturePasswordSettings: {
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: false,
+      },
+      picturePassword: '3.7.12',
+    });
+
+    expect(await screen.findByTestId('picture-password-display')).toBeInTheDocument();
+    // Three icons, no labels — per the AC.
+    const icons = screen.queryAllByTestId(/^picture-password-icon-/);
+    expect(icons).toHaveLength(3);
+  });
+
+  it('renders the empty-value placeholder when the learner has no picture_password', async () => {
+    await renderProfile({
+      userKind: UserKinds.LEARNER,
+      picturePasswordSettings: {
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: false,
+      },
+      picturePassword: null,
+    });
+
+    expect(await screen.findByTestId('picture-password-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('picture-password-display')).not.toBeInTheDocument();
+  });
+
+  it('omits the picture password row when picture_password_settings is null', async () => {
+    await renderProfile({
+      userKind: UserKinds.LEARNER,
+      picturePasswordSettings: null,
+      picturePassword: null,
+    });
+
+    // Wait for the page to actually render before negative-asserting.
+    await screen.findByText(fullNameLabel$());
+
+    expect(screen.queryByTestId('picture-password-display')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('picture-password-empty')).not.toBeInTheDocument();
+  });
+
+  it('omits the picture password row for a coach in a picture-login facility', async () => {
+    await renderProfile({
+      userKind: UserKinds.COACH,
+      picturePasswordSettings: {
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: false,
+      },
+      picturePassword: null,
+    });
+
+    await screen.findByText(fullNameLabel$());
+
+    expect(screen.queryByTestId('picture-password-display')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('picture-password-empty')).not.toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
@@ -114,6 +114,16 @@ describe('picture password row', () => {
     });
   }
 
+  it('fetches the facility and its config on mount', async () => {
+    // Without this fetch the page-level facilityConfig is empty, which silently
+    // disables every facility-config-driven row on the Profile (#14545 fallout).
+    await renderProfile({ userKind: UserKinds.LEARNER });
+
+    const { fetchFacilities, updateFacilityConfig } = useFacilityMock();
+    expect(fetchFacilities).toHaveBeenCalled();
+    expect(updateFacilityConfig).toHaveBeenCalled();
+  });
+
   it('renders the picture password display for a learner with a picture_password', async () => {
     await renderProfile({
       userKind: UserKinds.LEARNER,

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
@@ -121,10 +121,9 @@
                 :picturePassword="currentUser.picture_password"
                 :showIconText="false"
               />
-              <KOptionalText
+              <KEmptyPlaceholder
                 v-else
                 data-testid="picture-password-empty"
-                :text="''"
               />
             </td>
           </tr>

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
@@ -112,6 +112,23 @@
             </td>
           </tr>
 
+          <tr v-if="showPicturePasswordRow">
+            <th>{{ coreString('passwordLabel') }}</th>
+            <td>
+              <UserPicturePassword
+                v-if="currentUser.picture_password"
+                data-testid="picture-password-display"
+                :picturePassword="currentUser.picture_password"
+                :showIconText="false"
+              />
+              <KOptionalText
+                v-else
+                data-testid="picture-password-empty"
+                :text="''"
+              />
+            </td>
+          </tr>
+
           <tr v-if="!isLearnerOnlyImport && canEditPassword">
             <th>{{ coreString('passwordLabel') }}</th>
             <td>
@@ -194,8 +211,9 @@
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import PermissionsIcon from 'kolibri-common/components/labels/PermissionsIcon';
+  import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
   import UserTypeDisplay from 'kolibri-common/components/UserTypeDisplay';
-  import { PermissionTypes } from 'kolibri/constants';
+  import { PermissionTypes, UserKinds } from 'kolibri/constants';
   import useUser from 'kolibri/composables/useUser';
   import GenderDisplayText from 'kolibri-common/components/userAccounts/GenderDisplayText';
   import BirthYearDisplayText from 'kolibri-common/components/userAccounts/BirthYearDisplayText';
@@ -222,6 +240,7 @@
       NotificationsRoot,
       GenderDisplayText,
       PermissionsIcon,
+      UserPicturePassword,
       UserTypeDisplay,
     },
     mixins: [commonCoreStrings],
@@ -288,6 +307,12 @@
           return this.$tr('limitedPermissions');
         }
         return '';
+      },
+      showPicturePasswordRow() {
+        return (
+          this.userKind === UserKinds.LEARNER &&
+          this.facilityConfig?.picture_password_settings != null
+        );
       },
       canEditPassword() {
         const learner_can_edit =

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
@@ -259,7 +259,7 @@
       const { onMyOwnSetup } = useOnMyOwnSetup();
       const { fetchPoints, totalPoints } = useTotalProgress();
       const { facilities } = useFacilities();
-      const { facilityConfig } = useFacility();
+      const { facilityConfig, fetchFacilities, updateFacilityConfig } = useFacility();
       const userPermissions = computed(() => pickBy(_userPermissions));
 
       return {
@@ -279,6 +279,8 @@
         totalPoints,
         facilityConfig,
         facilities,
+        fetchFacilities,
+        updateFacilityConfig,
       };
     },
     computed: {
@@ -320,8 +322,12 @@
         return this.isSuperuser || this.isCoach || learner_can_edit;
       },
     },
-    created() {
+    async created() {
       this.fetchPoints();
+      // Load the facility list and selected-facility config so facilityConfig is
+      // populated for everything on this page that depends on it (#14545).
+      await this.fetchFacilities();
+      await this.updateFacilityConfig();
     },
     methods: {
       getPermissionString(permission) {

--- a/kolibri/plugins/user_profile/package.json
+++ b/kolibri/plugins/user_profile/package.json
@@ -16,6 +16,8 @@
         "xstate": "catalog:"
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "catalog:",
+        "@testing-library/vue": "catalog:",
         "@vue/test-utils": "catalog:"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1050,6 +1050,12 @@ importers:
         specifier: 'catalog:'
         version: 4.38.3
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/vue':
+        specifier: 'catalog:'
+        version: 5.9.0(vue-template-compiler@2.7.16)(vue@2.7.16)
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 1.3.6(vue-template-compiler@2.7.16)(vue@2.7.16)
@@ -4355,10 +4361,6 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
     engines: {node: '>= 0.4'}
 
   call-bind@1.0.9:
@@ -12771,13 +12773,6 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
   call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -13312,7 +13307,7 @@ snapshots:
   deep-equal@2.2.3:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       es-get-iterator: 1.1.3
       get-intrinsic: 1.3.0
       is-arguments: 1.2.0
@@ -13603,7 +13598,7 @@ snapshots:
 
   es-get-iterator@1.1.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       is-arguments: 1.2.0
@@ -14703,7 +14698,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -16039,14 +16034,14 @@ snapshots:
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -16784,7 +16779,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -18502,7 +18497,7 @@ snapshots:
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1


### PR DESCRIPTION
## Summary

Adds a "Password" row to the learner Profile page that shows the learner's
assigned picture password (three icons, no labels) when picture login is
enabled for their facility. Falls back to `KOptionalText` empty placeholder
when picture login is enabled but the learner has no `picture_password`
assigned (e.g. picture-password limit exhausted, or transient state before
the post-sync assignment hook runs).

The row is gated by `userKind === LEARNER && facilityConfig.picture_password_settings != null`,
so coaches/admins/superusers and learners in non-picture-login facilities are
unaffected. The existing "Change password" row's conditions are untouched.

A second commit adds a local fix for #14545 — `facilityConfig` was empty on
the Profile page, which silently disabled both the new row and other
config-driven rendering. `created()` now awaits the facility fetchers
already exposed from `useFacility`.

## References

Closes #14613.

Picture password infrastructure used here was landed in #14495, #14573, and
#14632. Local workaround for #14545.

## Reviewer guidance

**Tested via** `pnpm test-jest kolibri/plugins/user_profile/`. Five behavior-
level tests in `ProfilePage.spec.js`:
- Three states from the AC (3-icon render, KOptionalText empty, settings null)
- Coach exclusion (extra explicit AC coverage)
- `fetchFacilities` + `updateFacilityConfig` are called on mount

**Manual smoke test (4 states):**

1. As an admin, enable picture login in Facility Settings (pick either icon
   style). Sign in as a learner in that facility — Profile should show three
   icons, no labels, in the configured style.
2. With picture login still on, clear that learner's picture password via
   `kolibri shell` (`u.picture_password = None; u.save(update_fields=["picture_password"])`).
   Reload Profile — should show the empty-value em-dash.
3. Sign in as a coach in the same facility — no picture-password row (the
   regular Change password row still appears under its own conditions).
4. As an admin, disable picture login. Sign in as the learner from #1 — no
   picture-password row at all.

**Worth a careful look:**

- The `showPicturePasswordRow` computed (`ProfilePage/index.vue`) — the
  `userKind === LEARNER` check uses the exclusive `userKind` rather than
  `isLearner` because coaches/admins also carry `LEARNER` in their `kind`
  array; using `isLearner` would over-render.
- Two `data-testid` attributes added to the slots
  (`picture-password-display`, `picture-password-empty`) are referenced from
  the spec; please flag if the project prefers a different testability hook.
- `package.json` adds `@testing-library/jest-dom` and `@testing-library/vue`
  as devDeps (separate commit) — needed for ESLint's import resolver to find
  the modules from the spec file. `kolibri-coach-plugin` already declares
  them the same way.
- The `created()` fetch fix is intentionally local to the Profile page; the
  broader composable refactor that would remove the need for this lives in
  #14545.

## Screenshots

Three states + close-ups, plus a11y. Full versions and rationale in the
[follow-up PR comment](https://github.com/learningequality/kolibri/pull/14679#issuecomment-4375422227).

| State | Password row close-up |
|-------|-----------------------|
| Learner with `picture_password` | ![row close-up](https://i.imgur.com/J0I2OKp.png) |
| Learner with `picture_password=null` | ![row close-up](https://i.imgur.com/xLGZXei.png) |
| Coach in same facility | _(no picture-password row; existing Change-password row visible — see comment)_ |

axe-core audit on state #1: **0 moderate-or-above violations**.

## AI usage

Used Claude Code (Opus 4.7, 1M context) to draft both the implementation
and the tests TDD-style — wrote and watched each test fail, then made the
minimum change to GREEN it. Reviewer feedback (Liana) on the empty
`facilityConfig` was diagnosed and fixed using the same TDD loop, with a new
failing test pinning the fetch behavior before implementing. I directed the
design (gate predicate, slot layout, `data-testid` placement, separating
the fetch fix into its own commit), reviewed every diff, ran the test +
lint sweep, and captured the screenshots from a local server myself.