### PR TITLE
fix(decorators): fix ____name__ typo and wrong eq constraint error message

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -103,7 +103,7 @@ class ParamValidator:
             param = query_set.get(**{self.field: param})
         else:
             raise InvalidQueryParamsException(
-                "Invalid param type: %s" % self.param_type.____name__
+                "Invalid param type: %s" % self.param_type.__name__
             )
         return param
 
@@ -126,7 +126,7 @@ class ParamValidator:
     def check_value_constraints(self, param):
         try:
             if self.eq and param != self.eq:
-                raise InvalidQueryParamsException("must be less than %s!" % self.eq)
+                raise InvalidQueryParamsException("must be equal to %s!" % self.eq)
             else:
                 if self.lt and param >= self.lt:
                     raise InvalidQueryParamsException("must be less than %s!" % self.lt)


### PR DESCRIPTION
## Bug

Two correctness bugs in `kolibri/core/decorators.py` (`ParamValidator`):

### 1. `AttributeError` on unrecognised `param_type` (line 106)

```python
# Before (buggy)
raise InvalidQueryParamsException(
    "Invalid param type: %s" % self.param_type.____name__
)
```

`____name__` has **four** leading underscores. Python's class name attribute is `__name__` (two per side). Any `param_type` that falls through to the `else` branch — i.e. every type that is neither a Django model nor in `VALID_TYPES` nor a `TUPLE_TYPES` instance — raises `AttributeError: type object '…' has no attribute '____name__'` instead of the intended `InvalidQueryParamsException`.

### 2. Wrong error message for `eq` constraint (line 129)

```python
# Before (buggy)
if self.eq and param != self.eq:
    raise InvalidQueryParamsException("must be less than %s!" % self.eq)
```

`self.eq` is the **equality** constraint — the message should say "must be equal to", not "must be less than". The "less than" message was copy-pasted from the adjacent `lt` check.

## Fix

```python
# After (line 106)
raise InvalidQueryParamsException(
    "Invalid param type: %s" % self.param_type.__name__
)

# After (line 129)
raise InvalidQueryParamsException("must be equal to %s!" % self.eq)
```

Both changes are one character or one word — no logic change, no new code paths.