### PR TITLE
Responsive picture password sign in

### DIFF
--- a/kolibri/plugins/user_auth/frontend/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/frontend/views/AuthBase.vue
@@ -4,9 +4,7 @@
     <div class="wrapper-table">
       <div class="main-row table-row">
         <div class="main-cell table-cell">
-          <!-- remote access disabled -->
           <div
-            v-if="!allowAccess || deviceUnusableReason"
             class="box"
             :style="{ backgroundColor: $themeTokens.surface }"
           >
@@ -25,103 +23,86 @@
               {{ logoText }}
             </h1>
             <template v-if="!allowAccess">
+              <!-- remote access disabled -->
               <p data-testid="restrictedAccess">
                 {{ $tr('restrictedAccess') }}
               </p>
               <p>{{ $tr('restrictedAccessDescription') }}</p>
             </template>
             <DeviceUnusableMessage
-              v-else
+              v-else-if="deviceUnusableReason"
               :reason="deviceUnusableReason"
             />
-          </div>
-          <!-- remote access enabled -->
-          <div
-            v-else
-            class="box"
-            :style="{ backgroundColor: $themeTokens.surface }"
-          >
-            <CoreLogo
-              v-if="themeConfig.signIn.topLogo"
-              class="logo"
-              :src="themeConfig.signIn.topLogo.src"
-              :alt="themeConfig.signIn.topLogo.alt"
-              :style="themeConfig.signIn.topLogo.style"
-            />
-            <h1
-              v-if="themeConfig.signIn.showTitle"
-              class="kolibri-title"
-              :style="[{ color: $themeTokens.primary }, themeConfig.signIn.titleStyle]"
-            >
-              {{ logoText }}
-            </h1>
-            <p
-              v-if="themeConfig.signIn.showPoweredBy"
-              :style="themeConfig.signIn.poweredByStyle"
-              class="small-text"
-            >
-              <KButton
-                v-if="oidcProviderFlow"
-                :text="$tr('poweredByKolibri')"
-                appearance="basic-link"
-                @click="whatsThisModalVisible = true"
-              />
-              <KExternalLink
-                v-else
-                :text="$tr('poweredByKolibri')"
-                :primary="true"
-                href="https://learningequality.org/r/powered_by_kolibri"
-                :openInNewTab="true"
-                appearance="basic-link"
-              />
-            </p>
+            <!-- Regular auth layout (remote access enabled) -->
+            <template v-else>
+              <p
+                v-if="themeConfig.signIn.showPoweredBy"
+                :style="themeConfig.signIn.poweredByStyle"
+                class="small-text"
+              >
+                <KButton
+                  v-if="oidcProviderFlow"
+                  :text="$tr('poweredByKolibri')"
+                  appearance="basic-link"
+                  @click="whatsThisModalVisible = true"
+                />
+                <KExternalLink
+                  v-else
+                  :text="$tr('poweredByKolibri')"
+                  :primary="true"
+                  href="https://learningequality.org/r/powered_by_kolibri"
+                  :openInNewTab="true"
+                  appearance="basic-link"
+                />
+              </p>
 
-            <slot></slot>
+              <slot></slot>
 
-            <p
-              v-if="showCreateAccountButton"
-              class="create"
-            >
-              <KRouterLink
-                :text="userString('createAccountAction')"
-                :to="signUpRoute"
-                :primary="false"
-                appearance="raised-button"
-                :disabled="busy"
-                style="width: 100%"
-                data-testid="createUser"
-              />
-            </p>
+              <p
+                v-if="showCreateAccountButton"
+                class="create"
+              >
+                <KRouterLink
+                  :text="userString('createAccountAction')"
+                  :to="signUpRoute"
+                  :primary="false"
+                  appearance="raised-button"
+                  :disabled="busy"
+                  style="width: 100%"
+                  data-testid="createUser"
+                />
+              </p>
 
-            <div>
-              <component
-                :is="component"
-                v-for="component in loginOptions"
-                :key="component.name"
-              />
-            </div>
-            <p
-              v-if="allowAlternateSignIn"
-              class="alternative-link small-text"
-            >
-              <KRouterLink
-                :text="alternateSignInText$()"
-                :to="alternateSignInRoute"
-                :primary="true"
-                appearance="basic-link"
-              />
-            </p>
-            <p
-              v-if="showGuestAccess"
-              class="alternative-link small-text"
-            >
-              <KExternalLink
-                :text="$tr('accessAsGuest')"
-                :href="guestURL"
-                :primary="true"
-                appearance="basic-link"
-              />
-            </p>
+              <div>
+                <component
+                  :is="component"
+                  v-for="component in loginOptions"
+                  :key="component.name"
+                />
+              </div>
+              <p
+                v-if="allowAlternateSignIn"
+                class="alternative-link small-text"
+              >
+                <KRouterLink
+                  :text="alternateSignInText$()"
+                  :to="alternateSignInRoute"
+                  :primary="true"
+                  appearance="basic-link"
+                />
+              </p>
+              <p
+                v-if="showGuestAccess"
+                class="alternative-link small-text"
+              >
+                <KExternalLink
+                  :text="$tr('accessAsGuest')"
+                  :href="guestURL"
+                  :primary="true"
+                  appearance="basic-link"
+                />
+              </p>
+            </template>
           </div>
           <div
             class="background"

--- a/kolibri/plugins/user_auth/frontend/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/frontend/views/AuthBase.vue
@@ -6,22 +6,41 @@
         <div class="main-cell table-cell">
           <div
             class="box"
+            :class="{
+              landscape: showLandscapeLayout,
+            }"
             :style="{ backgroundColor: $themeTokens.surface }"
           >
-            <CoreLogo
-              v-if="themeConfig.signIn.topLogo"
-              class="logo"
-              :src="themeConfig.signIn.topLogo.src"
-              :alt="themeConfig.signIn.topLogo.alt"
-              :style="themeConfig.signIn.topLogo.style"
-            />
-            <h1
-              v-if="themeConfig.signIn.showTitle"
-              class="kolibri-title"
-              :style="[{ color: $themeTokens.primary }, themeConfig.signIn.titleStyle]"
+            <div
+              :class="{
+                'header-row': showLandscapeLayout,
+              }"
             >
-              {{ logoText }}
-            </h1>
+              <div v-if="showLandscapeLayout">
+                <slot name="header-leading-actions"></slot>
+              </div>
+              <div
+                :class="{
+                  'header-title-row': showLandscapeLayout,
+                }"
+              >
+                <CoreLogo
+                  v-if="themeConfig.signIn.topLogo"
+                  class="logo"
+                  :src="themeConfig.signIn.topLogo.src"
+                  :alt="themeConfig.signIn.topLogo.alt"
+                  :style="themeConfig.signIn.topLogo.style"
+                />
+                <h1
+                  v-if="themeConfig.signIn.showTitle"
+                  class="kolibri-title"
+                  :style="[{ color: $themeTokens.primary }, themeConfig.signIn.titleStyle]"
+                >
+                  {{ logoText }}
+                </h1>
+              </div>
+            </div>
+
             <template v-if="!allowAccess">
               <!-- remote access disabled -->
               <p data-testid="restrictedAccess">
@@ -80,28 +99,40 @@
                   :key="component.name"
                 />
               </div>
-              <p
-                v-if="allowAlternateSignIn"
-                class="alternative-link small-text"
+              <div
+                :class="{
+                  'footer-links-landscape': showLandscapeLayout,
+                }"
               >
-                <KRouterLink
-                  :text="alternateSignInText$()"
-                  :to="alternateSignInRoute"
-                  :primary="true"
-                  appearance="basic-link"
-                />
-              </p>
-              <p
-                v-if="showGuestAccess"
-                class="alternative-link small-text"
-              >
-                <KExternalLink
-                  :text="$tr('accessAsGuest')"
-                  :href="guestURL"
-                  :primary="true"
-                  appearance="basic-link"
-                />
-              </p>
+                <p
+                  v-if="allowAlternateSignIn"
+                  class="alternative-link small-text"
+                  :style="{
+                    borderColor: $themeTokens.text,
+                  }"
+                >
+                  <KRouterLink
+                    :text="alternateSignInText$()"
+                    :to="alternateSignInRoute"
+                    :primary="true"
+                    appearance="basic-link"
+                  />
+                </p>
+                <p
+                  v-if="showGuestAccess"
+                  class="alternative-link small-text"
+                  :style="{
+                    borderColor: $themeTokens.text,
+                  }"
+                >
+                  <KExternalLink
+                    :text="$tr('accessAsGuest')"
+                    :href="guestURL"
+                    :primary="true"
+                    appearance="basic-link"
+                  />
+                </p>
+              </div>
             </template>
           </div>
           <div
@@ -236,12 +267,22 @@
         return showPictureSignInOption.value ? pictureSignInRoute.value : usernameSignInRoute.value;
       });
 
+      const deviceUnusableReason = plugin_data.deviceUnusableReason;
+
+      const showLandscapeLayout = computed(() => {
+        // Prevent landscape layout from showing if the device is unusable or
+        // remote access is disabled.
+        return props.landscapeLayout && allowAccess.value && !deviceUnusableReason;
+      });
+
       return {
         themeConfig,
         allowAccess,
         allowAlternateSignIn,
         showCreateAccountButton,
         alternateSignInRoute,
+        deviceUnusableReason,
+        showLandscapeLayout,
         signUpRoute,
         nextParam,
         // strings
@@ -249,6 +290,11 @@
       };
     },
     props: {
+      landscapeLayout: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
       hideFacilityBasedOptions: {
         type: Boolean,
         required: false,
@@ -298,9 +344,6 @@
       },
       showGuestAccess() {
         return plugin_data.allowGuestAccess && !this.oidcProviderFlow;
-      },
-      deviceUnusableReason() {
-        return plugin_data.deviceUnusableReason;
       },
       versionMsg() {
         return this.$tr('poweredBy', { version: __version });
@@ -413,6 +456,12 @@
     padding: 24px 32px;
     margin: 16px auto;
     border-radius: $radius;
+
+    &.landscape {
+      width: 70%;
+      min-width: 360px;
+      max-width: 1000px;
+    }
   }
 
   .create {
@@ -489,6 +538,36 @@
     margin-right: 10px;
     margin-left: 8px;
     vertical-align: middle;
+  }
+
+  .footer-links-landscape {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+
+    p {
+      padding: 0 16px;
+      border-right: 1px solid;
+
+      &:last-child {
+        border-right: 0;
+      }
+    }
+  }
+
+  .header-title-row {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .header-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 
   /deep/ .ui-textbox-input {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -1,7 +1,10 @@
 <template>
 
   <div class="picture-password-grid">
-    <div class="icon-grid">
+    <div
+      class="icon-grid"
+      :style="{ gridTemplateColumns: `repeat(${columns}, 1fr)` }"
+    >
       <PicturePasswordOption
         v-for="iconData in icons"
         :key="iconData.id"
@@ -77,6 +80,7 @@
   import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import useKResponsiveElement from 'kolibri-design-system/lib/composables/useKResponsiveElement';
   import PicturePasswordOption from './PicturePasswordOption';
 
   // Pre-compute once at module scope — PICTURE_PASSWORD_SET is static JSON so
@@ -95,6 +99,7 @@
       const $themeTokens = themeTokens();
       const $themePalette = themePalette();
       const { sendPoliteMessage } = useKLiveRegion();
+      const { elementWidth } = useKResponsiveElement();
 
       const {
         iconSelectedAsFirst$,
@@ -117,6 +122,22 @@
         const entry = PICTURE_PASSWORD_SET[String(id)];
         return picturePasswordStrings[`${entry.name}$`]();
       };
+
+      // empiric value, options below this width look very squished
+      // This value accounts for the grid gap as well.
+      const minOptionWidth = 80;
+
+      const allowedColumns = [3, 4, 6];
+
+      // How many columns can we fit given the current width of the component?
+      // Pick the largest allowed number of columns that will fit.
+      const columns = computed(() => {
+        const maxPossible = Math.floor(elementWidth.value / minOptionWidth);
+
+        const validOptions = allowedColumns.filter(num => num <= maxPossible);
+
+        return validOptions.length > 0 ? Math.max(...validOptions) : 3;
+      });
 
       const icons = computed(() =>
         ICON_ENTRIES.map(entry => {
@@ -218,6 +239,7 @@
 
       return {
         icons,
+        columns,
         progressSlots,
         submitEnabled,
         submitButtonAriaLabel,
@@ -272,7 +294,6 @@
 
   .icon-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
     gap: 22px;
   }
 
@@ -292,7 +313,7 @@
     display: flex;
     gap: 12px;
     align-items: center;
-    justify-content: center;
+    justify-content: space-around;
     min-height: 56px;
     padding: 12px;
     // enforce width to be 50%, and set width and height for icons
@@ -302,11 +323,13 @@
 
   .progress-icon {
     width: 100%;
+    max-width: 50px;
     height: 100%;
   }
 
   .progress-empty {
     width: 100%;
+    max-width: 50px;
     height: 7px;
     border-radius: 16px;
   }

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -3,7 +3,10 @@
   <div class="picture-password-grid">
     <div
       class="icon-grid"
-      :style="{ gridTemplateColumns: `repeat(${columns}, 1fr)` }"
+      :style="{
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        gap: landscapeLayout ? '14px' : '22px',
+      }"
     >
       <PicturePasswordOption
         v-for="iconData in icons"
@@ -275,6 +278,13 @@
         type: Boolean,
         default: false,
       },
+      /* Whether the parent AuthBase is in landscape layout, which affects the
+       * layout of this component.
+       */
+      landscapeLayout: {
+        type: Boolean,
+        default: false,
+      },
     },
   };
 
@@ -294,7 +304,6 @@
 
   .icon-grid {
     display: grid;
-    gap: 22px;
   }
 
   /* Ensure each PicturePasswordOption fills its grid cell. */

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordGrid.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordGrid.spec.js
@@ -1,7 +1,9 @@
+import { ref } from 'vue';
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import useKResponsiveElement from 'kolibri-design-system/lib/composables/useKResponsiveElement';
 import PicturePasswordGrid from '../PicturePasswordGrid.vue';
 
 const mockSendPoliteMessage = jest.fn();
@@ -9,6 +11,11 @@ const mockSendPoliteMessage = jest.fn();
 jest.mock('kolibri-design-system/lib/composables/useKLiveRegion', () => ({
   __esModule: true,
   default: jest.fn(() => ({ sendPoliteMessage: mockSendPoliteMessage })),
+}));
+
+jest.mock('kolibri-design-system/lib/composables/useKResponsiveElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
 }));
 
 function renderComponent(props = {}) {
@@ -35,6 +42,7 @@ const submitButton = () => screen.getByTestId('submit-button');
 describe('PicturePasswordGrid', () => {
   beforeEach(() => {
     mockSendPoliteMessage.mockClear();
+    useKResponsiveElement.mockReturnValue({ elementWidth: ref(0) });
   });
 
   describe('submit event', () => {
@@ -205,6 +213,29 @@ describe('PicturePasswordGrid', () => {
       expect(mockSendPoliteMessage).toHaveBeenLastCalledWith(
         picturePasswordStrings.allIconsSelected$(),
       );
+    });
+  });
+
+  describe('responsive columns', () => {
+    it.each([
+      [3, 100],
+      [3, 240],
+      [3, 319],
+      [4, 320],
+      [4, 479],
+      [6, 480],
+      [6, 1000],
+    ])('shows %i-column grid at %i px wide', (expectedColumns, width) => {
+      useKResponsiveElement.mockReturnValue({ elementWidth: ref(width) });
+      const { container } = renderComponent();
+      const grid = container.querySelector('.icon-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: `repeat(${expectedColumns}, 1fr)` });
+    });
+
+    it('falls back to 3 columns when elementWidth is 0', () => {
+      const { container } = renderComponent();
+      const grid = container.querySelector('.icon-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: 'repeat(3, 1fr)' });
     });
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -1,11 +1,30 @@
 <template>
 
-  <AuthBase :busy="busy">
+  <AuthBase
+    :busy="busy"
+    :landscapeLayout="landscapeLayout"
+  >
+    <template #header-leading-actions>
+      <!--
+        AuthBase only renders `header-leading-actions` in landscape layout, so this
+        AuthContextHeading will only render in that layout. The AuthContextHeading
+        outside of this slot will render in portrait layout.
+      -->
+      <AuthContextHeading
+        class="landscape-auth-context-heading"
+        :useBackAction="hasMultipleFacilities"
+        :backLabel="coreString('changeLearningFacility')"
+        :backTo="backTo"
+      />
+    </template>
+
     <AuthContextHeading
+      v-if="!landscapeLayout"
       :useBackAction="hasMultipleFacilities"
       :backLabel="coreString('changeLearningFacility')"
       :backTo="backTo"
     />
+
     <PicturePasswordGrid
       class="picture-grid"
       :class="{ 'after-action': hasMultipleFacilities }"
@@ -29,6 +48,9 @@
   import commonCoreStrings, { coreString } from 'kolibri/uiText/commonCoreStrings';
   import { useFacilitySelect } from 'kolibri-common/composables/useFacility';
   import useSnackbar from 'kolibri/composables/useSnackbar';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { isTouchDevice } from 'kolibri/utils/browserInfo';
+
   import AuthBase from '../AuthBase';
   import useAuthFlow from '../../composables/useAuthFlow';
   import useAuthWatcher from '../../composables/useAuthWatcher';
@@ -54,6 +76,7 @@
       const route = useRoute();
       const { login } = useUser();
       const { createSnackbar } = useSnackbar();
+      const { windowIsLandscape } = useKResponsiveWindow();
       const { nextParam, defaultRoute, getFacilitySelectionRoute } = useAuthRouter(route);
       const {
         hasMultipleFacilities,
@@ -69,6 +92,12 @@
       const wrongSequence = ref(false);
       const backTo = computed(() => {
         return hasMultipleFacilities.value ? getFacilitySelectionRoute(false) : null;
+      });
+
+      const landscapeLayout = computed(() => {
+        // Only show the landscape layout if the window is wide enough and it's a touch device.
+        // So that we don't change the layout for desktop users.
+        return windowIsLandscape.value && isTouchDevice;
       });
 
       watchForFacilityChange((newFacilityId, oldFacilityId) => {
@@ -129,6 +158,7 @@
         // state
         busy,
         wrongSequence,
+        landscapeLayout,
         backTo,
         picturePasswordStyle,
         picturePasswordShowIconText,
@@ -156,6 +186,10 @@
     &.after-action {
       margin-top: 10px;
     }
+  }
+
+  .landscape-auth-context-heading {
+    margin-top: 0;
   }
 
 </style>

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -31,6 +31,7 @@
       :iconStyle="picturePasswordStyle"
       :showIconText="picturePasswordShowIconText"
       :wrongSequence="wrongSequence"
+      :landscapeLayout="landscapeLayout"
       @wrongSequenceHandled="wrongSequence = false"
       @submit="createSession"
     />


### PR DESCRIPTION
## Summary

Display a 4 or 6-column grid for picture login sign-in in landscape mode, depending on available space.
* `columns` number calculated on PicturePasswordGrid depending on available space. Given that the login card in portrait mode has a fixed value, it will always only show 3 columns on that layout.
* `AuthBase` component update to match the layout for landscape mode, when a `landscapeLayout` prop is passed. Adds `#header-leading-actions` slot so that pages can render elements next to the Kolibri logo.
* `PicturePasswordSignInPage` modified to set the `landscapeLayout` prop to true when picture password sign-in is displayed in landscape mode.

https://github.com/user-attachments/assets/6eec646b-50f3-44a8-be5d-dd662cbb40a0

## References
Closes #14662.

## Notes

* I have added the responsive `columns` to consider a 4-column layout too, because on small devices, there was the possibility of getting a layout like this, where icons couldn't shrink further (we could still play with the gap, but that was going to be a bit more complex IMO, and wouldn't probably handle all cases):
<img width="648" height="304" alt="image" src="https://github.com/user-attachments/assets/691c0a29-630e-4862-8542-df054a9b91e3" />

* I am adding this just for touch devices, so that computers don't get this layout by default. If there is a better way, let me know :).