### PR TITLE
Upgrade morango to resolve dirty-bit issue and cleanup

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -434,7 +434,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 content_id=content_id,
                 user=user,
             )
-            updated_fields = ("end_timestamp", "channel_id", "_morango_dirty_bit")
+            updated_fields = ("end_timestamp", "channel_id")
             if repeat:
                 summarylog.progress = 0
                 updated_fields += ("progress",)
@@ -753,9 +753,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                     if end_timestamp:
                         masterylog.end_timestamp = end_timestamp
                         update_fields += ("end_timestamp",)
-                    masterylog.save(
-                        update_fields=update_fields + ("_morango_dirty_bit",)
-                    )
+                    masterylog.save(update_fields=update_fields)
                 return masterylog.id
             except MasteryLog.DoesNotExist:
                 raise ValidationError(
@@ -860,7 +858,6 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 "interaction_history",
                 "end_timestamp",
                 "time_spent",
-                "_morango_dirty_bit",
             }
             item_interactions = list(item_interactions)
             attemptlog = self._get_attemptlog(
@@ -937,7 +934,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
         return max(0, min(1.0, progress))
 
     def _update_content_log(self, log, end_timestamp, validated_data):
-        update_fields = ("end_timestamp", "_morango_dirty_bit")
+        update_fields = ("end_timestamp",)
 
         log.end_timestamp = end_timestamp
         if "progress_delta" in validated_data:

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -897,6 +897,17 @@ class ProgressTrackingViewSetStartSessionResumeTestCase(APITestCase):
         self.assertEqual(self.node.id, data["context"]["node_id"])
         self.assertEqual(session_id, data["session_id"])
 
+    def test_start_session_updates_summarylog_morango_dirty_bit(self):
+        self.summary_log.save(update_dirty_bit_to=False)
+        self.summary_log.refresh_from_db()
+        self.assertFalse(self.summary_log._morango_dirty_bit)
+
+        response = self._make_request({})
+
+        self.assertEqual(response.status_code, 200)
+        self.summary_log.refresh_from_db()
+        self.assertTrue(self.summary_log._morango_dirty_bit)
+
     def tearDown(self):
         self.client.logout()
 
@@ -1706,6 +1717,27 @@ class ProgressTrackingViewSetLoggedInUpdateSessionTestCase(
         self.assertEqual(response.json()["complete"], True)
         log = ContentSummaryLog.objects.get()
         self.assertEqual(1.0, log.progress)
+
+    def test_update_session_sets_morango_dirty_bit_for_session_and_summary_logs(self):
+        self.session_log.save(update_dirty_bit_to=False)
+        self.summary_log.save(update_dirty_bit_to=False)
+
+        self.session_log.refresh_from_db()
+        self.summary_log.refresh_from_db()
+        self.assertFalse(self.session_log._morango_dirty_bit)
+        self.assertFalse(self.summary_log._morango_dirty_bit)
+
+        response = self._make_request(
+            {
+                "progress_delta": 0.1,
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.session_log.refresh_from_db()
+        self.summary_log.refresh_from_db()
+        self.assertTrue(self.session_log._morango_dirty_bit)
+        self.assertTrue(self.summary_log._morango_dirty_bit)
 
     def test_anonymous_user_session_404(self):
         session_log = ContentSessionLog.objects.create(
@@ -2536,6 +2568,56 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentTestCase(
         self.assertNotEqual(
             self.mastery_log.end_timestamp, self.mastery_log.start_timestamp
         )
+
+    def test_update_assessment_session_sets_masterylog_morango_dirty_bit(self):
+        self.mastery_log.save(update_dirty_bit_to=False)
+        self.mastery_log.refresh_from_db()
+        self.assertFalse(self.mastery_log._morango_dirty_bit)
+
+        response = self._make_request(
+            {
+                "time_spent_delta": 5,
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.mastery_log.refresh_from_db()
+        self.assertTrue(self.mastery_log._morango_dirty_bit)
+
+    def test_update_assessment_session_sets_existing_attempt_morango_dirty_bit(self):
+        timestamp = local_now()
+        attemptlog = AttemptLog.objects.create(
+            masterylog=self.mastery_log,
+            sessionlog=self.session_log,
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            correct=0,
+            item=self.item,
+            user=self.user,
+            interaction_history=[],
+        )
+        attemptlog.save(update_dirty_bit_to=False)
+        attemptlog.refresh_from_db()
+        self.assertFalse(attemptlog._morango_dirty_bit)
+
+        response = self._make_request(
+            {
+                "interactions": [
+                    {
+                        "id": attemptlog.id,
+                        "item": self.item,
+                        "answer": {"response": "updated"},
+                        "correct": 1.0,
+                        "time_spent": 5,
+                        "replace": True,
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        attemptlog.refresh_from_db()
+        self.assertTrue(attemptlog._morango_dirty_bit)
 
     def test_update_assessment_session_create_attempt_in_lesson_succeeds(self):
         lesson = create_assigned_lesson_for_user(self.user)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.15
 jsonfield==3.1.0
-morango==0.8.11
+morango==0.8.12
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Upgrades Morango which includes a fix to correct behavior handling the dirty bit when models are saved with `update_fields`
- Adds regression tests for the existing logging functionality that was avoiding this issue

### Verifications

#### Tests added to verify existing fix
<img width="1662" height="124" alt="image" src="https://github.com/user-attachments/assets/e24cf45d-69ea-47fb-8746-695b4eb05b66" />

#### Existing fix is removed exposing failed tests
<img width="1662" height="124" alt="image" src="https://github.com/user-attachments/assets/3eeae4d3-1783-4193-ba5c-23e73c292526" />

#### Morango is upgraded showing it covers existing fix
<img width="1662" height="124" alt="image" src="https://github.com/user-attachments/assets/d1cee559-ca53-42bb-9ba7-73b74792d70f" />


## References
<!--
 * references to related issues and PRs
-->
https://github.com/learningequality/morango/pull/326

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See verifications list above, which shows:
1. The existing logging API handled this issue manually
2. Without that manual fix, those cases are problematic
3. Morango solves the issue and removes the need for the manual fix

This methodology was for the benefit of the reviewer. After review, I think we could drop the first commit, which adds the tests, with confidence in Morango, but feel free to specify otherwise.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage

Asked AI to write the tests, but I had to update how they were setting the dirty bit to `False` before the actual scenario.
