### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -90,9 +90,8 @@ class ParamValidator:
                 param = False
             else:
                 raise InvalidQueryParamsException(
-                    "%s is not a valid bool: must be one of: %s",
-                    param,
-                    TRUE_VALUES + FALSE_VALUES,
+                    "%s is not a valid bool: must be one of: %s"
+                    % (param, TRUE_VALUES + FALSE_VALUES)
                 )
         elif hasattr(
             self.param_type, "_default_manager"
@@ -103,7 +102,7 @@ class ParamValidator:
             param = query_set.get(**{self.field: param})
         else:
             raise InvalidQueryParamsException(
-                "Invalid param type: %s" % self.param_type.____name__
+                "Invalid param type: %s" % self.param_type.__name__
             )
         return param
 
@@ -126,7 +125,7 @@ class ParamValidator:
     def check_value_constraints(self, param):
         try:
             if self.eq and param != self.eq:
-                raise InvalidQueryParamsException("must be less than %s!" % self.eq)
+                raise InvalidQueryParamsException("must be equal to %s!" % self.eq)
             else:
                 if self.lt and param >= self.lt:
                     raise InvalidQueryParamsException("must be less than %s!" % self.lt)

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -82,10 +82,6 @@ class _registry(dict):
         self.__init_check()
         return super().items()
 
-    def __cmp__(self, other):
-        self.__init_check()
-        return super().__cmp__(other)
-
     def _initialize(self):
         logger.debug("Importing 'tasks' module from django apps")
 
@@ -110,7 +106,7 @@ class _registry(dict):
 
     def update(self, other):
         # Coerce args to a dict and then set each key in that dict
-        other = {}.update(other)
+        other = dict(other)
         for key, value in other.items():
             self[key] = value
 

--- a/kolibri/core/tasks/test/test_registry.py
+++ b/kolibri/core/tasks/test/test_registry.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from kolibri.core.tasks.registry import _registry
+from kolibri.core.tasks.registry import RegisteredTask
+
+
+def _task():
+    return RegisteredTask(lambda: None)
+
+
+class TestRegistryUpdate(TestCase):
+    def test_update_from_mapping_populates_entries(self):
+        reg = _registry()
+        task_a, task_b = _task(), _task()
+
+        reg.update({"a": task_a, "b": task_b})
+
+        self.assertIs(dict.__getitem__(reg, "a"), task_a)
+        self.assertIs(dict.__getitem__(reg, "b"), task_b)
+
+    def test_update_from_iterable_of_pairs_populates_entries(self):
+        reg = _registry()
+        task = _task()
+
+        reg.update([("k", task)])
+
+        self.assertIs(dict.__getitem__(reg, "k"), task)
+
+    def test_update_enforces_registered_task_value_type(self):
+        reg = _registry()
+
+        with self.assertRaises(TypeError):
+            reg.update({"k": "not a RegisteredTask"})

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -1,0 +1,23 @@
+from django.test import SimpleTestCase
+
+from kolibri.core.decorators import InvalidQueryParamsException
+from kolibri.core.decorators import ParamValidator
+
+
+class ParamValidatorTestCase(SimpleTestCase):
+    def test_eq_constraint_message_says_equal_to(self):
+        validator = ParamValidator("count")
+        validator.set_type(int)
+        validator.eq = 5
+
+        with self.assertRaises(InvalidQueryParamsException) as ctx:
+            validator.check_value_constraints(7)
+
+        self.assertIn("must be equal to 5", str(ctx.exception))
+
+    def test_invalid_bool_param_raises_query_params_exception(self):
+        validator = ParamValidator("flag")
+        validator.set_type(bool)
+
+        with self.assertRaises(InvalidQueryParamsException):
+            validator.check_non_tuple_types("yes")

--- a/kolibri/utils/database.py
+++ b/kolibri/utils/database.py
@@ -83,7 +83,6 @@ def sqlite_check_foreign_keys(database_paths):
         if not os.path.exists(name):
             continue
 
-        db_connection = sqlite3.connect(name)
         with sqlite3.connect(name) as db_connection:
             cursor = db_connection.cursor()
 


### PR DESCRIPTION
## Summary

Five small correctness fixes across three files; each fix is its own commit:

- `kolibri/utils/database.py` — drop a redundant `sqlite3.connect()` immediately before the `with sqlite3.connect(...)` block.
- `kolibri/core/decorators.py` — three `ParamValidator` bugs: `____name__` typo, eq-constraint message copy-pasted from the `lt` branch, and an invalid-bool path that crashed with `TypeError` instead of returning 400.
- `kolibri/core/tasks/registry.py` — `_registry.update` was crashing on `None.items()`; coerce with `dict(other)`. Also drop the dead Python-2 `__cmp__` override.

Regression tests added where reachable through normal use.

## References

These fixes were originally identified by a bot opening PRs against this repository. The PRs did not follow our contribution guidelines (notably the AI-usage disclosure in the PR template), so they will not be merged. Preserving the fixes here because they are useful.

## Reviewer guidance

Nothing risky — five one-line correctness fixes across three files, with regression tests for two of them.

## AI usage

Used Claude Code (Opus 4.7) to triage the bot's three open PRs, verify each claim against the source, and recreate the fixes locally with regression tests under TDD (red-green for each). Then ran a sweep — pyright in basic mode plus targeted greps for the same bug shapes — which surfaced two more bugs in the same files (the bool-path `TypeError` in `decorators.py` and the dead `__cmp__` in `registry.py`). I reviewed every change and verified the test suite passes.