### PR TITLE
Add picture password confirm modal

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1478,7 +1478,7 @@ class SessionViewSet(viewsets.ViewSet):
         )
         if serializer.is_valid():
             user = serializer.validated_data["user"]
-            if request.data.get("prevalidate"):
+            if request.query_params.get("prevalidate") == "true":
                 return Response({"full_name": user.full_name})
             login(request, user)
             return self.get_session_response(request)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1478,6 +1478,8 @@ class SessionViewSet(viewsets.ViewSet):
         )
         if serializer.is_valid():
             user = serializer.validated_data["user"]
+            if request.data.get("prevalidate"):
+                return Response({"full_name": user.full_name})
             login(request, user)
             return self.get_session_response(request)
 

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -4062,12 +4062,6 @@ class FacilityUserSerializerPicturePasswordTestCase(APITestCase):
 
 
 class PicturePasswordPrevalidateTestCase(APITestCase):
-    """Tests for prevalidate=True in the POST body of the session endpoint.
-
-    Validates a picture password server-side without creating a session,
-    returning the learner's full name on success.
-    """
-
     databases = "__all__"
 
     @classmethod
@@ -4080,16 +4074,12 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
         cls.learner.save(update_fields=["picture_password"])
 
     def _url(self):
-        return reverse("kolibri:core:session-list")
+        return reverse("kolibri:core:session-list") + "?prevalidate=true"
 
     def test_valid_picture_password_returns_full_name(self):
         response = self.client.post(
             self._url(),
-            data={
-                "picture_password": "1.2.3",
-                "facility": self.facility.id,
-                "prevalidate": True,
-            },
+            data={"picture_password": "1.2.3", "facility": self.facility.id},
             format="json",
         )
         self.assertEqual(response.status_code, 200)
@@ -4098,11 +4088,7 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
     def test_valid_picture_password_does_not_create_session(self):
         self.client.post(
             self._url(),
-            data={
-                "picture_password": "1.2.3",
-                "facility": self.facility.id,
-                "prevalidate": True,
-            },
+            data={"picture_password": "1.2.3", "facility": self.facility.id},
             format="json",
         )
         self.assertFalse(self.client.session.get("_auth_user_id"))
@@ -4110,11 +4096,7 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
     def test_wrong_picture_password_returns_not_found(self):
         response = self.client.post(
             self._url(),
-            data={
-                "picture_password": "9.9.9",
-                "facility": self.facility.id,
-                "prevalidate": True,
-            },
+            data={"picture_password": "9.9.9", "facility": self.facility.id},
             format="json",
         )
         self.assertEqual(response.status_code, 400)
@@ -4123,11 +4105,7 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
     def test_wrong_facility_returns_not_found(self):
         response = self.client.post(
             self._url(),
-            data={
-                "picture_password": "1.2.3",
-                "facility": self.other_facility.id,
-                "prevalidate": True,
-            },
+            data={"picture_password": "1.2.3", "facility": self.other_facility.id},
             format="json",
         )
         self.assertEqual(response.status_code, 400)
@@ -4140,11 +4118,7 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
         self.facility.add_coach(coach)
         response = self.client.post(
             self._url(),
-            data={
-                "picture_password": "4.5.6",
-                "facility": self.facility.id,
-                "prevalidate": True,
-            },
+            data={"picture_password": "4.5.6", "facility": self.facility.id},
             format="json",
         )
         self.assertEqual(response.status_code, 400)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -4062,7 +4062,7 @@ class FacilityUserSerializerPicturePasswordTestCase(APITestCase):
 
 
 class PicturePasswordPrevalidateTestCase(APITestCase):
-    """Tests for ?prevalidate=true on the session endpoint.
+    """Tests for prevalidate=True in the POST body of the session endpoint.
 
     Validates a picture password server-side without creating a session,
     returning the learner's full name on success.

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -4059,3 +4059,93 @@ class FacilityUserSerializerPicturePasswordTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         user = models.FacilityUser.objects.get(id=response.data["id"])
         self.assertIsNone(user.picture_password)
+
+
+class PicturePasswordPrevalidateTestCase(APITestCase):
+    """Tests for ?prevalidate=true on the session endpoint.
+
+    Validates a picture password server-side without creating a session,
+    returning the learner's full name on success.
+    """
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.other_facility = FacilityFactory.create()
+        cls.learner = FacilityUserFactory.create(facility=cls.facility)
+        cls.learner.picture_password = "1.2.3"
+        cls.learner.save(update_fields=["picture_password"])
+
+    def _url(self):
+        return reverse("kolibri:core:session-list")
+
+    def test_valid_picture_password_returns_full_name(self):
+        response = self.client.post(
+            self._url(),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.facility.id,
+                "prevalidate": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["full_name"], self.learner.full_name)
+
+    def test_valid_picture_password_does_not_create_session(self):
+        self.client.post(
+            self._url(),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.facility.id,
+                "prevalidate": True,
+            },
+            format="json",
+        )
+        self.assertFalse(self.client.session.get("_auth_user_id"))
+
+    def test_wrong_picture_password_returns_not_found(self):
+        response = self.client.post(
+            self._url(),
+            data={
+                "picture_password": "9.9.9",
+                "facility": self.facility.id,
+                "prevalidate": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_wrong_facility_returns_not_found(self):
+        response = self.client.post(
+            self._url(),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.other_facility.id,
+                "prevalidate": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+    def test_non_learner_not_authenticated_via_picture_password(self):
+        coach = FacilityUserFactory.create(facility=self.facility)
+        coach.picture_password = "4.5.6"
+        coach.save(update_fields=["picture_password"])
+        self.facility.add_coach(coach)
+        response = self.client.post(
+            self._url(),
+            data={
+                "picture_password": "4.5.6",
+                "facility": self.facility.id,
+                "prevalidate": True,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)

--- a/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
@@ -230,7 +230,7 @@
             this.wrapOnboarding();
             if (this.deviceProvisioningData.superuser || this.userBasedOnOs) {
               const { password } = this.deviceProvisioningData.superuser || {};
-              const error = await this.login({
+              const { error } = await this.login({
                 facilityId,
                 username,
                 password,

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -1,90 +1,93 @@
 <template>
 
-  <div
-    class="modal-overlay"
-    @mousedown.prevent
-  >
-    <div class="modal-wrapper">
-      <KFocusTrap
-        @shouldFocusFirstEl="modalTitle.focus()"
-        @shouldFocusLastEl="confirmBtn.$el.focus()"
-      >
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="confirm-modal-title"
-          class="modal-card"
-          tabindex="-1"
-          :style="{ backgroundColor: $themeTokens.surface }"
+  <KOverlay>
+    <Backdrop class="confirm-backdrop" />
+    <div
+      class="modal-overlay"
+      @mousedown.prevent
+    >
+      <div class="modal-wrapper">
+        <KFocusTrap
+          @shouldFocusFirstEl="modalTitle.focus()"
+          @shouldFocusLastEl="confirmBtn.$el.focus()"
         >
           <div
-            class="header"
-            :style="{ backgroundColor: $themePalette.yellow.v_500 }"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-modal-title"
+            class="modal-card"
+            tabindex="-1"
+            :style="{ backgroundColor: $themeTokens.surface }"
           >
-            <h1
-              id="confirm-modal-title"
-              ref="modalTitle"
-              class="modal-title"
-              tabindex="-1"
-              :style="{ color: $themeTokens.text }"
-            >
-              {{ isThisYou$() }}
-            </h1>
-
-            <p
-              class="learner-name"
-              :style="{ color: $themeTokens.text }"
-            >
-              {{ learnerName }}
-            </p>
-          </div>
-
-          <span class="visuallyhidden">{{ sequenceAriaLabel }}</span>
-          <div
-            class="icon-sequence"
-            aria-hidden="true"
-            :style="{ backgroundColor: $themePalette.grey.v_100 }"
-          >
-            <KIcon
-              v-for="(iconToken, i) in iconTokens"
-              :key="i"
-              class="seq-icon"
-              :icon="iconToken"
-            />
-          </div>
-
-          <div class="action-buttons">
             <div
-              class="btn-bg"
-              :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
-              @mouseenter="cancelHovered = true"
-              @mouseleave="cancelHovered = false"
+              class="header"
+              :style="{ backgroundColor: $themePalette.yellow.v_500 }"
             >
-              <KIconButton
-                icon="close"
-                :ariaLabel="noGoBackAction$()"
-                @click="$emit('cancel')"
+              <h1
+                id="confirm-modal-title"
+                ref="modalTitle"
+                class="modal-title"
+                tabindex="-1"
+                :style="{ color: $themeTokens.text }"
+              >
+                {{ isThisYou$() }}
+              </h1>
+
+              <p
+                class="learner-name"
+                :style="{ color: $themeTokens.text }"
+              >
+                {{ learnerName }}
+              </p>
+            </div>
+
+            <span class="visuallyhidden">{{ sequenceAriaLabel }}</span>
+            <div
+              class="icon-sequence"
+              aria-hidden="true"
+              :style="{ backgroundColor: $themePalette.grey.v_100 }"
+            >
+              <KIcon
+                v-for="(iconToken, i) in iconTokens"
+                :key="i"
+                class="seq-icon"
+                :icon="iconToken"
               />
             </div>
-            <div
-              class="btn-bg"
-              :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
-              @mouseenter="confirmHovered = true"
-              @mouseleave="confirmHovered = false"
-            >
-              <KIconButton
-                ref="confirmBtn"
-                icon="check"
-                :color="$themePalette.white"
-                :ariaLabel="yesConfirmAction$()"
-                @click="$emit('confirm')"
-              />
+
+            <div class="action-buttons">
+              <div
+                class="btn-bg"
+                :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
+                @mouseenter="cancelHovered = true"
+                @mouseleave="cancelHovered = false"
+              >
+                <KIconButton
+                  icon="close"
+                  :ariaLabel="noGoBackAction$()"
+                  @click="$emit('cancel')"
+                />
+              </div>
+              <div
+                class="btn-bg"
+                :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
+                @mouseenter="confirmHovered = true"
+                @mouseleave="confirmHovered = false"
+              >
+                <KIconButton
+                  ref="confirmBtn"
+                  icon="check"
+                  :color="$themePalette.white"
+                  :ariaLabel="yesConfirmAction$()"
+                  @click="$emit('confirm')"
+                />
+              </div>
             </div>
           </div>
-        </div>
-      </KFocusTrap>
+        </KFocusTrap>
+      </div>
     </div>
-  </div>
+  </KOverlay>
 
 </template>
 
@@ -93,6 +96,8 @@
 
   import { computed, onMounted, ref } from 'vue';
   import KFocusTrap from 'kolibri-design-system/lib/KFocusTrap';
+  import KOverlay from 'kolibri-design-system/lib/KOverlay';
+  import Backdrop from 'kolibri/components/Backdrop';
   import { PICTURE_PASSWORD_SET } from 'kolibri/constants';
   import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
@@ -102,7 +107,7 @@
   export default {
     name: 'PicturePasswordConfirmModal',
 
-    components: { KFocusTrap },
+    components: { KFocusTrap, KOverlay, Backdrop },
 
     setup(props) {
       const confirmBtn = ref(null);
@@ -191,6 +196,10 @@
 
 <style lang="scss" scoped>
 
+  .confirm-backdrop {
+    z-index: 24;
+  }
+
   .modal-overlay {
     position: fixed;
     inset: 0;
@@ -200,7 +209,6 @@
     align-items: center;
     justify-content: center;
     padding: 0 16px;
-    background: rgba(0, 0, 0, 0.7);
   }
 
   .modal-wrapper {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -136,7 +136,7 @@
       });
 
       onMounted(() => {
-        modalTitle.value.focus();
+        confirmBtn.value.$el.focus();
       });
 
       return {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -16,7 +16,6 @@
             aria-modal="true"
             aria-labelledby="confirm-modal-title"
             class="modal-card"
-            tabindex="-1"
             :style="{ backgroundColor: $themeTokens.surface }"
           >
             <div
@@ -58,9 +57,12 @@
             <div class="action-buttons">
               <div
                 class="btn-bg"
-                :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
-                @mouseenter="cancelHovered = true"
-                @mouseleave="cancelHovered = false"
+                :class="
+                  $computedClass({
+                    backgroundColor: cancelBg,
+                    ':hover': { backgroundColor: cancelBgHover },
+                  })
+                "
               >
                 <KIconButton
                   icon="close"
@@ -70,9 +72,12 @@
               </div>
               <div
                 class="btn-bg"
-                :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
-                @mouseenter="confirmHovered = true"
-                @mouseleave="confirmHovered = false"
+                :class="
+                  $computedClass({
+                    backgroundColor: confirmBg,
+                    ':hover': { backgroundColor: confirmBgHover },
+                  })
+                "
               >
                 <KIconButton
                   ref="confirmBtn"
@@ -94,13 +99,14 @@
 
 <script>
 
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onMounted, onUnmounted, ref } from 'vue';
   import KFocusTrap from 'kolibri-design-system/lib/KFocusTrap';
   import KOverlay from 'kolibri-design-system/lib/KOverlay';
   import Backdrop from 'kolibri/components/Backdrop';
-  import { PICTURE_PASSWORD_SET } from 'kolibri/constants';
   import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import { getPicturePasswordIcons } from 'kolibri-common/utils/picturePassword';
+  import useReturnFocusOnUnmount from 'kolibri-common/composables/useReturnFocusOnUnmount';
   import { themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
 
@@ -110,40 +116,37 @@
     components: { KFocusTrap, KOverlay, Backdrop },
 
     setup(props) {
+      useReturnFocusOnUnmount();
       const confirmBtn = ref(null);
       const modalTitle = ref(null);
       const { isThisYou$, yourPasswordIs$, yesConfirmAction$, noGoBackAction$ } =
         picturePasswordStrings;
       const palette = themePalette();
-      const cancelHovered = ref(false);
-      const confirmHovered = ref(false);
       const cancelBg = palette.grey.v_200;
       const cancelBgHover = darken1(cancelBg);
       const confirmBg = palette.green.v_600;
       const confirmBgHover = darken1(confirmBg);
 
-      const iconTokens = computed(() => {
-        return props.picturePassword.split('.').map(idStr => {
-          const entry = PICTURE_PASSWORD_SET[idStr];
-          return props.iconStyle === PicturePasswordIconStyle.STANDARD
-            ? entry.iconStandard
-            : entry.iconColorful;
-        });
-      });
+      const passwordIcons = computed(() =>
+        getPicturePasswordIcons(props.picturePassword, props.iconStyle),
+      );
+
+      const iconTokens = computed(() => passwordIcons.value.map(item => item.iconName));
 
       const sequenceAriaLabel = computed(() => {
-        const labels = props.picturePassword
-          .split('.')
-          .map(idStr => {
-            const entry = PICTURE_PASSWORD_SET[idStr];
-            return picturePasswordStrings[`${entry.name}$`]();
-          })
+        const labels = passwordIcons.value
+          .map(item => picturePasswordStrings[`${item.label}$`]())
           .join(', ');
         return yourPasswordIs$({ labels });
       });
 
       onMounted(() => {
+        document.documentElement.style.overflow = 'hidden';
         confirmBtn.value.$el.focus();
+      });
+
+      onUnmounted(() => {
+        document.documentElement.style.overflow = '';
       });
 
       return {
@@ -154,8 +157,6 @@
         isThisYou$,
         yesConfirmAction$,
         noGoBackAction$,
-        cancelHovered,
-        confirmHovered,
         cancelBg,
         cancelBgHover,
         confirmBg,
@@ -208,7 +209,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0 16px;
+    padding: 16px;
   }
 
   .modal-wrapper {
@@ -218,7 +219,8 @@
   }
 
   .modal-card {
-    max-height: 428px;
+    max-height: calc(100vh - 32px);
+    overflow-y: auto;
     border-radius: 8px;
   }
 

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -4,84 +4,86 @@
     class="modal-overlay"
     @mousedown.prevent
   >
-    <KFocusTrap
-      @shouldFocusFirstEl="modalTitle.focus()"
-      @shouldFocusLastEl="confirmBtn.$el.focus()"
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="confirm-modal-title"
-        class="modal-card"
-        tabindex="-1"
-        :style="{ backgroundColor: $themeTokens.surface }"
+    <div class="modal-wrapper">
+      <KFocusTrap
+        @shouldFocusFirstEl="modalTitle.focus()"
+        @shouldFocusLastEl="confirmBtn.$el.focus()"
       >
         <div
-          class="header"
-          :style="{ backgroundColor: $themePalette.yellow.v_500 }"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-modal-title"
+          class="modal-card"
+          tabindex="-1"
+          :style="{ backgroundColor: $themeTokens.surface }"
         >
-          <h1
-            id="confirm-modal-title"
-            ref="modalTitle"
-            class="modal-title"
-            tabindex="-1"
-            :style="{ color: $themeTokens.text }"
-          >
-            {{ isThisYou$() }}
-          </h1>
-
-          <p
-            class="learner-name"
-            :style="{ color: $themeTokens.text }"
-          >
-            {{ learnerName }}
-          </p>
-        </div>
-
-        <span class="visuallyhidden">{{ sequenceAriaLabel }}</span>
-        <div
-          class="icon-sequence"
-          aria-hidden="true"
-          :style="{ backgroundColor: $themePalette.grey.v_100 }"
-        >
-          <KIcon
-            v-for="(iconToken, i) in iconTokens"
-            :key="i"
-            class="seq-icon"
-            :icon="iconToken"
-          />
-        </div>
-
-        <div class="action-buttons">
           <div
-            class="btn-bg"
-            :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
-            @mouseenter="cancelHovered = true"
-            @mouseleave="cancelHovered = false"
+            class="header"
+            :style="{ backgroundColor: $themePalette.yellow.v_500 }"
           >
-            <KIconButton
-              icon="close"
-              :ariaLabel="noGoBackAction$()"
-              @click="$emit('cancel')"
+            <h1
+              id="confirm-modal-title"
+              ref="modalTitle"
+              class="modal-title"
+              tabindex="-1"
+              :style="{ color: $themeTokens.text }"
+            >
+              {{ isThisYou$() }}
+            </h1>
+
+            <p
+              class="learner-name"
+              :style="{ color: $themeTokens.text }"
+            >
+              {{ learnerName }}
+            </p>
+          </div>
+
+          <span class="visuallyhidden">{{ sequenceAriaLabel }}</span>
+          <div
+            class="icon-sequence"
+            aria-hidden="true"
+            :style="{ backgroundColor: $themePalette.grey.v_100 }"
+          >
+            <KIcon
+              v-for="(iconToken, i) in iconTokens"
+              :key="i"
+              class="seq-icon"
+              :icon="iconToken"
             />
           </div>
-          <div
-            class="btn-bg"
-            :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
-            @mouseenter="confirmHovered = true"
-            @mouseleave="confirmHovered = false"
-          >
-            <KIconButton
-              ref="confirmBtn"
-              icon="check"
-              :color="$themePalette.white"
-              :ariaLabel="yesConfirmAction$()"
-              @click="$emit('confirm')"
-            />
+
+          <div class="action-buttons">
+            <div
+              class="btn-bg"
+              :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
+              @mouseenter="cancelHovered = true"
+              @mouseleave="cancelHovered = false"
+            >
+              <KIconButton
+                icon="close"
+                :ariaLabel="noGoBackAction$()"
+                @click="$emit('cancel')"
+              />
+            </div>
+            <div
+              class="btn-bg"
+              :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
+              @mouseenter="confirmHovered = true"
+              @mouseleave="confirmHovered = false"
+            >
+              <KIconButton
+                ref="confirmBtn"
+                icon="check"
+                :color="$themePalette.white"
+                :ariaLabel="yesConfirmAction$()"
+                @click="$emit('confirm')"
+              />
+            </div>
           </div>
         </div>
-      </div>
-    </KFocusTrap>
+      </KFocusTrap>
+    </div>
   </div>
 
 </template>
@@ -191,19 +193,24 @@
 
   .modal-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
+    inset: 0;
     z-index: 24;
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    height: 100%;
+    padding: 0 16px;
     background: rgba(0, 0, 0, 0.7);
   }
 
+  .modal-wrapper {
+    width: 100%;
+    min-width: 0;
+    max-width: 412px;
+  }
+
   .modal-card {
-    width: max-content;
+    max-height: 428px;
     border-radius: 8px;
   }
 
@@ -251,10 +258,12 @@
   }
 
   .btn-bg {
+    flex: 1;
+    min-width: 0;
     border-radius: 8px;
 
     /deep/ button {
-      width: 166px !important;
+      width: 100% !important;
       height: 96px !important;
       padding: 16px !important;
       background-color: inherit !important;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -1,0 +1,275 @@
+<template>
+
+  <div class="modal-overlay">
+    <KFocusTrap>
+      <div
+        ref="modalCard"
+        role="dialog"
+        aria-modal="true"
+        class="modal-card"
+        tabindex="-1"
+        :style="{ backgroundColor: $themeTokens.surface }"
+      >
+        <div
+          class="header"
+          :style="{ backgroundColor: $themePalette.yellow.v_500 }"
+        >
+          <h1
+            class="modal-title"
+            :style="{ color: $themeTokens.text }"
+          >
+            {{ isThisYou$() }}
+          </h1>
+
+          <p
+            class="learner-name"
+            :style="{ color: $themeTokens.text }"
+          >
+            {{ learnerName }}
+          </p>
+        </div>
+
+        <span class="visuallyhidden">{{ sequenceAriaLabel }}</span>
+        <div
+          class="icon-sequence"
+          aria-hidden="true"
+          :style="{ backgroundColor: $themePalette.grey.v_100 }"
+        >
+          <KIcon
+            v-for="(iconToken, i) in iconTokens"
+            :key="i"
+            class="seq-icon"
+            :icon="iconToken"
+          />
+        </div>
+
+        <div class="action-buttons">
+          <div
+            class="btn-bg"
+            :style="{ backgroundColor: cancelHovered ? cancelBgHover : cancelBg }"
+            @mouseenter="cancelHovered = true"
+            @mouseleave="cancelHovered = false"
+          >
+            <KIconButton
+              icon="close"
+              :ariaLabel="noGoBackAction$()"
+              @click="$emit('cancel')"
+            />
+          </div>
+          <div
+            class="btn-bg"
+            :style="{ backgroundColor: confirmHovered ? confirmBgHover : confirmBg }"
+            @mouseenter="confirmHovered = true"
+            @mouseleave="confirmHovered = false"
+          >
+            <KIconButton
+              ref="confirmBtn"
+              icon="check"
+              :color="$themePalette.white"
+              :ariaLabel="yesConfirmAction$()"
+              @click="$emit('confirm')"
+            />
+          </div>
+        </div>
+      </div>
+    </KFocusTrap>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed, onMounted, onUnmounted, ref } from 'vue';
+  import KFocusTrap from 'kolibri-design-system/lib/KFocusTrap';
+  import { PICTURE_PASSWORD_SET } from 'kolibri/constants';
+  import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import { themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
+
+  export default {
+    name: 'PicturePasswordConfirmModal',
+
+    components: { KFocusTrap },
+
+    setup(props) {
+      const confirmBtn = ref(null);
+      const modalCard = ref(null);
+      const { isThisYou$, yourPasswordIs$, yesConfirmAction$, noGoBackAction$ } =
+        picturePasswordStrings;
+      const palette = themePalette();
+      const cancelHovered = ref(false);
+      const confirmHovered = ref(false);
+      const cancelBg = palette.grey.v_200;
+      const cancelBgHover = darken1(cancelBg);
+      const confirmBg = palette.green.v_600;
+      const confirmBgHover = darken1(confirmBg);
+
+      const iconTokens = computed(() => {
+        return props.picturePassword.split('.').map(idStr => {
+          const entry = PICTURE_PASSWORD_SET[idStr];
+          return props.iconStyle === PicturePasswordIconStyle.STANDARD
+            ? entry.iconStandard
+            : entry.iconColorful;
+        });
+      });
+
+      const sequenceAriaLabel = computed(() => {
+        const labels = props.picturePassword
+          .split('.')
+          .map(idStr => {
+            const entry = PICTURE_PASSWORD_SET[idStr];
+            return picturePasswordStrings[`${entry.name}$`]();
+          })
+          .join(', ');
+        return yourPasswordIs$({ labels });
+      });
+
+      function handleFocusEscape(event) {
+        if (!modalCard.value) return;
+        if (!modalCard.value.contains(event.target)) {
+          modalCard.value.focus();
+        }
+      }
+
+      onMounted(() => {
+        if (confirmBtn.value && confirmBtn.value.$el) {
+          confirmBtn.value.$el.focus();
+        }
+        window.addEventListener('focus', handleFocusEscape, true);
+      });
+
+      onUnmounted(() => {
+        window.removeEventListener('focus', handleFocusEscape, true);
+      });
+
+      return {
+        confirmBtn,
+        modalCard,
+        iconTokens,
+        sequenceAriaLabel,
+        isThisYou$,
+        yesConfirmAction$,
+        noGoBackAction$,
+        cancelHovered,
+        confirmHovered,
+        cancelBg,
+        cancelBgHover,
+        confirmBg,
+        confirmBgHover,
+      };
+    },
+
+    props: {
+      /**
+       * Full name of the authenticated learner from the session API response.
+       */
+      learnerName: {
+        type: String,
+        required: true,
+      },
+      /**
+       * Dot-separated picture password sequence string (e.g. "1.2.3").
+       */
+      picturePassword: {
+        type: String,
+        required: true,
+      },
+      /**
+       * Icon style variant: 'colorful' or 'standard'.
+       */
+      iconStyle: {
+        type: String,
+        default: PicturePasswordIconStyle.COLORFUL,
+        validator: value => Object.values(PicturePasswordIconStyle).includes(value),
+      },
+    },
+
+    emits: ['confirm', 'cancel'],
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 24;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+  }
+
+  .modal-card {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: max-content;
+    border-radius: 8px;
+    transform: translate(-50%, -50%);
+  }
+
+  .header {
+    padding: 24px;
+    border-radius: 8px 8px 0 0;
+  }
+
+  .modal-title {
+    margin: 0 0 8px;
+    font-size: 20px;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  .learner-name {
+    margin: 0;
+    font-size: 32px;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  .icon-sequence {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+    justify-content: center;
+    padding: 16px 32px;
+    margin: 32px;
+    border-radius: 8px;
+  }
+
+  .seq-icon {
+    width: 80px;
+    height: 80px;
+  }
+
+  .action-buttons {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    padding: 0 32px 32px;
+  }
+
+  .btn-bg {
+    display: inline-block;
+    border-radius: 8px;
+
+    /deep/ button {
+      width: 166px !important;
+      height: 96px !important;
+      padding: 16px !important;
+      background-color: inherit !important;
+      border-radius: 8px !important;
+
+      svg {
+        width: 48px !important;
+        height: 48px !important;
+      }
+    }
+  }
+
+</style>

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -218,18 +218,20 @@
     border-radius: 8px 8px 0 0;
   }
 
-  .modal-title {
-    margin: 0 0 8px;
-    font-size: 20px;
+  .modal-title,
+  .learner-name {
+    margin: 0;
     font-weight: 600;
     text-align: center;
   }
 
+  .modal-title {
+    margin-bottom: 8px;
+    font-size: 20px;
+  }
+
   .learner-name {
-    margin: 0;
     font-size: 32px;
-    font-weight: 600;
-    text-align: center;
   }
 
   .icon-sequence {
@@ -249,13 +251,12 @@
 
   .action-buttons {
     display: flex;
-    gap: 16px;
+    gap: 22px;
     justify-content: center;
     padding: 0 32px 32px;
   }
 
   .btn-bg {
-    display: inline-block;
     border-radius: 8px;
 
     /deep/ button {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -1,11 +1,17 @@
 <template>
 
-  <div class="modal-overlay">
-    <KFocusTrap>
+  <div
+    class="modal-overlay"
+    @mousedown.prevent
+  >
+    <KFocusTrap
+      @shouldFocusFirstEl="modalTitle.focus()"
+      @shouldFocusLastEl="confirmBtn.$el.focus()"
+    >
       <div
-        ref="modalCard"
         role="dialog"
         aria-modal="true"
+        aria-labelledby="confirm-modal-title"
         class="modal-card"
         tabindex="-1"
         :style="{ backgroundColor: $themeTokens.surface }"
@@ -15,7 +21,10 @@
           :style="{ backgroundColor: $themePalette.yellow.v_500 }"
         >
           <h1
+            id="confirm-modal-title"
+            ref="modalTitle"
             class="modal-title"
+            tabindex="-1"
             :style="{ color: $themeTokens.text }"
           >
             {{ isThisYou$() }}
@@ -80,7 +89,7 @@
 
 <script>
 
-  import { computed, onMounted, onUnmounted, ref } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
   import KFocusTrap from 'kolibri-design-system/lib/KFocusTrap';
   import { PICTURE_PASSWORD_SET } from 'kolibri/constants';
   import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
@@ -95,7 +104,7 @@
 
     setup(props) {
       const confirmBtn = ref(null);
-      const modalCard = ref(null);
+      const modalTitle = ref(null);
       const { isThisYou$, yourPasswordIs$, yesConfirmAction$, noGoBackAction$ } =
         picturePasswordStrings;
       const palette = themePalette();
@@ -126,27 +135,13 @@
         return yourPasswordIs$({ labels });
       });
 
-      function handleFocusEscape(event) {
-        if (!modalCard.value) return;
-        if (!modalCard.value.contains(event.target)) {
-          modalCard.value.focus();
-        }
-      }
-
       onMounted(() => {
-        if (confirmBtn.value && confirmBtn.value.$el) {
-          confirmBtn.value.$el.focus();
-        }
-        window.addEventListener('focus', handleFocusEscape, true);
-      });
-
-      onUnmounted(() => {
-        window.removeEventListener('focus', handleFocusEscape, true);
+        modalTitle.value.focus();
       });
 
       return {
         confirmBtn,
-        modalCard,
+        modalTitle,
         iconTokens,
         sequenceAriaLabel,
         isThisYou$,
@@ -199,18 +194,17 @@
     top: 0;
     left: 0;
     z-index: 24;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.7);
   }
 
   .modal-card {
-    position: absolute;
-    top: 50%;
-    left: 50%;
     width: max-content;
     border-radius: 8px;
-    transform: translate(-50%, -50%);
   }
 
   .header {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -235,6 +235,16 @@
         },
       );
 
+      watch(
+        () => props.clearSelection,
+        value => {
+          if (value) {
+            sequence.value = [];
+            emit('clearSelectionHandled');
+          }
+        },
+      );
+
       const submitButtonStyle = computed(() => ({
         backgroundColor: submitEnabled.value ? $themeTokens.primary : $themePalette.grey.v_200,
         cursor: submitEnabled.value ? 'pointer' : 'not-allowed',
@@ -275,6 +285,15 @@
        * so the parent can reset this prop back to false.
        */
       wrongSequence: {
+        type: Boolean,
+        default: false,
+      },
+      /**
+       * Set to true by the parent to clear the selection without implying an
+       * error (e.g. when the user cancels the confirm modal). Emits
+       * `clearSelectionHandled` so the parent can reset this prop back to false.
+       */
+      clearSelection: {
         type: Boolean,
         default: false,
       },

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -33,7 +33,7 @@
       :wrongSequence="wrongSequence"
       :landscapeLayout="landscapeLayout"
       @wrongSequenceHandled="wrongSequence = false"
-      @submit="createSession"
+      @submit="prevalidate"
     />
     <PicturePasswordConfirmModal
       v-if="showConfirmModal"
@@ -134,38 +134,23 @@
         }
       });
 
-      /**
-       * Handles authentication once the user has entered a picture password and submits it
-       *
-       * @param {string} picturePassword
-       * @return {Promise<void>}
-       */
-      async function createSession(picturePassword) {
+      async function prevalidate(picturePassword) {
         busy.value = true;
-        const sessionPayload = {
-          facility: facilityId.value,
-          picture_password: picturePassword,
-          disableRedirect: true,
-        };
-
-        if (nextParam.value) {
-          sessionPayload['next'] = nextParam.value;
-        }
-
-        // ensure selected facility in local storage is synchronized
         setSelectedFacilityId(facilityId.value);
-
         try {
-          const { data, error } = await login(sessionPayload);
+          const { data, error } = await login(
+            { picture_password: picturePassword, facility: facilityId.value },
+            true,
+            false,
+          );
           if (data) {
             submittedPicturePassword.value = picturePassword;
-            confirmedLearnerName.value = data.full_name || '';
+            confirmedLearnerName.value = data.full_name;
             showConfirmModal.value = true;
           } else if (error) {
             wrongSequence.value = true;
           }
         } catch (error) {
-          // The `login` function already handles logging errors
           createSnackbar({
             text: coreString('defaultErrorMessage'),
             autoDismiss: true,
@@ -175,27 +160,34 @@
         }
       }
 
-      function handleConfirm() {
-        showConfirmModal.value = false;
+      async function handleConfirm() {
+        busy.value = true;
+        const sessionPayload = {
+          facility: facilityId.value,
+          picture_password: submittedPicturePassword.value,
+        };
         if (nextParam.value) {
-          redirectBrowser(nextParam.value);
-        } else {
-          redirectBrowser();
+          sessionPayload['next'] = nextParam.value;
+        }
+        try {
+          const { error } = await login(sessionPayload);
+          if (error) {
+            showConfirmModal.value = false;
+            wrongSequence.value = true;
+          }
+        } catch (_) {
+          createSnackbar({
+            text: coreString('defaultErrorMessage'),
+            autoDismiss: true,
+          });
+        } finally {
+          busy.value = false;
         }
       }
 
-      async function handleCancel() {
-        try {
-          await client({
-            url: urls['kolibri:core:session_detail']('current'),
-            method: 'delete',
-          });
-        } catch (_) {
-          // Best-effort logout — proceed regardless
-        } finally {
-          showConfirmModal.value = false;
-          wrongSequence.value = true;
-        }
+      function handleCancel() {
+        showConfirmModal.value = false;
+        wrongSequence.value = true;
       }
 
       return {
@@ -211,7 +203,7 @@
         picturePasswordShowIconText,
         hasMultipleFacilities,
         // actions
-        createSession,
+        prevalidate,
         handleConfirm,
         handleCancel,
       };

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -35,6 +35,14 @@
       @wrongSequenceHandled="wrongSequence = false"
       @submit="createSession"
     />
+    <PicturePasswordConfirmModal
+      v-if="showConfirmModal"
+      :learnerName="confirmedLearnerName"
+      :picturePassword="submittedPicturePassword"
+      :iconStyle="picturePasswordStyle"
+      @confirm="handleConfirm"
+      @cancel="handleCancel"
+    />
   </AuthBase>
 
 </template>
@@ -51,13 +59,16 @@
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
-
+  import client from 'kolibri/client';
+  import urls from 'kolibri/urls';
+  import redirectBrowser from 'kolibri/utils/redirectBrowser';
   import AuthBase from '../AuthBase';
   import useAuthFlow from '../../composables/useAuthFlow';
   import useAuthWatcher from '../../composables/useAuthWatcher';
   import useAuthRouter from '../../composables/useAuthRouter';
   import AuthContextHeading from '../AuthContextHeading.vue';
   import PicturePasswordGrid from './PictureSignIn/PicturePasswordGrid.vue';
+  import PicturePasswordConfirmModal from './PictureSignIn/PicturePasswordConfirmModal.vue';
 
   export default {
     name: 'PictureSignInPage',
@@ -70,6 +81,7 @@
       AuthBase,
       AuthContextHeading,
       PicturePasswordGrid,
+      PicturePasswordConfirmModal,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -91,6 +103,9 @@
 
       const busy = ref(false);
       const wrongSequence = ref(false);
+      const showConfirmModal = ref(false);
+      const confirmedLearnerName = ref('');
+      const submittedPicturePassword = ref('');
       const backTo = computed(() => {
         return hasMultipleFacilities.value ? getFacilitySelectionRoute(false) : null;
       });
@@ -130,6 +145,7 @@
         const sessionPayload = {
           facility: facilityId.value,
           picture_password: picturePassword,
+          disableRedirect: true,
         };
 
         if (nextParam.value) {
@@ -140,8 +156,12 @@
         setSelectedFacilityId(facilityId.value);
 
         try {
-          const err = await login(sessionPayload);
-          if (err) {
+          const { data, error } = await login(sessionPayload);
+          if (data) {
+            submittedPicturePassword.value = picturePassword;
+            confirmedLearnerName.value = data.full_name || '';
+            showConfirmModal.value = true;
+          } else if (error) {
             wrongSequence.value = true;
           }
         } catch (error) {
@@ -155,17 +175,45 @@
         }
       }
 
+      function handleConfirm() {
+        showConfirmModal.value = false;
+        if (nextParam.value) {
+          redirectBrowser(nextParam.value);
+        } else {
+          redirectBrowser();
+        }
+      }
+
+      async function handleCancel() {
+        try {
+          await client({
+            url: urls['kolibri:core:session_detail']('current'),
+            method: 'delete',
+          });
+        } catch (_) {
+          // Best-effort logout — proceed regardless
+        } finally {
+          showConfirmModal.value = false;
+          wrongSequence.value = true;
+        }
+      }
+
       return {
         // state
         busy,
         wrongSequence,
         landscapeLayout,
+        showConfirmModal,
+        confirmedLearnerName,
+        submittedPicturePassword,
         backTo,
         picturePasswordStyle,
         picturePasswordShowIconText,
         hasMultipleFacilities,
         // actions
         createSession,
+        handleConfirm,
+        handleCancel,
       };
     },
     $trs: {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -173,6 +173,8 @@
           const { error } = await login(sessionPayload);
           if (error) {
             showConfirmModal.value = false;
+            submittedPicturePassword.value = '';
+            confirmedLearnerName.value = '';
             wrongSequence.value = true;
           }
         } catch (_) {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -61,9 +61,6 @@
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
-  import client from 'kolibri/client';
-  import urls from 'kolibri/urls';
-  import redirectBrowser from 'kolibri/utils/redirectBrowser';
   import AuthBase from '../AuthBase';
   import useAuthFlow from '../../composables/useAuthFlow';
   import useAuthWatcher from '../../composables/useAuthWatcher';
@@ -180,7 +177,7 @@
             confirmedLearnerName.value = '';
             wrongSequence.value = true;
           }
-        } catch (_) {
+        } catch {
           createSnackbar({
             text: coreString('defaultErrorMessage'),
             autoDismiss: true,

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -31,8 +31,10 @@
       :iconStyle="picturePasswordStyle"
       :showIconText="picturePasswordShowIconText"
       :wrongSequence="wrongSequence"
+      :clearSelection="clearSelection"
       :landscapeLayout="landscapeLayout"
       @wrongSequenceHandled="wrongSequence = false"
+      @clearSelectionHandled="clearSelection = false"
       @submit="prevalidate"
     />
     <PicturePasswordConfirmModal
@@ -103,6 +105,7 @@
 
       const busy = ref(false);
       const wrongSequence = ref(false);
+      const clearSelection = ref(false);
       const showConfirmModal = ref(false);
       const confirmedLearnerName = ref('');
       const submittedPicturePassword = ref('');
@@ -189,7 +192,7 @@
 
       function handleCancel() {
         showConfirmModal.value = false;
-        wrongSequence.value = true;
+        clearSelection.value = true;
       }
 
       return {
@@ -197,6 +200,7 @@
         busy,
         wrongSequence,
         landscapeLayout,
+        clearSelection,
         showConfirmModal,
         confirmedLearnerName,
         submittedPicturePassword,

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -161,6 +161,27 @@ describe('PictureSignInPage', () => {
       });
     });
 
+    it('dismisses the modal and triggers wrong sequence when confirm login fails', async () => {
+      mockLogin
+        .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
+        .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
+
+      renderComponent();
+      await submitSequence();
+
+      await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
+
+      const confirmButton = screen.getByRole('button', { name: confirmLabel() });
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(MOCK_LEARNER_NAME)).not.toBeInTheDocument();
+        expect(checkbox(bee())).not.toBeChecked();
+        expect(checkbox(star())).not.toBeChecked();
+        expect(checkbox(moon())).not.toBeChecked();
+      });
+    });
+
     it('hides the modal and clears grid when cancel is clicked, without making a delete request', async () => {
       const client = require('kolibri/client').default;
       renderComponent();

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -79,21 +79,24 @@ describe('PictureSignInPage', () => {
     mockRouterPush.mockReset();
   });
 
-  it('submitting a sequence calls login with picture_password payload and disableRedirect', async () => {
+  it('submitting a sequence calls login with prevalidate=true, not a real login', async () => {
+    mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     renderComponent();
     await userEvent.click(checkbox(bee()));
     await userEvent.click(checkbox(star()));
     await userEvent.click(checkbox(moon()));
     await userEvent.click(screen.getByTestId('submit-button'));
 
-    expect(mockLogin).toHaveBeenCalledWith({
-      facility: 'facility_1',
-      picture_password: '1.2.3',
-      disableRedirect: true,
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith(
+        expect.objectContaining({ picture_password: '1.2.3', facility: 'facility_1' }),
+        true,
+        false,
+      );
     });
   });
 
-  it('a failed sequence response clears the grid selection', async () => {
+  it('a failed prevalidation clears the grid selection', async () => {
     mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     renderComponent();
     await userEvent.click(checkbox(bee()));
@@ -110,10 +113,7 @@ describe('PictureSignInPage', () => {
 
   describe('confirmation modal', () => {
     beforeEach(() => {
-      mockLogin.mockResolvedValue({
-        data: { full_name: MOCK_LEARNER_NAME, user_id: 'user-1' },
-        error: null,
-      });
+      mockLogin.mockResolvedValue({ data: { full_name: MOCK_LEARNER_NAME }, error: null });
     });
 
     async function submitSequence() {
@@ -123,7 +123,7 @@ describe('PictureSignInPage', () => {
       await userEvent.click(screen.getByTestId('submit-button'));
     }
 
-    it('shows the confirmation modal with learner name after successful authentication', async () => {
+    it('shows the confirmation modal with learner name after successful prevalidation', async () => {
       renderComponent();
       await submitSequence();
 
@@ -133,7 +133,7 @@ describe('PictureSignInPage', () => {
       });
     });
 
-    it('does not redirect immediately after a successful sequence', async () => {
+    it('does not redirect immediately after a successful prevalidation', async () => {
       const redirectBrowser = require('kolibri/utils/redirectBrowser').default;
       renderComponent();
       await submitSequence();
@@ -145,8 +145,7 @@ describe('PictureSignInPage', () => {
       expect(redirectBrowser).not.toHaveBeenCalled();
     });
 
-    it('redirects when confirm is clicked', async () => {
-      const redirectBrowser = require('kolibri/utils/redirectBrowser').default;
+    it('calls login when confirm is clicked', async () => {
       renderComponent();
       await submitSequence();
 
@@ -155,10 +154,14 @@ describe('PictureSignInPage', () => {
       const confirmButton = screen.getByRole('button', { name: confirmLabel() });
       await userEvent.click(confirmButton);
 
-      expect(redirectBrowser).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(
+          expect.objectContaining({ facility: 'facility_1', picture_password: '1.2.3' }),
+        );
+      });
     });
 
-    it('discards session and clears grid when cancel is clicked', async () => {
+    it('hides the modal and clears grid when cancel is clicked, without making a delete request', async () => {
       const client = require('kolibri/client').default;
       renderComponent();
       await submitSequence();
@@ -169,12 +172,12 @@ describe('PictureSignInPage', () => {
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
-        expect(client).toHaveBeenCalledWith(expect.objectContaining({ method: 'delete' }));
         expect(screen.queryByText(MOCK_LEARNER_NAME)).not.toBeInTheDocument();
         expect(checkbox(bee())).not.toBeChecked();
         expect(checkbox(star())).not.toBeChecked();
         expect(checkbox(moon())).not.toBeChecked();
       });
+      expect(client).not.toHaveBeenCalledWith(expect.objectContaining({ method: 'delete' }));
     });
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -13,6 +13,8 @@ import PictureSignInPage from '../PictureSignInPage.vue';
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
 jest.mock('kolibri/urls');
+jest.mock('kolibri/client');
+jest.mock('kolibri/utils/redirectBrowser');
 jest.mock('kolibri-plugin-data', () => ({
   __esModule: true,
   default: {
@@ -32,7 +34,12 @@ const mockRouterPush = jest.fn();
 const bee = () => picturePasswordStrings.bee$();
 const star = () => picturePasswordStrings.star$();
 const moon = () => picturePasswordStrings.moon$();
+const isThisYou = () => picturePasswordStrings.isThisYou$();
+const cancelLabel = () => picturePasswordStrings.noGoBackAction$();
+const confirmLabel = () => picturePasswordStrings.yesConfirmAction$();
 const checkbox = name => screen.getByRole('checkbox', { name });
+
+const MOCK_LEARNER_NAME = 'Alice Example';
 
 function renderComponent() {
   useRoute.mockReturnValue({ query: {} });
@@ -72,7 +79,7 @@ describe('PictureSignInPage', () => {
     mockRouterPush.mockReset();
   });
 
-  it('submitting a sequence calls createSession with picture_password payload', async () => {
+  it('submitting a sequence calls login with picture_password payload and disableRedirect', async () => {
     renderComponent();
     await userEvent.click(checkbox(bee()));
     await userEvent.click(checkbox(star()));
@@ -82,11 +89,12 @@ describe('PictureSignInPage', () => {
     expect(mockLogin).toHaveBeenCalledWith({
       facility: 'facility_1',
       picture_password: '1.2.3',
+      disableRedirect: true,
     });
   });
 
   it('a failed sequence response clears the grid selection', async () => {
-    mockLogin.mockResolvedValue(LoginErrors.INVALID_CREDENTIALS);
+    mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     renderComponent();
     await userEvent.click(checkbox(bee()));
     await userEvent.click(checkbox(star()));
@@ -97,6 +105,76 @@ describe('PictureSignInPage', () => {
       expect(checkbox(bee())).not.toBeChecked();
       expect(checkbox(star())).not.toBeChecked();
       expect(checkbox(moon())).not.toBeChecked();
+    });
+  });
+
+  describe('confirmation modal', () => {
+    beforeEach(() => {
+      mockLogin.mockResolvedValue({
+        data: { full_name: MOCK_LEARNER_NAME, user_id: 'user-1' },
+        error: null,
+      });
+    });
+
+    async function submitSequence() {
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+    }
+
+    it('shows the confirmation modal with learner name after successful authentication', async () => {
+      renderComponent();
+      await submitSequence();
+
+      await waitFor(() => {
+        expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument();
+        expect(screen.getByText(isThisYou())).toBeInTheDocument();
+      });
+    });
+
+    it('does not redirect immediately after a successful sequence', async () => {
+      const redirectBrowser = require('kolibri/utils/redirectBrowser').default;
+      renderComponent();
+      await submitSequence();
+
+      await waitFor(() => {
+        expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument();
+      });
+
+      expect(redirectBrowser).not.toHaveBeenCalled();
+    });
+
+    it('redirects when confirm is clicked', async () => {
+      const redirectBrowser = require('kolibri/utils/redirectBrowser').default;
+      renderComponent();
+      await submitSequence();
+
+      await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
+
+      const confirmButton = screen.getByRole('button', { name: confirmLabel() });
+      await userEvent.click(confirmButton);
+
+      expect(redirectBrowser).toHaveBeenCalled();
+    });
+
+    it('discards session and clears grid when cancel is clicked', async () => {
+      const client = require('kolibri/client').default;
+      renderComponent();
+      await submitSequence();
+
+      await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
+
+      const cancelButton = screen.getByRole('button', { name: cancelLabel() });
+      await userEvent.click(cancelButton);
+
+      await waitFor(() => {
+        expect(client).toHaveBeenCalledWith(expect.objectContaining({ method: 'delete' }));
+        expect(screen.queryByText(MOCK_LEARNER_NAME)).not.toBeInTheDocument();
+        expect(checkbox(bee())).not.toBeChecked();
+        expect(checkbox(star())).not.toBeChecked();
+        expect(checkbox(moon())).not.toBeChecked();
+      });
     });
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/index.vue
@@ -461,18 +461,18 @@
         }
 
         try {
-          const err = await this.doLogin(sessionPayload);
+          const { error } = await this.doLogin(sessionPayload);
           // If we don't have a password, we submitted without a username
-          if (err) {
-            if (err === LoginErrors.PASSWORD_NOT_SPECIFIED) {
+          if (error) {
+            if (error === LoginErrors.PASSWORD_NOT_SPECIFIED) {
               this.$router.push({
                 name: ComponentMap.NEW_PASSWORD,
                 query: sessionPayload,
               });
-            } else if (err === LoginErrors.PASSWORD_MISSING) {
+            } else if (error === LoginErrors.PASSWORD_MISSING) {
               this.usernameSubmittedWithoutPassword = true;
             } else {
-              this.loginError = err;
+              this.loginError = error;
             }
           }
 

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -299,4 +299,23 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     message: 'Enter username instead',
     context: 'Link text on the sign-in page for switching to the username & password method',
   },
+  isThisYou: {
+    message: 'Is this you?',
+    context:
+      'Title of the confirmation modal shown after a successful picture password sign-in, asking the learner to confirm their identity.',
+  },
+  yesConfirmAction: {
+    message: 'Yes',
+    context: 'Button label confirming identity in the picture password sign-in confirmation modal.',
+  },
+  noGoBackAction: {
+    message: 'No, go back',
+    context:
+      'Button label denying identity and returning to the sign-in grid in the picture password confirmation modal.',
+  },
+  yourPasswordIs: {
+    message: 'Your password is: {labels}',
+    context:
+      "Screen reader sentence describing the learner's picture password sequence in the confirmation modal. For example: 'Your password is: dog, water, bee'.",
+  },
 });

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -63,21 +63,29 @@ export default function useUser() {
   const userHasPermissions = computed(() => Object.values(userPermissions.value).some(Boolean));
 
   // Login/Logout Functions
-  async function login(sessionPayload) {
-    Lockr.set(UPDATE_MODAL_DISMISSED, false);
+  /**
+   * Creates an authenticated session for the given credentials.
+   *
+   * @param {Object} sessionPayload - Credentials sent to the server.
+   * @param {boolean} [prevalidate=false] - When true, validates credentials server-side without
+   *   creating a session. Returns { full_name } on success so the caller can confirm the user's
+   *   identity before committing to a real login (e.g. the picture-password confirm flow).
+   *   Skips the Lockr update-modal flag and all redirect logic.
+   * @param {boolean} [enableRedirect=true] - When false, suppresses the post-login redirect,
+   *   allowing the caller to handle navigation manually.
+   */
+  async function login(sessionPayload, prevalidate = false, enableRedirect = true) {
+    if (!prevalidate) {
+      Lockr.set(UPDATE_MODAL_DISMISSED, false);
+    }
     try {
       const response = await client({
-        data: {
-          ...sessionPayload,
-          active: true,
-          browser,
-          os,
-        },
+        data: { ...sessionPayload, active: true, browser, os, prevalidate },
         url: urls['kolibri:core:session_list'](),
         method: 'post',
       });
 
-      if (!sessionPayload.disableRedirect) {
+      if (enableRedirect) {
         if (sessionPayload.next) {
           // OIDC redirect
           redirectBrowser(sessionPayload.next);

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -118,6 +118,7 @@ export default function useUser() {
         return { data: null, error: loginError };
       } else {
         handleApiError({ error });
+        return { data: null, error: null };
       }
     }
   }

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -66,7 +66,7 @@ export default function useUser() {
   async function login(sessionPayload) {
     Lockr.set(UPDATE_MODAL_DISMISSED, false);
     try {
-      await client({
+      const response = await client({
         data: {
           ...sessionPayload,
           active: true,
@@ -86,6 +86,7 @@ export default function useUser() {
           redirectBrowser();
         }
       }
+      return { data: response.data, error: null };
     } catch (error) {
       const errorsCaught = CatchErrors(error, [
         ERROR_CONSTANTS.INVALID_CREDENTIALS,
@@ -95,15 +96,17 @@ export default function useUser() {
       ]);
 
       if (errorsCaught) {
+        let loginError;
         if (errorsCaught.includes(ERROR_CONSTANTS.INVALID_CREDENTIALS)) {
-          return LoginErrors.INVALID_CREDENTIALS;
+          loginError = LoginErrors.INVALID_CREDENTIALS;
         } else if (errorsCaught.includes(ERROR_CONSTANTS.MISSING_PASSWORD)) {
-          return LoginErrors.PASSWORD_MISSING;
+          loginError = LoginErrors.PASSWORD_MISSING;
         } else if (errorsCaught.includes(ERROR_CONSTANTS.PASSWORD_NOT_SPECIFIED)) {
-          return LoginErrors.PASSWORD_NOT_SPECIFIED;
+          loginError = LoginErrors.PASSWORD_NOT_SPECIFIED;
         } else if (errorsCaught.includes(ERROR_CONSTANTS.NOT_FOUND)) {
-          return LoginErrors.USER_NOT_FOUND;
+          loginError = LoginErrors.USER_NOT_FOUND;
         }
+        return { data: null, error: loginError };
       } else {
         handleApiError({ error });
       }

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -118,7 +118,6 @@ export default function useUser() {
         return { data: null, error: loginError };
       } else {
         handleApiError({ error });
-        return { data: null, error: null };
       }
     }
   }

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -80,7 +80,8 @@ export default function useUser() {
     }
     try {
       const response = await client({
-        data: { ...sessionPayload, active: true, browser, os, prevalidate },
+        params: prevalidate ? { prevalidate } : undefined,
+        data: { ...sessionPayload, active: true, browser, os },
         url: urls['kolibri:core:session_list'](),
         method: 'post',
       });


### PR DESCRIPTION
## Summary

- Creates `PicturePasswordConfirmModal` — displays the learner's name and icon sequence after a correct picture password entry, with confirm and cancel actions
- Adds a `prevalidate` flag to `POST /api/auth/session/` that validates credentials without creating a session, returning `{ full_name }` — prevents a page refresh while the modal is open from redirecting to a secure area
- Extends `login()` in `useUser.js` with explicit `prevalidate` and `enableRedirect` parameters, keeping frontend-only concerns out of the server payload
- Cancel clears the grid with no network requests; confirm triggers the real login and redirect

https://github.com/user-attachments/assets/3b117fee-75e0-4312-a5d3-7db8c330e629

## Checklist

### General
- [x] A correct sequence response renders a modal with the learner's display name
- [x] Confirming in the modal completes the sign-in and redirects
- [x] Cancelling in the modal discards the session and returns to the grid with selections cleared
- [x] "Is this you?" heading is present
- [x] Modal cannot be dismissed by clicking outside or pressing Escape

### Accessibility and i18n
- [x] Modal focus is managed correctly on open; initial focus lands on the confirm or cancel action

## References

Closes https://github.com/learningequality/kolibri/issues/14428

## Reviewer guidance

- Enable picture password for a facility
- Enter a correct picture sequence → confirm modal should appear with the learner's name and icon sequence
- Refresh the page while the modal is open → sign-in page should reappear (not the secure home area)
- Tap the confirm (✓) button → redirected to the learner's home
- Enter a correct sequence again → tap cancel (✗) → modal dismissed, grid cleared, no network request made

## AI usage

I used Claude Code to implement the feature, prompting it to follow existing patterns in the codebase. I reviewed and directed the generated code throughout, making decisions on API design (prevalidate as a body param, `login()` signature) and removing unnecessary complexity at each step. I verified all tests pass after each change.