### PR TITLE
Show Change password row for admins; respect facility's show_icon_text

### DIFF
--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/__tests__/ProfilePage.spec.js
@@ -7,6 +7,7 @@ import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResp
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
 import { UserKinds } from 'kolibri/constants';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
 import { PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import ProfilePage from '../index';
 import makeStore from '../../../__tests__/utils/makeStore';
@@ -26,6 +27,7 @@ jest.mock('kolibri-common/composables/useFacilities');
 jest.mock('kolibri-common/composables/useFacility');
 
 const { fullNameLabel$ } = coreStrings;
+const { changePasswordPrompt$ } = createTranslator(ProfilePage.name, ProfilePage.$trs);
 
 FacilityUserResource.fetchModel = jest.fn().mockResolvedValue({});
 
@@ -124,7 +126,7 @@ describe('picture password row', () => {
     expect(updateFacilityConfig).toHaveBeenCalled();
   });
 
-  it('renders the picture password display for a learner with a picture_password', async () => {
+  it("hides figcaption labels when the facility's show_icon_text is false", async () => {
     await renderProfile({
       userKind: UserKinds.LEARNER,
       picturePasswordSettings: {
@@ -134,10 +136,12 @@ describe('picture password row', () => {
       picturePassword: '3.7.12',
     });
 
-    expect(await screen.findByTestId('picture-password-display')).toBeInTheDocument();
-    // Three icons, no labels — per the AC.
+    const display = await screen.findByTestId('picture-password-display');
     const icons = screen.queryAllByTestId(/^picture-password-icon-/);
     expect(icons).toHaveLength(3);
+    const captions = [...display.querySelectorAll('figcaption')];
+    expect(captions).toHaveLength(3);
+    expect(captions.every(el => el.classList.contains('visuallyhidden'))).toBe(true);
   });
 
   it('renders the empty-value placeholder when the learner has no picture_password', async () => {
@@ -183,4 +187,30 @@ describe('picture password row', () => {
     expect(screen.queryByTestId('picture-password-display')).not.toBeInTheDocument();
     expect(screen.queryByTestId('picture-password-empty')).not.toBeInTheDocument();
   });
+
+  it("shows figcaption labels when the facility's show_icon_text is true", async () => {
+    await renderProfile({
+      userKind: UserKinds.LEARNER,
+      picturePasswordSettings: {
+        icon_style: PicturePasswordIconStyle.COLORFUL,
+        show_icon_text: true,
+      },
+      picturePassword: '3.7.12',
+    });
+
+    const display = await screen.findByTestId('picture-password-display');
+    const captions = [...display.querySelectorAll('figcaption')];
+    expect(captions).toHaveLength(3);
+    expect(captions.every(el => !el.classList.contains('visuallyhidden'))).toBe(true);
+  });
+
+  it.each([UserKinds.COACH, UserKinds.ADMIN, UserKinds.SUPERUSER])(
+    'shows the Change password button for a %s when learner_can_edit_password is false',
+    async userKind => {
+      await renderProfile({ userKind });
+
+      await screen.findByText(fullNameLabel$());
+      expect(screen.getByText(changePasswordPrompt$())).toBeVisible();
+    },
+  );
 });

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
@@ -119,7 +119,6 @@
                 v-if="currentUser.picture_password"
                 data-testid="picture-password-display"
                 :picturePassword="currentUser.picture_password"
-                :showIconText="false"
               />
               <KEmptyPlaceholder
                 v-else
@@ -252,6 +251,7 @@
         userKind,
         userPermissions: _userPermissions,
         isCoach,
+        isAdmin,
         isSuperuser,
         userHasPermissions,
         userFacilityId,
@@ -270,6 +270,7 @@
         userKind,
         userPermissions,
         isCoach,
+        isAdmin,
         isSuperuser,
         userHasPermissions,
         userFacilityId,
@@ -319,7 +320,7 @@
         const learner_can_edit =
           this.facilityConfig.learner_can_edit_password &&
           !this.facilityConfig.learner_can_login_with_no_password;
-        return this.isSuperuser || this.isCoach || learner_can_edit;
+        return this.isSuperuser || this.isAdmin || this.isCoach || learner_can_edit;
       },
     },
     async created() {


### PR DESCRIPTION
## Summary

- Add `isAdmin` to `canEditPassword` so admins see the Change password row.
- Drop hardcoded `:showIconText="false"` so the facility's "Show icon names" setting drives label visibility.

## References

Closes #14687.

| State | Screenshot |
|-------|------------|
| Admin profile, Change password row | ![Admin](https://i.imgur.com/eB3fVsz.png) |
| Learner profile, "Show icon names" on | ![Labels on](https://i.imgur.com/g6ag3Ok.png) |
| Learner profile, "Show icon names" off | ![Labels off](https://i.imgur.com/0SS2PlI.png) |

## Reviewer guidance

- Sign in as a facility admin (without superuser): the Change password row should appear on the profile.
- Toggle "Show icon names" in Facility > Settings and reload a learner's profile: labels should appear/disappear under the icons accordingly.

## AI usage

Used Claude Code to investigate the bugs, write failing tests, and apply the fixes. I steered the test design (parameterising user types, tightening assertions, covering both `show_icon_text` states) and verified both fixes in a running instance before commit.