### PR TITLE
Fix new user creation when picture password is enabled

### DIFF
--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/__tests__/UserCreateSidePanel.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/__tests__/UserCreateSidePanel.spec.js
@@ -1,322 +1,291 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/vue';
 import { ref } from 'vue';
 import useFacility from 'kolibri-common/composables/useFacility';
 import { useFacilityMock } from 'kolibri-common/composables/__mocks__/useFacility';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
+import RoleResource from 'kolibri-common/apiResources/RoleResource';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import { DemographicConstants, UserKinds } from 'kolibri/constants';
 import UserCreateSidePanel from '../index.vue';
+
+const { NOT_SPECIFIED } = DemographicConstants;
 
 jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri/composables/useSnackbar');
-jest.mock('kolibri-common/apiResources/FacilityUserResource', () => ({
-  fetchCollection: jest.fn(),
-  saveModel: jest.fn(),
-}));
-jest.mock('kolibri-common/apiResources/RoleResource', () => ({
-  saveModel: jest.fn(),
-  saveCollection: jest.fn(),
-}));
-jest.mock('kolibri-common/apiResources/MembershipResource', () => ({
-  saveCollection: jest.fn(),
-}));
+jest.mock('kolibri-common/apiResources/FacilityUserResource');
+jest.mock('kolibri-common/apiResources/RoleResource');
+jest.mock('kolibri-common/apiResources/MembershipResource');
 jest.mock('kolibri/store', () => ({
-  state: {
-    userManagement: { facilityUsers: [] },
-    route: { params: { facility_id: 'test-facility-id' }, query: {} },
-  },
+  state: { userManagement: { facilityUsers: [] } },
 }));
 jest.mock('vue-router/composables', () => ({
-  useRoute: jest.fn(() => ({ params: { facility_id: 'test-facility-id' } })),
-  useRouter: jest.fn(() => ({ push: jest.fn(), back: jest.fn() })),
+  useRoute: () => ({ params: { facility_id: 'test-facility-id' } }),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
   onBeforeRouteLeave: jest.fn(),
 }));
 
 const PICTURE_PASSWORD_SETTINGS = { icon_style: 'colorful', show_icon_text: false };
 
-function makeFacilityConfig({
-  picturePasswordSettings = null,
-  learnerCanLoginWithNoPassword = false,
-} = {}) {
-  return ref({
-    picture_password_settings: picturePasswordSettings,
-    learner_can_login_with_no_password: learnerCanLoginWithNoPassword,
-    extra_fields: null,
-  });
-}
-
-function renderComponent({
-  picturePasswordSettings = null,
-  picturePasswordsExhausted = false,
+function setup({
+  pictureLogin = false,
+  exhausted = false,
   learnerCanLoginWithNoPassword = false,
 } = {}) {
   useFacility.mockImplementation(() =>
     useFacilityMock({
-      facilityConfig: makeFacilityConfig({
-        picturePasswordSettings,
-        learnerCanLoginWithNoPassword,
+      facilityConfig: ref({
+        picture_password_settings: pictureLogin ? PICTURE_PASSWORD_SETTINGS : null,
+        learner_can_login_with_no_password: learnerCanLoginWithNoPassword,
+        extra_fields: null,
       }),
-      selectedFacility: ref({
-        picture_passwords_exhausted: picturePasswordsExhausted,
-      }),
+      selectedFacility: ref({ picture_passwords_exhausted: exhausted }),
       setFacilityId: jest.fn().mockResolvedValue(undefined),
     }),
   );
-
-  const onChange = jest.fn();
-  const result = render(UserCreateSidePanel, {
-    props: {
-      classes: [],
-      onChange,
-    },
+  return render(UserCreateSidePanel, {
+    props: { classes: [], onChange: jest.fn() },
   });
-  return { ...result, onChange };
 }
-const waitForFormReady = () =>
-  waitFor(() => expect(screen.getByText(coreStrings.userTypeLabel$())).toBeInTheDocument());
 
-async function selectUserType(optionText) {
+const waitForFormReady = () =>
+  waitFor(() => expect(screen.getByText(coreStrings.userTypeLabel$())).toBeVisible());
+
+async function selectKind(label) {
   const trigger = screen.getByText(coreStrings.userTypeLabel$()).closest('.ui-select-label');
   await fireEvent.click(trigger);
-  await fireEvent.click(await screen.findByText(optionText));
+  const optionsList = await waitFor(() => {
+    const list = document.querySelector('.ui-select-options');
+    if (!list) {
+      throw new Error('options list not open');
+    }
+    return list;
+  });
+  await fireEvent.click(within(optionsList).getByText(label));
 }
 
-describe('UserCreateSidePanel — picture password behavior', () => {
+async function fillRequired() {
+  await fireEvent.update(screen.getByLabelText(coreStrings.fullNameLabel$()), 'Test User');
+  await fireEvent.update(screen.getByLabelText(coreStrings.usernameLabel$()), 'testuser');
+}
+
+async function setPassword(value) {
+  const fields = screen.getAllByLabelText(coreStrings.passwordLabel$(), { exact: false });
+  await fireEvent.update(fields[0], value);
+  await fireEvent.update(fields[fields.length - 1], value);
+}
+
+const saveAndCloseButton = () => screen.getByRole('button', { name: coreStrings.saveAndClose$() });
+const saveAndAddAnotherButton = () =>
+  screen.getByRole('button', { name: bulkUserManagementStrings.saveAndAddAnother$() });
+
+describe('UserCreateSidePanel', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders without throwing', () => {
-    expect(() => renderComponent()).not.toThrow();
-  });
-
-  describe('picture password informational message', () => {
-    it('is not shown when picture login is disabled', () => {
-      renderComponent({ picturePasswordSettings: null });
+  describe('initial state', () => {
+    it('shows the password input when picture login is disabled', async () => {
+      setup();
+      await waitForFormReady();
+      expect(screen.getByLabelText(coreStrings.passwordLabel$())).toHaveValue('');
       expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
     });
 
-    it('is not shown when no user type is selected, even with picture login enabled', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: false,
-      });
-
+    it('hides the password input and shows the picture password info when picture login is enabled', async () => {
+      setup({ pictureLogin: true });
       await waitForFormReady();
-      expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(coreStrings.passwordLabel$())).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: picturePasswordStrings.signingInHeading$() }),
+      ).toBeVisible();
+      expect(
+        screen.getByText(picturePasswordStrings.picturePasswordWillBeAssigned$()),
+      ).toBeVisible();
     });
 
-    it('is shown when picture login is enabled and the Learner type is selected', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: false,
-      });
-
+    it('hides the password input for learners when learner_can_login_with_no_password is true', async () => {
+      setup({ learnerCanLoginWithNoPassword: true });
       await waitForFormReady();
-      await selectUserType(coreStrings.learnerLabel$());
-
-      await waitFor(() => {
-        expect(screen.getByTestId('picture-password-info')).toBeInTheDocument();
-      });
-    });
-
-    it('is not shown when a non-Learner role is selected', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: false,
-      });
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.learnerLabel$());
-
-      // Learner selected — info is visible
-      await waitFor(() => {
-        expect(screen.getByTestId('picture-password-info')).toBeInTheDocument();
-      });
-
-      await selectUserType(coreStrings.coachLabel$());
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByLabelText(coreStrings.passwordLabel$())).not.toBeInTheDocument();
     });
   });
 
-  describe('learner limit reached state', () => {
-    it('shows the learner limit message with a "Learn more" button when limit is reached', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: true,
-      });
+  describe('user type selection', () => {
+    it('shows the password input and hides picture-password info when Coach is selected', async () => {
+      setup({ pictureLogin: true });
+      await waitForFormReady();
+      await selectKind(coreStrings.coachLabel$());
 
       await waitFor(() => {
-        expect(screen.getByTestId('learn-more-button')).toBeInTheDocument();
+        expect(screen.getByLabelText(coreStrings.passwordLabel$())).toHaveValue('');
       });
+      expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
+      expect(screen.getByLabelText(coreStrings.classCoachLabel$(), { exact: false })).toBeChecked();
     });
 
-    it('does not show the learner limit message when under the limit', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: false,
-      });
-
+    it('shows the password input when Admin is selected with picture login enabled', async () => {
+      setup({ pictureLogin: true });
       await waitForFormReady();
-      expect(screen.queryByTestId('learn-more-button')).not.toBeInTheDocument();
-    });
+      await selectKind(coreStrings.adminLabel$());
 
-    it('leaves the user type dropdown empty when learner limit is reached', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: true,
+      await waitFor(() => {
+        expect(screen.getByLabelText(coreStrings.passwordLabel$())).toHaveValue('');
       });
-
-      await waitForFormReady();
-      // No type pre-selected, so the coach radio group should not be visible
+      expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
       expect(screen.queryByTestId('coach-type-selector')).not.toBeInTheDocument();
     });
+  });
 
-    it('Learner option is disabled and Coach/Admin are not when limit is reached', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: true,
-      });
-
+  describe('learner limit reached', () => {
+    it('shows the warning and disables the submit buttons when picture passwords are exhausted', async () => {
+      setup({ pictureLogin: true, exhausted: true });
       await waitForFormReady();
+      expect(screen.getByText(picturePasswordStrings.learnerCreationDisabled$())).toBeVisible();
+      expect(saveAndCloseButton()).toBeDisabled();
+      expect(saveAndAddAnotherButton()).toBeDisabled();
+    });
 
-      const trigger = screen.getByText(coreStrings.userTypeLabel$()).closest('.ui-select-label');
-      await fireEvent.click(trigger);
+    it('hides the warning and enables the submit buttons when the user switches to Coach', async () => {
+      setup({ pictureLogin: true, exhausted: true });
+      await waitForFormReady();
+      await selectKind(coreStrings.coachLabel$());
 
-      const learnerOption = (await screen.findByText(coreStrings.learnerLabel$())).closest('li');
-      const coachOption = screen.getByText(coreStrings.coachLabel$()).closest('li');
-      const adminOption = screen.getByText(coreStrings.adminLabel$()).closest('li');
-
-      expect(learnerOption).toHaveClass('is-disabled');
-      expect(coachOption).not.toHaveClass('is-disabled');
-      expect(adminOption).not.toHaveClass('is-disabled');
+      await waitFor(() => {
+        expect(screen.queryByTestId('learn-more-button')).not.toBeInTheDocument();
+      });
+      expect(saveAndCloseButton()).toBeEnabled();
+      expect(saveAndAddAnotherButton()).toBeEnabled();
     });
 
     it('opens the learner limit modal when the "Learn more" button is clicked', async () => {
-      renderComponent({
-        picturePasswordSettings: PICTURE_PASSWORD_SETTINGS,
-        picturePasswordsExhausted: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('learn-more-button')).toBeInTheDocument();
-      });
+      setup({ pictureLogin: true, exhausted: true });
+      await waitForFormReady();
       await fireEvent.click(screen.getByTestId('learn-more-button'));
 
       await waitFor(() => {
-        expect(screen.getByTestId('context-paragraph')).toBeInTheDocument();
-      });
-    });
-  });
-});
-
-describe('UserCreateSidePanel — user creation form behavior', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('renders without throwing', () => {
-    expect(() => renderComponent()).not.toThrow();
-  });
-
-  describe('password field visibility', () => {
-    it('is shown when the facility requires a password', async () => {
-      renderComponent();
-
-      await waitFor(() => {
-        expect(screen.getByLabelText(coreStrings.passwordLabel$())).toBeInTheDocument();
-      });
-    });
-
-    it('is hidden for learners when the facility allows no-password login', async () => {
-      renderComponent({ learnerCanLoginWithNoPassword: true });
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.learnerLabel$());
-
-      await waitFor(() => {
-        expect(screen.queryByLabelText(coreStrings.passwordLabel$())).not.toBeInTheDocument();
-      });
-    });
-
-    it('is shown for coaches even when the facility allows no-password login', async () => {
-      renderComponent({ learnerCanLoginWithNoPassword: true });
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.coachLabel$());
-
-      await waitFor(() => {
-        expect(screen.getByLabelText(coreStrings.passwordLabel$())).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('coach type selection', () => {
-    it('shows the class/facility coach radio group when Coach is selected', async () => {
-      renderComponent();
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.coachLabel$());
-
-      await waitFor(() => {
-        expect(screen.getByTestId('coach-type-selector')).toBeInTheDocument();
-      });
-    });
-
-    it('does not show the coach radio group when Learner is selected', async () => {
-      renderComponent();
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.learnerLabel$());
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('coach-type-selector')).not.toBeInTheDocument();
-      });
-    });
-
-    it('does not show the coach radio group when Admin is selected', async () => {
-      renderComponent();
-
-      await waitForFormReady();
-      await selectUserType(coreStrings.adminLabel$());
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('coach-type-selector')).not.toBeInTheDocument();
+        expect(
+          screen.getByRole('heading', {
+            name: picturePasswordStrings.learnerLimitReachedHeading$(),
+          }),
+        ).toBeVisible();
       });
     });
   });
 
   describe('form submission', () => {
+    it.each([
+      {
+        name: 'a learner with a password',
+        setupOpts: {},
+        kindLabel: null,
+        facilityCoach: false,
+        password: 'secret123',
+        expectedRole: null,
+      },
+      {
+        name: 'a learner with no password',
+        setupOpts: { learnerCanLoginWithNoPassword: true },
+        kindLabel: null,
+        facilityCoach: false,
+        password: NOT_SPECIFIED,
+        expectedRole: null,
+      },
+      {
+        name: 'a learner with picture login',
+        setupOpts: { pictureLogin: true },
+        kindLabel: null,
+        facilityCoach: false,
+        password: NOT_SPECIFIED,
+        expectedRole: null,
+      },
+      {
+        name: 'a class coach',
+        setupOpts: {},
+        kindLabel: 'coachLabel',
+        facilityCoach: false,
+        password: 'secret123',
+        expectedRole: UserKinds.ASSIGNABLE_COACH,
+      },
+      {
+        name: 'a facility coach',
+        setupOpts: {},
+        kindLabel: 'coachLabel',
+        facilityCoach: true,
+        password: 'secret123',
+        expectedRole: UserKinds.COACH,
+      },
+      {
+        name: 'an admin',
+        setupOpts: {},
+        kindLabel: 'adminLabel',
+        facilityCoach: false,
+        password: 'secret123',
+        expectedRole: UserKinds.ADMIN,
+      },
+    ])(
+      'creates $name with the correct role and password',
+      async ({ setupOpts, kindLabel, facilityCoach, password, expectedRole }) => {
+        FacilityUserResource.saveModel.mockResolvedValue({
+          id: 'new-user-id',
+          facility: 'fac-1',
+        });
+        RoleResource.saveModel.mockResolvedValue({});
+        setup(setupOpts);
+        await waitForFormReady();
+        if (kindLabel) {
+          await selectKind(coreStrings[`${kindLabel}$`]());
+        }
+        if (facilityCoach) {
+          await fireEvent.click(
+            screen.getByLabelText(coreStrings.facilityCoachLabel$(), { exact: false }),
+          );
+        }
+        await fillRequired();
+        if (password !== NOT_SPECIFIED) {
+          await setPassword(password);
+        }
+        await fireEvent.click(saveAndCloseButton());
+
+        await waitFor(() => {
+          expect(FacilityUserResource.saveModel).toHaveBeenCalledTimes(1);
+        });
+        expect(FacilityUserResource.saveModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              username: 'testuser',
+              full_name: 'Test User',
+              password,
+            }),
+          }),
+        );
+        if (expectedRole === null) {
+          expect(RoleResource.saveModel).not.toHaveBeenCalled();
+        } else {
+          await waitFor(() => {
+            expect(RoleResource.saveModel).toHaveBeenCalledWith(
+              expect.objectContaining({
+                data: expect.objectContaining({ kind: expectedRole }),
+              }),
+            );
+          });
+        }
+      },
+    );
+
     it('does not call FacilityUserResource when the form is submitted with empty fields', async () => {
-      FacilityUserResource.saveModel.mockResolvedValue({ id: 'new-user-id', facility: 'fac-1' });
-      renderComponent();
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: coreStrings.saveAndClose$() }),
-        ).toBeInTheDocument();
-      });
-      await fireEvent.click(screen.getByRole('button', { name: coreStrings.saveAndClose$() }));
-
+      setup();
+      await waitForFormReady();
+      await fireEvent.click(saveAndCloseButton());
       expect(FacilityUserResource.saveModel).not.toHaveBeenCalled();
     });
 
-    it('does not call FacilityUserResource when "Save and add another" is clicked with empty fields', async () => {
-      FacilityUserResource.saveModel.mockResolvedValue({ id: 'new-user-id', facility: 'fac-1' });
-      renderComponent();
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: bulkUserManagementStrings.saveAndAddAnother$() }),
-        ).toBeInTheDocument();
-      });
-      await fireEvent.click(
-        screen.getByRole('button', { name: bulkUserManagementStrings.saveAndAddAnother$() }),
-      );
-
+    it('does not call FacilityUserResource when picture passwords are exhausted', async () => {
+      setup({ pictureLogin: true, exhausted: true });
+      await waitForFormReady();
+      await fillRequired();
+      await fireEvent.click(saveAndCloseButton());
       expect(FacilityUserResource.saveModel).not.toHaveBeenCalled();
     });
   });

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
@@ -68,7 +68,7 @@
             :options="userTypeOptions"
           />
           <div
-            v-if="learnerLimitReached"
+            v-if="userCreationBlocked"
             class="learner-limit-message"
             :style="{ color: $themeTokens.annotation }"
           >
@@ -169,13 +169,13 @@
           primary
           :form="formId"
           :text="saveAndClose$()"
-          :disabled="busy"
+          :disabled="busy || userCreationBlocked"
           @click="saveAndClose()"
         />
         <KButton
           :form="formId"
           :text="saveAndAddAnother$()"
-          :disabled="busy"
+          :disabled="busy || userCreationBlocked"
           @click="saveAndAddAnother()"
         />
       </div>
@@ -255,15 +255,27 @@
       const learnerLimitReached = computed(
         () => isPictureLoginActive.value && selectedFacility.value?.picture_passwords_exhausted,
       );
+
+      const coachIsSelected = computed(() => {
+        return kind.value?.value === UserKinds.COACH;
+      });
+
+      const newUserRole = computed(() => {
+        if (coachIsSelected.value) {
+          return classCoachIsSelected.value ? UserKinds.ASSIGNABLE_COACH : UserKinds.COACH;
+        }
+        // Admin or Learner
+        return kind.value?.value ?? UserKinds.LEARNER;
+      });
+
       const showPicturePasswordInfo = computed(
-        () => isPictureLoginActive.value && kind.value?.value === UserKinds.LEARNER,
+        () => isPictureLoginActive.value && newUserRole.value === UserKinds.LEARNER,
       );
 
-      const userTypeOptions = computed(() => [
+      const userTypeOptions = [
         {
           label: coreStrings.learnerLabel$(),
           value: UserKinds.LEARNER,
-          disabled: learnerLimitReached.value,
         },
         {
           label: coreStrings.coachLabel$(),
@@ -273,7 +285,11 @@
           label: coreStrings.adminLabel$(),
           value: UserKinds.ADMIN,
         },
-      ]);
+      ];
+
+      const userCreationBlocked = computed(
+        () => newUserRole.value === UserKinds.LEARNER && learnerLimitReached.value,
+      );
 
       const closeConfirmationGuardRef = ref(null);
 
@@ -288,15 +304,13 @@
       const extraDemographics = ref({});
       const idNumber = ref('');
       const loading = ref(true);
-      const kind = ref({});
+      const kind = ref(userTypeOptions[0]);
       const selectedClasses = ref([]);
       const classCoachIsSelected = ref(true);
       const busy = ref(false);
       const formSubmitted = ref(false);
       const caughtErrors = ref([]);
       const showErrorWarning = ref(false);
-      // Tracks the role that resetForm() last set so hasUnsavedChanges has the correct baseline.
-      const defaultRole = ref(null);
 
       const resetForm = () => {
         fullName.value = '';
@@ -307,8 +321,7 @@
         extraDemographics.value = {};
         idNumber.value = '';
         classCoachIsSelected.value = true;
-        kind.value = {};
-        defaultRole.value = null;
+        kind.value = userTypeOptions[0];
         formSubmitted.value = false;
         caughtErrors.value = [];
         busy.value = false;
@@ -322,22 +335,10 @@
       const facilityUsers = computed(() => store.state.userManagement.facilityUsers);
 
       const showPasswordInput = computed(() => {
-        if (facilityConfig.value.learner_can_login_with_no_password) {
-          return kind.value?.value !== UserKinds.LEARNER;
+        if (isPictureLoginActive.value || facilityConfig.value.learner_can_login_with_no_password) {
+          return newUserRole.value !== UserKinds.LEARNER;
         }
         return true;
-      });
-
-      const coachIsSelected = computed(() => {
-        return kind.value?.value === UserKinds.COACH;
-      });
-
-      const newUserRole = computed(() => {
-        if (coachIsSelected.value) {
-          return classCoachIsSelected.value ? UserKinds.ASSIGNABLE_COACH : UserKinds.COACH;
-        }
-        // Admin or Learner
-        return kind.value?.value ?? null;
       });
 
       const formIsValid = computed(() => {
@@ -352,7 +353,7 @@
           idNumber.value,
           gender.value !== NOT_SPECIFIED,
           birthYear.value !== NOT_SPECIFIED,
-          newUserRole.value !== defaultRole.value,
+          kind.value !== userTypeOptions[0],
           Object.values(extraDemographics.value).some(value => {
             if (Array.isArray(value)) {
               return value.length > 0;
@@ -365,7 +366,7 @@
       });
 
       const classesAction = computed(() =>
-        kind.value?.value === UserKinds.LEARNER
+        newUserRole.value === UserKinds.LEARNER
           ? ClassesActions.ENROLL_LEARNER
           : ClassesActions.ASSIGN_COACH,
       );
@@ -463,6 +464,9 @@
       };
 
       const submitForm = async () => {
+        if (userCreationBlocked.value) {
+          return false;
+        }
         formSubmitted.value = true;
         if (!showPasswordInput.value && !passwordValid.value) {
           passwordValid.value = true;
@@ -579,7 +583,7 @@
         facilityCoachLabel$,
         facilityCoachDescription$,
         // picture password
-        learnerLimitReached,
+        userCreationBlocked,
         showPicturePasswordInfo,
         showLearnerLimitModal,
 


### PR DESCRIPTION
## Summary

The kind selector defaulted to {}, leaving newUserRole null and the password input visible — with picture login the flow does not collect a password. Default kind to Learner; disable the submit buttons (rather than the Learner dropdown option) when the picture password limit is reached.

Tests streamlined: behaviour-focused initial-state assertions, parameterised submission cases per user type, automocked API resources.

## References

- Fixes #14677

## Reviewer guidance

- Verify the bug from #14677 is fixed
- Check no regressions for non-picture-password facilities: password login, no-password login, coach/admin creation


https://github.com/user-attachments/assets/20229c10-d1c2-46ee-90b2-2a9d1dc7f28e



## AI usage

Used Claude Code to refine my initial manual fix (replacing the disabled-Learner-option approach with disabled submit buttons + warning gated on the same condition) and to rewrite the tests for clearer behaviour coverage. Reviewed each change and ran the suite.