### PR TITLE
Cancel outdated CI runs when a PR is updated

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/morango_integration.yml
+++ b/.github/workflows/morango_integration.yml
@@ -8,6 +8,10 @@ on:
       - develop
       - release-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/npm_version_check.yml
+++ b/.github/workflows/npm_version_check.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'packages/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_build_comment.yml
+++ b/.github/workflows/pr_build_comment.yml
@@ -10,6 +10,7 @@ jobs:
   post:
     name: Add build artifact PR comment
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       - uses: actions/checkout@v6
       - name: Make text for build comment

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -2,6 +2,10 @@ name: Kolibri Build Assets for Pull Request
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   prnumber:
     # The workflow_run event can't access the pull request

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,6 +10,10 @@ on:
     - develop
     - 'release-v**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: Path match check


### PR DESCRIPTION
## Summary

- Adds `concurrency` to the nine push/PR-triggered CI workflows
- New commits on a PR cancel in-progress runs for the same head ref
- Group key falls back to `github.run_id` when `github.head_ref` is empty, so non-PR runs (pushes to `develop`/`release-v**`, the `morango_integration` cron) never collide
- Skips the asset-comment workflow on cancelled parent builds (still runs on failures)

## References

- [GitHub Actions concurrency syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)
- [Cancelled asset build run](https://github.com/learningequality/kolibri/actions/runs/25579727522) from a previous SHA on this PR — proof the cancellation fires on push

## Reviewer guidance

- Check the `head_ref || run_id` fallback — wrong group key would cancel develop/release pushes
- This PR exercises the change: a follow-up push should cancel the previous run

## AI usage

Used Claude Code (Opus 4.7) to survey the workflow files, decide which to update, and apply the same `concurrency` block to all nine. I reviewed and edited the body section by section.