### PR TITLE
Implement sign-up/join picture password confirmation modal

### DIFF
--- a/kolibri/plugins/user_auth/frontend/views/SignUpPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignUpPage.vue
@@ -102,6 +102,12 @@
     >
       <LanguageSwitcherFooter />
     </div>
+
+    <PicturePasswordAssignedModal
+      v-if="showPicturePasswordModal"
+      :picturePassword="picturePassword"
+      @confirm="handlePicturePasswordConfirm"
+    />
   </div>
 
 </template>
@@ -118,12 +124,14 @@
   import UsernameTextbox from 'kolibri-common/components/userAccounts/UsernameTextbox';
   import PasswordTextbox from 'kolibri-common/components/userAccounts/PasswordTextbox';
   import PrivacyLinkAndModal from 'kolibri-common/components/userAccounts/PrivacyLinkAndModal';
+  import PicturePasswordAssignedModal from 'kolibri-common/components/PicturePasswordAssignedModal.vue';
   import redirectBrowser from 'kolibri/utils/redirectBrowser';
   import urls from 'kolibri/urls';
   import client from 'kolibri/client';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { handleApiError } from 'kolibri/utils/appError';
+  import { OptionsForSignIn } from 'kolibri-common/constants/Auth';
   import { ComponentMap } from '../constants';
   import { SignUpResource } from '../apiResource';
   import useAuthFlow from '../composables/useAuthFlow';
@@ -149,13 +157,14 @@
       PasswordTextbox,
       UsernameTextbox,
       PrivacyLinkAndModal,
+      PicturePasswordAssignedModal,
     },
     mixins: [commonCoreStrings, commonUserStrings],
     setup() {
       const router = useRouter();
       const route = useRoute();
       const { defaultRoute, nextParam } = useAuthRouter(route);
-      const { selectedFacility, facilityConfig, canSignUpWithFacility } = useAuthFlow();
+      const { selectedFacility, signInOptions, canSignUpWithFacility } = useAuthFlow();
       const { watchForFacilityChange, watchForFacilityConfigChange } = useAuthWatcher();
 
       watchForFacilityChange((newFacilityId, oldFacilityId) => {
@@ -177,7 +186,7 @@
       return {
         nextParam,
         selectedFacility,
-        facilityConfig,
+        signInOptions,
         handleApiError,
       };
     },
@@ -194,6 +203,8 @@
         birthYear: '',
         caughtErrors: [],
         busy: false,
+        picturePassword: '',
+        showPicturePasswordModal: false,
       };
     },
     computed: {
@@ -207,7 +218,7 @@
         return ComponentMap;
       },
       showPasswordInput() {
-        return !this.facilityConfig.learner_can_login_with_no_password;
+        return this.signInOptions.includes(OptionsForSignIn.USERNAME_PASSWORD);
       },
     },
     beforeMount() {
@@ -217,6 +228,13 @@
       }
     },
     methods: {
+      redirectAfterSignup() {
+        if (this.nextParam) {
+          redirectBrowser(this.nextParam);
+        } else {
+          redirectBrowser();
+        }
+      },
       checkForDuplicateUsername(username) {
         if (!username) {
           return Promise.resolve();
@@ -272,7 +290,7 @@
         }
       },
       passwordToSave() {
-        if (this.facilityConfig.learner_can_login_with_no_password && this.password === '')
+        if (this.signInOptions.includes(OptionsForSignIn.USERNAME_ONLY) && this.password === '')
           return 'NOT_SPECIFIED';
 
         return this.password;
@@ -294,12 +312,17 @@
             birth_year: this.birthYear || DEFERRED,
           };
           SignUpResource.saveModel({ data: payload })
-            .then(() => {
-              if (this.nextParam) {
-                redirectBrowser(this.nextParam);
-              } else {
-                redirectBrowser();
+            .then(user => {
+              if (
+                this.signInOptions.includes(OptionsForSignIn.PICTURE_PASSWORD) &&
+                user?.picture_password
+              ) {
+                this.picturePassword = user.picture_password;
+                this.showPicturePasswordModal = true;
+                this.busy = false;
+                return;
               }
+              this.redirectAfterSignup();
             })
             .catch(error => {
               this.busy = false;
@@ -330,6 +353,10 @@
             this.$refs.passwordTextbox.focus();
           }
         });
+      },
+      handlePicturePasswordConfirm() {
+        this.showPicturePasswordModal = false;
+        this.redirectAfterSignup();
       },
     },
     $trs: {

--- a/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/__tests__/sign-up-page.spec.js
@@ -1,26 +1,45 @@
-import { render, screen } from '@testing-library/vue';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/vue';
 import { ref, computed } from 'vue';
+import client from 'kolibri/client';
+import { OptionsForSignIn } from 'kolibri-common/constants/Auth';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
+import redirectBrowser from 'kolibri/utils/redirectBrowser';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import useAuthFlow, { useAuthFlowMock } from '../../composables/useAuthFlow'; // eslint-disable-line import-x/named
 import useAuthRouter, { useAuthRouterMock } from '../../composables/useAuthRouter'; // eslint-disable-line import-x/named
+import { SignUpResource } from '../../apiResource';
 import SignUpPage from '../SignUpPage';
 import { ComponentMap } from '../../constants';
 
 jest.mock('../../composables/useAuthFlow');
 jest.mock('../../composables/useAuthRouter');
+jest.mock('../../apiResource', () => ({
+  SignUpResource: {
+    saveModel: jest.fn(),
+  },
+}));
+jest.mock('kolibri/client');
+jest.mock('kolibri/utils/redirectBrowser');
+jest.mock('kolibri/urls', () => ({
+  'kolibri:core:usernameavailable': () => '/usernameavailable',
+}));
+const { picturePasswordAssignedTitle$, readyToContinue$ } = picturePasswordStrings;
 
 const selectedFacility = ref({
   id: 1,
   name: 'Facility 1',
   dataset: {
-    learner_can_login_with_no_password: false,
+    learner_can_login_with_no_password: true,
   },
 });
+const signInOptions = ref([OptionsForSignIn.USERNAME_PASSWORD]);
 
-function renderComponent() {
+function renderComponent({ step = 1, _signInOptions = [OptionsForSignIn.USERNAME_PASSWORD] } = {}) {
+  signInOptions.value = _signInOptions;
   useAuthFlow.mockReturnValue(
     useAuthFlowMock({
       selectedFacility,
-      facilityConfig: ref({ learner_can_login_with_no_password: false }),
+      signInOptions,
       facilityId: computed(() => selectedFacility.value?.id || null),
       canSignUpWithFacility: computed(() => true),
     }),
@@ -35,9 +54,21 @@ function renderComponent() {
   return render(
     SignUpPage,
     {
-      routes: [{ name: ComponentMap.USERNAME_SIGN_IN, path: '/signin' }],
+      routes: [
+        { name: ComponentMap.SIGN_UP, path: '/signup' },
+        { name: ComponentMap.USERNAME_SIGN_IN, path: '/signin' },
+      ],
     },
     (_vue, _store, router) => {
+      router.push({
+        name: ComponentMap.SIGN_UP,
+        path: '/signup',
+        query: {
+          step,
+        },
+      });
+      router.push = jest.fn(() => Promise.resolve());
+      router.replace = jest.fn(() => Promise.resolve());
       router.getRoute = () => {
         return { name: ComponentMap.USERNAME_SIGN_IN, path: '/signin' };
       };
@@ -46,6 +77,11 @@ function renderComponent() {
 }
 
 describe('signUpPage component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client.mockResolvedValue({});
+  });
+
   it('smoke test', () => {
     renderComponent();
     expect(screen.getByTestId('facilityLabel')).toBeInTheDocument();
@@ -60,8 +96,89 @@ describe('multiFacility signUpPage component', () => {
     selectedFacility.value = {
       id: 2,
       name: FACILITY_2_NAME,
-      dataset: { learner_can_login_with_no_password: false },
+      dataset: { learner_can_login_with_no_password: true },
     };
     expect(await screen.findByText(FACILITY_2_NAME)).toBeInTheDocument();
+  });
+});
+
+describe('picture password modal behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client.mockResolvedValue({});
+  });
+
+  async function proceedToSignupSubmit(container) {
+    await fireEvent.update(container.querySelector('input[autocomplete="name"]'), 'Jane Doe');
+    await fireEvent.update(container.querySelector('input[autocomplete="username"]'), 'jdoe');
+    const passwordInputs = container.querySelectorAll('input[autocomplete="new-password"]');
+    for (const passwordInput of passwordInputs) {
+      await fireEvent.update(passwordInput, 'password123');
+    }
+    await fireEvent.click(
+      within(container).getByRole('button', { name: coreString('finishAction') }),
+    );
+  }
+
+  it('shows modal after signup when picture password is assigned', async () => {
+    SignUpResource.saveModel.mockResolvedValue({ id: 'new_user', picture_password: '3.7.12' });
+    const { container } = renderComponent({
+      step: 2,
+      _signInOptions: [OptionsForSignIn.USERNAME_PASSWORD, OptionsForSignIn.PICTURE_PASSWORD],
+    });
+
+    await proceedToSignupSubmit(container);
+
+    expect(await screen.findByText(picturePasswordAssignedTitle$())).toBeInTheDocument();
+    expect(redirectBrowser).not.toHaveBeenCalled();
+  });
+
+  it('redirects without modal when picture password is null', async () => {
+    SignUpResource.saveModel.mockResolvedValue({ id: 'new_user', picture_password: null });
+    const { container } = renderComponent({
+      step: 2,
+      _signInOptions: [OptionsForSignIn.USERNAME_PASSWORD, OptionsForSignIn.PICTURE_PASSWORD],
+    });
+
+    await proceedToSignupSubmit(container);
+
+    await waitFor(() => {
+      expect(redirectBrowser).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(picturePasswordAssignedTitle$())).not.toBeInTheDocument();
+  });
+
+  it('redirects without modal when picture sign-in is not enabled', async () => {
+    SignUpResource.saveModel.mockResolvedValue({ id: 'new_user', picture_password: '3.7.12' });
+    const { container } = renderComponent({
+      step: 2,
+      _signInOptions: [OptionsForSignIn.USERNAME_PASSWORD],
+    });
+
+    await proceedToSignupSubmit(container);
+
+    await waitFor(() => {
+      expect(redirectBrowser).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(picturePasswordAssignedTitle$())).not.toBeInTheDocument();
+  });
+
+  it('redirects after picture password confirmation', async () => {
+    SignUpResource.saveModel.mockResolvedValue({ id: 'new_user', picture_password: '3.7.12' });
+    const { container } = renderComponent({
+      step: 2,
+      _signInOptions: [OptionsForSignIn.USERNAME_PASSWORD, OptionsForSignIn.PICTURE_PASSWORD],
+    });
+
+    await proceedToSignupSubmit(container);
+    const dialog = await screen.findByRole('dialog', { name: picturePasswordAssignedTitle$() });
+    await fireEvent.click(within(dialog).getByLabelText(readyToContinue$()));
+    await fireEvent.click(
+      within(dialog).getByRole('button', { name: coreString('continueAction') }),
+    );
+
+    await waitFor(() => {
+      expect(redirectBrowser).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/MergeFacility.vue
@@ -83,6 +83,14 @@
         </KButtonGroup>
       </slot>
     </BottomAppBar>
+
+    <PicturePasswordAssignedModal
+      v-if="showPicturePasswordModal"
+      :picturePassword="picturePassword"
+      :iconStyle="state.targetFacility.picture_password_settings.icon_style"
+      :showIconText="state.targetFacility.picture_password_settings.show_icon_text"
+      @confirm="handlePicturePasswordConfirm"
+    />
   </div>
 
 </template>
@@ -93,6 +101,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
+  import PicturePasswordAssignedModal from 'kolibri-common/components/PicturePasswordAssignedModal.vue';
   import { computed, inject, onMounted, ref } from 'vue';
   import TaskResource from 'kolibri/apiResources/TaskResource';
   import get from 'lodash/get';
@@ -109,7 +118,10 @@
         title: this.$tr('documentTitle'),
       };
     },
-    components: { BottomAppBar },
+    components: {
+      BottomAppBar,
+      PicturePasswordAssignedModal,
+    },
     mixins: [commonCoreStrings],
     setup() {
       const changeFacilityService = inject('changeFacilityService');
@@ -117,6 +129,8 @@
       const taskId = computed(() => get(state, 'value.taskId', null));
       const task = ref(null);
       const taskError = ref(false);
+      const picturePassword = ref('');
+      const showPicturePasswordModal = ref(false);
       let isPolling = true;
       let isTaskRequested = false;
       const taskCompleted = computed(() =>
@@ -281,9 +295,20 @@
           url: urls['kolibri:kolibri.plugins.user_profile:loginmergeduser'](),
           method: 'POST',
           data: params,
-        }).then(() => {
-          redirectBrowser();
+        }).then(response => {
+          const picturePasswordSettings = state.value.targetFacility.picture_password_settings;
+          if (picturePasswordSettings && response.data?.picture_password) {
+            picturePassword.value = response.data?.picture_password;
+            showPicturePasswordModal.value = true;
+          } else {
+            redirectBrowser();
+          }
         });
+      }
+
+      function handlePicturePasswordConfirm() {
+        showPicturePasswordModal.value = false;
+        redirectBrowser();
       }
 
       function to_retry() {
@@ -333,7 +358,11 @@
         to_retry,
         successfullyJoined,
         errorMessage,
+        state,
         windowIsSmall,
+        picturePassword,
+        showPicturePasswordModal,
+        handlePicturePasswordConfirm,
       };
     },
 

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/SelectFacility.vue
@@ -132,6 +132,7 @@
                 address_id: device.id,
                 learner_can_sign_up: facility.learner_can_sign_up,
                 learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
+                picture_password_settings: facility.picture_password_settings,
                 kolibri_version: device.kolibri_version,
               };
             });
@@ -261,6 +262,7 @@
             id: facility.id,
             learner_can_sign_up: facility.learner_can_sign_up,
             learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
+            picture_password_settings: facility.picture_password_settings,
           },
         });
       },

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
@@ -17,7 +17,11 @@ jest.mock('kolibri/apiResources/TaskResource', () => ({
   clear: jest.fn(),
 }));
 
-function makeWrapper({ taskId = 'task_1' } = {}) {
+function makeWrapper({
+  taskId = 'task_1',
+  targetFacility = { name: 'Test Facility', url: 'http://url1' },
+  targetAccount = { username: 'test2' },
+} = {}) {
   return mount(MergeFacility, {
     provide: {
       changeFacilityService: {
@@ -25,11 +29,12 @@ function makeWrapper({ taskId = 'task_1' } = {}) {
         state: { value: 'syncChangeFacility' },
       },
       state: {
+        targetFacility,
         value: {
-          targetFacility: { name: 'Test Facility', url: 'http://url1' },
+          targetFacility,
           fullname: 'Test User 1',
           username: 'test1',
-          targetAccount: { username: 'test2' },
+          targetAccount,
           taskId,
         },
       },
@@ -44,7 +49,7 @@ const task = {
   status: TaskStatuses.PENDING,
   percentage: 0,
   facility_id: 'facility_id1',
-  extra_metadata: { facility_name: 'Test Facility' },
+  extra_metadata: { facility_name: 'Test Facility', remote_user_pk: 'remote-user-id' },
 };
 const incompleteTask = { ...task, status: TaskStatuses.PENDING };
 const completedTask = { ...task, status: TaskStatuses.COMPLETED };
@@ -90,7 +95,7 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
 
   it(`clicking finish button sends the finish event to the state machine`, async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
-    client.mockResolvedValue({});
+    client.mockResolvedValue({ data: { picture_password: null } });
     const wrapper = makeWrapper();
     await global.flushPromises();
     await wrapper.vm.$nextTick();
@@ -101,6 +106,55 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
       type: 'FINISH',
     });
     expect(client).toHaveBeenCalled();
+    expect(redirectBrowser).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows picture password confirmation modal after facility change when picture password is assigned', async () => {
+    TaskResource.fetchModel.mockResolvedValue(completedTask);
+    client.mockResolvedValue({ data: { picture_password: '3.7.12' } });
+    const wrapper = makeWrapper({
+      targetFacility: {
+        name: 'Test Facility',
+        url: 'http://url1',
+        picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
+      },
+    });
+    await global.flushPromises();
+    await wrapper.vm.$nextTick();
+    clickFinishButton(wrapper);
+    await global.flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.showPicturePasswordModal).toBe(true);
+    expect(redirectBrowser).not.toHaveBeenCalled();
+  });
+
+  it('redirects immediately when picture password is null after facility change', async () => {
+    TaskResource.fetchModel.mockResolvedValue(completedTask);
+    client.mockResolvedValue({ data: { picture_password: null } });
+    const wrapper = makeWrapper({
+      targetFacility: {
+        name: 'Test Facility',
+        url: 'http://url1',
+        picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
+      },
+    });
+    await global.flushPromises();
+    await wrapper.vm.$nextTick();
+    clickFinishButton(wrapper);
+    await global.flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.showPicturePasswordModal).toBe(false);
+    expect(redirectBrowser).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects when picture password modal is confirmed', () => {
+    const wrapper = makeWrapper();
+    wrapper.vm.showPicturePasswordModal = true;
+    wrapper.vm.handlePicturePasswordConfirm();
+
+    expect(wrapper.vm.showPicturePasswordModal).toBe(false);
     expect(redirectBrowser).toHaveBeenCalledTimes(1);
   });
 

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
@@ -1,11 +1,12 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { fireEvent, render, screen } from '@testing-library/vue';
 import TaskResource from 'kolibri/apiResources/TaskResource';
 import { TaskStatuses } from 'kolibri-common/utils/syncTaskUtils';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import client from 'kolibri/client';
 import MergeFacility from '../MergeFacility';
 
-const localVue = createLocalVue();
 const sendMachineEvent = jest.fn();
 jest.mock('kolibri/client');
 jest.mock('kolibri/urls');
@@ -17,12 +18,17 @@ jest.mock('kolibri/apiResources/TaskResource', () => ({
   clear: jest.fn(),
 }));
 
-function makeWrapper({
+const TARGET_FACILITY_NAME = 'Test Facility';
+const TARGET_FACILITY_URL = 'http://url1';
+const { continueAction$ } = coreStrings;
+const { documentTitle$, success$ } = createTranslator(MergeFacility.name, MergeFacility.$trs);
+
+function renderComponent({
   taskId = 'task_1',
-  targetFacility = { name: 'Test Facility', url: 'http://url1' },
-  targetAccount = { username: 'test2' },
+  targetFacility = { id: 'facility_id1', name: TARGET_FACILITY_NAME, url: TARGET_FACILITY_URL },
+  targetAccount = { id: 'target-user-id', username: 'test2' },
 } = {}) {
-  return mount(MergeFacility, {
+  return render(MergeFacility, {
     provide: {
       changeFacilityService: {
         send: sendMachineEvent,
@@ -34,13 +40,18 @@ function makeWrapper({
           targetFacility,
           fullname: 'Test User 1',
           username: 'test1',
+          userId: 'local-user-id',
           targetAccount,
           taskId,
         },
       },
     },
-    localVue,
   });
+}
+
+async function flushUi() {
+  await global.flushPromises();
+  await global.flushPromises();
 }
 
 const task = {
@@ -54,54 +65,51 @@ const task = {
 const incompleteTask = { ...task, status: TaskStatuses.PENDING };
 const completedTask = { ...task, status: TaskStatuses.COMPLETED };
 
-const getFinishButton = wrapper => wrapper.find('[data-testid="finishButton"]');
-const clickFinishButton = wrapper => getFinishButton(wrapper).trigger('click');
-const getRetryButton = wrapper => wrapper.find('[data-testid="retryButton"]');
-const clickRetryButton = wrapper => getRetryButton(wrapper).trigger('click');
-
 describe(`ChangeFacility/ConfirmMerge`, () => {
+  let setTimeoutSpy;
+
   beforeEach(() => {
     jest.clearAllMocks();
     TaskResource.fetchModel.mockResolvedValue(task);
+    setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(() => 0);
+  });
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore();
   });
 
   it(`smoke test`, () => {
-    const wrapper = makeWrapper();
-    expect(wrapper.exists()).toBeTruthy();
+    renderComponent();
+    expect(screen.getByRole('heading', { name: documentTitle$() })).toBeInTheDocument();
   });
 
   it(`finish button does not appear if the task is not completed`, async () => {
     TaskResource.fetchModel.mockResolvedValue(incompleteTask);
 
-    const wrapper = makeWrapper();
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    expect(getFinishButton(wrapper).exists()).toBeFalsy();
-    expect(wrapper.vm.taskCompleted).toBe(false);
+    renderComponent();
+    await flushUi();
+    expect(screen.queryByTestId('finishButton')).not.toBeInTheDocument();
   });
 
   it(`when the task is completed, finish button appears`, async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
 
-    const wrapper = makeWrapper();
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    expect(getFinishButton(wrapper).exists()).toBeTruthy();
-    expect(wrapper.vm.taskCompleted).toBe(true);
-    await wrapper.vm.$nextTick();
-    const messageDiv = wrapper.find('[data-testid="completedMessage"]');
-    expect(messageDiv.text()).toEqual("Successfully joined 'Test Facility' learning facility.");
+    renderComponent();
+    await flushUi();
+    expect(screen.getByTestId('finishButton')).toBeInTheDocument();
+    expect(screen.getByTestId('completedMessage')).toHaveTextContent(
+      success$({ target_facility: TARGET_FACILITY_NAME }),
+    );
   });
 
   it(`clicking finish button sends the finish event to the state machine`, async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
     client.mockResolvedValue({ data: { picture_password: null } });
-    const wrapper = makeWrapper();
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    clickFinishButton(wrapper);
+    renderComponent();
 
-    await wrapper.vm.$nextTick();
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('finishButton'));
+    await flushUi();
     expect(sendMachineEvent).toHaveBeenCalledWith({
       type: 'FINISH',
     });
@@ -112,49 +120,59 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
   it('shows picture password confirmation modal after facility change when picture password is assigned', async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
     client.mockResolvedValue({ data: { picture_password: '3.7.12' } });
-    const wrapper = makeWrapper({
+    renderComponent({
       targetFacility: {
-        name: 'Test Facility',
-        url: 'http://url1',
+        id: 'facility_id1',
+        name: TARGET_FACILITY_NAME,
+        url: TARGET_FACILITY_URL,
         picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
       },
     });
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    clickFinishButton(wrapper);
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('finishButton'));
+    await flushUi();
 
-    expect(wrapper.vm.showPicturePasswordModal).toBe(true);
+    expect(screen.getByTestId('continue-checkbox')).toBeInTheDocument();
     expect(redirectBrowser).not.toHaveBeenCalled();
   });
 
   it('redirects immediately when picture password is null after facility change', async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
     client.mockResolvedValue({ data: { picture_password: null } });
-    const wrapper = makeWrapper({
+    renderComponent({
       targetFacility: {
-        name: 'Test Facility',
-        url: 'http://url1',
+        id: 'facility_id1',
+        name: TARGET_FACILITY_NAME,
+        url: TARGET_FACILITY_URL,
         picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
       },
     });
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    clickFinishButton(wrapper);
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.vm.showPicturePasswordModal).toBe(false);
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('finishButton'));
+    await flushUi();
     expect(redirectBrowser).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('continue-checkbox')).not.toBeInTheDocument();
   });
 
-  it('redirects when picture password modal is confirmed', () => {
-    const wrapper = makeWrapper();
-    wrapper.vm.showPicturePasswordModal = true;
-    wrapper.vm.handlePicturePasswordConfirm();
+  it('redirects when picture password modal is confirmed', async () => {
+    TaskResource.fetchModel.mockResolvedValue(completedTask);
+    client.mockResolvedValue({ data: { picture_password: '3.7.12' } });
 
-    expect(wrapper.vm.showPicturePasswordModal).toBe(false);
+    renderComponent({
+      targetFacility: {
+        id: 'facility_id1',
+        name: TARGET_FACILITY_NAME,
+        url: TARGET_FACILITY_URL,
+        picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
+      },
+    });
+
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('finishButton'));
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('continue-checkbox'));
+    await fireEvent.click(screen.getByRole('button', { name: continueAction$() }));
+    await flushUi();
     expect(redirectBrowser).toHaveBeenCalledTimes(1);
   });
 
@@ -164,12 +182,9 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
       response: { status: 400, data: [{ metadata: { message: 'USERNAME_ALREADY_EXISTS' } }] },
     });
     client.mockResolvedValue({});
-    const wrapper = makeWrapper({ taskId: null });
-    await global.flushPromises();
-    await wrapper.vm.$nextTick();
-    clickRetryButton(wrapper);
-
-    await wrapper.vm.$nextTick();
+    renderComponent({ taskId: null });
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('retryButton'));
     expect(sendMachineEvent).toHaveBeenCalledWith('TASKERROR');
   });
 });

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -35,4 +35,6 @@ class LoginMergedUserViewset(APIView):
         if not TokenGenerator().check_token(new_user.id, token):
             return Response({"error": "Unauthorized"}, status=401)
         login(request, new_user)
-        return Response({"success": True})
+        return Response(
+            {"success": True, "picture_password": new_user.picture_password}
+        )

--- a/packages/kolibri-common/components/PicturePasswordAssignedModal.vue
+++ b/packages/kolibri-common/components/PicturePasswordAssignedModal.vue
@@ -1,0 +1,101 @@
+<template>
+
+  <KModal
+    :title="picturePasswordAssignedTitle$()"
+    :submitText="coreString('continueAction')"
+    :submitDisabled="!isConfirmed"
+    :cancelDisabled="true"
+    @submit="handleAction"
+  >
+    <p class="modal-block">{{ picturePasswordAssignedDescription$() }}</p>
+    <UserPicturePassword
+      class="picture-password"
+      :picturePassword="picturePassword"
+      :iconStyle="iconStyle"
+      :showIconText="showIconText"
+      iconSize="60px"
+    />
+    <p class="modal-block">{{ picturePasswordAssignedAddendum$() }}</p>
+    <KCheckbox
+      data-testid="continue-checkbox"
+      :label="readyToContinue$()"
+      :checked="isConfirmed"
+      @change="isConfirmed = !isConfirmed"
+    />
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+  import { coreString } from 'kolibri/uiText/commonCoreStrings';
+  import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import UserPicturePassword from './UserPicturePassword';
+
+  export default {
+    name: 'PicturePasswordAssignedModal',
+    components: {
+      UserPicturePassword,
+    },
+    setup(_, { emit }) {
+      const {
+        picturePasswordAssignedTitle$,
+        picturePasswordAssignedDescription$,
+        picturePasswordAssignedAddendum$,
+        readyToContinue$,
+      } = picturePasswordStrings;
+      const isConfirmed = ref(false);
+
+      function handleAction() {
+        if (!isConfirmed.value) {
+          return;
+        }
+        emit('confirm');
+      }
+
+      return {
+        coreString,
+        picturePasswordAssignedTitle$,
+        picturePasswordAssignedDescription$,
+        picturePasswordAssignedAddendum$,
+        readyToContinue$,
+        isConfirmed,
+        handleAction,
+      };
+    },
+    props: {
+      picturePassword: {
+        type: String,
+        required: true,
+      },
+      iconStyle: {
+        type: String,
+        required: false,
+        default: null,
+      },
+      showIconText: {
+        type: Boolean,
+        required: false,
+        default: null,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .modal-block {
+    margin-top: 0;
+    margin-bottom: 24px;
+  }
+
+  .picture-password {
+    width: 204px;
+    margin: 0 auto 30px;
+  }
+
+</style>

--- a/packages/kolibri-common/components/__tests__/PicturePasswordAssignedModal.spec.js
+++ b/packages/kolibri-common/components/__tests__/PicturePasswordAssignedModal.spec.js
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/vue';
+import { ref } from 'vue';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import PicturePasswordAssignedModal from '../PicturePasswordAssignedModal.vue';
+
+jest.mock('kolibri-common/composables/useFacility');
+const {
+  picturePasswordAssignedTitle$,
+  picturePasswordAssignedDescription$,
+  picturePasswordAssignedAddendum$,
+  readyToContinue$,
+} = picturePasswordStrings;
+
+function setupFacilityMock() {
+  useFacility.mockImplementation(() =>
+    useFacilityMock({
+      facilityConfig: ref({
+        picture_password_settings: null,
+      }),
+    }),
+  );
+}
+
+function renderComponent() {
+  setupFacilityMock();
+  return render(PicturePasswordAssignedModal, {
+    props: {
+      picturePassword: '3.7.12',
+    },
+  });
+}
+
+describe('PicturePasswordAssignedModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('disables continue until checkbox is checked', async () => {
+    renderComponent();
+    const continueButton = screen.getByRole('button', { name: coreString('continueAction') });
+    expect(continueButton).toBeDisabled();
+
+    await fireEvent.click(screen.getByLabelText(readyToContinue$()));
+    expect(continueButton).toBeEnabled();
+  });
+
+  it('renders title and explanatory text', () => {
+    renderComponent();
+    expect(screen.getByText(picturePasswordAssignedTitle$())).toBeInTheDocument();
+    expect(screen.getByText(picturePasswordAssignedDescription$())).toBeInTheDocument();
+    expect(screen.getByText(picturePasswordAssignedAddendum$())).toBeInTheDocument();
+  });
+
+  it('emits confirm after checkbox is checked and continue is clicked', async () => {
+    const { emitted } = renderComponent();
+
+    await fireEvent.click(screen.getByLabelText(readyToContinue$()));
+    await fireEvent.click(screen.getByRole('button', { name: coreString('continueAction') }));
+
+    expect(emitted().confirm).toHaveLength(1);
+  });
+
+  it('does not render a cancel button', () => {
+    renderComponent();
+    expect(
+      screen.queryByRole('button', { name: coreString('cancelAction') }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -220,6 +220,27 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
     context:
       'Note shown in the picture password info modal about learners added after the limit is reached.',
   },
+  picturePasswordAssignedTitle: {
+    message: 'New password',
+    context:
+      'Title of the modal shown after learner signup or facility change when a picture password has been assigned.',
+  },
+  picturePasswordAssignedDescription: {
+    message:
+      'Remember these pictures and write them down if you need to. You will need them to sign in to Kolibri in the future.',
+    context:
+      'Description in the modal shown after learner signup or facility change when a picture password has been assigned.',
+  },
+  picturePasswordAssignedAddendum: {
+    message: 'If you forget, your coach can help.',
+    context:
+      'Short note in the modal shown after learner signup or facility change when a picture password has been assigned.',
+  },
+  readyToContinue: {
+    message: "I'm ready to continue",
+    context:
+      'Checkbox label in the picture password confirmation modal that must be checked before continue is enabled.',
+  },
 
   // Info modal for child-friendly icons radio option
   childFriendlyIconsInfoLabel: {


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Adds picture password confirmation modal that appears when:
1) a user creates an account on a facility with sign-up and picture passwords enabled
2) an on-my-own device user joins a facility that has sign-up and picture passwords enabled

Updates the API that authenticates a user after joining (2) to return the picture password to eliminate an extra API call.

### Screenshots

| Sign Up | Join Facility|
| --- | --- |
| <img width="989" height="888" alt="Screenshot from 2026-05-12 12-56-40" src="https://github.com/user-attachments/assets/7cc84c56-d013-40cd-9fea-0c763fd738d2" /> | <img width="989" height="888" alt="image" src="https://github.com/user-attachments/assets/e093c9f2-cb3c-41c4-847f-fa51e659f58f" /> |


## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/kolibri/issues/14558

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Create account flow is straightforward
- Joining a facility requires 2 instances, where one has a facility with signup and picture passwords enabled and the other is set up as an 'On my own' device. Then from the latter, the Change Facility flow can be accessed from the Profile page.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Had AI autonomously handle this, then walked through the commits and simplified each during review and testing.