### PR TITLE
Add route wrapper components for Coach and Facility picture password page

### DIFF
--- a/kolibri/plugins/coach/frontend/routes/learnersRoutes.js
+++ b/kolibri/plugins/coach/frontend/routes/learnersRoutes.js
@@ -1,7 +1,6 @@
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
-import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
+import CoachAllPasswordsPage from '../views/learners/CoachAllPasswordsPage';
 import { PageNames } from '../constants';
-import { LastPages } from '../constants/lastPagesConstants';
 import LearnersRootPage from '../views/learners/LearnersRootPage';
 import LearnerSummaryPage from '../views/learners/LearnerSummaryPage';
 import LearnerLessonPage from '../views/learners/reports/LearnerLessonPage.vue';
@@ -31,15 +30,7 @@ export default [
   {
     name: PageNames.LEARNER_PASSWORDS,
     path: OPTIONAL_CLASS + '/passwords',
-    component: AllPasswordsPage,
-    props: route => {
-      const classId = route.params.classId;
-      const backRoute =
-        route.query.last === LastPages.HOME_PAGE
-          ? { name: PageNames.HOME_PAGE, params: { classId } }
-          : { name: PageNames.LEARNERS_ROOT, params: { classId } };
-      return { classId, route: backRoute };
-    },
+    component: CoachAllPasswordsPage,
     handler(toRoute, fromRoute, next) {
       if (classIdParamRequiredGuard(toRoute, PageNames.LEARNER_PASSWORDS, next)) {
         return;

--- a/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
+++ b/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
@@ -13,6 +13,7 @@
 <script>
 
   import { computed } from 'vue';
+  import { useRoute } from 'vue-router/composables';
   import store from 'kolibri/store';
   import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
   import useFacility from 'kolibri-common/composables/useFacility';
@@ -24,20 +25,19 @@
     components: { AllPasswordsPage },
     setup() {
       const { currentFacilityName } = useFacility();
+      const route = useRoute();
 
       const learners = computed(() => store.getters['classSummary/learners']);
       const className = computed(() => store.state.classSummary.name);
       const facilityName = computed(() => currentFacilityName.value);
-
-      return { learners, className, facilityName };
-    },
-    computed: {
-      backRoute() {
-        const classId = this.$route.params.classId;
-        return this.$route.query.last === LastPages.HOME_PAGE
+      const backRoute = computed(() => {
+        const classId = route.params.classId;
+        return route.query.last === LastPages.HOME_PAGE
           ? { name: PageNames.HOME_PAGE, params: { classId } }
           : { name: PageNames.LEARNERS_ROOT, params: { classId } };
-      },
+      });
+
+      return { learners, className, facilityName, backRoute };
     },
   };
 

--- a/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
+++ b/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
@@ -12,7 +12,8 @@
 
 <script>
 
-  import { computed, getCurrentInstance } from 'vue';
+  import { computed } from 'vue';
+  import store from 'kolibri/store';
   import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
   import useFacility from 'kolibri-common/composables/useFacility';
   import { PageNames } from '../../constants';
@@ -22,7 +23,6 @@
     name: 'CoachAllPasswordsPage',
     components: { AllPasswordsPage },
     setup() {
-      const store = getCurrentInstance().proxy.$store;
       const { currentFacilityName } = useFacility();
 
       const learners = computed(() => store.getters['classSummary/learners']);

--- a/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
+++ b/kolibri/plugins/coach/frontend/views/learners/CoachAllPasswordsPage.vue
@@ -1,0 +1,44 @@
+<template>
+
+  <AllPasswordsPage
+    :learners="learners"
+    :className="className"
+    :facilityName="facilityName"
+    :route="backRoute"
+  />
+
+</template>
+
+
+<script>
+
+  import { computed, getCurrentInstance } from 'vue';
+  import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
+  import useFacility from 'kolibri-common/composables/useFacility';
+  import { PageNames } from '../../constants';
+  import { LastPages } from '../../constants/lastPagesConstants';
+
+  export default {
+    name: 'CoachAllPasswordsPage',
+    components: { AllPasswordsPage },
+    setup() {
+      const store = getCurrentInstance().proxy.$store;
+      const { currentFacilityName } = useFacility();
+
+      const learners = computed(() => store.getters['classSummary/learners']);
+      const className = computed(() => store.state.classSummary.name);
+      const facilityName = computed(() => currentFacilityName.value);
+
+      return { learners, className, facilityName };
+    },
+    computed: {
+      backRoute() {
+        const classId = this.$route.params.classId;
+        return this.$route.query.last === LastPages.HOME_PAGE
+          ? { name: PageNames.HOME_PAGE, params: { classId } }
+          : { name: PageNames.LEARNERS_ROOT, params: { classId } };
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/vue';
+import { ref } from 'vue';
+import store from 'kolibri/store';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
+import classSummaryModule from '../../../modules/classSummary';
+import makeStore from '../../../__tests__/utils/makeStore';
+import CoachAllPasswordsPage from '../CoachAllPasswordsPage.vue';
+
+jest.mock('kolibri-common/composables/useFacility');
+jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow', () => () => ({
+  windowBreakpoint: { value: 4 },
+}));
+jest.mock('vue-router/composables', () => ({
+  useRoute: jest.fn(() => ({ params: {}, query: {}, name: null })),
+  useRouter: jest.fn(() => ({ push: jest.fn(), currentRoute: {} })),
+}));
+jest.mock('kolibri-common/utils/picturePassword', () => ({
+  getPicturePasswordIcons: jest.fn(() => []),
+}));
+
+const FACILITY_NAME = 'Test Facility';
+const CLASS_NAME = 'Test Class';
+const LEARNERS = [
+  { id: 'u1', full_name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
+  { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
+];
+
+const routes = [
+  { path: '/home', name: 'HOME_PAGE' },
+  { path: '/learners', name: 'LEARNERS_ROOT' },
+];
+
+function renderComponent({ learners = LEARNERS, className = CLASS_NAME } = {}) {
+  useFacility.mockImplementation(() =>
+    useFacilityMock({ currentFacilityName: ref(FACILITY_NAME) }),
+  );
+  const testStore = makeStore();
+  const learnerMap = {};
+  learners.forEach(l => {
+    learnerMap[l.id] = l;
+  });
+  testStore.state.classSummary.learnerMap = learnerMap;
+  testStore.state.classSummary.name = className;
+
+  if (!store.hasModule('classSummary')) {
+    store.registerModule('classSummary', classSummaryModule);
+  }
+  store.replaceState(testStore.state);
+
+  return render(CoachAllPasswordsPage, { routes });
+}
+
+describe('CoachAllPasswordsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes classSummary learners into AllPasswordsPage', () => {
+    renderComponent();
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+  });
+
+  it('passes the class name from classSummary into AllPasswordsPage', () => {
+    renderComponent({ className: 'My Class' });
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+  });
+
+  it('renders a learner with picture_password and a learner without one', () => {
+    renderComponent();
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+  });
+
+  it('renders an empty table when classSummary has no learners', () => {
+    renderComponent({ learners: [] });
+    expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
+  });
+});

--- a/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
@@ -21,9 +21,10 @@ jest.mock('kolibri-common/utils/picturePassword', () => ({
 
 const FACILITY_NAME = 'Test Facility';
 const CLASS_NAME = 'Test Class';
+// classSummary stores learners with `name`, not `full_name` (aliased in the Python API)
 const LEARNERS = [
-  { id: 'u1', full_name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
-  { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
+  { id: 'u1', name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
+  { id: 'u2', name: 'Bob Jones', username: 'bob', picture_password: null },
 ];
 
 const routes = [
@@ -58,23 +59,23 @@ describe('CoachAllPasswordsPage', () => {
 
   it('passes classSummary learners into AllPasswordsPage', () => {
     renderComponent();
-    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
-    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[0].name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].name)).toBeInTheDocument();
   });
 
   it('passes the class name from classSummary into AllPasswordsPage', () => {
     renderComponent({ className: 'My Class' });
-    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[0].name)).toBeInTheDocument();
   });
 
   it('renders a learner with picture_password and a learner without one', () => {
     renderComponent();
-    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
-    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[0].name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].name)).toBeInTheDocument();
   });
 
   it('renders an empty table when classSummary has no learners', () => {
     renderComponent({ learners: [] });
-    expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
+    expect(screen.queryByText(LEARNERS[0].name)).not.toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/__tests__/CoachAllPasswordsPage.spec.js
@@ -63,9 +63,10 @@ describe('CoachAllPasswordsPage', () => {
     expect(screen.getByText(LEARNERS[1].name)).toBeInTheDocument();
   });
 
-  it('passes the class name from classSummary into AllPasswordsPage', () => {
+  it('renders learners when a custom className is provided', () => {
     renderComponent({ className: 'My Class' });
     expect(screen.getByText(LEARNERS[0].name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].name)).toBeInTheDocument();
   });
 
   it('renders a learner with picture_password and a learner without one', () => {

--- a/kolibri/plugins/facility/frontend/modules/__tests__/mappers.spec.js
+++ b/kolibri/plugins/facility/frontend/modules/__tests__/mappers.spec.js
@@ -1,0 +1,36 @@
+import { _userState } from '../mappers';
+
+describe('_userState', () => {
+  const baseFacilityUser = {
+    id: 'user-1',
+    facility: 'facility-1',
+    username: 'testuser',
+    full_name: 'Test User',
+    is_superuser: false,
+    roles: [],
+    gender: 'MALE',
+    birth_year: '1990',
+    id_number: null,
+    date_joined: '2023-01-01',
+    date_deleted: null,
+    picture_password: '3.7.12',
+  };
+
+  it('includes picture_password in the mapped state', () => {
+    const state = _userState(baseFacilityUser);
+    expect(state.picture_password).toBe('3.7.12');
+  });
+
+  it('preserves picture_password when it is null', () => {
+    const state = _userState({ ...baseFacilityUser, picture_password: null });
+    expect(state.picture_password).toBeNull();
+  });
+
+  it('maps core user fields correctly', () => {
+    const state = _userState(baseFacilityUser);
+    expect(state.id).toBe('user-1');
+    expect(state.facility_id).toBe('facility-1');
+    expect(state.username).toBe('testuser');
+    expect(state.full_name).toBe('Test User');
+  });
+});

--- a/kolibri/plugins/facility/frontend/modules/mappers.js
+++ b/kolibri/plugins/facility/frontend/modules/mappers.js
@@ -21,5 +21,6 @@ export function _userState(facilityUser) {
     id_number: facilityUser.id_number,
     date_joined: facilityUser.date_joined,
     date_deleted: facilityUser.date_deleted,
+    picture_password: facilityUser.picture_password,
   };
 }

--- a/kolibri/plugins/facility/frontend/routes.js
+++ b/kolibri/plugins/facility/frontend/routes.js
@@ -1,12 +1,12 @@
 import store from 'kolibri/store';
 import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyncSchedule';
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
-import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
 import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
 import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
 import useFacilities from 'kolibri-common/composables/useFacilities';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import FacilityAllPasswordsPage from './views/FacilityAllPasswordsPage';
 import ClassEditPage from './views/ClassEditPage';
 import CoachClassAssignmentPage from './views/CoachClassAssignmentPage';
 import LearnerClassEnrollmentPage from './views/LearnerClassEnrollmentPage';
@@ -65,14 +65,10 @@ export default [
   {
     name: PageNames.CLASS_PASSWORDS_PAGE,
     path: '/:facility_id?/classes/:id/passwords/',
-    component: AllPasswordsPage,
-    props: route => ({
-      classId: route.params.id,
-      route: {
-        name: PageNames.CLASS_EDIT_MGMT_PAGE,
-        params: { id: route.params.id, facility_id: route.params.facility_id },
-      },
-    }),
+    component: FacilityAllPasswordsPage,
+    handler: toRoute => {
+      showClassEditPage(store, toRoute.params.id);
+    },
   },
   {
     name: PageNames.CLASS_ENROLL_LEARNER,

--- a/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
@@ -12,7 +12,8 @@
 
 <script>
 
-  import { computed, getCurrentInstance } from 'vue';
+  import { computed } from 'vue';
+  import store from 'kolibri/store';
   import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
   import useFacility from 'kolibri-common/composables/useFacility';
   import { PageNames } from '../constants';
@@ -21,25 +22,20 @@
     name: 'FacilityAllPasswordsPage',
     components: { AllPasswordsPage },
     setup() {
-      const store = getCurrentInstance().proxy.$store;
       const { currentFacilityName } = useFacility();
 
       const learners = computed(() => store.state.classEditManagement.classLearners);
       const className = computed(() => store.state.classEditManagement.currentClass?.name || '');
       const facilityName = computed(() => currentFacilityName.value);
+      const backRoute = computed(() => ({
+        name: PageNames.CLASS_EDIT_MGMT_PAGE,
+        params: {
+          id: store.state.classEditManagement.currentClass?.id,
+          facility_id: store.getters.activeFacilityId,
+        },
+      }));
 
-      return { learners, className, facilityName };
-    },
-    computed: {
-      backRoute() {
-        return {
-          name: PageNames.CLASS_EDIT_MGMT_PAGE,
-          params: {
-            id: this.$route.params.id,
-            facility_id: this.$route.params.facility_id,
-          },
-        };
-      },
+      return { learners, className, facilityName, backRoute };
     },
   };
 

--- a/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
@@ -1,0 +1,46 @@
+<template>
+
+  <AllPasswordsPage
+    :learners="learners"
+    :className="className"
+    :facilityName="facilityName"
+    :route="backRoute"
+  />
+
+</template>
+
+
+<script>
+
+  import { computed, getCurrentInstance } from 'vue';
+  import AllPasswordsPage from 'kolibri-common/components/AllPasswordsPage';
+  import useFacility from 'kolibri-common/composables/useFacility';
+  import { PageNames } from '../constants';
+
+  export default {
+    name: 'FacilityAllPasswordsPage',
+    components: { AllPasswordsPage },
+    setup() {
+      const store = getCurrentInstance().proxy.$store;
+      const { currentFacilityName } = useFacility();
+
+      const learners = computed(() => store.state.classEditManagement.classLearners);
+      const className = computed(() => store.state.classEditManagement.currentClass?.name || '');
+      const facilityName = computed(() => currentFacilityName.value);
+
+      return { learners, className, facilityName };
+    },
+    computed: {
+      backRoute() {
+        return {
+          name: PageNames.CLASS_EDIT_MGMT_PAGE,
+          params: {
+            id: this.$route.params.id,
+            facility_id: this.$route.params.facility_id,
+          },
+        };
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/frontend/views/__tests__/FacilityAllPasswordsPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/FacilityAllPasswordsPage.spec.js
@@ -66,8 +66,9 @@ describe('FacilityAllPasswordsPage', () => {
     expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
   });
 
-  it('passes the class name from currentClass into AllPasswordsPage', () => {
+  it('renders learners when a custom className is provided', () => {
     renderComponent({ className: 'My Class' });
     expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/facility/frontend/views/__tests__/FacilityAllPasswordsPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/FacilityAllPasswordsPage.spec.js
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/vue';
+import { ref } from 'vue';
+import store from 'kolibri/store';
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
+import classEditManagementModule from '../../modules/classEditManagement';
+import makeStore from '../../__tests__/utils/makeStore';
+import FacilityAllPasswordsPage from '../FacilityAllPasswordsPage.vue';
+
+jest.mock('kolibri-common/composables/useFacility');
+jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow', () => () => ({
+  windowBreakpoint: { value: 4 },
+}));
+jest.mock('vue-router/composables', () => ({
+  useRoute: jest.fn(() => ({ params: {}, query: {}, name: null })),
+  useRouter: jest.fn(() => ({ push: jest.fn(), currentRoute: {} })),
+}));
+jest.mock('kolibri-common/utils/picturePassword', () => ({
+  getPicturePasswordIcons: jest.fn(() => []),
+}));
+
+const FACILITY_NAME = 'Test Facility';
+const CLASS_NAME = 'Test Class';
+const LEARNERS = [
+  { id: 'u1', full_name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
+  { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
+];
+
+const routes = [{ path: '/classes/:id', name: 'CLASS_EDIT_MGMT_PAGE' }];
+
+function renderComponent({ learners = LEARNERS, className = CLASS_NAME } = {}) {
+  useFacility.mockImplementation(() =>
+    useFacilityMock({ currentFacilityName: ref(FACILITY_NAME) }),
+  );
+  const testStore = makeStore();
+  testStore.state.classEditManagement.classLearners = learners;
+  testStore.state.classEditManagement.currentClass = { id: 'class-1', name: className };
+
+  if (!store.hasModule('classEditManagement')) {
+    store.registerModule('classEditManagement', classEditManagementModule);
+  }
+  store.replaceState(testStore.state);
+
+  return render(FacilityAllPasswordsPage, { routes });
+}
+
+describe('FacilityAllPasswordsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes classEditManagement learners into AllPasswordsPage', () => {
+    renderComponent();
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+  });
+
+  it('renders a learner with picture_password and a learner without one', () => {
+    renderComponent();
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+    expect(screen.getByText(LEARNERS[1].full_name)).toBeInTheDocument();
+  });
+
+  it('renders an empty table when classLearners is empty', () => {
+    renderComponent({ learners: [] });
+    expect(screen.queryByText(LEARNERS[0].full_name)).not.toBeInTheDocument();
+  });
+
+  it('passes the class name from currentClass into AllPasswordsPage', () => {
+    renderComponent({ className: 'My Class' });
+    expect(screen.getByText(LEARNERS[0].full_name)).toBeInTheDocument();
+  });
+});

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -41,7 +41,6 @@
         :headers="tableHeaders"
         :rows="tableRows"
         :caption="allPasswordsHeader$()"
-        :dataLoading="loading"
         :emptyMessage="noLearnersInClass$()"
         :defaultSort="{ columnId: 'full_name', direction: 'asc' }"
         sortable
@@ -142,17 +141,14 @@
 
 <script>
 
-  import { ref, computed, onMounted } from 'vue';
+  import { ref, computed } from 'vue';
   import orderBy from 'lodash/orderBy';
-  import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
-  import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import ImmersivePage from 'kolibri/components/pages/ImmersivePage';
   import UserPicturePassword from 'kolibri-common/components/UserPicturePassword';
   import NoPasswordInfo from 'kolibri-common/components/NoPasswordInfo';
   import LearnerPasswordCard from 'kolibri-common/components/LearnerPasswordCard';
-  import useFacility from 'kolibri-common/composables/useFacility';
   import useUser from 'kolibri/composables/useUser';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 
@@ -163,13 +159,9 @@
     },
     components: { ImmersivePage, UserPicturePassword, NoPasswordInfo, LearnerPasswordCard },
     setup(props) {
-      const learners = ref([]);
-      const loading = ref(true);
       const showPrintDialog = ref(false);
       const printFormat = ref('images');
-      const className = ref('');
 
-      const { currentFacilityName } = useFacility();
       const { isAppContext } = useUser();
       const { windowBreakpoint } = useKResponsiveWindow();
 
@@ -192,7 +184,7 @@
       } = picturePasswordStrings;
 
       const previewLearner = computed(() => {
-        return learners.value.find(learner => learner.picture_password) || null;
+        return props.learners.find(learner => learner.picture_password) || null;
       });
 
       const hasPicturePasswords = computed(() => {
@@ -213,29 +205,12 @@
       const sortConfig = ref({ columnId: 'full_name', direction: 'asc' });
 
       const sortedLearners = computed(() =>
-        orderBy(learners.value, [sortConfig.value.columnId], [sortConfig.value.direction]),
+        orderBy(props.learners, [sortConfig.value.columnId], [sortConfig.value.direction]),
       );
 
       const printLearners = computed(() => sortedLearners.value);
 
       const tableRows = computed(() => sortedLearners.value.map(l => [l.full_name, l.username, l]));
-
-      onMounted(() => {
-        Promise.all([
-          FacilityUserResource.fetchCollection({
-            getParams: { member_of: props.classId },
-            force: true,
-          }),
-          ClassroomResource.fetchModel({ id: props.classId }),
-        ])
-          .then(([users, classroom]) => {
-            learners.value = users;
-            className.value = classroom.name;
-          })
-          .finally(() => {
-            loading.value = false;
-          });
-      });
 
       function handleSortChange({ sortKey, sortOrder }) {
         const columnId = tableHeaders.value[sortKey]?.columnId;
@@ -255,13 +230,10 @@
       }
 
       return {
-        loading,
         isAppContext,
         handleSortChange,
         showPrintDialog,
         printFormat,
-        className,
-        currentFacilityName,
         windowBreakpoint,
         previewLearner,
         hasPicturePasswords,
@@ -283,7 +255,15 @@
       };
     },
     props: {
-      classId: {
+      learners: {
+        type: Array,
+        required: true,
+      },
+      className: {
+        type: String,
+        required: true,
+      },
+      facilityName: {
         type: String,
         required: true,
       },
@@ -294,12 +274,7 @@
     },
     computed: {
       pageTitle() {
-        return [
-          this.allPasswordsHeader$(),
-          this.className,
-          this.currentFacilityName,
-          this.kolibriLabel$(),
-        ]
+        return [this.allPasswordsHeader$(), this.className, this.facilityName, this.kolibriLabel$()]
           .filter(Boolean)
           .join(' - ');
       },

--- a/packages/kolibri-common/components/AllPasswordsPage.vue
+++ b/packages/kolibri-common/components/AllPasswordsPage.vue
@@ -183,8 +183,14 @@
         printFormatPreviewLabel$,
       } = picturePasswordStrings;
 
+      // Normalize learners so full_name is always populated regardless of
+      // whether the source uses full_name (Facility) or name (Coach classSummary)
+      const normalizedLearners = computed(() =>
+        props.learners.map(l => ({ ...l, full_name: l.full_name ?? l.name })),
+      );
+
       const previewLearner = computed(() => {
-        return props.learners.find(learner => learner.picture_password) || null;
+        return normalizedLearners.value.find(learner => learner.picture_password) || null;
       });
 
       const hasPicturePasswords = computed(() => {
@@ -205,7 +211,11 @@
       const sortConfig = ref({ columnId: 'full_name', direction: 'asc' });
 
       const sortedLearners = computed(() =>
-        orderBy(props.learners, [sortConfig.value.columnId], [sortConfig.value.direction]),
+        orderBy(
+          normalizedLearners.value,
+          [sortConfig.value.columnId],
+          [sortConfig.value.direction],
+        ),
       );
 
       const printLearners = computed(() => sortedLearners.value);

--- a/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
+++ b/packages/kolibri-common/components/__tests__/AllPasswordsPage.spec.js
@@ -1,30 +1,19 @@
 import { ref } from 'vue';
 import { render, screen, fireEvent } from '@testing-library/vue';
-import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
-import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
-import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import AllPasswordsPage from '../AllPasswordsPage.vue';
 
 const { noPicturePasswordDescription$, printAction$, noLearnersInClass$ } = picturePasswordStrings;
 
-const CLASS_ID = 'class-abc';
+const CLASS_NAME = 'Test Class';
+const FACILITY_NAME = 'Test Facility';
 const LEARNERS = {
   alice: { id: 'u1', full_name: 'Alice Smith', username: 'alice', picture_password: '3.7.12' },
   bob: { id: 'u2', full_name: 'Bob Jones', username: 'bob', picture_password: null },
 };
 const ICON_LABELS = ['testIcon1', 'testIcon2', 'testIcon3'];
 
-jest.mock('kolibri-common/apiResources/FacilityUserResource', () => ({
-  fetchCollection: jest.fn(),
-}));
-
-jest.mock('kolibri-common/apiResources/ClassroomResource', () => ({
-  fetchModel: jest.fn(),
-}));
-
-jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
 jest.mock('vue-router/composables', () => ({
@@ -38,20 +27,21 @@ jest.mock('kolibri-common/utils/picturePassword', () => ({
     return [];
   }),
 }));
+
 function renderComponent(props = {}) {
   return render(AllPasswordsPage, {
-    props: { classId: CLASS_ID, ...props },
+    props: {
+      learners: Object.values(LEARNERS),
+      className: CLASS_NAME,
+      facilityName: FACILITY_NAME,
+      ...props,
+    },
     routes: [],
   });
 }
 
 describe('AllPasswordsPage', () => {
   beforeEach(() => {
-    FacilityUserResource.fetchCollection.mockResolvedValue(Object.values(LEARNERS));
-    ClassroomResource.fetchModel.mockResolvedValue({ name: 'Test Class' });
-    useFacility.mockImplementation(() =>
-      useFacilityMock({ currentFacilityName: ref('Test Facility') }),
-    );
     useKResponsiveWindow.mockImplementation(() => ({
       windowBreakpoint: ref(4),
     }));
@@ -61,61 +51,31 @@ describe('AllPasswordsPage', () => {
     jest.clearAllMocks();
   });
 
-  describe('loading state', () => {
-    it('does not show learner data while the fetch is pending', () => {
-      FacilityUserResource.fetchCollection.mockImplementation(() => new Promise(() => {}));
-      renderComponent();
-      expect(screen.queryByText(LEARNERS.alice.full_name)).not.toBeInTheDocument();
-      expect(screen.queryByText(LEARNERS.bob.full_name)).not.toBeInTheDocument();
-    });
-
-    it('hides the loading indicator after the fetch resolves', async () => {
-      renderComponent();
-      await global.flushPromises();
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('data fetching', () => {
-    it('calls FacilityUserResource.fetchCollection with the classId as member_of', async () => {
-      renderComponent();
-      await global.flushPromises();
-      expect(FacilityUserResource.fetchCollection).toHaveBeenCalledWith(
-        expect.objectContaining({ getParams: expect.objectContaining({ member_of: CLASS_ID }) }),
-      );
-    });
-  });
-
   describe('learner list', () => {
-    it('renders the full name of each learner', async () => {
+    it('renders the full name of each learner', () => {
       renderComponent();
-      await global.flushPromises();
       expect(screen.getByText(LEARNERS.alice.full_name)).toBeInTheDocument();
       expect(screen.getByText(LEARNERS.bob.full_name)).toBeInTheDocument();
     });
 
-    it('renders the username of each learner', async () => {
+    it('renders the username of each learner', () => {
       renderComponent();
-      await global.flushPromises();
       expect(screen.getByText(LEARNERS.alice.username)).toBeInTheDocument();
       expect(screen.getByText(LEARNERS.bob.username)).toBeInTheDocument();
     });
 
-    it('renders resolved icon labels for a learner with a picture_password', async () => {
+    it('renders resolved icon labels for a learner with a picture_password', () => {
       renderComponent();
-      await global.flushPromises();
       ICON_LABELS.forEach(label => expect(screen.getByText(label)).toBeInTheDocument());
     });
 
-    it('renders the "no password" description for a learner with picture_password=null', async () => {
+    it('renders the "no password" description for a learner with picture_password=null', () => {
       renderComponent();
-      await global.flushPromises();
       expect(screen.getByText(noPicturePasswordDescription$())).toBeInTheDocument();
     });
 
-    it('renders one row per learner', async () => {
+    it('renders one row per learner', () => {
       renderComponent();
-      await global.flushPromises();
       const rows = screen.getAllByRole('row');
       // 1 header row + 2 learner rows
       expect(rows).toHaveLength(3);
@@ -123,9 +83,8 @@ describe('AllPasswordsPage', () => {
   });
 
   describe('print button', () => {
-    it('renders a Print button', async () => {
+    it('renders a Print button', () => {
       renderComponent();
-      await global.flushPromises();
       expect(screen.getByRole('button', { name: printAction$() })).toBeInTheDocument();
     });
   });
@@ -133,7 +92,6 @@ describe('AllPasswordsPage', () => {
   describe('print dialog', () => {
     it('opens the print format dialog when the Print button is clicked', async () => {
       renderComponent();
-      await global.flushPromises();
       fireEvent.click(screen.getByRole('button', { name: picturePasswordStrings.printAction$() }));
       await global.flushPromises();
       expect(
@@ -143,7 +101,6 @@ describe('AllPasswordsPage', () => {
 
     it('shows hyphenated icon labels in the preview when text format is selected', async () => {
       renderComponent();
-      await global.flushPromises();
       fireEvent.click(screen.getByRole('button', { name: picturePasswordStrings.printAction$() }));
       await global.flushPromises();
       fireEvent.click(
@@ -154,20 +111,15 @@ describe('AllPasswordsPage', () => {
     });
   });
 
-  describe('when the fetch returns an empty list', () => {
-    it('renders no learner content', async () => {
-      FacilityUserResource.fetchCollection.mockResolvedValue([]);
-      renderComponent();
-      await global.flushPromises();
-      // KTable hides the table element entirely when rows are empty
+  describe('when the learners prop is an empty list', () => {
+    it('renders no learner content', () => {
+      renderComponent({ learners: [] });
       expect(screen.queryByText(LEARNERS.alice.full_name)).not.toBeInTheDocument();
       expect(screen.queryByText(LEARNERS.bob.full_name)).not.toBeInTheDocument();
     });
 
-    it('renders the empty class message', async () => {
-      FacilityUserResource.fetchCollection.mockResolvedValue([]);
-      renderComponent();
-      await global.flushPromises();
+    it('renders the empty class message', () => {
+      renderComponent({ learners: [] });
       expect(screen.getByText(noLearnersInClass$())).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

Adds route-level wrapper components for the Coach and Facility plugins that supply context-specific data to the shared \`AllPasswordsPage\` via props, replacing its previous self-contained API fetch.

**What changed:**
- \`AllPasswordsPage\` no longer fetches its own learner/class data on mount. It now receives \`learners\`, \`className\`, and \`facilityName\` as required props. A \`normalizedLearners\` computed handles the field name difference between Facility (\`full_name\`) and Coach classSummary (\`name\`).
- \`CoachAllPasswordsPage\` (new) — route component for \`LEARNER_PASSWORDS\`; reads learners and class name from \`classSummary\` Vuex state, facility name from \`useFacility\`.
- \`FacilityAllPasswordsPage\` (new) — route component for \`CLASS_PASSWORDS_PAGE\`; reads learners and class name from \`classEditManagement\` Vuex state. The route handler reuses \`showClassEditPage\` so state is populated on direct navigation/refresh.
- \`picture_password\` added to \`_userState\` in \`kolibri/plugins/facility/frontend/modules/mappers.js\` so the field flows through to \`classLearners\` in Vuex.

**Manual verification performed:**
- Coach flow: navigated from Coach home → View passwords; learners listed with picture passwords and no-password states correct.
- Facility flow: navigated from Facility class edit page → View passwords dropdown; same verification.
- Direct URL navigation populates state correctly in both plugins.
- Print dialog and print mode continue to work.

No UI changes — visual output is identical to before.

## References

Closes learningequality/kolibri#14661

## Reviewer guidance

To verify the page works correctly in both contexts:

**Coach flow:**
1. Go to Coach and open a class.
2. From the class home page, click "View passwords" in the Overview block — or navigate to the Learners tab and click "View passwords" there.
3. Confirm the passwords page loads with the correct learners, class name, and facility name.
4. Confirm learners with a picture password show it, and learners without one show the no-password message.
5. Open the print dialog, confirm the preview works, and confirm print mode shows the correct facility/class header.

**Facility flow:**
1. Go to Facility and open a class edit page.
2. Use the "View passwords" option from the dropdown menu.
3. Confirm the same points as above — correct learners, class name, facility name, password display, and print behavior.

## AI usage

Implemented with Claude Code support.