### PR TITLE
Enable postgres SSL configuration through Kolibri options

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -127,6 +127,49 @@ jobs:
     - name: Test with tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e postgres
+  postgres_ssl:
+    name: Python postgres SSL smoke tests
+    needs: pre_job
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+        command: >-
+          -c ssl=on
+          -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+          -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.9 for Postgres
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.9
+    - name: Install tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install "tox<4"
+    - name: tox env cache
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.tox/py3.9
+        key: ${{ runner.os }}-tox-py3.9-${{ hashFiles('requirements/*.txt') }}
+    - name: Test with SSL enabled (require mode)
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      run: tox -e postgres-ssl
   macos:
     name: Python unit tests on Mac OS
     needs: pre_job

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -37,6 +37,18 @@ except ImportError:
     pass
 
 
+def _get_postgres_ssl_options(database_options):
+    ssl_mode = database_options["DATABASE_SSL_MODE"]
+    if ssl_mode == "disable":
+        return {}
+
+    ssl_options = {"sslmode": ssl_mode}
+    ssl_root_cert = database_options["DATABASE_SSL_ROOT_CERT"].strip()
+    if ssl_root_cert:
+        ssl_options["sslrootcert"] = ssl_root_cert
+    return ssl_options
+
+
 if not os.path.exists(conf.KOLIBRI_HOME):
     raise RuntimeError("The KOLIBRI_HOME dir does not exist")
 
@@ -179,6 +191,12 @@ if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
     )
 
 elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
+    postgres_ssl_options = _get_postgres_ssl_options(conf.OPTIONS["Database"])
+
+    default_db_options = {}
+    if postgres_ssl_options:
+        default_db_options["OPTIONS"] = postgres_ssl_options.copy()
+
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
@@ -188,6 +206,7 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
             "HOST": conf.OPTIONS["Database"]["DATABASE_HOST"],
             "PORT": conf.OPTIONS["Database"]["DATABASE_PORT"],
             "TEST": {"NAME": "test"},
+            **default_db_options,
         },
         "default-serializable": {
             "ENGINE": "django.db.backends.postgresql",
@@ -196,7 +215,10 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
             "USER": conf.OPTIONS["Database"]["DATABASE_USER"],
             "HOST": conf.OPTIONS["Database"]["DATABASE_HOST"],
             "PORT": conf.OPTIONS["Database"]["DATABASE_PORT"],
-            "OPTIONS": {"isolation_level": isolation_level},
+            "OPTIONS": {
+                "isolation_level": isolation_level,
+                **postgres_ssl_options,
+            },
             "TEST": {"MIRROR": "default"},
         },
     }

--- a/kolibri/deployment/default/settings/test_base.py
+++ b/kolibri/deployment/default/settings/test_base.py
@@ -1,0 +1,40 @@
+from kolibri.deployment.default.settings.base import _get_postgres_ssl_options
+
+
+def test_get_postgres_ssl_options_disabled():
+    assert (
+        _get_postgres_ssl_options(
+            {"DATABASE_SSL_MODE": "disable", "DATABASE_SSL_ROOT_CERT": ""}
+        )
+        == {}
+    )
+
+
+def test_get_postgres_ssl_options_with_mode_only():
+    assert _get_postgres_ssl_options(
+        {"DATABASE_SSL_MODE": "require", "DATABASE_SSL_ROOT_CERT": ""}
+    ) == {"sslmode": "require"}
+
+
+def test_get_postgres_ssl_options_with_root_cert():
+    assert (
+        _get_postgres_ssl_options(
+            {
+                "DATABASE_SSL_MODE": "verify-full",
+                "DATABASE_SSL_ROOT_CERT": "  /tmp/ca.pem  ",
+            }
+        )
+        == {"sslmode": "verify-full", "sslrootcert": "/tmp/ca.pem"}
+    )
+
+
+def test_get_postgres_ssl_options_skips_whitespace_only_cert():
+    assert (
+        _get_postgres_ssl_options(
+            {
+                "DATABASE_SSL_MODE": "verify-ca",
+                "DATABASE_SSL_ROOT_CERT": "   ",
+            }
+        )
+        == {"sslmode": "verify-ca"}
+    )

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -549,6 +549,24 @@ base_option_spec = {
             "type": "string",
             "description": "The port on which to connect to the database, Postgresql only.",
         },
+        "DATABASE_SSL_MODE": {
+            "type": "option",
+            "options": (
+                "disable",
+                "allow",
+                "prefer",
+                "require",
+                "verify-ca",
+                "verify-full",
+            ),
+            "default": "disable",
+            "description": "The sslmode for the connection, Postgresql only.",
+        },
+        "DATABASE_SSL_ROOT_CERT": {
+            "type": "path",
+            "default": "",
+            "description": "Path to the SSL certificate authority (CA) file for verifying the server certificate (maps to sslrootcert), Postgresql only.",
+        },
     },
     "Server": {
         "CHERRYPY_START": {

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -113,6 +113,21 @@ def test_default_envvar_generation():
         assert OPTIONS["Paths"]["CONTENT_DIR"] == _CONTENT_DIR
 
 
+def test_database_ssl_mode_envvar():
+    _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "KOLIBRI_HOME": os.environ["KOLIBRI_HOME"],
+            "KOLIBRI_DATABASE_SSL_MODE": "require",
+        },
+        clear=True,
+    ):
+        OPTIONS = options.read_options_file(ini_filename=tmp_ini_path)
+        assert OPTIONS["Database"]["DATABASE_SSL_MODE"] == "require"
+
+
 def test_improper_settings_display_errors_and_exit(monkeypatch):
     """
     Checks invalid options log errors and exit.
@@ -153,6 +168,16 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
             with pytest.raises(SystemExit):
                 options.read_options_file(ini_filename=tmp_ini_path)
             assert 'value "penguin" is unacceptable' in LOG_LOGGER[-2][1]
+
+        # invalid choice for postgres ssl mode causes it to bail
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Database]", "DATABASE_SSL_MODE = maybe"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
+        ):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "maybe" is unacceptable' in LOG_LOGGER[-2][1]
 
 
 def test_deprecated_values_ini_file(monkeypatch):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13,3.14}, postgres
+envlist = py{3.6,3.7,3.8,3.9,3.10,3.11,3.12,3.13,3.14}, postgres, postgres-ssl
 
 [testenv]
 usedevelop = True
@@ -59,3 +59,17 @@ deps =
 commands =
     python -O -m pytest {posargs:kolibri --color=no}
     python -O -m pytest --color=no -p no:django test
+
+[testenv:postgres-ssl]
+passenv =
+    TOX_ENV
+    INTEGRATION_TEST
+setenv =
+    {[testenv:postgres]setenv}
+    KOLIBRI_DATABASE_SSL_MODE = require
+basepython =
+    postgres-ssl: python3.9
+deps = {[testenv:postgres]deps}
+commands =
+    # smoke test, runs Morango serialization
+    python -O -m pytest kolibri/core/public/test/test_api.py -k SyncQueueViewSetDeletedUsersTestCase --color=no


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds new `DATABASE_SSL_MODE` option to enable SSL with PostgreSQL
- Adds additional `DATABASE_SSL_ROOT_CERT` option that may be used when SSL is enabled, to verify the certificate of the server
- Uses the above options to configure Django's database settings
- Adds tests for functional changes, and a dedicated smoke test with SSL configured

## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/kolibri/issues/14431

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Does the smoke test cover it? should we add a dedicated test for the smoke test that verifies SSL is enabled during the test?

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I have 22 AI credits I can burn before May 19th. So I let AI tackle the issue, since it was pretty well scoped. The changes seem straightforward, too. Although, I only used 1.25 credits :melting_face: 