### PR TITLE
Fixes for global facility state handling

### DIFF
--- a/kolibri/plugins/facility/frontend/app.js
+++ b/kolibri/plugins/facility/frontend/app.js
@@ -3,7 +3,10 @@ import useUser from 'kolibri/composables/useUser';
 import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import router from 'kolibri/router';
 import KolibriApp from 'kolibri-app';
+import useFacility, { setSelectedFacilityId } from 'kolibri-common/composables/useFacility';
 import useFacilities from 'kolibri-common/composables/useFacilities';
+import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import { handleApiError } from 'kolibri/utils/appError';
 import RootVue from './views/FacilityIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
@@ -20,15 +23,34 @@ class FacilityManagementModule extends KolibriApp {
   }
   ready() {
     const { isLearnerOnlyImport, isSuperuser } = useUser();
-    const { fetchFacilities, facilities } = useFacilities();
-    router.beforeEach((to, from, next) => {
+    const { facilities } = useFacilities();
+    const { fetchFacility, fetchFacilities, fetchFacilityConfig } = useFacility();
+
+    router.beforeEach(async (to, from, next) => {
       if (get(isLearnerOnlyImport)) {
         redirectBrowser();
         return;
       }
-      if (get(isSuperuser) && facilities.value.length === 0) {
-        fetchFacilities().then(next, next);
-      } else {
+
+      pageLoading.value = true;
+
+      setSelectedFacilityId(to.params.facility_id || null);
+
+      try {
+        if (facilities.value.length === 0) {
+          if (get(isSuperuser)) {
+            await fetchFacilities();
+          } else {
+            await fetchFacility();
+          }
+        }
+
+        // always ensure updated config
+        await fetchFacilityConfig();
+      } catch (error) {
+        handleApiError({ error, reloadOnReconnect: true });
+      } finally {
+        pageLoading.value = false;
         next();
       }
     });

--- a/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
+++ b/kolibri/plugins/facility/frontend/composables/__tests__/useFacilityEditor.spec.js
@@ -3,8 +3,7 @@ import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
-import useFacilities, { useFacilitiesMock } from 'kolibri-common/composables/useFacilities'; // eslint-disable-line
-import { useFacilityConfig, useFacilityConfigMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line
 import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import useFacilityEditor from '../useFacilityEditor';
 
@@ -12,7 +11,6 @@ jest.mock('kolibri-common/apiResources/FacilityResource');
 jest.mock('kolibri-common/apiResources/FacilityDatasetResource');
 jest.mock('kolibri/client');
 jest.mock('kolibri/urls');
-jest.mock('kolibri-common/composables/useFacilities');
 jest.mock('kolibri-common/composables/useFacility');
 
 function mockSignInOptions(facilityConfig) {
@@ -50,23 +48,35 @@ describe('useFacilityEditor', () => {
     extra_fields: { pin_code: '5678' },
   };
 
-  beforeEach(() => {
-    // Mock useFacilities
-    useFacilities.mockReturnValue(
-      useFacilitiesMock({
-        fetchFacilities: jest.fn().mockResolvedValue([mockFacility]),
-        getFacility: jest.fn().mockReturnValue(mockFacility),
-      }),
-    );
+  function buildUseFacilityState(overrides = {}) {
+    const facilityConfig = overrides.facilityConfig || ref(mockFacilityConfig);
+    const signInOptions =
+      overrides.signInOptions || computed(() => [OptionsForSignIn.USERNAME_PASSWORD]);
+    const picturePasswordSettings =
+      overrides.picturePasswordSettings ||
+      computed(() => {
+        if (signInOptions.value.includes(OptionsForSignIn.PICTURE_PASSWORD)) {
+          return facilityConfig.value.picture_password_settings;
+        }
+        return null;
+      });
 
-    // Mock useFacilityConfig
-    useFacilityConfig.mockReturnValue(
-      useFacilityConfigMock({
-        fetchFacilityConfig: jest.fn().mockResolvedValue(mockFacilityConfig),
-        facilityConfig: ref(mockFacilityConfig),
-        signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
-      }),
-    );
+    return useFacilityMock({
+      facilityId: ref(mockFacilityId),
+      selectedFacility: ref(mockFacility),
+      facilityConfig,
+      isAttendanceFeatureEnabled: computed(() => true),
+      isPictureLoginFeatureEnabled: computed(() => true),
+      signInOptions,
+      picturePasswordSettings,
+      fetchFacility: jest.fn().mockResolvedValue(mockFacility),
+      fetchFacilityConfig: jest.fn().mockResolvedValue(mockFacilityConfig),
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    useFacility.mockReturnValue(buildUseFacilityState());
 
     // Mock urls
     urls['kolibri:core:facilitydataset_update_pin'] = jest
@@ -83,7 +93,7 @@ describe('useFacilityEditor', () => {
         settingsCopy,
         isFacilityPinValid,
         facilityDataLoading,
-      } = useFacilityEditor(mockFacilityId);
+      } = useFacilityEditor();
 
       expect(facilityDatasetId.value).toBe('');
       expect(facilityName.value).toBe('');
@@ -94,8 +104,8 @@ describe('useFacilityEditor', () => {
     });
 
     it('returns computed properties with correct initial values', () => {
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig: ref({}),
           signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
         }),
@@ -111,7 +121,7 @@ describe('useFacilityEditor', () => {
         picturePasswordSettings,
         picturePasswordStyle,
         picturePasswordShowIconText,
-      } = useFacilityEditor(mockFacilityId);
+      } = useFacilityEditor();
 
       expect(settingsHaveChanged.value).toBe(false);
       expect(isPinSet.value).toBeNull();
@@ -128,14 +138,14 @@ describe('useFacilityEditor', () => {
   describe('computed properties', () => {
     describe('settingsHaveChanged', () => {
       it('returns false when settings match settingsCopy', () => {
-        const { settings, copySettings, settingsHaveChanged } = useFacilityEditor(mockFacilityId);
+        const { settings, copySettings, settingsHaveChanged } = useFacilityEditor();
         settings.value = { learner_can_edit_username: true };
         copySettings();
         expect(settingsHaveChanged.value).toBe(false);
       });
 
       it('returns true when settings differ from settingsCopy', () => {
-        const { settings, copySettings, settingsHaveChanged } = useFacilityEditor(mockFacilityId);
+        const { settings, copySettings, settingsHaveChanged } = useFacilityEditor();
         settings.value = { learner_can_edit_username: true };
         copySettings();
         settings.value.learner_can_edit_username = false;
@@ -145,19 +155,19 @@ describe('useFacilityEditor', () => {
 
     describe('isPinSet', () => {
       it('returns pin_code when extra_fields.pin_code exists', () => {
-        const { settings, isPinSet } = useFacilityEditor(mockFacilityId);
+        const { settings, isPinSet } = useFacilityEditor();
         settings.value = { extra_fields: { pin_code: '5678' } };
         expect(isPinSet.value).toBe('5678');
       });
 
       it('returns null when extra_fields.pin_code does not exist', () => {
-        const { settings, isPinSet } = useFacilityEditor(mockFacilityId);
+        const { settings, isPinSet } = useFacilityEditor();
         settings.value = { extra_fields: {} };
         expect(isPinSet.value).toBe(null);
       });
 
       it('returns null when extra_fields is undefined', () => {
-        const { settings, isPinSet } = useFacilityEditor(mockFacilityId);
+        const { settings, isPinSet } = useFacilityEditor();
         settings.value = {};
         expect(isPinSet.value).toBe(null);
       });
@@ -165,48 +175,37 @@ describe('useFacilityEditor', () => {
   });
 
   describe('fetchFacility', () => {
-    it('loads facility config and updates reactive state', async () => {
-      const { fetchFacility, facilityDatasetId, facilityName, settings, settingsCopy } =
-        useFacilityEditor(mockFacilityId);
+    it('delegates to useFacility fetchFacility', async () => {
+      const fetchFacilityMock = jest.fn().mockResolvedValue();
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
+          fetchFacility: fetchFacilityMock,
+        }),
+      );
+
+      const { fetchFacility } = useFacilityEditor();
 
       await fetchFacility();
 
-      expect(facilityDatasetId.value).toBe(mockDatasetId);
-      expect(facilityName.value).toBe('Test Facility');
-      expect(settings.value).toEqual(mockFacilityConfig);
-      expect(settingsCopy.value).toEqual(mockFacilityConfig);
+      expect(fetchFacilityMock).toHaveBeenCalledTimes(1);
     });
 
-    it('sets loading state during fetch', async () => {
-      const { fetchFacility, facilityDataLoading } = useFacilityEditor(mockFacilityId);
+    it('keeps local facility identity state unchanged when fetchFacility is delegated', async () => {
+      const { fetchFacility, facilityDatasetId, facilityName, settings, settingsCopy } =
+        useFacilityEditor();
 
-      const fetchPromise = fetchFacility();
-      expect(facilityDataLoading.value).toBe(true);
+      await fetchFacility();
 
-      await fetchPromise;
-      expect(facilityDataLoading.value).toBe(false);
-    });
-
-    it('resets state on error', async () => {
-      const mockError = new Error('Failed to fetch');
-      useFacilityConfig.mockReturnValue({
-        fetchFacilityConfig: jest.fn().mockRejectedValue(mockError),
-        facilityConfig: ref({}),
-      });
-
-      const { fetchFacility, facilityName, settings, settingsCopy } =
-        useFacilityEditor(mockFacilityId);
-
-      await expect(fetchFacility()).rejects.toThrow('Failed to fetch');
+      expect(facilityDatasetId.value).toBe('');
       expect(facilityName.value).toBe('');
-      expect(settings.value).toEqual({});
+      expect(settings.value).toEqual(mockFacilityConfig);
       expect(settingsCopy.value).toEqual({});
     });
   });
 
   describe('modifySetting', () => {
     it('updates a setting value', () => {
-      const { settings, modifySetting } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySetting } = useFacilityEditor();
       settings.value = { learner_can_edit_username: false };
 
       modifySetting('learner_can_edit_username', true);
@@ -215,7 +214,7 @@ describe('useFacilityEditor', () => {
     });
 
     it('does not update non-existent settings', () => {
-      const { settings, modifySetting } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySetting } = useFacilityEditor();
       settings.value = { learner_can_edit_username: false };
 
       modifySetting('non_existent_setting', true);
@@ -224,7 +223,7 @@ describe('useFacilityEditor', () => {
     });
 
     it('disables learner_can_edit_password when learner_can_login_with_no_password is true', () => {
-      const { settings, modifySetting } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySetting } = useFacilityEditor();
       settings.value = {
         learner_can_login_with_no_password: false,
         learner_can_edit_password: true,
@@ -239,8 +238,8 @@ describe('useFacilityEditor', () => {
 
   describe('signInOption computed', () => {
     it('returns PICTURE_PASSWORD when in signInOptions', () => {
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig: ref({
             ...mockFacilityConfig,
             picture_password_settings: { icon_style: 'colorful' },
@@ -249,12 +248,12 @@ describe('useFacilityEditor', () => {
         }),
       );
 
-      const { signInOption } = useFacilityEditor(mockFacilityId);
+      const { signInOption } = useFacilityEditor();
       expect(signInOption.value).toBe(OptionsForSignIn.PICTURE_PASSWORD);
     });
 
     it('returns first signInOption when PICTURE_PASSWORD is not available', () => {
-      const { signInOption } = useFacilityEditor(mockFacilityId);
+      const { signInOption } = useFacilityEditor();
       expect(signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
     });
 
@@ -272,15 +271,15 @@ describe('useFacilityEditor', () => {
         return null;
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions,
           picturePasswordSettings,
         }),
       );
 
-      const { signInOption, modifySignInOption, settings } = useFacilityEditor(mockFacilityId);
+      const { signInOption, modifySignInOption, settings } = useFacilityEditor();
       expect(signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
       modifySignInOption(OptionsForSignIn.PICTURE_PASSWORD);
       // modifySignInOption updates settings.value which is the same ref as facilityConfig
@@ -298,15 +297,15 @@ describe('useFacilityEditor', () => {
         learner_can_login_with_no_password: true,
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { picturePasswordStyle } = useFacilityEditor(mockFacilityId);
+      const { picturePasswordStyle } = useFacilityEditor();
       expect(picturePasswordStyle.value).toBe(PicturePasswordIconStyle.STANDARD);
     });
 
@@ -317,16 +316,15 @@ describe('useFacilityEditor', () => {
         learner_can_login_with_no_password: true,
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { picturePasswordStyle, modifyPicturePasswordSetting } =
-        useFacilityEditor(mockFacilityId);
+      const { picturePasswordStyle, modifyPicturePasswordSetting } = useFacilityEditor();
       modifyPicturePasswordSetting('icon_style', PicturePasswordIconStyle.STANDARD);
       expect(picturePasswordStyle.value).toBe(PicturePasswordIconStyle.STANDARD);
     });
@@ -340,15 +338,15 @@ describe('useFacilityEditor', () => {
         learner_can_login_with_no_password: true,
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { picturePasswordShowIconText } = useFacilityEditor(mockFacilityId);
+      const { picturePasswordShowIconText } = useFacilityEditor();
       expect(picturePasswordShowIconText.value).toBe(true);
     });
 
@@ -359,16 +357,15 @@ describe('useFacilityEditor', () => {
         learner_can_login_with_no_password: true,
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { picturePasswordShowIconText, modifyPicturePasswordSetting } =
-        useFacilityEditor(mockFacilityId);
+      const { picturePasswordShowIconText, modifyPicturePasswordSetting } = useFacilityEditor();
       modifyPicturePasswordSetting('show_icon_text', true);
       expect(picturePasswordShowIconText.value).toBe(true);
     });
@@ -382,15 +379,15 @@ describe('useFacilityEditor', () => {
       });
       const signInOptions = mockSignInOptions(facilityConfig);
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions,
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySignInOption } = useFacilityEditor();
 
       modifySignInOption(OptionsForSignIn.PICTURE_PASSWORD);
 
@@ -408,15 +405,15 @@ describe('useFacilityEditor', () => {
       });
       const signInOptions = mockSignInOptions(facilityConfig);
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions,
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySignInOption } = useFacilityEditor();
 
       modifySignInOption(OptionsForSignIn.USERNAME_ONLY);
 
@@ -431,15 +428,15 @@ describe('useFacilityEditor', () => {
       });
       const signInOptions = mockSignInOptions(facilityConfig);
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions,
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { settings, modifySignInOption } = useFacilityEditor(mockFacilityId);
+      const { settings, modifySignInOption } = useFacilityEditor();
 
       modifySignInOption(OptionsForSignIn.USERNAME_PASSWORD);
 
@@ -456,15 +453,15 @@ describe('useFacilityEditor', () => {
         learner_can_login_with_no_password: true,
       });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
           signInOptions: computed(() => [OptionsForSignIn.PICTURE_PASSWORD]),
           picturePasswordSettings: computed(() => facilityConfig.value.picture_password_settings),
         }),
       );
 
-      const { settings, modifyPicturePasswordSetting } = useFacilityEditor(mockFacilityId);
+      const { settings, modifyPicturePasswordSetting } = useFacilityEditor();
 
       modifyPicturePasswordSetting('icon_style', PicturePasswordIconStyle.STANDARD);
 
@@ -478,13 +475,13 @@ describe('useFacilityEditor', () => {
     it('updates extra_fields in settings', () => {
       const facilityConfig = ref({ extra_fields: { pin_code: '1234' } });
 
-      useFacilityConfig.mockReturnValue(
-        useFacilityConfigMock({
+      useFacility.mockReturnValue(
+        buildUseFacilityState({
           facilityConfig,
         }),
       );
 
-      const { settings, modifyExtraFields } = useFacilityEditor(mockFacilityId);
+      const { settings, modifyExtraFields } = useFacilityEditor();
 
       modifyExtraFields({ pin_code: '5678' });
 
@@ -494,7 +491,7 @@ describe('useFacilityEditor', () => {
 
   describe('copySettings', () => {
     it('copies current settings to settingsCopy', () => {
-      const { settings, settingsCopy, copySettings } = useFacilityEditor(mockFacilityId);
+      const { settings, settingsCopy, copySettings } = useFacilityEditor();
       settings.value = { learner_can_edit_username: true };
 
       copySettings();
@@ -505,7 +502,7 @@ describe('useFacilityEditor', () => {
 
   describe('undoSettingsChange', () => {
     it('restores settings from settingsCopy', () => {
-      const { settings, settingsCopy, undoSettingsChange } = useFacilityEditor(mockFacilityId);
+      const { settings, settingsCopy, undoSettingsChange } = useFacilityEditor();
       settings.value = { learner_can_edit_username: true };
       settingsCopy.value = { learner_can_edit_username: false };
 
@@ -526,7 +523,7 @@ describe('useFacilityEditor', () => {
         facilityDataLoading,
         resetState,
         setLoading,
-      } = useFacilityEditor(mockFacilityId);
+      } = useFacilityEditor();
 
       // Set non-initial values
       facilityDatasetId.value = 'some-id';
@@ -551,7 +548,7 @@ describe('useFacilityEditor', () => {
       const newName = 'New Facility Name';
       FacilityResource.saveModel.mockResolvedValue({ id: mockFacilityId, name: newName });
 
-      const { saveFacilityName, facilityName } = useFacilityEditor(mockFacilityId);
+      const { saveFacilityName, facilityName } = useFacilityEditor();
 
       await saveFacilityName(newName);
 
@@ -565,7 +562,7 @@ describe('useFacilityEditor', () => {
 
   describe('saveFacilityConfig', () => {
     it('saves facility config excluding login settings fields', async () => {
-      const { saveFacilityConfig, settings, facilityDatasetId } = useFacilityEditor(mockFacilityId);
+      const { saveFacilityConfig, settings, facilityDatasetId } = useFacilityEditor();
       settings.value = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'standard', show_icon_text: true },
@@ -590,7 +587,7 @@ describe('useFacilityEditor', () => {
 
       client.mockResolvedValue(mockResponse);
 
-      const { setPin, settings } = useFacilityEditor(mockFacilityId);
+      const { setPin, settings } = useFacilityEditor();
       settings.value = mockFacilityConfig;
 
       await setPin(mockPayload);
@@ -610,7 +607,7 @@ describe('useFacilityEditor', () => {
 
       client.mockResolvedValue(mockResponse);
 
-      const { unsetPin, settings } = useFacilityEditor(mockFacilityId);
+      const { unsetPin, settings } = useFacilityEditor();
       settings.value = mockFacilityConfig;
 
       await unsetPin();
@@ -625,13 +622,13 @@ describe('useFacilityEditor', () => {
 
   describe('setLoading', () => {
     it('sets facilityDataLoading to true', () => {
-      const { setLoading, facilityDataLoading } = useFacilityEditor(mockFacilityId);
+      const { setLoading, facilityDataLoading } = useFacilityEditor();
       setLoading(true);
       expect(facilityDataLoading.value).toBe(true);
     });
 
     it('sets facilityDataLoading to false', () => {
-      const { setLoading, facilityDataLoading } = useFacilityEditor(mockFacilityId);
+      const { setLoading, facilityDataLoading } = useFacilityEditor();
       setLoading(true);
       setLoading(false);
       expect(facilityDataLoading.value).toBe(false);
@@ -648,8 +645,7 @@ describe('useFacilityEditor', () => {
     it('calls the save-facility-login-settings endpoint via PATCH with login fields', async () => {
       client.mockResolvedValue({ data: {} });
 
-      const { saveFacilityLoginSettings, settings, facilityDatasetId } =
-        useFacilityEditor(mockFacilityId);
+      const { saveFacilityLoginSettings, settings, facilityDatasetId } = useFacilityEditor();
       settings.value = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'standard', show_icon_text: true },
@@ -678,7 +674,7 @@ describe('useFacilityEditor', () => {
       });
 
       const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
-        useFacilityEditor(mockFacilityId);
+        useFacilityEditor();
       settings.value = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'standard', show_icon_text: true },
@@ -696,7 +692,7 @@ describe('useFacilityEditor', () => {
       client.mockResolvedValue({ status: 200, data: { dataset: { id: 'dataset-id' } } });
 
       const { saveFacilityLoginSettings, pictureLoginTaskId, settings, facilityDatasetId } =
-        useFacilityEditor(mockFacilityId);
+        useFacilityEditor();
       settings.value = { ...mockFacilityConfig };
       facilityDatasetId.value = mockDatasetId;
 
@@ -712,8 +708,7 @@ describe('useFacilityEditor', () => {
       };
       client.mockResolvedValue({ status: 202, data: mockTaskData });
 
-      const { saveFacilityLoginSettings, settings, facilityDatasetId } =
-        useFacilityEditor(mockFacilityId);
+      const { saveFacilityLoginSettings, settings, facilityDatasetId } = useFacilityEditor();
       settings.value = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'standard', show_icon_text: true },

--- a/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
+++ b/kolibri/plugins/facility/frontend/composables/useFacilityEditor.js
@@ -1,28 +1,28 @@
-import { ref, computed } from 'vue';
+import { ref, computed, onBeforeMount } from 'vue';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
-import useFacilities from 'kolibri-common/composables/useFacilities';
 import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
-import { useFacilityConfig } from 'kolibri-common/composables/useFacility';
+import useFacility from 'kolibri-common/composables/useFacility';
 
 /**
- * @param {string} facilityId  The ID of the facility to edit
+ * A composable for editing facility settings and configuration
  */
-export default function useFacilityEditor(facilityId) {
-  const { fetchFacilities, getFacility } = useFacilities();
+export default function useFacilityEditor() {
   const {
+    facilityId,
+    selectedFacility: facility,
+    facilityConfig: settings,
     isAttendanceFeatureEnabled,
     isPictureLoginFeatureEnabled,
     signInOptions,
     picturePasswordSettings,
-    // TODO: update this composable to use 'facilityConfig' naming instead
-    facilityConfig: settings,
+    fetchFacility,
     fetchFacilityConfig,
-  } = useFacilityConfig(facilityId);
+  } = useFacility();
 
   // Reactive state
   const facilityDatasetId = ref('');
@@ -32,8 +32,6 @@ export default function useFacilityEditor(facilityId) {
   const facilityDataLoading = ref(false);
 
   // Computed properties
-  const facility = computed(() => getFacility(facilityId));
-
   const settingsHaveChanged = computed(() => !isEqual(settings.value, settingsCopy.value));
   const isPinSet = computed(() => {
     if (settings.value.extra_fields?.pin_code) {
@@ -76,28 +74,6 @@ export default function useFacilityEditor(facilityId) {
   // Actions
   function setLoading(loading) {
     facilityDataLoading.value = loading;
-  }
-
-  /**
-   * Loads the facility and it's config into the composable state
-   */
-  async function fetchFacility() {
-    setLoading(true);
-
-    try {
-      await Promise.all([fetchFacilityConfig(), fetchFacilities()]);
-
-      // Facility name set with watcher
-      facilityDatasetId.value = settings.value.id;
-      facilityName.value = facility.value.name;
-      settingsCopy.value = { ...settings.value };
-      setLoading(false);
-    } catch (error) {
-      facilityName.value = '';
-      settingsCopy.value = {};
-      setLoading(false);
-      throw error;
-    }
   }
 
   function modifySetting(name, value) {
@@ -149,6 +125,12 @@ export default function useFacilityEditor(facilityId) {
     settings.value = Object.assign({}, settingsCopy.value);
   }
 
+  onBeforeMount(() => {
+    facilityDatasetId.value = settings.value.id;
+    facilityName.value = facility.value.name;
+    copySettings();
+  });
+
   function resetState() {
     facilityDatasetId.value = '';
     facilityName.value = '';
@@ -164,12 +146,12 @@ export default function useFacilityEditor(facilityId) {
    */
   async function saveFacilityName(name) {
     const facility = await FacilityResource.saveModel({
-      id: facilityId,
+      id: facilityId.value,
       data: { name },
     });
 
     // Update facilities list
-    await fetchFacilities();
+    await fetchFacility();
 
     facilityName.value = name;
     return facility;
@@ -190,6 +172,7 @@ export default function useFacilityEditor(facilityId) {
       id: facilityDatasetId.value,
       data,
     });
+    await fetchFacilityConfig();
     copySettings();
   }
 

--- a/kolibri/plugins/facility/frontend/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/frontend/modules/classAssignMembers/handlers.js
@@ -4,10 +4,12 @@ import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import { handleApiError } from 'kolibri/utils/appError';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import useFacility from 'kolibri-common/composables/useFacility';
 import { _userState } from '../mappers';
 
 export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
-  const { id, facility_id } = toRoute.params;
+  const { facilityId } = useFacility();
+  const { id } = toRoute.params;
   if (toRoute.name !== fromRoute.name) {
     store.dispatch('preparePage');
   }
@@ -15,7 +17,7 @@ export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
   // facility users that are not enrolled in this class
   const userPromise = FacilityUserResource.fetchCollection({
     getParams: pickBy({
-      member_of: facility_id || store.getters.activeFacilityId,
+      member_of: facilityId.value,
       page: toRoute.query.page || 1,
       page_size: toRoute.query.page_size || 30,
       search: toRoute.query.search && toRoute.query.search.trim(),
@@ -50,15 +52,15 @@ export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
 }
 
 export function showCoachClassAssignmentPage(store, toRoute, fromRoute) {
-  const { id, facility_id } = toRoute.params;
+  const { facilityId } = useFacility();
+  const { id } = toRoute.params;
   if (toRoute.name !== fromRoute.name) {
     pageLoading.value = true;
   }
-  const facilityId = facility_id || store.getters.activeFacilityId;
   // all users in facility eligible to be a coach that is not already a coach
   const userPromise = FacilityUserResource.fetchCollection({
     getParams: {
-      member_of: facilityId,
+      member_of: facilityId.value,
       exclude_member_of: id,
       exclude_user_type: 'learner',
       exclude_coach_for: id,

--- a/kolibri/plugins/facility/frontend/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/frontend/modules/classEditManagement/handlers.js
@@ -3,6 +3,7 @@ import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResour
 import { localeCompare } from 'kolibri/utils/i18n';
 import { handleApiError } from 'kolibri/utils/appError';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import useFacility from 'kolibri-common/composables/useFacility';
 import { _userState } from '../mappers';
 
 export function sortUsersByFullName(users) {
@@ -13,11 +14,12 @@ export function sortUsersByFullName(users) {
 
 export function showClassEditPage(store, classId) {
   store.dispatch('preparePage');
-  const facilityId = store.getters.activeFacilityId;
+  const { facilityId } = useFacility();
+
   const promises = [
     FacilityUserResource.fetchCollection({ getParams: { member_of: classId }, force: true }),
     ClassroomResource.fetchModel({ id: classId, force: true }),
-    ClassroomResource.fetchCollection({ getParams: { parent: facilityId }, force: true }),
+    ClassroomResource.fetchCollection({ getParams: { parent: facilityId.value }, force: true }),
   ];
   store.commit('classEditManagement/SET_DATA_LOADING', true);
   Promise.all(promises)

--- a/kolibri/plugins/facility/frontend/modules/classManagement/actions.js
+++ b/kolibri/plugins/facility/frontend/modules/classManagement/actions.js
@@ -1,5 +1,6 @@
 import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
 import { handleApiError } from 'kolibri/utils/appError';
+import { selectedFacilityId } from 'kolibri-common/composables/useFacility';
 
 /**
  * Do a POST to create new class
@@ -9,7 +10,7 @@ export function createClass(store, name) {
   return ClassroomResource.saveModel({
     data: {
       name,
-      parent: store.rootGetters.activeFacilityId,
+      parent: selectedFacilityId.value,
     },
   }).then(
     classroom => {

--- a/kolibri/plugins/facility/frontend/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/frontend/modules/classManagement/handlers.js
@@ -1,13 +1,15 @@
 import ClassroomResource from 'kolibri-common/apiResources/ClassroomResource';
 import { handleApiError } from 'kolibri/utils/appError';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import useFacility from 'kolibri-common/composables/useFacility';
 
-export function showClassesPage(store, toRoute) {
+export function showClassesPage(store) {
   store.dispatch('preparePage');
   store.commit('classManagement/SET_STATE', { dataLoading: true });
-  const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
+  const { facilityId } = useFacility();
+
   return ClassroomResource.fetchCollection({
-    getParams: { parent: facilityId },
+    getParams: { parent: facilityId.value },
     force: true,
   })
     .then(classrooms => {

--- a/kolibri/plugins/facility/frontend/modules/pluginModule.js
+++ b/kolibri/plugins/facility/frontend/modules/pluginModule.js
@@ -1,9 +1,8 @@
-import useUser from 'kolibri/composables/useUser';
 import { get } from '@vueuse/core';
 import useFacilities from 'kolibri-common/composables/useFacilities';
-import { getReactiveRoute } from 'kolibri/router';
 import { clearError } from 'kolibri/utils/appError';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import { selectedFacilityId } from 'kolibri-common/composables/useFacility';
 import { pageNameToModuleMap, PageNames } from '../constants';
 import classAssignMembers from './classAssignMembers';
 import classEditManagement from './classEditManagement';
@@ -39,18 +38,7 @@ export default {
   },
   getters: {
     activeFacilityId() {
-      // Return either the facility_id param in the route module,
-      // or the userFacilityId value from core.session
-
-      // For multi-facility case, only use facility_id if in route because userFacilityId
-      // fallback would always navigate to our default facility, not multi-facility landing page
-      const { userFacilityId } = useUser();
-      const { userIsMultiFacilityAdmin } = useFacilities();
-      const routeParams = getReactiveRoute().params || {};
-      if (userIsMultiFacilityAdmin.value) {
-        return routeParams.facility_id;
-      }
-      return routeParams.facility_id || get(userFacilityId);
+      return get(selectedFacilityId);
     },
     facilityPageLinks(state, getters) {
       // Use this getter to get Link objects that have the optional 'facility_id'

--- a/kolibri/plugins/facility/frontend/modules/userManagement/actions.js
+++ b/kolibri/plugins/facility/frontend/modules/userManagement/actions.js
@@ -1,6 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import { UserKinds } from 'kolibri/constants';
+import { selectedFacilityId } from 'kolibri-common/composables/useFacility';
 import { updateFacilityLevelRoles } from './utils';
 
 /**
@@ -26,7 +27,7 @@ function setUserRole(user, role) {
 export function createFacilityUser(store, payload) {
   return FacilityUserResource.saveModel({
     data: {
-      facility: store.rootGetters.activeFacilityId,
+      facility: selectedFacilityId.value,
       username: payload.username,
       full_name: payload.full_name,
       password: payload.password,

--- a/kolibri/plugins/facility/frontend/routes.js
+++ b/kolibri/plugins/facility/frontend/routes.js
@@ -2,10 +2,8 @@ import store from 'kolibri/store';
 import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyncSchedule';
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
 import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
-import useUser from 'kolibri/composables/useUser';
-import { get } from '@vueuse/core';
 import useFacilities from 'kolibri-common/composables/useFacilities';
-import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+import useFacility from 'kolibri-common/composables/useFacility';
 import FacilityAllPasswordsPage from './views/FacilityAllPasswordsPage';
 import ClassEditPage from './views/ClassEditPage';
 import CoachClassAssignmentPage from './views/CoachClassAssignmentPage';
@@ -36,9 +34,6 @@ export default [
     path: '/:subtopicName?/facilities',
     component: AllFacilitiesPage,
     props: true,
-    handler() {
-      store.dispatch('preparePage', { isAsync: false });
-    },
   },
   // In the multi-facility case, the optional facility_id needs to be provided.
   // If it's missing, then we are likely in single-facility situation and we use
@@ -47,18 +42,18 @@ export default [
     name: PageNames.CLASS_MGMT_PAGE,
     path: '/:facility_id?/classes',
     component: ManageClassPage,
-    handler: toRoute => {
+    async handler(toRoute) {
       if (facilityParamRequiredGuard(toRoute, ManageClassPage.name)) {
         return;
       }
-      showClassesPage(store, toRoute);
+      showClassesPage(store);
     },
   },
   {
     name: PageNames.CLASS_EDIT_MGMT_PAGE,
     path: '/:facility_id?/classes/:id',
     component: ClassEditPage,
-    handler: toRoute => {
+    async handler(toRoute) {
       showClassEditPage(store, toRoute.params.id);
     },
   },
@@ -91,9 +86,7 @@ export default [
     component: UsersRootPage,
     path: '/:facility_id?/users/',
     handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, UsersRootPage.name)) {
-        return;
-      }
+      facilityParamRequiredGuard(toRoute, UsersRootPage.name);
     },
     children: getSidePanelRoutes([
       PageNames.FILTER_USERS_SIDE_PANEL,
@@ -107,9 +100,7 @@ export default [
     component: NewUsersPage,
     path: '/:facility_id?/users/new-users',
     handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, NewUsersPage.name)) {
-        return;
-      }
+      facilityParamRequiredGuard(toRoute, NewUsersPage.name);
     },
     children: getSidePanelRoutes(
       [
@@ -127,9 +118,7 @@ export default [
     component: UsersTrashPage,
     path: '/:facility_id?/users/deleted',
     handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, UsersTrashPage.name)) {
-        return;
-      }
+      facilityParamRequiredGuard(toRoute, UsersTrashPage.name);
     },
     children: getSidePanelRoutes([PageNames.FILTER_USERS_SIDE_PANEL], 'TRASH'),
   },
@@ -165,10 +154,7 @@ export default [
     component: FacilityConfigPage,
     path: '/:facility_id?/settings',
     handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, FacilityConfigPage.name)) {
-        return;
-      }
-      pageLoading.value = false;
+      facilityParamRequiredGuard(toRoute, FacilityConfigPage.name);
     },
   },
   {
@@ -185,21 +171,20 @@ export default [
   },
   {
     path: '/:facility_id?/managesync',
-    props: route => {
-      const { userFacilityId } = useUser();
-      const facilityId = route.params.facility_id || get(userFacilityId);
+    props: () => {
+      const { facilityId } = useFacility();
       return {
-        facilityId,
+        facilityId: facilityId.value,
         goBackRoute: {
           name: PageNames.DATA_EXPORT_PAGE,
-          params: { facility_id: route.params.facility_id },
+          params: { facility_id: facilityId.value },
         },
         editSyncRoute: function (deviceId) {
           return {
             name: SyncPageNames.EDIT_SYNC_SCHEDULE,
             params: {
               deviceId,
-              facility_id: facilityId,
+              facility_id: facilityId.value,
             },
           };
         },
@@ -213,13 +198,13 @@ export default [
     component: EditDeviceSyncSchedule,
     name: SyncPageNames.EDIT_SYNC_SCHEDULE,
     props: route => {
-      const { userFacilityId } = useUser();
+      const { facilityId } = useFacility();
       return {
-        facilityId: route.params.facility_id || get(userFacilityId),
+        facilityId: facilityId.value,
         deviceId: route.params.deviceId,
         goBackRoute: {
           name: SyncPageNames.MANAGE_SYNC_SCHEDULE,
-          params: { facility_id: route.params.facility_id },
+          params: { facility_id: facilityId.value },
         },
       };
     },

--- a/kolibri/plugins/facility/frontend/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/frontend/views/DataPage/ImportInterface/index.vue
@@ -55,6 +55,7 @@
 
   import urls from 'kolibri/urls';
   import { mapState, mapActions, mapGetters } from 'vuex';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import { UsersExportStatuses } from '../../../constants';
   import DataPageTaskProgress from '../DataPageTaskProgress';
   import CsvInfoModal from '../../CsvInfoModal';
@@ -64,6 +65,10 @@
     components: {
       DataPageTaskProgress,
       CsvInfoModal,
+    },
+    setup() {
+      const { facilityId } = useFacility();
+      return { facilityId };
     },
     data() {
       return {
@@ -84,10 +89,7 @@
       },
       downloadCsv() {
         window.open(
-          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
-            'user',
-            this.$store.getters.activeFacilityId,
-          ),
+          urls['kolibri:kolibri.plugins.facility:download_csv_file']('user', this.facilityId),
           '_blank',
         );
       },

--- a/kolibri/plugins/facility/frontend/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/frontend/views/DataPage/SyncInterface/index.vue
@@ -16,10 +16,10 @@
       </template>
       <template #tbody>
         <tbody>
-          <tr v-if="facility">
+          <tr v-if="selectedFacility">
             <td>
               <FacilityNameAndSyncStatus
-                :facility="facility"
+                :facility="selectedFacility"
                 :isSyncing="isSyncing"
                 :syncHasFailed="syncHasFailed"
                 :goToRoute="manageSyncRoute"
@@ -88,7 +88,7 @@
     />
     <ConfirmationRegisterModal
       v-if="modalShown === Modals.CONFIRMATION_REGISTER"
-      :targetFacility="facility"
+      :targetFacility="selectedFacility"
       :projectName="kdpProject.name"
       :token="kdpProject.token"
       @success="handleConfirmationSuccess"
@@ -97,7 +97,7 @@
 
     <SyncFacilityModalGroup
       v-if="modalShown === Modals.SYNC_FACILITY"
-      :facilityForSync="facility"
+      :facilityForSync="selectedFacility"
       @close="closeModal"
       @syncKDP="handleKDPSync"
       @syncPeer="handlePeerSync"
@@ -117,12 +117,12 @@
   import SyncFacilityModalGroup from 'kolibri-common/components/syncComponentSet/SyncFacilityModalGroup';
   import commonSyncElements from 'kolibri-common/mixins/commonSyncElements';
   import TaskResource from 'kolibri/apiResources/TaskResource';
-  import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import CoreMenu from 'kolibri/components/CoreMenu';
   import CoreMenuOption from 'kolibri/components/CoreMenu/CoreMenuOption';
   import { TaskStatuses } from 'kolibri-common/utils/syncTaskUtils';
   import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import PrivacyModal from './PrivacyModal';
 
   const Modals = Object.freeze({
@@ -147,15 +147,19 @@
     mixins: [commonSyncElements, commonCoreStrings],
     setup() {
       const { windowIsLarge, windowIsMedium, windowIsSmall } = useKResponsiveWindow();
+      const { facilityId, fetchFacilityConfig, fetchFacility, selectedFacility } = useFacility();
       return {
+        facilityId,
+        selectedFacility,
         windowIsLarge,
         windowIsMedium,
         windowIsSmall,
+        fetchFacility,
+        fetchFacilityConfig,
       };
     },
     data() {
       return {
-        facility: null,
         kdpProject: null, // { name, token }
         modalShown: null,
         syncTaskId: '',
@@ -170,7 +174,7 @@
         return {
           name: SyncPageNames.MANAGE_SYNC_SCHEDULE,
           params: {
-            facility_id: this.facility.id,
+            facility_id: this.facilityId,
           },
         };
       },
@@ -199,22 +203,12 @@
         }
       },
     },
-    beforeMount() {
-      this.fetchFacility();
-    },
     beforeDestroy() {
       this.syncTaskId = '';
     },
     methods: {
       manageSyncAction() {
         this.$router.push(this.manageSyncRoute);
-      },
-      fetchFacility() {
-        FacilityResource.fetchModel({ id: this.$store.getters.activeFacilityId, force: true }).then(
-          facility => {
-            this.facility = { ...facility };
-          },
-        );
       },
       closeModal() {
         this.modalShown = null;
@@ -247,7 +241,7 @@
       },
       handleConfirmationSuccess(payload) {
         this.$store.commit('manageCSV/SET_REGISTERED', payload);
-        this.facility.dataset.registered = true;
+        this.fetchFacilityConfig();
         this.closeModal();
       },
       handleSyncFacilitySuccess(taskId) {
@@ -264,7 +258,7 @@
       },
       handleKDPSync() {
         this.closeModal();
-        this.startKdpSyncTask(this.facility.id)
+        this.startKdpSyncTask(this.facilityId)
           .then(task => {
             this.handleSyncFacilitySuccess(task.id);
           })
@@ -275,7 +269,7 @@
       handlePeerSync(peerData) {
         this.closeModal();
         this.startPeerSyncTask({
-          facility: this.facility.id,
+          facility: this.facilityId,
           device_id: peerData.id,
         })
           .then(task => {

--- a/kolibri/plugins/facility/frontend/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/DataPage/index.vue
@@ -204,6 +204,7 @@
   import format from 'date-fns/format';
   import KDateRange from 'kolibri-design-system/lib/KDateRange';
   import useFacilities from 'kolibri-common/composables/useFacilities';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
   import { PageNames } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
@@ -234,7 +235,15 @@
       const { windowIsMedium, windowIsSmall } = useKResponsiveWindow();
       const { isAppContext } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
-      return { pageLoading, windowIsMedium, windowIsSmall, isAppContext, userIsMultiFacilityAdmin };
+      const { facilityId } = useFacility();
+      return {
+        pageLoading,
+        windowIsMedium,
+        windowIsSmall,
+        isAppContext,
+        userIsMultiFacilityAdmin,
+        facilityId,
+      };
     },
     data() {
       return {
@@ -255,7 +264,7 @@
         'inSummaryCSVCreation',
         'firstLogDate',
       ]),
-      ...mapGetters(['activeFacilityId', 'facilityPageLinks']),
+      ...mapGetters(['facilityPageLinks']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       // NOTE: We disable CSV file upload/download on embedded web views like the Mac
       // and Android apps
@@ -350,19 +359,13 @@
       },
       downloadSessionLog() {
         window.open(
-          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
-            'session',
-            this.activeFacilityId,
-          ),
+          urls['kolibri:kolibri.plugins.facility:download_csv_file']('session', this.facilityId),
           '_blank',
         );
       },
       downloadSummaryLog() {
         window.open(
-          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
-            'summary',
-            this.activeFacilityId,
-          ),
+          urls['kolibri:kolibri.plugins.facility:download_csv_file']('summary', this.facilityId),
           '_blank',
         );
       },

--- a/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityAllPasswordsPage.vue
@@ -22,7 +22,7 @@
     name: 'FacilityAllPasswordsPage',
     components: { AllPasswordsPage },
     setup() {
-      const { currentFacilityName } = useFacility();
+      const { facilityId, currentFacilityName } = useFacility();
 
       const learners = computed(() => store.state.classEditManagement.classLearners);
       const className = computed(() => store.state.classEditManagement.currentClass?.name || '');
@@ -31,7 +31,7 @@
         name: PageNames.CLASS_EDIT_MGMT_PAGE,
         params: {
           id: store.state.classEditManagement.currentClass?.id,
-          facility_id: store.getters.activeFacilityId,
+          facility_id: facilityId.value,
         },
       }));
 

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -28,11 +28,7 @@
         </p>
       </div>
 
-      <KCircularLoader
-        v-if="facilityDataLoading"
-        class="facility-loader"
-      />
-      <template v-else-if="settings !== null">
+      <template v-if="settings !== null">
         <section class="facility-name facility-settings">
           <h2>{{ coreString('facilityLabel') }}</h2>
           <p class="current-facility-name">
@@ -337,8 +333,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { useRoute } from 'vue-router/composables';
-  import { ref, onMounted, computed, watch } from 'vue';
+  import { ref, computed, watch } from 'vue';
   import commonCoreStrings, { coreString } from 'kolibri/uiText/commonCoreStrings';
   import urls from 'kolibri/urls';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
@@ -347,7 +342,6 @@
   import useFacilities from 'kolibri-common/composables/useFacilities';
   import useTaskPolling from 'kolibri-common/composables/useTaskPolling';
   import { TaskStatuses } from 'kolibri-common/utils/syncTaskUtils';
-  import { handleApiError } from 'kolibri/utils/appError';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
   import { createTranslator } from 'kolibri/utils/i18n';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
@@ -466,12 +460,11 @@
     mixins: [commonCoreStrings],
     setup() {
       const { showSnackbarNotification } = commonCoreStrings.methods;
-      const route = useRoute();
       const { createSnackbar } = useSnackbar();
-      const { isAppContext, isSuperuser, userFacilityId } = useUser();
+      const { isAppContext, isSuperuser } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
-      const facilityId = route.params.facility_id || userFacilityId.value;
       const {
+        facilityId,
         facility,
         facilityName,
         settings,
@@ -484,14 +477,13 @@
         picturePasswordStyle,
         picturePasswordShowIconText,
         pictureLoginTaskId,
-        fetchFacility,
         undoSettingsChange,
         saveFacilityName,
         saveFacilityConfig,
         saveFacilityLoginSettings,
         setPin,
         unsetPin,
-      } = useFacilityEditor(facilityId);
+      } = useFacilityEditor();
 
       const {
         pageHeader$,
@@ -548,7 +540,7 @@
         return null;
       });
       const lastPartId = computed(() => {
-        return facilityId ? facilityId.slice(0, 4) : '';
+        return facilityId.value ? facilityId.value.slice(0, 4) : '';
       });
       const changePINLabel = computed(() => {
         return `${changeLocation$()} ${pinPlaceholder$()}`;
@@ -580,8 +572,9 @@
       async function saveConfig() {
         try {
           pictureLoginTaskLoading.value = true;
-          await saveFacilityConfig();
+          // save login settings first, since config will reset the settings state
           await saveFacilityLoginSettings();
+          await saveFacilityConfig();
           if (!pictureLoginTaskId.value) {
             createSnackbar(saveSuccess$());
           }
@@ -638,14 +631,6 @@
           handleRemovePinModal.value = true;
         }
       }
-
-      onMounted(async () => {
-        try {
-          await fetchFacility();
-        } catch (error) {
-          handleApiError({ error, reloadOnReconnect: true, shouldThrow: false });
-        }
-      });
 
       const { tasks: facilityTasks } = useTaskPolling('facility_task');
       const pictureLoginTaskLoading = ref(false);

--- a/kolibri/plugins/facility/frontend/views/FacilityIndex.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityIndex.vue
@@ -12,10 +12,10 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
   import NotificationsRoot from 'kolibri/components/pages/NotificationsRoot';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useUser from 'kolibri/composables/useUser';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import { PageNames } from '../constants';
 
   export default {
@@ -26,15 +26,16 @@
     mixins: [commonCoreStrings],
     setup() {
       const { isAdmin, isSuperuser, session } = useUser();
+      const { facilityId } = useFacility();
 
       return {
+        facilityId,
         isAdmin,
         isSuperuser,
         session,
       };
     },
     computed: {
-      ...mapGetters(['activeFacilityId']),
       pageName() {
         return this.$route.name;
       },
@@ -50,7 +51,7 @@
             return false;
           }
           // Admins can only see the facility they belong to
-          return this.session.facility_id === this.activeFacilityId;
+          return this.session.facility_id === this.facilityId;
         }
         return false;
       },

--- a/kolibri/plugins/facility/frontend/views/users/NewUsersPage.vue
+++ b/kolibri/plugins/facility/frontend/views/users/NewUsersPage.vue
@@ -210,7 +210,6 @@
 
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import PaginationActions from 'kolibri-common/components/PaginationActions';
-  import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
@@ -253,10 +252,8 @@
       const route = useRoute();
       const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin } = useUser();
-      const { setFacilityId, facilityConfig } = useFacility();
+      const { facilityId, facilityConfig } = useFacility();
       const isMoveToTrashModalOpen = ref(false);
-
-      const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
 
       const newUsersCreationTreshold = new Date();
       newUsersCreationTreshold.setDate(newUsersCreationTreshold.getDate() - MAX_NEW_USER_DAYS);
@@ -275,7 +272,7 @@
         resetFilters,
         clearSelectedUsers,
       } = useUserManagement({
-        activeFacilityId,
+        activeFacilityId: facilityId.value,
         dateJoinedGt: newUsersCreationTreshold,
       });
 
@@ -360,7 +357,6 @@
       }
 
       onMounted(() => {
-        setFacilityId(activeFacilityId);
         fetchClasses();
       });
 

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/__tests__/UsersRootPage.spec.js
@@ -5,6 +5,8 @@ import VueRouter from 'vue-router';
 import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { bulkUserManagementStrings } from 'kolibri-common/strings/bulkUserManagementStrings';
+// eslint-disable-next-line import-x/named
+import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility';
 import useUserManagement from '../../../../composables/useUserManagement';
 import { useUserManagementMock } from '../../../../composables/__mocks__/useUserManagement';
 import makeStore from '../../../../__tests__/utils/makeStore';
@@ -17,6 +19,7 @@ const { noUsersMatchSearch$, noUsersMatchFilter$, noUsersMatchFiltersAndSearch$ 
 jest.mock('kolibri/urls');
 jest.mock('lockr');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow');
+jest.mock('kolibri-common/composables/useFacility');
 jest.mock('../../../../composables/useUserManagement');
 
 const router = new VueRouter({
@@ -65,6 +68,7 @@ describe('UserPage component', () => {
       windowIsSmall: false,
       windowBreakpoint: 4,
     }));
+    useFacility.mockImplementation(() => useFacilityMock());
     useUserManagement.mockImplementation(() => useUserManagementMock());
   });
 

--- a/kolibri/plugins/facility/frontend/views/users/UsersRootPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/UsersRootPage/index.vue
@@ -198,7 +198,7 @@
 
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import PaginationActions from 'kolibri-common/components/PaginationActions';
-  import { ref, computed, getCurrentInstance, onMounted } from 'vue';
+  import { ref, computed, onMounted } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
@@ -241,7 +241,7 @@
       const router = useRouter();
       const { currentUserId, isSuperuser, isAdmin, isAppContext } = useUser();
       const { userIsMultiFacilityAdmin } = useFacilities();
-      const { setFacilityId, facilityConfig } = useFacility();
+      const { facilityId, facilityConfig } = useFacility();
       const isMoveToTrashModalOpen = ref(false);
 
       const {
@@ -257,9 +257,6 @@
         clearFiltersLabel$,
       } = bulkUserManagementStrings;
 
-      const { $store, $router } = getCurrentInstance().proxy;
-      const activeFacilityId =
-        $router.currentRoute.params.facility_id || $store.getters.activeFacilityId;
       const {
         selectedUsers,
         facilityUsers,
@@ -272,7 +269,7 @@
         fetchClasses,
         resetFilters,
         clearSelectedUsers,
-      } = useUserManagement({ activeFacilityId });
+      } = useUserManagement({ activeFacilityId: facilityId.value });
 
       // Use our new composables
       const { searchTerm, filterTextboxRef } = useUsersTableSearch();
@@ -282,7 +279,6 @@
         Boolean(facilityConfig.value.picture_password_settings),
       );
       onMounted(() => {
-        setFacilityId(activeFacilityId);
         fetchClasses();
       });
 
@@ -359,6 +355,7 @@
         // User and facility info
         userIsMultiFacilityAdmin,
         currentUserId,
+        facilityId,
         isSuperuser,
         isAdmin,
 
@@ -479,7 +476,7 @@
         if (option.value) {
           this.$router.push({
             name: option.value,
-            params: { facility_id: this.$store.getters.activeFacilityId },
+            params: { facility_id: this.facilityId },
           });
         }
       },

--- a/kolibri/plugins/facility/frontend/views/users/UsersTrashPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/UsersTrashPage/index.vue
@@ -174,9 +174,7 @@
 
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import PaginationActions from 'kolibri-common/components/PaginationActions';
-  import store from 'kolibri/store';
   import { computed, onMounted, ref } from 'vue';
-  import { useRoute } from 'vue-router/composables';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
 
   import useSnackbar from 'kolibri/composables/useSnackbar';
@@ -187,6 +185,7 @@
 
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
+  import useFacility from 'kolibri-common/composables/useFacility';
   import useUserManagement from '../../../composables/useUserManagement';
   import { PageNames } from '../../../constants';
   import { overrideRoute } from '../../../utils';
@@ -210,12 +209,10 @@
     mixins: [commonCoreStrings],
     setup() {
       const { createSnackbar } = useSnackbar();
+      const { facilityId } = useFacility();
       usePreviousRoute();
-      const route = useRoute();
       const usersToDelete = ref(null);
       const loading = ref(false);
-
-      const activeFacilityId = route.params.facility_id || store.getters.activeFacilityId;
 
       const {
         selectedUsers,
@@ -231,7 +228,7 @@
         resetFilters,
         clearSelectedUsers,
       } = useUserManagement({
-        activeFacilityId,
+        activeFacilityId: facilityId.value,
         softDeletedUsers: true,
       });
 

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
@@ -189,7 +189,7 @@
 
   import store from 'kolibri/store';
   import { ref, computed, nextTick, onBeforeMount, getCurrentInstance } from 'vue';
-  import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router/composables';
+  import { useRouter, onBeforeRouteLeave } from 'vue-router/composables';
   import CatchErrors from 'kolibri/utils/CatchErrors';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import notificationStrings from 'kolibri/uiText/notificationStrings';
@@ -239,11 +239,10 @@
     },
     setup(props) {
       const formId = 'create-user-form';
-      const route = useRoute();
       const router = useRouter();
       const instance = getCurrentInstance();
       const $refs = instance.proxy.$refs;
-      const { setFacilityId, facilityConfig, selectedFacility, fetchFacilities } = useFacility();
+      const { facilityConfig, selectedFacility, facilityId, fetchFacilities } = useFacility();
       const picturePasswordSettings = computed(
         () => facilityConfig.value?.picture_password_settings || null,
       );
@@ -331,7 +330,6 @@
         $refs.passwordTextbox?.reset();
       };
 
-      const activeFacilityId = computed(() => route.params.facility_id);
       const facilityUsers = computed(() => store.state.userManagement.facilityUsers);
 
       const showPasswordInput = computed(() => {
@@ -441,7 +439,7 @@
         }
         const facilityUser = await FacilityUserResource.saveModel({
           data: {
-            facility: activeFacilityId.value,
+            facility: facilityId.value,
             username: username.value,
             full_name: fullName.value,
             password: passwordValue,
@@ -516,7 +514,6 @@
       };
 
       onBeforeMount(async () => {
-        await setFacilityId(activeFacilityId.value);
         // facilityConfig is now loaded; reset form so kind reflects picture_passwords_exhausted.
         resetForm();
         loading.value = false;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { ref } from 'vue';
-import useUser from 'kolibri/composables/useUser';
+import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import { LoginErrors } from 'kolibri/constants';
 import { OptionsForSignIn } from 'kolibri-common/constants/Auth';
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
@@ -46,10 +46,15 @@ function renderComponent() {
   useRouter.mockReturnValue({
     push: mockRouterPush,
   });
-  useUser.mockReturnValue({
-    login: mockLogin,
-    isAppContext: ref(true),
-  });
+  useUser.mockReturnValue(
+    useUserMock({
+      login: mockLogin,
+      isAppContext: true,
+      isUserLoggedIn: false,
+      userFacilityId: null,
+      isSuperuser: false,
+    }),
+  );
   useAuthFlow.mockReturnValue({
     hasMultipleFacilities: ref(false),
     facilityId: ref('facility_1'),

--- a/packages/kolibri-common/composables/__mocks__/useFacilities.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacilities.js
@@ -5,6 +5,7 @@ const MOCK_DEFAULTS = {
   hasMultipleFacilities: computed(() => false),
   userIsMultiFacilityAdmin: computed(() => false),
   fetchFacilities: jest.fn(),
+  fetchFacility: jest.fn(),
   getFacility: jest.fn(),
 };
 

--- a/packages/kolibri-common/composables/__mocks__/useFacility.js
+++ b/packages/kolibri-common/composables/__mocks__/useFacility.js
@@ -1,19 +1,28 @@
 import { ref, computed } from 'vue';
 import { OptionsForSignIn } from '../../constants/Auth';
 
+export const selectedFacilityId = ref(null);
+export const setSelectedFacilityId = jest.fn();
+
 const MOCK_DEFAULTS = {
   selectedFacility: ref({}),
   facilityId: ref(null),
   facilityConfig: ref({}),
   currentFacilityName: ref(''),
+  isAttendanceFeatureEnabled: computed(() => true),
+  isPictureLoginFeatureEnabled: computed(() => true),
+  signInOptions: computed(() => [OptionsForSignIn.USERNAME_PASSWORD]),
+  picturePasswordSettings: computed(() => null),
   fetchFacilities: jest.fn(),
+  fetchFacility: jest.fn(),
+  fetchFacilityConfig: jest.fn(),
   updateFacilityConfig: jest.fn(),
   setFacilityId: jest.fn(),
 };
 
 const MOCK_DEFAULTS_SELECT = {
-  selectedFacilityId: ref(null),
-  setSelectedFacilityId: jest.fn(),
+  selectedFacilityId,
+  setSelectedFacilityId,
 };
 
 const MOCK_DEFAULTS_CONFIG = {

--- a/packages/kolibri-common/composables/__tests__/useFacilities.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useFacilities.spec.js
@@ -1,7 +1,6 @@
 import { ref } from 'vue';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import useUser from 'kolibri/composables/useUser';
-import useFacilities from '../useFacilities';
 
 jest.mock('kolibri-common/apiResources/FacilityResource');
 jest.mock('kolibri/composables/useUser');
@@ -11,6 +10,14 @@ describe('useFacilities', () => {
     { id: 'facility-1', name: 'Facility 1', dataset: 'dataset-1' },
     { id: 'facility-2', name: 'Facility 2', dataset: 'dataset-2' },
   ];
+
+  function createUseFacilities() {
+    let useFacilities;
+    jest.isolateModules(() => {
+      useFacilities = require('../useFacilities').default;
+    });
+    return useFacilities();
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -24,17 +31,17 @@ describe('useFacilities', () => {
 
   describe('initial state', () => {
     it('returns empty facilities list initially', () => {
-      const { facilities } = useFacilities();
+      const { facilities } = createUseFacilities();
       expect(facilities.value).toEqual([]);
     });
 
     it('returns false for hasMultipleFacilities initially', () => {
-      const { hasMultipleFacilities } = useFacilities();
+      const { hasMultipleFacilities } = createUseFacilities();
       expect(hasMultipleFacilities.value).toBe(false);
     });
 
     it('returns false for userIsMultiFacilityAdmin initially', () => {
-      const { userIsMultiFacilityAdmin } = useFacilities();
+      const { userIsMultiFacilityAdmin } = createUseFacilities();
       expect(userIsMultiFacilityAdmin.value).toBe(false);
     });
   });
@@ -43,7 +50,7 @@ describe('useFacilities', () => {
     it('fetches facilities from FacilityResource', async () => {
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, facilities } = useFacilities();
+      const { fetchFacilities, facilities } = createUseFacilities();
       await fetchFacilities();
 
       expect(FacilityResource.fetchCollection).toHaveBeenCalledWith({ force: true });
@@ -53,7 +60,7 @@ describe('useFacilities', () => {
     it('updates hasMultipleFacilities when multiple facilities are fetched', async () => {
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, hasMultipleFacilities } = useFacilities();
+      const { fetchFacilities, hasMultipleFacilities } = createUseFacilities();
       await fetchFacilities();
 
       expect(hasMultipleFacilities.value).toBe(true);
@@ -62,9 +69,56 @@ describe('useFacilities', () => {
     it('handles fetch error gracefully', async () => {
       FacilityResource.fetchCollection.mockRejectedValue(new Error('Fetch failed'));
 
-      const { fetchFacilities } = useFacilities();
+      const { fetchFacilities } = createUseFacilities();
 
       await expect(fetchFacilities()).rejects.toThrow('Fetch failed');
+    });
+  });
+
+  describe('fetchFacility', () => {
+    it('fetches a single facility and adds it to the cache', async () => {
+      const singleFacility = { id: 'facility-3', name: 'Facility 3', dataset: 'dataset-3' };
+      FacilityResource.fetchModel.mockResolvedValue(singleFacility);
+
+      const { fetchFacility, facilities } = createUseFacilities();
+      await fetchFacility('facility-3');
+
+      expect(FacilityResource.fetchModel).toHaveBeenCalledWith({ id: 'facility-3', force: true });
+      expect(facilities.value).toEqual([singleFacility]);
+    });
+
+    it('updates existing facility if it already exists in cache', async () => {
+      const updatedFacility = {
+        id: 'facility-1',
+        name: 'Updated Facility 1',
+        dataset: 'updated-dataset-1',
+      };
+
+      // First, add a facility to the cache
+      FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
+      let useFacilitiesModule;
+      jest.isolateModules(() => {
+        useFacilitiesModule = require('../useFacilities');
+      });
+      const { fetchFacilities, fetchFacility, facilities } = useFacilitiesModule.default();
+
+      await fetchFacilities();
+      FacilityResource.fetchModel.mockResolvedValue(updatedFacility);
+      await fetchFacility('facility-1');
+
+      expect(facilities.value[0].name).toBe('Updated Facility 1');
+      expect(facilities.value[0].dataset).toBe('updated-dataset-1');
+    });
+
+    it('supports Ref as facilityId parameter', async () => {
+      const singleFacility = { id: 'facility-4', name: 'Facility 4', dataset: 'dataset-4' };
+      FacilityResource.fetchModel.mockResolvedValue(singleFacility);
+
+      const { fetchFacility } = createUseFacilities();
+      const facilityRef = ref('facility-4');
+      await fetchFacility(facilityRef);
+
+      expect(FacilityResource.fetchModel).toHaveBeenCalledWith({ id: 'facility-4', force: true });
     });
   });
 
@@ -72,7 +126,7 @@ describe('useFacilities', () => {
     it('returns facility matching the given facilityId', async () => {
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, getFacility } = useFacilities();
+      const { fetchFacilities, getFacility } = createUseFacilities();
       await fetchFacilities();
 
       expect(getFacility('facility-2')).toEqual(mockFacilities[1]);
@@ -81,10 +135,20 @@ describe('useFacilities', () => {
     it('returns undefined when facilityId is not found', async () => {
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, getFacility } = useFacilities();
+      const { fetchFacilities, getFacility } = createUseFacilities();
       await fetchFacilities();
 
       expect(getFacility('non-existent-id')).toBeUndefined();
+    });
+
+    it('supports Ref as facilityId parameter', async () => {
+      FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
+
+      const { fetchFacilities, getFacility } = createUseFacilities();
+      await fetchFacilities();
+
+      const facilityRef = ref('facility-1');
+      expect(getFacility(facilityRef)).toEqual(mockFacilities[0]);
     });
   });
 
@@ -97,7 +161,7 @@ describe('useFacilities', () => {
 
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, userIsMultiFacilityAdmin } = useFacilities();
+      const { fetchFacilities, userIsMultiFacilityAdmin } = createUseFacilities();
       await fetchFacilities();
 
       expect(userIsMultiFacilityAdmin.value).toBe(true);
@@ -111,7 +175,7 @@ describe('useFacilities', () => {
 
       FacilityResource.fetchCollection.mockResolvedValue(mockFacilities);
 
-      const { fetchFacilities, userIsMultiFacilityAdmin } = useFacilities();
+      const { fetchFacilities, userIsMultiFacilityAdmin } = createUseFacilities();
       await fetchFacilities();
 
       expect(userIsMultiFacilityAdmin.value).toBe(false);
@@ -125,7 +189,7 @@ describe('useFacilities', () => {
 
       FacilityResource.fetchCollection.mockResolvedValue([mockFacilities[0]]);
 
-      const { fetchFacilities, userIsMultiFacilityAdmin } = useFacilities();
+      const { fetchFacilities, userIsMultiFacilityAdmin } = createUseFacilities();
       await fetchFacilities();
 
       expect(userIsMultiFacilityAdmin.value).toBe(false);

--- a/packages/kolibri-common/composables/__tests__/useFacility.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useFacility.spec.js
@@ -1,7 +1,9 @@
-import { ref } from 'vue';
+import { ref, nextTick } from 'vue';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
-import useUser from 'kolibri/composables/useUser';
-import useFacilities from '../useFacilities';
+// eslint-disable-next-line import-x/named
+import useUser, { useUserMock } from 'kolibri/composables/useUser';
+// eslint-disable-next-line import-x/named
+import useFacilities, { useFacilitiesMock } from '../useFacilities';
 import useFacility, { useFacilitySelect, useFacilityConfig } from '../useFacility';
 import { OptionsForSignIn } from '../../constants/Auth';
 
@@ -13,11 +15,68 @@ jest.mock('kolibri/utils/i18n', () => ({
 }));
 
 describe('useFacilitySelect', () => {
-  it('should provide facility selection', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.clearAllMocks();
+    useUser.mockImplementation(() =>
+      useUserMock({
+        isUserLoggedIn: false,
+        userFacilityId: null,
+      }),
+    );
+    useFacilities.mockImplementation(() => useFacilitiesMock());
+  });
+
+  it('persists selected facility for signed out users', () => {
     const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
     expect(selectedFacilityId.value).toBeNull();
     setSelectedFacilityId('facility-1');
     expect(selectedFacilityId.value).toBe('facility-1');
+  });
+
+  it('uses user facility for logged-in users who are not multi-facility admins', () => {
+    window.localStorage.setItem('facilityId', 'facility-2');
+    useUser.mockImplementation(() =>
+      useUserMock({
+        isUserLoggedIn: true,
+        userFacilityId: 'facility-1',
+      }),
+    );
+    useFacilities.mockImplementation(() =>
+      useFacilitiesMock({
+        userIsMultiFacilityAdmin: ref(false),
+      }),
+    );
+
+    const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
+    expect(selectedFacilityId.value).toBe('facility-1');
+
+    setSelectedFacilityId('facility-3');
+    expect(window.localStorage.getItem('facilityId')).toBe('facility-2');
+    expect(selectedFacilityId.value).toBe('facility-1');
+  });
+
+  it('allows multi-facility admins to select and persist facility while logged in', async () => {
+    window.localStorage.setItem('facilityId', 'facility-2');
+    useUser.mockImplementation(() =>
+      useUserMock({
+        isUserLoggedIn: true,
+        userFacilityId: 'facility-1',
+      }),
+    );
+    useFacilities.mockImplementation(() =>
+      useFacilitiesMock({
+        userIsMultiFacilityAdmin: ref(true),
+      }),
+    );
+
+    const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
+    expect(selectedFacilityId.value).toBe('facility-2');
+
+    setSelectedFacilityId('facility-3');
+    await nextTick();
+    expect(window.localStorage.getItem('facilityId')).toBe('facility-3');
+    expect(selectedFacilityId.value).toBe('facility-3');
   });
 });
 
@@ -34,6 +93,7 @@ describe('useFacility', () => {
   };
 
   beforeEach(() => {
+    window.localStorage.clear();
     jest.clearAllMocks();
 
     // Mock useUser - return null to start with no facility selected

--- a/packages/kolibri-common/composables/__tests__/useFacility.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useFacility.spec.js
@@ -4,7 +4,6 @@ import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDataset
 import useUser, { useUserMock } from 'kolibri/composables/useUser';
 // eslint-disable-next-line import-x/named
 import useFacilities, { useFacilitiesMock } from '../useFacilities';
-import useFacility, { useFacilitySelect, useFacilityConfig } from '../useFacility';
 import { OptionsForSignIn } from '../../constants/Auth';
 
 jest.mock('kolibri-common/apiResources/FacilityDatasetResource');
@@ -13,6 +12,15 @@ jest.mock('../useFacilities');
 jest.mock('kolibri/utils/i18n', () => ({
   currentLanguage: 'en',
 }));
+
+function loadUseFacilityModule() {
+  let module;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line global-require
+    module = require('../useFacility');
+  });
+  return module;
+}
 
 describe('useFacilitySelect', () => {
   beforeEach(() => {
@@ -28,6 +36,7 @@ describe('useFacilitySelect', () => {
   });
 
   it('persists selected facility for signed out users', () => {
+    const { useFacilitySelect } = loadUseFacilityModule();
     const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
     expect(selectedFacilityId.value).toBeNull();
     setSelectedFacilityId('facility-1');
@@ -48,6 +57,7 @@ describe('useFacilitySelect', () => {
       }),
     );
 
+    const { useFacilitySelect } = loadUseFacilityModule();
     const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
     expect(selectedFacilityId.value).toBe('facility-1');
 
@@ -70,6 +80,7 @@ describe('useFacilitySelect', () => {
       }),
     );
 
+    const { useFacilitySelect } = loadUseFacilityModule();
     const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
     expect(selectedFacilityId.value).toBe('facility-2');
 
@@ -86,100 +97,85 @@ describe('useFacility', () => {
     { id: 'facility-2', name: 'Facility 2', dataset: { id: 'dataset-2' } },
   ];
 
-  const mockFacilityConfig = {
-    id: 'dataset-1',
-    learner_can_edit_username: true,
-    learner_can_edit_password: false,
-  };
-
   beforeEach(() => {
     window.localStorage.clear();
     jest.clearAllMocks();
+    FacilityDatasetResource.fetchCollection.mockResolvedValue([]);
 
-    // Mock useUser - return null to start with no facility selected
-    useUser.mockReturnValue({
-      userFacilityId: ref(null),
-    });
-
-    // Mock useFacilities - return null for getFacility initially
-    useFacilities.mockReturnValue({
-      fetchFacilities: jest.fn(),
-      getFacility: jest.fn().mockReturnValue(null),
-    });
+    useUser.mockImplementation(() =>
+      useUserMock({
+        isUserLoggedIn: false,
+        userFacilityId: null,
+      }),
+    );
+    useFacilities.mockImplementation(() =>
+      useFacilitiesMock({
+        fetchFacility: jest.fn(),
+        getFacility: jest.fn().mockReturnValue(null),
+      }),
+    );
   });
 
   describe('initial state', () => {
     it('returns empty object for selectedFacility initially', () => {
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(null),
-      });
-
+      const { default: useFacility } = loadUseFacilityModule();
       const { selectedFacility } = useFacility();
       expect(selectedFacility.value).toEqual({});
     });
 
     it('returns undefined for currentFacilityName initially', () => {
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(null),
-      });
-
+      const { default: useFacility } = loadUseFacilityModule();
       const { currentFacilityName } = useFacility();
       expect(currentFacilityName.value).toBeUndefined();
     });
 
-    it('returns undefined for facilityId initially', () => {
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(null),
-      });
-
+    it('returns null for facilityId initially', () => {
+      const { default: useFacility } = loadUseFacilityModule();
       const { facilityId } = useFacility();
-      expect(facilityId.value).toBeUndefined();
+      expect(facilityId.value).toBeNull();
     });
   });
 
   describe('selectedFacility', () => {
     it('returns facility matching userFacilityId', () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
-      });
-
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: true,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          userIsMultiFacilityAdmin: ref(false),
+          getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { selectedFacility } = useFacility();
       expect(selectedFacility.value).toEqual(mockFacilities[0]);
     });
 
-    it('uses userFacilityId when no Lockr facility is saved', () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
-      });
-
+    it('uses persisted selected facility when user is signed out', () => {
+      window.localStorage.setItem('facilityId', 'facility-2');
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: false,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { selectedFacility, facilityId } = useFacility();
-      expect(facilityId.value).toBe('facility-1');
-      expect(selectedFacility.value).toEqual(mockFacilities[0]);
+      expect(facilityId.value).toBe('facility-2');
+      expect(selectedFacility.value).toEqual(mockFacilities[1]);
     });
 
     it('returns empty object when facility is not found', () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref(null),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(null),
-      });
-
+      const { default: useFacility } = loadUseFacilityModule();
       const { selectedFacility } = useFacility();
       expect(selectedFacility.value).toEqual({});
     });
@@ -187,15 +183,19 @@ describe('useFacility', () => {
 
   describe('facilityId', () => {
     it('returns id of selected facility', () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
-      });
-
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: true,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          userIsMultiFacilityAdmin: ref(false),
+          getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { facilityId } = useFacility();
       expect(facilityId.value).toBe('facility-1');
     });
@@ -203,15 +203,19 @@ describe('useFacility', () => {
 
   describe('currentFacilityName', () => {
     it('returns name of selected facility', () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
-      });
-
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: true,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          userIsMultiFacilityAdmin: ref(false),
+          getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { currentFacilityName } = useFacility();
       expect(currentFacilityName.value).toBe('Facility 1');
     });
@@ -225,97 +229,89 @@ describe('useFacility', () => {
         dataset: { id: 'dataset-1', learner_can_edit_username: true },
       };
 
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: true,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          getFacility: jest.fn().mockReturnValue(facilityWithDataset),
+        }),
+      );
 
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(facilityWithDataset),
-      });
-
+      const { default: useFacility } = loadUseFacilityModule();
       const { facilityConfig } = useFacility();
       expect(facilityConfig.value).toEqual(facilityWithDataset.dataset);
+    });
+
+    it('uses fetched config when available', async () => {
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([
+        { id: 'dataset-2', setting: true },
+      ]);
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          fetchFacility: jest.fn().mockResolvedValue(),
+          getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
+        }),
+      );
+
+      const { default: useFacility } = loadUseFacilityModule();
+      const { setFacilityId, facilityConfig } = useFacility();
+      await setFacilityId('facility-2');
+      expect(facilityConfig.value).toEqual({ id: 'dataset-2', setting: true });
     });
   });
 
   describe('setFacilityId', () => {
     it('sets the facilityId and updates config', async () => {
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      // getFacility should return the facility for the new ID after setFacilityId is called
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
-      });
-
+      const fetchFacility = jest.fn().mockResolvedValue();
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          fetchFacility,
+          getFacility: jest.fn().mockImplementation(id => mockFacilities.find(f => f.id === id)),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { setFacilityId, facilityId } = useFacility();
-
       await setFacilityId('facility-2');
-
+      expect(fetchFacility).toHaveBeenCalledWith('facility-2');
+      expect(FacilityDatasetResource.fetchCollection).toHaveBeenCalledWith({
+        getParams: { facility_id: 'facility-2' },
+        force: true,
+      });
       expect(facilityId.value).toBe('facility-2');
     });
   });
 
   describe('updateFacilityConfig', () => {
-    it('returns dataset from facility when it is a plain object', async () => {
-      const facilityWithDataset = {
-        id: 'facility-1',
-        name: 'Facility 1',
-        dataset: { id: 'dataset-1' },
-      };
-
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(facilityWithDataset),
-      });
-
+    it('fetches config with the selected facility id', async () => {
+      FacilityDatasetResource.fetchCollection.mockResolvedValue([{ id: 'dataset-1' }]);
+      useUser.mockImplementation(() =>
+        useUserMock({
+          isUserLoggedIn: true,
+          userFacilityId: 'facility-1',
+        }),
+      );
+      useFacilities.mockImplementation(() =>
+        useFacilitiesMock({
+          userIsMultiFacilityAdmin: ref(false),
+          getFacility: jest.fn().mockReturnValue(mockFacilities[0]),
+        }),
+      );
+      const { default: useFacility } = loadUseFacilityModule();
       const { updateFacilityConfig } = useFacility();
       const result = await updateFacilityConfig();
-
-      expect(FacilityDatasetResource.fetchCollection).not.toHaveBeenCalled();
-      expect(result).toEqual(facilityWithDataset.dataset);
-    });
-
-    it('fetches config from API when facility dataset is not a plain object', async () => {
-      const facilityWithoutDataset = {
-        id: 'facility-1',
-        name: 'Facility 1',
-        dataset: 'dataset-1',
-      };
-
-      FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
-
-      useUser.mockReturnValue({
-        userFacilityId: ref('facility-1'),
-      });
-
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(facilityWithoutDataset),
-      });
-
-      const { updateFacilityConfig } = useFacility();
-      await updateFacilityConfig();
-
       expect(FacilityDatasetResource.fetchCollection).toHaveBeenCalledWith({
         getParams: { facility_id: 'facility-1' },
         force: true,
       });
+      expect(result).toEqual({ id: 'dataset-1' });
     });
 
     it('does nothing when no facilityId is available', async () => {
-      useFacilities.mockReturnValue({
-        fetchFacilities: jest.fn(),
-        getFacility: jest.fn().mockReturnValue(null),
-      });
-
+      const { default: useFacility } = loadUseFacilityModule();
       const { updateFacilityConfig } = useFacility();
       const result = await updateFacilityConfig();
 
@@ -338,34 +334,39 @@ describe('useFacilityConfig', () => {
 
   describe('initial state', () => {
     it('returns empty facilityConfig initially', () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { facilityConfig } = useFacilityConfig('facility-1');
       expect(facilityConfig.value).toEqual({});
     });
 
     it('returns isAttendanceFeatureEnabled as true when currentLanguage is en', () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { isAttendanceFeatureEnabled } = useFacilityConfig('facility-1');
       expect(isAttendanceFeatureEnabled.value).toBe(true);
     });
 
     it('returns isPictureLoginFeatureEnabled as true when currentLanguage is en', () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { isPictureLoginFeatureEnabled } = useFacilityConfig('facility-1');
       expect(isPictureLoginFeatureEnabled.value).toBe(true);
     });
 
     it('returns signInOptions with USERNAME_PASSWORD by default', () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { signInOptions } = useFacilityConfig('facility-1');
       // Default config has learner_can_login_with_no_password: false, so USERNAME_PASSWORD
       expect(signInOptions.value).toEqual([OptionsForSignIn.USERNAME_PASSWORD]);
     });
 
     it('returns null for picturePasswordSettings initially', () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { picturePasswordSettings } = useFacilityConfig('facility-1');
       expect(picturePasswordSettings.value).toBeNull();
     });
   });
 
   describe('signInOptions computed', () => {
-    it('includes PICTURE_PASSWORD when picture_password_settings is set', () => {
+    it('includes PICTURE_PASSWORD when picture_password_settings is set', async () => {
       const configWithPicturePassword = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'colorful' },
@@ -373,14 +374,13 @@ describe('useFacilityConfig', () => {
 
       FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithPicturePassword]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
-
-      return fetchFacilityConfig().then(() => {
-        expect(signInOptions.value).toContain(OptionsForSignIn.PICTURE_PASSWORD);
-      });
+      await fetchFacilityConfig();
+      expect(signInOptions.value).toContain(OptionsForSignIn.PICTURE_PASSWORD);
     });
 
-    it('includes USERNAME_ONLY when learner_can_login_with_no_password is true', () => {
+    it('includes USERNAME_ONLY when learner_can_login_with_no_password is true', async () => {
       const configWithUsernameOnly = {
         ...mockFacilityConfig,
         learner_can_login_with_no_password: true,
@@ -388,26 +388,24 @@ describe('useFacilityConfig', () => {
 
       FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithUsernameOnly]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
-
-      return fetchFacilityConfig().then(() => {
-        expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_ONLY);
-      });
+      await fetchFacilityConfig();
+      expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_ONLY);
     });
 
-    it('includes USERNAME_PASSWORD when learner_can_login_with_no_password is false', () => {
+    it('includes USERNAME_PASSWORD when learner_can_login_with_no_password is false', async () => {
       FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, signInOptions } = useFacilityConfig('facility-1');
-
-      return fetchFacilityConfig().then(() => {
-        expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_PASSWORD);
-      });
+      await fetchFacilityConfig();
+      expect(signInOptions.value).toContain(OptionsForSignIn.USERNAME_PASSWORD);
     });
   });
 
   describe('picturePasswordSettings computed', () => {
-    it('returns picture_password_settings when PICTURE_PASSWORD is in signInOptions', () => {
+    it('returns picture_password_settings when PICTURE_PASSWORD is in signInOptions', async () => {
       const configWithPicturePassword = {
         ...mockFacilityConfig,
         picture_password_settings: { icon_style: 'colorful', show_icon_names: false },
@@ -416,24 +414,22 @@ describe('useFacilityConfig', () => {
 
       FacilityDatasetResource.fetchCollection.mockResolvedValue([configWithPicturePassword]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, picturePasswordSettings } = useFacilityConfig('facility-1');
-
-      return fetchFacilityConfig().then(() => {
-        expect(picturePasswordSettings.value).toEqual({
-          icon_style: 'colorful',
-          show_icon_names: false,
-        });
+      await fetchFacilityConfig();
+      expect(picturePasswordSettings.value).toEqual({
+        icon_style: 'colorful',
+        show_icon_names: false,
       });
     });
 
-    it('returns null when PICTURE_PASSWORD is not in signInOptions', () => {
+    it('returns null when PICTURE_PASSWORD is not in signInOptions', async () => {
       FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, picturePasswordSettings } = useFacilityConfig('facility-1');
-
-      return fetchFacilityConfig().then(() => {
-        expect(picturePasswordSettings.value).toBeNull();
-      });
+      await fetchFacilityConfig();
+      expect(picturePasswordSettings.value).toBeNull();
     });
   });
 
@@ -441,6 +437,7 @@ describe('useFacilityConfig', () => {
     it('fetches facility config for given facilityId', async () => {
       FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, facilityConfig } = useFacilityConfig('facility-1');
       const result = await fetchFacilityConfig();
 
@@ -456,6 +453,7 @@ describe('useFacilityConfig', () => {
     it('uses provided facilityId parameter over constructor parameter', async () => {
       FacilityDatasetResource.fetchCollection.mockResolvedValue([mockFacilityConfig]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig } = useFacilityConfig('facility-1');
       await fetchFacilityConfig('facility-2');
 
@@ -466,6 +464,7 @@ describe('useFacilityConfig', () => {
     });
 
     it('does nothing when no facilityId is provided', async () => {
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, facilityConfig } = useFacilityConfig(null);
       const result = await fetchFacilityConfig();
 
@@ -477,6 +476,7 @@ describe('useFacilityConfig', () => {
     it('returns empty config when facility is not found', async () => {
       FacilityDatasetResource.fetchCollection.mockResolvedValue([]);
 
+      const { useFacilityConfig } = loadUseFacilityModule();
       const { fetchFacilityConfig, facilityConfig } = useFacilityConfig('facility-1');
       const result = await fetchFacilityConfig();
 

--- a/packages/kolibri-common/composables/__tests__/useFacility.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useFacility.spec.js
@@ -222,7 +222,7 @@ describe('useFacility', () => {
   });
 
   describe('facilityConfig', () => {
-    it('returns dataset from facility object when available', () => {
+    it('does not derive config from facility dataset', () => {
       const facilityWithDataset = {
         id: 'facility-1',
         name: 'Facility 1',
@@ -243,7 +243,7 @@ describe('useFacility', () => {
 
       const { default: useFacility } = loadUseFacilityModule();
       const { facilityConfig } = useFacility();
-      expect(facilityConfig.value).toEqual(facilityWithDataset.dataset);
+      expect(facilityConfig.value).toEqual({});
     });
 
     it('uses fetched config when available', async () => {

--- a/packages/kolibri-common/composables/useFacilities.js
+++ b/packages/kolibri-common/composables/useFacilities.js
@@ -1,9 +1,26 @@
-import { ref, computed } from 'vue';
+import { ref, computed, unref } from 'vue';
 import FacilityResource from 'kolibri-common/apiResources/FacilityResource';
 import useUser from 'kolibri/composables/useUser';
 
+/**
+ * @typedef {Object} UseFacilitiesReturn
+ * @property {import('vue').ComputedRef<Object[]>} facilities
+ * @property {import('vue').ComputedRef<boolean>} hasMultipleFacilities
+ * @property {import('vue').ComputedRef<boolean>} userIsMultiFacilityAdmin
+ * @property {() => Promise<void>} fetchFacilities
+ * @property {(facilityId: import('vue').Ref<string>|string) => Promise<void>} fetchFacility
+ * @property {(facilityId: import('vue').Ref<string>|string) => Object|undefined} getFacility
+ */
+
+/**
+ * @type {import('vue').Ref<Object[]>}
+ * @private
+ */
 const _facilities = ref([]);
 
+/**
+ * @return {UseFacilitiesReturn}
+ */
 export default function useFacilities() {
   const { isSuperuser } = useUser();
 
@@ -16,13 +33,47 @@ export default function useFacilities() {
     return isSuperuser.value && hasMultipleFacilities.value;
   });
 
+  /**
+   * Get a particular facility from the cache
+   * @param {import('vue').Ref<string>|string} facilityId
+   * @return {Object|null}
+   */
+  function getFacility(facilityId) {
+    return _facilities.value.find(f => f.id === unref(facilityId));
+  }
+
   // actions
+  /**
+   * Fetch all facilities from the backend
+   * @return {Promise<void>}
+   */
   async function fetchFacilities() {
     _facilities.value = await FacilityResource.fetchCollection({ force: true });
   }
 
-  function getFacility(facilityId) {
-    return _facilities.value.find(f => f.id === facilityId);
+  /**
+   * Fetch a single facility from the backend
+   * @param {import('vue').Ref<string>|string} facilityId
+   * @return {Promise<void>}
+   */
+  async function fetchFacility(facilityId) {
+    const facility = await FacilityResource.fetchModel({ id: unref(facilityId), force: true });
+    let replaced = false;
+
+    for (let i = 0; i < _facilities.value.length; i++) {
+      if (_facilities.value[i].id === facility.id) {
+        replaced = true;
+        _facilities.value.splice(i, 1, {
+          ..._facilities.value[i],
+          ...facility,
+        });
+        break;
+      }
+    }
+
+    if (!replaced) {
+      _facilities.value.push(facility);
+    }
   }
 
   return {
@@ -30,6 +81,7 @@ export default function useFacilities() {
     hasMultipleFacilities,
     userIsMultiFacilityAdmin,
     fetchFacilities,
+    fetchFacility,
     getFacility,
   };
 }

--- a/packages/kolibri-common/composables/useFacility.js
+++ b/packages/kolibri-common/composables/useFacility.js
@@ -1,6 +1,5 @@
 import { ref, computed, unref } from 'vue';
 import { useLocalStorage, StorageSerializers } from '@vueuse/core';
-import isPlainObject from 'lodash/isPlainObject';
 import { currentLanguage } from 'kolibri/utils/i18n';
 import useUser from 'kolibri/composables/useUser';
 import FacilityDatasetResource from 'kolibri-common/apiResources/FacilityDatasetResource';
@@ -52,8 +51,7 @@ const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
  * changed by calling `setFacilityId`
  */
 export default function useFacility() {
-  const { userFacilityId } = useUser();
-  const { fetchFacilities, getFacility } = useFacilities();
+  const { fetchFacilities, fetchFacility, getFacility } = useFacilities();
   const { facilityConfig: _facilityConfig, fetchFacilityConfig } = useFacilityConfig(
     selectedFacilityId.value,
   );
@@ -61,24 +59,21 @@ export default function useFacility() {
   // getters
   const selectedFacility = computed(() => {
     if (selectedFacilityId.value) {
-      const facilityById = getFacility(selectedFacilityId.value);
-      if (facilityById) {
-        return facilityById;
-      }
+      return getFacility(selectedFacilityId.value) || {};
     }
-    return getFacility(userFacilityId.value) || {};
+    return {};
   });
   const facilityId = computed(() => {
     // keep facility ID in sync with logic on selected facility
-    return selectedFacility.value ? selectedFacility.value.id : null;
+    return selectedFacility.value?.id ? selectedFacility.value.id : null;
   });
   const facilityConfig = computed(() => {
-    // if we have dataset from the facility object
-    if (isPlainObject(selectedFacility.value?.dataset)) {
-      return selectedFacility.value.dataset;
+    // prefer the useFacilityConfig composable's value
+    if (_facilityConfig.value?.id) {
+      return _facilityConfig.value;
     }
-    // otherwise leverage the useFacilityConfig composable's value
-    return _facilityConfig.value;
+
+    return selectedFacility.value.dataset || {};
   });
   const currentFacilityName = computed(() => {
     return selectedFacility.value ? selectedFacility.value.name : '';
@@ -91,7 +86,8 @@ export default function useFacility() {
    */
   async function setFacilityId(facilityId) {
     setSelectedFacilityId(facilityId);
-    await updateFacilityConfig();
+    await fetchFacility(facilityId);
+    await fetchFacilityConfig(facilityId);
   }
 
   /**
@@ -99,10 +95,6 @@ export default function useFacility() {
    * @return {Promise<object>}
    */
   async function updateFacilityConfig() {
-    if (!facilityId.value || isPlainObject(selectedFacility.value?.dataset)) {
-      return selectedFacility.value?.dataset;
-    }
-    // update facility config
     return await fetchFacilityConfig(facilityId);
   }
 

--- a/packages/kolibri-common/composables/useFacility.js
+++ b/packages/kolibri-common/composables/useFacility.js
@@ -12,14 +12,33 @@ import useFacilities from './useFacilities';
  * @param {boolean} listenToStorageChanges Whether to be reactive to localStorage changes
  */
 export function useFacilitySelect(listenToStorageChanges = false) {
-  const selectedFacilityId = useLocalStorage('facilityId', null, {
+  const { userIsMultiFacilityAdmin } = useFacilities();
+  const { userFacilityId, isUserLoggedIn } = useUser();
+
+  const defaultFacilityId = useLocalStorage('facilityId', null, {
     listenToStorageChanges,
     serializer: StorageSerializers.string,
   });
 
+  const selectedFacilityId = computed(() => {
+    // don't bother with the persisted store value if user is logged in and not multi-facility admin
+    if (isUserLoggedIn.value && !userIsMultiFacilityAdmin.value) {
+      return userFacilityId.value;
+    }
+
+    return defaultFacilityId.value || userFacilityId.value;
+  });
+
+  function setSelectedFacilityId(facilityId) {
+    // places like the sign-in flow persist a default facility
+    if (!isUserLoggedIn.value || userIsMultiFacilityAdmin.value) {
+      defaultFacilityId.value = facilityId;
+    }
+  }
+
   return {
     selectedFacilityId,
-    setSelectedFacilityId: facilityId => (selectedFacilityId.value = unref(facilityId)),
+    setSelectedFacilityId,
   };
 }
 

--- a/packages/kolibri-common/composables/useFacility.js
+++ b/packages/kolibri-common/composables/useFacility.js
@@ -42,79 +42,11 @@ export function useFacilitySelect(listenToStorageChanges = false) {
 }
 
 /**
- * We don't allow this to be reactive to storage changes, since that could cause issues for SPAs
- */
-const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
-
-/**
- * Composable for the context of a single facility, defaulting to the user's facility, but can be
- * changed by calling `setFacilityId`
- */
-export default function useFacility() {
-  const { fetchFacilities, fetchFacility, getFacility } = useFacilities();
-  const { facilityConfig: _facilityConfig, fetchFacilityConfig } = useFacilityConfig(
-    selectedFacilityId.value,
-  );
-
-  // getters
-  const selectedFacility = computed(() => {
-    if (selectedFacilityId.value) {
-      return getFacility(selectedFacilityId.value) || {};
-    }
-    return {};
-  });
-  const facilityId = computed(() => {
-    // keep facility ID in sync with logic on selected facility
-    return selectedFacility.value?.id ? selectedFacility.value.id : null;
-  });
-  const facilityConfig = computed(() => {
-    // prefer the useFacilityConfig composable's value
-    if (_facilityConfig.value?.id) {
-      return _facilityConfig.value;
-    }
-
-    return selectedFacility.value.dataset || {};
-  });
-  const currentFacilityName = computed(() => {
-    return selectedFacility.value ? selectedFacility.value.name : '';
-  });
-
-  /**
-   * Sets the selected facility
-   * @param {string} facilityId
-   * @return {Promise<void>}
-   */
-  async function setFacilityId(facilityId) {
-    setSelectedFacilityId(facilityId);
-    await fetchFacility(facilityId);
-    await fetchFacilityConfig(facilityId);
-  }
-
-  /**
-   * Updates the facility config, if necessary
-   * @return {Promise<object>}
-   */
-  async function updateFacilityConfig() {
-    return await fetchFacilityConfig(facilityId);
-  }
-
-  return {
-    facilityId,
-    facilityConfig,
-    fetchFacilities,
-    updateFacilityConfig,
-    selectedFacility,
-    currentFacilityName,
-    setFacilityId,
-  };
-}
-
-/**
  * Composable for accessing a facility's configuration
- * @param {string} facilityId
+ * @param {Ref<string>|string} facilityId
  */
 export function useFacilityConfig(facilityId) {
-  const _facilityId = unref(facilityId);
+  const _facilityId = facilityId;
   const facilityConfig = ref({});
 
   // computed feature flags
@@ -151,7 +83,7 @@ export function useFacilityConfig(facilityId) {
    * @return {Promise<void>}
    */
   async function fetchFacilityConfig(facilityId = null) {
-    facilityId = unref(facilityId) || _facilityId;
+    facilityId = unref(facilityId) || unref(_facilityId);
 
     if (!facilityId) {
       return;
@@ -181,5 +113,90 @@ export function useFacilityConfig(facilityId) {
     signInOptions,
     picturePasswordSettings,
     fetchFacilityConfig,
+  };
+}
+
+/**
+ * We don't allow this to be reactive to storage changes, since that could cause issues for SPAs
+ */
+export const { selectedFacilityId, setSelectedFacilityId } = useFacilitySelect();
+
+const { fetchFacilities, fetchFacility: _fetchFacility, getFacility } = useFacilities();
+const {
+  facilityConfig,
+  fetchFacilityConfig: _fetchFacilityConfig,
+  isAttendanceFeatureEnabled,
+  isPictureLoginFeatureEnabled,
+  signInOptions,
+  picturePasswordSettings,
+} = useFacilityConfig(selectedFacilityId);
+
+// getters
+const selectedFacility = computed(() => {
+  if (selectedFacilityId.value) {
+    return getFacility(selectedFacilityId.value) || {};
+  }
+  return {};
+});
+const facilityId = computed(() => selectedFacilityId.value);
+const currentFacilityName = computed(() => {
+  return selectedFacility.value ? selectedFacility.value.name : '';
+});
+
+/**
+ * Sets the selected facility
+ * @param {string} facilityId
+ * @return {Promise<void>}
+ */
+async function setFacilityId(facilityId) {
+  setSelectedFacilityId(facilityId);
+  await _fetchFacility(facilityId);
+  await _fetchFacilityConfig(facilityId);
+}
+
+/**
+ * Refetches the selected facility
+ * @return {Promise<void>}
+ */
+async function fetchFacility() {
+  return await _fetchFacility(facilityId);
+}
+
+/**
+ * Updates the facility config, if necessary
+ * @deprecated Use `fetchFacilityConfig` instead
+ * @return {Promise<object>}
+ */
+async function updateFacilityConfig() {
+  return await _fetchFacilityConfig(facilityId);
+}
+
+/**
+ * Updates the facility config, if necessary
+ * @return {Promise<object>}
+ */
+async function fetchFacilityConfig() {
+  return await _fetchFacilityConfig(facilityId);
+}
+
+/**
+ * Composable for the context of a single facility, defaulting to the user's facility, but can be
+ * changed by calling `setFacilityId`
+ */
+export default function useFacility() {
+  return {
+    facilityId,
+    selectedFacility,
+    currentFacilityName,
+    facilityConfig,
+    isAttendanceFeatureEnabled,
+    isPictureLoginFeatureEnabled,
+    signInOptions,
+    picturePasswordSettings,
+    fetchFacilities,
+    fetchFacility,
+    fetchFacilityConfig,
+    updateFacilityConfig,
+    setFacilityId,
   };
 }


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds dedicated helper to `useFacilities` to re-fetch a facility, updating its global state
- Updates `useFacilitySelect` to utilize logic that aligns with expected behavior across Kolibri
- Updates `useFacility` to maintain a global state to keep consistent `facilityConfig` state across usages on a page
- Refactors facility plugin and routing to use `useFacility` state as much as possible, and avoid reloading facility config
  - The facility and its config are reloaded on every route change
  - Many usages of `activeFacilityId` from the vuex store have been replaced, but some vuex items still use it so it wasn't entirely removed.

### Facility Settings Loading state

https://github.com/user-attachments/assets/e7cbd504-a16f-4a64-b9d9-f7ccc85a2b86

## References
<!--
 * references to related issues and PRs
-->
Addresses some major aspects, but doesn't completely solve potential stale facility state handling across Kolibri https://github.com/learningequality/kolibri/issues/14545

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Flows worth testing:
- facility settings
- CSV import / export
- User CRUD
- Facility switching for superuser
- Facility admin access restricted to only one facility
- User sign-in, including picture sign-in

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI was used to keep tests up-to-date with changes as they were made.