### PR TITLE
Reload on back/forward navigation to prevent stale auth state

### DIFF
--- a/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
@@ -241,7 +241,6 @@
                 // If we get an error logging in, just redirect to the sign-in page
                 return redirectBrowser();
               }
-              return;
             } else {
               return redirectBrowser();
             }

--- a/kolibri/plugins/user_auth/frontend/app.js
+++ b/kolibri/plugins/user_auth/frontend/app.js
@@ -40,6 +40,14 @@ class UserAuthModule extends KolibriApp {
         initializeFlow(true);
       }
     });
+
+    // User auth only: reload on back/forward navigation so stale auth state is never shown.
+    window.addEventListener('pageshow', event => {
+      const navType = performance.getEntriesByType('navigation')[0]?.type;
+      if (event.persisted || navType === 'back_forward') {
+        window.location.reload();
+      }
+    });
   }
 }
 

--- a/kolibri/plugins/user_auth/frontend/app.js
+++ b/kolibri/plugins/user_auth/frontend/app.js
@@ -40,14 +40,6 @@ class UserAuthModule extends KolibriApp {
         initializeFlow(true);
       }
     });
-
-    // User auth only: reload on back/forward navigation so stale auth state is never shown.
-    window.addEventListener('pageshow', event => {
-      const navType = performance.getEntriesByType('navigation')[0]?.type;
-      if (event.persisted || navType === 'back_forward') {
-        window.location.reload();
-      }
-    });
   }
 }
 

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -12,11 +12,15 @@
           @shouldFocusLastEl="confirmBtn.$el.focus()"
         >
           <div
+            ref="modalCard"
             role="dialog"
             aria-modal="true"
             aria-labelledby="confirm-modal-title"
             class="modal-card"
-            :style="{ backgroundColor: $themeTokens.surface }"
+            :style="{
+              backgroundColor: $themeTokens.surface,
+              zoom: cardScale < 1 ? cardScale : undefined,
+            }"
           >
             <div
               class="header"
@@ -100,6 +104,7 @@
 <script>
 
   import { computed, onMounted, onUnmounted, ref } from 'vue';
+  import { useWindowSize } from '@vueuse/core';
   import KFocusTrap from 'kolibri-design-system/lib/KFocusTrap';
   import KOverlay from 'kolibri-design-system/lib/KOverlay';
   import Backdrop from 'kolibri/components/Backdrop';
@@ -119,6 +124,15 @@
       useReturnFocusOnUnmount();
       const confirmBtn = ref(null);
       const modalTitle = ref(null);
+      const modalCard = ref(null);
+      const naturalCardHeight = ref(0);
+      const { height: windowHeight } = useWindowSize();
+
+      const cardScale = computed(() => {
+        if (!naturalCardHeight.value) return 1;
+        const available = windowHeight.value - 32; // 16px overlay padding each side
+        return Math.min(1, available / naturalCardHeight.value);
+      });
       const { isThisYou$, yourPasswordIs$, yesConfirmAction$, noGoBackAction$ } =
         picturePasswordStrings;
       const palette = themePalette();
@@ -142,6 +156,7 @@
 
       onMounted(() => {
         document.documentElement.style.overflow = 'hidden';
+        naturalCardHeight.value = modalCard.value.scrollHeight;
         confirmBtn.value.$el.focus();
       });
 
@@ -152,6 +167,8 @@
       return {
         confirmBtn,
         modalTitle,
+        modalCard,
+        cardScale,
         iconTokens,
         sequenceAriaLabel,
         isThisYou$,
@@ -219,8 +236,6 @@
   }
 
   .modal-card {
-    max-height: calc(100vh - 32px);
-    overflow-y: auto;
     border-radius: 8px;
   }
 

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
@@ -1,0 +1,124 @@
+import { ref, nextTick } from 'vue';
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { useWindowSize } from '@vueuse/core';
+import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+import PicturePasswordConfirmModal from '../PicturePasswordConfirmModal.vue';
+
+jest.mock('@vueuse/core', () => ({
+  useWindowSize: jest.fn(),
+}));
+
+jest.mock('kolibri-common/composables/useReturnFocusOnUnmount', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const defaultProps = {
+  learnerName: 'Alice Example',
+  picturePassword: '1.2.3',
+};
+
+function renderComponent(props = {}, windowHeight = 800) {
+  useWindowSize.mockReturnValue({ height: ref(windowHeight) });
+  return render(PicturePasswordConfirmModal, { props: { ...defaultProps, ...props } });
+}
+
+describe('PicturePasswordConfirmModal', () => {
+  describe('rendering', () => {
+    it('displays the learner name', () => {
+      renderComponent();
+      expect(screen.getByText(defaultProps.learnerName)).toBeInTheDocument();
+    });
+
+    it('renders a dialog with the correct aria label', () => {
+      renderComponent();
+      expect(
+        screen.getByRole('dialog', { name: picturePasswordStrings.isThisYou$() }),
+      ).toBeInTheDocument();
+    });
+
+    it('announces the icon sequence via a visually hidden label', () => {
+      renderComponent();
+      const expected = picturePasswordStrings.yourPasswordIs$({
+        labels: [
+          picturePasswordStrings.bee$(),
+          picturePasswordStrings.star$(),
+          picturePasswordStrings.moon$(),
+        ].join(', '),
+      });
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+  });
+
+  describe('events', () => {
+    it('emits confirm when the confirm button is clicked', async () => {
+      const { emitted } = renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.yesConfirmAction$() }),
+      );
+      expect(emitted()['confirm']).toBeTruthy();
+    });
+
+    it('emits cancel when the cancel button is clicked', async () => {
+      const { emitted } = renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
+      );
+      expect(emitted()['cancel']).toBeTruthy();
+    });
+  });
+
+  describe('scroll lock', () => {
+    it('sets overflow hidden on the document root when mounted', () => {
+      renderComponent();
+      expect(document.documentElement).toHaveStyle({ overflow: 'hidden' });
+    });
+
+    it('restores document overflow when unmounted', () => {
+      const { unmount } = renderComponent();
+      unmount();
+      expect(document.documentElement).toHaveStyle({ overflow: '' });
+    });
+  });
+
+  describe('landscape scaling', () => {
+    const CARD_HEIGHT = 420;
+
+    beforeEach(() => {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        get: () => CARD_HEIGHT,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        get: () => 0,
+      });
+    });
+
+    it('applies zoom when the card is taller than the available viewport height', async () => {
+      // viewport 400px → available 368px → scale = 368/420
+      renderComponent({}, 400);
+      await nextTick(); // wait for the re-render after naturalCardHeight is set in onMounted
+      const card = screen.getByRole('dialog');
+      const expectedScale = (400 - 32) / CARD_HEIGHT;
+      // Vue 2.7 vendor-prefixes zoom to -webkit-zoom in jsdom; match either form
+      const styleAttr = card.getAttribute('style') || '';
+      const zoomMatch = styleAttr.match(/zoom:\s*([\d.]+)/);
+      expect(zoomMatch).toBeTruthy();
+      expect(parseFloat(zoomMatch[1])).toBeCloseTo(expectedScale, 5);
+    });
+
+    it('does not apply zoom when the card fits within the viewport', async () => {
+      // viewport 800px → available 768px → scale = 1 (no zoom needed)
+      renderComponent({}, 800);
+      await nextTick();
+      const card = screen.getByRole('dialog');
+      expect(card.getAttribute('style') || '').not.toMatch(/zoom/);
+    });
+  });
+});

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
@@ -48,7 +48,7 @@ describe('PicturePasswordConfirmModal', () => {
           picturePasswordStrings.moon$(),
         ].join(', '),
       });
-      expect(screen.getByText(expected)).toBeInTheDocument();
+      expect(screen.getByText(expected)).toHaveClass('visuallyhidden');
     });
   });
 

--- a/packages/kolibri-app/package.json
+++ b/packages/kolibri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Kolibri app",
   "main": "src/index.js",
   "author": "Learning Equality",

--- a/packages/kolibri-app/src/__tests__/kolibri_app.spec.js
+++ b/packages/kolibri-app/src/__tests__/kolibri_app.spec.js
@@ -1,3 +1,4 @@
+import heartbeat from 'kolibri/heartbeat';
 import KolibriApp from '../index';
 import coreModule from '../../../../kolibri/core/frontend/state/modules/core';
 
@@ -15,6 +16,7 @@ jest.mock('kolibri/heartbeat', () => ({
   startPolling() {
     return Promise.resolve();
   },
+  pollSessionEndPoint: jest.fn(),
 }));
 
 jest.mock('kolibri/router', () => {
@@ -62,6 +64,27 @@ class TestApp extends KolibriApp {
 }
 
 describe('KolibriApp', function () {
+  // Track pageshow handlers registered by ready() so each test can remove them
+  // afterwards — preventing accumulated listeners from firing in subsequent tests.
+  const pagesShowHandlers = [];
+  const _origAddEventListener = window.addEventListener.bind(window);
+
+  beforeAll(() => {
+    window.addEventListener = (type, handler, ...rest) => {
+      if (type === 'pageshow') pagesShowHandlers.push(handler);
+      _origAddEventListener(type, handler, ...rest);
+    };
+  });
+
+  afterEach(() => {
+    pagesShowHandlers.forEach(h => window.removeEventListener('pageshow', h));
+    pagesShowHandlers.length = 0;
+  });
+
+  afterAll(() => {
+    window.addEventListener = _origAddEventListener;
+  });
+
   it('should register the plugin vuex components', async function () {
     const app = new TestApp();
     app.store.registerModule('core', coreModule);
@@ -77,5 +100,48 @@ describe('KolibriApp', function () {
     await app.ready();
     app.store.dispatch('incrementTwice');
     expect(app.store.getters.countGetter).toEqual(2);
+  });
+
+  describe('pageshow session refresh', () => {
+    let getEntriesByTypeMock;
+    let originalGetEntriesByType;
+
+    function firePageshow(persisted) {
+      window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted }));
+    }
+
+    beforeEach(async () => {
+      heartbeat.pollSessionEndPoint.mockClear();
+      // jsdom does not implement performance.getEntriesByType; assign a stub directly
+      // since jest.spyOn requires the property to already exist on the object.
+      originalGetEntriesByType = performance.getEntriesByType;
+      getEntriesByTypeMock = jest.fn().mockReturnValue([]);
+      performance.getEntriesByType = getEntriesByTypeMock;
+      // A bare TestApp.ready() is sufficient — no need to pre-register the core
+      // Vuex module, which would trigger a duplicate-registration warning on the
+      // singleton store shared across tests.
+      await new TestApp().ready();
+    });
+
+    afterEach(() => {
+      performance.getEntriesByType = originalGetEntriesByType;
+    });
+
+    it('calls pollSessionEndPoint when the page is restored from bfcache', () => {
+      firePageshow(true);
+      expect(heartbeat.pollSessionEndPoint).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls pollSessionEndPoint on back_forward navigation', () => {
+      getEntriesByTypeMock.mockReturnValueOnce([{ type: 'back_forward' }]);
+      firePageshow(false);
+      expect(heartbeat.pollSessionEndPoint).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call pollSessionEndPoint on normal navigation', () => {
+      getEntriesByTypeMock.mockReturnValueOnce([{ type: 'navigate' }]);
+      firePageshow(false);
+      expect(heartbeat.pollSessionEndPoint).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/kolibri-app/src/index.js
+++ b/packages/kolibri-app/src/index.js
@@ -99,6 +99,14 @@ export default class KolibriApp extends KolibriModule {
 
   ready() {
     this.setupVue();
+    // Refresh session state when the user returns to the SPA via back/forward navigation,
+    // so any auth changes that occurred since the page was cached are reflected immediately.
+    window.addEventListener('pageshow', event => {
+      const navType = performance.getEntriesByType('navigation')[0]?.type;
+      if (event.persisted || navType === 'back_forward') {
+        heartbeat.pollSessionEndPoint();
+      }
+    });
     return heartbeat.startPolling().then(() => {
       return Promise.all([
         // Invoke each of the state setters before initializing the app.

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -86,14 +86,12 @@ export default function useUser() {
         method: 'post',
       });
 
-      if (!prevalidate) {
+      if (enableRedirect) {
         // Update session state before redirecting so that bfcache stores the
         // logged-in user_id. If the user navigates back, pollSessionEndPoint
         // will see user_id change to null and trigger signOutDueToInactivity.
         setSession({ session: response.data });
-      }
 
-      if (enableRedirect) {
         if (sessionPayload.next) {
           // OIDC redirect
           redirectBrowser(sessionPayload.next);

--- a/packages/kolibri/composables/useUser.js
+++ b/packages/kolibri/composables/useUser.js
@@ -86,6 +86,13 @@ export default function useUser() {
         method: 'post',
       });
 
+      if (!prevalidate) {
+        // Update session state before redirecting so that bfcache stores the
+        // logged-in user_id. If the user navigates back, pollSessionEndPoint
+        // will see user_id change to null and trigger signOutDueToInactivity.
+        setSession({ session: response.data });
+      }
+
       if (enableRedirect) {
         if (sessionPayload.next) {
           // OIDC redirect


### PR DESCRIPTION
## Summary

When a user signs in and then navigates back using the browser's back button, Kolibri could restore a cached page showing the previous auth state from the back-forward cache (bfcache) — a regression found in #14691.

**Root cause:** Two gaps combined to cause this:
1. `login()` in `useUser` never called `setSession()` before redirecting, so `sessionState.user_id` stayed `null` (anonymous) in the bfcache snapshot.
2. On bfcache restore, `heartbeat.pollSessionEndPoint()` compares the fresh server response against the stored session. With both sides `null`, no change is detected and no redirect is triggered.

**Fixes:**
- A `pageshow` listener is added in `KolibriApp.ready()` (the base class for all Kolibri SPAs) that calls `heartbeat.pollSessionEndPoint()` when the page is restored from bfcache (`event.persisted`) or the Navigation Timing API reports a `back_forward` navigation type. Both signals are checked because browser support varies.
- `login()` in `useUser` now calls `setSession()` with the server response before redirecting (inside the `enableRedirect` block), so the bfcache snapshot stores the actual logged-in `user_id`. On restore, `pollSessionEndPoint` detects the change from the logged-in `user_id` to `null` and calls `signOutDueToInactivity()`, redirecting away from the stale page.

The confirm modal is also updated to scale down its contents proportionally on small landscape screens (measured via `scrollHeight` on mount, `zoom` applied reactively via `useWindowSize`) so the modal always fits within the available viewport height without scrolling.

https://github.com/user-attachments/assets/4def0dbf-2780-4168-9599-cd8147d55c51

## References

Fixes #14700

## Reviewer guidance

- Back/front navigation: To verify the back-navigation fix, use a facility with picture password enabled and at least two learners. 
  - Sign in as one learner then logout.
  -  Sign in as another learner then logout again, then press the browser back button. 
  - Observe the stale confirmation modal, or checked picture password grid is refreshed.

- Modal scaling: The PicturePasswordConfirmModal scales its content correctly on different screen sizes.

## AI usage

I used Claude Code to implement both fixes. I reviewed the generated code, confirmed `event.persisted` and the Navigation Timing API check are both needed for cross-browser coverage, verified the zoom approach correctly handles landscape scaling, and confirmed pre-commit hooks pass.