### PR TITLE
Tighten API endpoints that fetch from a caller-supplied remote URL

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -92,6 +92,7 @@ from kolibri.core.auth.utils.picture_passwords import are_picture_passwords_exha
 from kolibri.core.auth.utils.picture_passwords import get_learner_count
 from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.permissions import IsSuperuser
+from kolibri.core.device.permissions import NotProvisionedHasPermission
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import allow_other_browsers_to_connect
 from kolibri.core.device.utils import APP_AUTH_TOKEN_COOKIE_NAME
@@ -1558,6 +1559,8 @@ class _RemoteFacilityUserSearchSerializer(serializers.Serializer):
 
 
 class RemoteFacilityUserViewset(views.APIView):
+    permission_classes = [IsAuthenticated | NotProvisionedHasPermission]
+
     def get(self, request):
         baseurl = request.query_params.get("baseurl", "")
         try:
@@ -1588,6 +1591,8 @@ class RemoteFacilityUserViewset(views.APIView):
 
 
 class RemoteFacilityUserAuthenticatedViewset(views.APIView):
+    permission_classes = [IsAuthenticated | NotProvisionedHasPermission]
+
     def post(self, request):
         """
         If the request is done by an admin user  it will return a list of the users of the

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1552,6 +1552,11 @@ class SessionViewSet(viewsets.ViewSet):
         return response
 
 
+class _RemoteFacilityUserSearchSerializer(serializers.Serializer):
+    id = serializers.UUIDField(format="hex", allow_null=True)
+    username = serializers.CharField()
+
+
 class RemoteFacilityUserViewset(views.APIView):
     def get(self, request):
         baseurl = request.query_params.get("baseurl", "")
@@ -1572,9 +1577,12 @@ class RemoteFacilityUserViewset(views.APIView):
             response = client.get(
                 url, params={"facility": facility, "search": username}
             )
-            return Response(response.json())
+            serializer = _RemoteFacilityUserSearchSerializer(
+                data=response.json(), many=True
+            )
+            return Response(serializer.data if serializer.is_valid() else [])
         except NetworkLocationResponseFailure:
-            return Response({})
+            return Response([])
         except Exception as e:
             raise RestValidationError(detail="Remote user lookup failed") from e
 

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -99,6 +99,7 @@ from kolibri.core.device.utils import APP_AUTH_TOKEN_COOKIE_NAME
 from kolibri.core.device.utils import is_full_facility_import
 from kolibri.core.device.utils import valid_app_key_on_request
 from kolibri.core.discovery.utils.network.client import NetworkClient
+from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.mixins import BulkCreateMixin
@@ -111,7 +112,6 @@ from kolibri.core.tasks.main import job_storage
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.core.utils.token_generator import TokenGenerator
 from kolibri.core.utils.urls import reverse_path
-from kolibri.utils.urls import validator
 
 logger = logging.getLogger(__name__)
 
@@ -1563,18 +1563,14 @@ class RemoteFacilityUserViewset(views.APIView):
 
     def get(self, request):
         baseurl = request.query_params.get("baseurl", "")
-        try:
-            validator(baseurl)
-        except ValidationError as e:
-            raise RestValidationError(
-                detail="Invalid URL format",
-                code=error_constants.INVALID,
-            ) from e
         username = request.query_params.get("username", None)
         facility = request.query_params.get("facility", None)
         if username is None or facility is None:
             raise RestValidationError(detail="Both username and facility are required")
-        client = NetworkClient.build_for_address(baseurl)
+        try:
+            client = NetworkClient.build_for_address(baseurl)
+        except NetworkLocationNotFound:
+            raise RestValidationError(detail="Unknown peer: {}".format(baseurl))
         url = reverse_path("kolibri:core:publicsearchuser-list")
         try:
             response = client.get(
@@ -1605,13 +1601,6 @@ class RemoteFacilityUserAuthenticatedViewset(views.APIView):
         :return: List of the users of the facility.
         """
         baseurl = request.data.get("baseurl", "")
-        try:
-            validator(baseurl)
-        except ValidationError as e:
-            raise RestValidationError(
-                detail="Invalid URL format",
-                code=error_constants.INVALID,
-            ) from e
         username = request.data.get("username", None)
         facility_id = request.data.get("facility_id", None)
         password = request.data.get("password", None)
@@ -1624,6 +1613,8 @@ class RemoteFacilityUserAuthenticatedViewset(views.APIView):
             )
         except AuthenticationFailed:
             raise PermissionDenied()
+        except NetworkLocationNotFound:
+            raise RestValidationError(detail="Unknown peer: {}".format(baseurl))
 
         user_info = facility_info["user"]
         roles = user_info["roles"]

--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -34,7 +34,7 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        client = NetworkClient.build_for_address(base_url)
+        client = NetworkClient.discover_from_address(base_url)
         facility_url = reverse_path("kolibri:core:publicfacility-list")
         facility_resp = client.get(facility_url)
         facilities = facility_resp.json()

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -124,7 +124,7 @@ def get_facility(facility_id=None, noninteractive=False):
 
 def get_facility_dataset_id(baseurl, identifier=None, noninteractive=False):
     # get list of facilities and if more than 1, display all choices to user
-    client = NetworkClient.build_for_address(baseurl)
+    client = NetworkClient.discover_from_address(baseurl)
     facility_url = reverse_path("kolibri:core:publicfacility-list")
     response = client.get(facility_url)
     facilities = response.json()
@@ -166,7 +166,7 @@ def get_baseurl(address):
 
     # validate base url
     try:
-        return NetworkClient.build_for_address(address).base_url
+        return NetworkClient.discover_from_address(address).base_url
     except URLParseError:
         raise CommandError(
             "Base URL/IP: {} is not valid. Please retry command and enter a valid URL/IP.".format(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -4123,3 +4123,106 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
+
+
+class RemoteFacilityResponseSanitizationMixin:
+    """Shared assertions for endpoints that reflect a remote user list."""
+
+    valid_item = None
+
+    def _call_with_payload(self, payload):
+        raise NotImplementedError
+
+    def test_well_formed_response_passes_through(self):
+        response = self._call_with_payload([self.valid_item])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [self.valid_item])
+
+    def test_extra_keys_are_stripped(self):
+        smuggled = dict(self.valid_item, password="leaked-secret", token="AKIA...")
+        response = self._call_with_payload([smuggled])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [self.valid_item])
+
+
+class RemoteFacilityUserViewsetTestCase(
+    RemoteFacilityResponseSanitizationMixin, APITestCase
+):
+    valid_item = {"id": "00000000000000000000000000000001", "username": "alice"}
+
+    def _call_with_payload(self, payload):
+        with patch("kolibri.core.auth.api.NetworkClient") as NetworkClient:
+            client = NetworkClient.build_for_address.return_value
+            client.get.return_value.json.return_value = payload
+            return self.client.get(
+                reverse("kolibri:core:remotefacilityuser"),
+                {
+                    "baseurl": "http://remote.example",
+                    "username": "alice",
+                    "facility": uuid.uuid4().hex,
+                },
+            )
+
+    def test_non_list_response_returns_empty_list(self):
+        response = self._call_with_payload({"my_secret": "AKIA..."})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_passwordless_facility_response_with_null_id_passes_through(self):
+        payload = [{"id": None, "username": "alice"}]
+        response = self._call_with_payload(payload)
+        self.assertEqual(response.data, payload)
+
+    def test_any_invalid_item_rejects_whole_response(self):
+        valid_id = uuid.uuid4().hex
+        response = self._call_with_payload(
+            [
+                {"id": valid_id, "username": "alice"},
+                "not a dict",
+            ]
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_invalid_uuid_id_rejects_whole_response(self):
+        response = self._call_with_payload([{"id": "not-a-uuid", "username": "alice"}])
+        self.assertEqual(response.data, [])
+
+
+class RemoteFacilityUserAuthenticatedViewsetTestCase(
+    RemoteFacilityResponseSanitizationMixin, APITestCase
+):
+    valid_item = {
+        "id": "00000000000000000000000000000001",
+        "username": "alice",
+        "full_name": "Alice",
+        "facility": "00000000000000000000000000000002",
+        "roles": ["admin"],
+        "is_superuser": False,
+        "id_number": "",
+        "gender": "NOT_SPECIFIED",
+        "birth_year": "NOT_SPECIFIED",
+    }
+
+    def _call_with_payload(self, payload):
+        with patch("kolibri.core.auth.utils.users.NetworkClient") as NetworkClient:
+            client = NetworkClient.build_for_address.return_value
+            client.get.return_value.json.return_value = payload
+            return self.client.post(
+                reverse("kolibri:core:remotefacilityauthenticateduserinfo"),
+                {
+                    "baseurl": "http://remote.example",
+                    "username": self.valid_item["username"],
+                    "facility_id": self.valid_item["facility"],
+                    "password": "anything",
+                },
+                format="json",
+            )
+
+    def test_any_invalid_item_returns_403(self):
+        response = self._call_with_payload([self.valid_item, "not a dict"])
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_list_response_returns_403(self):
+        response = self._call_with_payload({"my_secret": "AKIA..."})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -4188,6 +4188,11 @@ class RemoteFacilityUserViewsetTestCase(
         response = self._call_with_payload([{"id": "not-a-uuid", "username": "alice"}])
         self.assertEqual(response.data, [])
 
+    def test_anonymous_request_to_provisioned_device_is_rejected(self):
+        provision_device()
+        response = self._call_with_payload([self.valid_item])
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class RemoteFacilityUserAuthenticatedViewsetTestCase(
     RemoteFacilityResponseSanitizationMixin, APITestCase
@@ -4219,10 +4224,12 @@ class RemoteFacilityUserAuthenticatedViewsetTestCase(
                 format="json",
             )
 
-    def test_any_invalid_item_returns_403(self):
-        response = self._call_with_payload([self.valid_item, "not a dict"])
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+    def test_blank_demographics_pass_through(self):
+        item = dict(self.valid_item, id_number="", gender="", birth_year="")
+        response = self._call_with_payload([item])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_non_list_response_returns_403(self):
-        response = self._call_with_payload({"my_secret": "AKIA..."})
+    def test_anonymous_request_to_provisioned_device_is_rejected(self):
+        provision_device()
+        response = self._call_with_payload([self.valid_item])
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -1,4 +1,5 @@
 from django.core.management.base import CommandError
+from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import NotFound
 
@@ -19,6 +20,18 @@ def create_adhoc_group_for_learners(classroom, learners):
     for learner in learners:
         Membership.objects.create(user=learner, collection=adhoc_group)
     return adhoc_group
+
+
+class _RemoteFacilityUserSerializer(serializers.Serializer):
+    id = serializers.UUIDField(format="hex")
+    username = serializers.CharField()
+    full_name = serializers.CharField(allow_blank=True)
+    facility = serializers.UUIDField(format="hex")
+    is_superuser = serializers.BooleanField()
+    id_number = serializers.CharField(allow_blank=True)
+    gender = serializers.CharField(allow_blank=True)
+    birth_year = serializers.CharField(allow_blank=True)
+    roles = serializers.ListField(child=serializers.CharField())
 
 
 def get_remote_users_info(baseurl, facility_id, username, password, client=None):
@@ -81,13 +94,13 @@ def get_remote_users_info(baseurl, facility_id, username, password, client=None)
                 detail="Authentication failed",
                 code=error_constants.AUTHENTICATION_FAILED,
             )
-    auth_info = response.json()
+    serializer = _RemoteFacilityUserSerializer(data=response.json(), many=True)
+    auth_info = serializer.data if serializer.is_valid() else []
     if len(auth_info) > 1:
-        user_info = [u for u in response.json() if u["username"] == username][0]
+        user_info = [u for u in auth_info if u["username"] == username][0]
     else:
         user_info = auth_info[0]
-    facility_info = {"user": user_info, "users": auth_info}
-    return facility_info
+    return {"user": user_info, "users": auth_info}
 
 
 def get_remote_user_info(client, facility_id, adminUsername, adminPassword, user_id):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -108,7 +108,6 @@ from kolibri.core.utils.pagination import ValuesViewsetCursorPagination
 from kolibri.core.utils.pagination import ValuesViewsetLimitOffsetPagination
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.utils.conf import OPTIONS
-from kolibri.utils.urls import validator
 
 logger = logging.getLogger(__name__)
 
@@ -242,10 +241,9 @@ class RemoteMixin:
         qs = request.GET.copy()
         del qs[REMOTE_URL_PARAM]
         try:
-            validator(baseurl)
-        except ValidationError:
+            client = NetworkClient.build_for_address(baseurl)
+        except NetworkLocationNotFound:
             raise Http404("Remote resource not found")
-        client = NetworkClient.build_for_address(baseurl)
         remote_url = remote_path
         try:
             response = client.get(
@@ -1908,9 +1906,8 @@ class RemoteChannelViewSet(viewsets.ViewSet):
     ):
         if baseurl is not None:
             try:
-                validator(baseurl)
                 client = NetworkClient.build_for_address(baseurl)
-            except ValidationError:
+            except NetworkLocationNotFound:
                 baseurl = None
         if baseurl is None:
             client = NetworkClient(CENTRAL_CONTENT_BASE_URL)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -32,6 +32,7 @@ from kolibri.core.content.utils.paths import get_v2_channel_lookup_url
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
+from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
@@ -2873,6 +2874,10 @@ class ProxyContentMetadataTestCase(ContentNodeAPIBase, LiveServerTestCase):
     @property
     def baseurl(self):
         return self.live_server_url
+
+    def setUp(self):
+        super().setUp()
+        NetworkLocation.objects.update_or_create(base_url=self.baseurl)
 
     def _get(self, *args, **kwargs):
         if "data" not in kwargs:

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1073,7 +1073,7 @@ class ChannelDbVersionTestCase(TestCase):
         )
 
     @patch(
-        "kolibri.core.content.utils.resource_import.requests.Session",
+        "kolibri.core.content.utils.resource_import.SameHostSession",
     )
     @patch(
         "kolibri.core.content.utils.resource_import.paths.get_content_database_file_url",
@@ -3667,7 +3667,7 @@ class ImportManagerWithChannelDatabaseTestCase(TestCase):
         mock_session.head.return_value = mock_response
 
         with patch(
-            "kolibri.core.content.utils.resource_import.requests.Session",
+            "kolibri.core.content.utils.resource_import.SameHostSession",
             return_value=mock_session,
         ):
             remoteimport(
@@ -3714,7 +3714,7 @@ class ImportManagerWithChannelDatabaseTestCase(TestCase):
         mock_session.head.return_value = mock_response
 
         with patch(
-            "kolibri.core.content.utils.resource_import.requests.Session",
+            "kolibri.core.content.utils.resource_import.SameHostSession",
             return_value=mock_session,
         ):
             remoteimport(

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -4025,7 +4025,9 @@ class LookupChannelListingStatusTest(TestCase):
         mock_client.get.return_value = mock_response
         return mock_client
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_returns_dict_with_all_fields(self, mock_build):
         mock_build.return_value = self._mock_client(
             [
@@ -4043,7 +4045,9 @@ class LookupChannelListingStatusTest(TestCase):
         self.assertEqual(result["version"], 5)
         self.assertEqual(result["library"], "KOLIBRI")
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_token_lookup_uses_channel_versions_param(self, mock_build):
         mock_client = self._mock_client(
             [
@@ -4060,7 +4064,9 @@ class LookupChannelListingStatusTest(TestCase):
         call_url = mock_client.get.call_args[0][0]
         self.assertIn("channel_versions=true", call_url)
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_channel_id_lookup_includes_channel_versions_param(self, mock_build):
         mock_client = self._mock_client(
             [
@@ -4077,7 +4083,9 @@ class LookupChannelListingStatusTest(TestCase):
         call_url = mock_client.get.call_args[0][0]
         self.assertIn("channel_versions=true", call_url)
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_token_with_channel_id_validates_match(self, mock_build):
         other_channel_id = "aa480b60a7f4526f886e7df9f4e9b8ca"
         mock_build.return_value = self._mock_client(
@@ -4095,7 +4103,9 @@ class LookupChannelListingStatusTest(TestCase):
                 channel_id=self.the_channel_id, token="test-token-abc"
             )
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_404_returns_none(self, mock_build):
         mock_response = MagicMock()
         mock_response.status_code = 404
@@ -4107,7 +4117,9 @@ class LookupChannelListingStatusTest(TestCase):
         result = lookup_channel_listing_status(channel_id=self.the_channel_id)
         self.assertIsNone(result)
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_draft_channel_version_null_returns_none_in_dict(self, mock_build):
         mock_build.return_value = self._mock_client(
             [
@@ -4122,7 +4134,9 @@ class LookupChannelListingStatusTest(TestCase):
         result = lookup_channel_listing_status(token="draft-token")
         self.assertIsNone(result["version"])
 
-    @patch("kolibri.core.content.utils.resource_import.NetworkClient.build_for_address")
+    @patch(
+        "kolibri.core.content.utils.resource_import.NetworkClient.discover_from_address"
+    )
     def test_token_only_multiple_channels_raises_location_error(self, mock_build):
         mock_build.return_value = self._mock_client(
             [

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -57,7 +57,7 @@ def lookup_channel_listing_status(channel_id=None, token=None, baseurl=None):
         raise ValueError("Either token or channel_id must be provided")
 
     identifier = token if token is not None else channel_id
-    client = NetworkClient.build_for_address(baseurl)
+    client = NetworkClient.discover_from_address(baseurl)
     try:
         resp = client.get(get_channel_lookup_url(identifier=identifier))
     except NetworkLocationResponseFailure as e:

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -36,6 +36,7 @@ from kolibri.core.tasks.utils import JobProgressMixin
 from kolibri.core.utils.urls import reverse_path
 from kolibri.utils import conf
 from kolibri.utils import file_transfer as transfer
+from kolibri.utils.http_session import SameHostSession
 from kolibri.utils.system import get_free_space
 
 logger = logging.getLogger(__name__)
@@ -663,7 +664,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
         else:
             self.public = self.library = self.remote_version = None
 
-        self.session = requests.Session()
+        self.session = SameHostSession()
 
         super().__init__(
             channel_id,

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -10,7 +10,6 @@ from urllib.parse import unquote
 import html5lib
 from cheroot import wsgi
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 from django.http import HttpResponseNotAllowed
@@ -32,8 +31,8 @@ from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.utils.paths import get_content_storage_file_path
 from kolibri.core.content.utils.paths import get_content_storage_remote_url
 from kolibri.core.content.utils.paths import get_zip_content_base_path
+from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.utils.file_transfer import RemoteFile
-from kolibri.utils.urls import validator
 
 
 logger = logging.getLogger(__name__)
@@ -337,12 +336,10 @@ def _zip_content_from_request(request):  # noqa: C901
         )
 
     if remote_baseurl:
-        try:
-            remote_baseurl = unquote(remote_baseurl)
-            validator(remote_baseurl)
-        except ValidationError:
+        remote_baseurl = unquote(remote_baseurl)
+        if NetworkClient.known_location_for_address(remote_baseurl) is None:
             return create_error_response(
-                "{baseurl} is not a valid URL".format(baseurl=remote_baseurl)
+                "{baseurl} is not a known peer".format(baseurl=remote_baseurl)
             )
 
     # if the zipfile does not exist on disk, return a 404

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import decorators
+from rest_framework import serializers
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
@@ -94,6 +95,23 @@ class StaticNetworkLocationViewSet(NetworkLocationViewSet):
     queryset = StaticNetworkLocation.objects.all()
 
 
+class _RemoteFacilityPicturePasswordSerializer(serializers.Serializer):
+    icon_style = serializers.ChoiceField(choices=["standard", "colorful"])
+    show_icon_text = serializers.BooleanField()
+
+
+class _RemoteFacilitySerializer(serializers.Serializer):
+    id = serializers.UUIDField(format="hex")
+    dataset = serializers.UUIDField(format="hex")
+    name = serializers.CharField()
+    learner_can_login_with_no_password = serializers.BooleanField()
+    learner_can_sign_up = serializers.BooleanField()
+    on_my_own_setup = serializers.BooleanField()
+    picture_password_settings = _RemoteFacilityPicturePasswordSerializer(
+        allow_null=True
+    )
+
+
 class NetworkLocationFacilitiesView(BaseValuesViewset):
     queryset = NetworkLocation.objects.all()
     permission_classes = [IsAuthenticated | NotProvisionedHasPermission]
@@ -115,7 +133,10 @@ class NetworkLocationFacilitiesView(BaseValuesViewset):
                     response = client.get(
                         reverse_path("kolibri:core:publicfacility-list")
                     )
-                    facilities = response.json()
+                    serializer = _RemoteFacilitySerializer(
+                        data=response.json(), many=True
+                    )
+                    facilities = serializer.data if serializer.is_valid() else []
         except (errors.NetworkClientError, NetworkLocation.DoesNotExist):
             raise NotFound()
 

--- a/kolibri/core/discovery/serializers.py
+++ b/kolibri/core/discovery/serializers.py
@@ -49,7 +49,7 @@ class NetworkLocationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         try:
-            client = NetworkClient.build_for_address(data["base_url"])
+            client = NetworkClient.discover_from_address(data["base_url"])
         except (errors.NetworkClientError, errors.URLParseError) as e:
             raise ValidationError(
                 "Error with address {} ({})".format(

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -231,6 +231,105 @@ class NetworkLocationAPITestCase(APITestCase):
                 )
 
 
+class NetworkLocationFacilitiesViewTestCase(APITestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.peer = models.StaticNetworkLocation.objects.create(
+            base_url="http://peer.example/",
+            instance_id="b" * 32,
+        )
+
+    def setUp(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    valid_facility = {
+        "id": "00000000000000000000000000000003",
+        "dataset": "00000000000000000000000000000004",
+        "name": "Peer Facility",
+        "learner_can_login_with_no_password": False,
+        "learner_can_sign_up": True,
+        "on_my_own_setup": False,
+        "picture_password_settings": {
+            "icon_style": "standard",
+            "show_icon_text": True,
+        },
+    }
+
+    def _retrieve(self, payload):
+        with mock.patch("kolibri.core.discovery.api.NetworkClient") as NetworkClient:
+            client = (
+                NetworkClient.build_from_network_location.return_value.__enter__.return_value
+            )
+            client.base_url = self.peer.base_url
+            client.get.return_value.json.return_value = payload
+            return self.client.get(
+                reverse(
+                    "kolibri:core:networklocation_facilities-detail",
+                    kwargs={"pk": self.peer.id},
+                )
+            )
+
+    def test_well_formed_response_passes_through(self):
+        response = self._retrieve([self.valid_facility])
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.data["facilities"], [self.valid_facility])
+
+    def test_null_picture_password_settings_passes_through(self):
+        payload = [dict(self.valid_facility, picture_password_settings=None)]
+        response = self._retrieve(payload)
+        self.assertEqual(response.data["facilities"], payload)
+
+    def test_extra_keys_are_stripped(self):
+        smuggled = dict(self.valid_facility, smuggled="AKIA...", token="leaked")
+        response = self._retrieve([smuggled])
+        self.assertEqual(response.data["facilities"], [self.valid_facility])
+
+    def test_extra_keys_inside_picture_password_settings_are_stripped(self):
+        smuggled = dict(
+            self.valid_facility,
+            picture_password_settings={
+                "icon_style": "standard",
+                "show_icon_text": True,
+                "smuggled": "AKIA...",
+            },
+        )
+        response = self._retrieve([smuggled])
+        self.assertEqual(response.data["facilities"], [self.valid_facility])
+
+    def test_non_list_response_yields_empty_facilities(self):
+        response = self._retrieve({"my_secret": "AKIA..."})
+        self.assertEqual(response.data["facilities"], [])
+
+    def test_any_invalid_item_rejects_whole_response(self):
+        response = self._retrieve([self.valid_facility, "not a dict"])
+        self.assertEqual(response.data["facilities"], [])
+
+    def test_invalid_uuid_id_rejects_whole_response(self):
+        bad = dict(self.valid_facility, id="not-a-uuid")
+        response = self._retrieve([bad])
+        self.assertEqual(response.data["facilities"], [])
+
+    def test_invalid_picture_password_icon_style_rejects_whole_response(self):
+        bad = dict(
+            self.valid_facility,
+            picture_password_settings={
+                "icon_style": "rogue",
+                "show_icon_text": True,
+            },
+        )
+        response = self._retrieve([bad])
+        self.assertEqual(response.data["facilities"], [])
+
+
 class PinnedDeviceAPITestCase(APITestCase):
     databases = "__all__"
 

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -169,21 +169,55 @@ class NetworkClientTestCase(TestCase):
     @mock.patch.object(
         requests.Session, "request", mock_happy_request("https://happyurl.qqq/")
     )
-    def test_build_for_address__success(self):
-        nc = NetworkClient.build_for_address("happyurl.qqq")
+    def test_discover_from_address__success(self):
+        nc = NetworkClient.discover_from_address("happyurl.qqq")
         self.assertEqual(nc.base_url, "https://happyurl.qqq/")
 
     @mock.patch.object(
         requests.Session, "request", mock_sad_request("https://sadurl.qqq/")
     )
-    def test_build_for_address__not_found__request_failure(self):
+    def test_discover_from_address__not_found__request_failure(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
-            NetworkClient.build_for_address("sadurl.qqq")
+            NetworkClient.discover_from_address("sadurl.qqq")
 
     @mock.patch.object(requests.Session, "request", mock_not_found())
-    def test_build_for_address__not_found(self):
+    def test_discover_from_address__not_found(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
-            NetworkClient.build_for_address("nonkolibrihappyurl.qqq")
+            NetworkClient.discover_from_address("nonkolibrihappyurl.qqq")
+
+    @mock.patch.object(
+        requests.Session, "request", mock_happy_request("https://happyurl.qqq/")
+    )
+    def test_build_for_address__success(self):
+        NetworkLocation.objects.create(base_url="https://happyurl.qqq/")
+        nc = NetworkClient.build_for_address("https://happyurl.qqq/")
+        self.assertEqual(nc.base_url, "https://happyurl.qqq/")
+
+    @mock.patch.object(
+        requests.Session, "request", mock_happy_request("https://happyurl.qqq/")
+    )
+    def test_build_for_address__matches_via_variation(self):
+        NetworkLocation.objects.create(base_url="https://happyurl.qqq/")
+        nc = NetworkClient.build_for_address("happyurl.qqq")
+        self.assertEqual(nc.base_url, "https://happyurl.qqq/")
+
+    @mock.patch.object(
+        requests.Session, "request", mock_happy_request("http://happyurl.qqq:8080/")
+    )
+    def test_build_for_address__stored_without_trailing_slash(self):
+        # Stored base_urls aren't always normalized to a trailing slash —
+        # `get_normalized_url_variations` always adds one, so the allowlist
+        # lookup must tolerate either shape.
+        NetworkLocation.objects.create(base_url="http://happyurl.qqq:8080")
+        nc = NetworkClient.build_for_address("http://happyurl.qqq:8080")
+        self.assertEqual(nc.base_url, "http://happyurl.qqq:8080/")
+
+    @mock.patch.object(
+        requests.Session, "request", mock_happy_request("https://attacker.qqq/")
+    )
+    def test_build_for_address__not_in_allowlist(self):
+        with self.assertRaises(errors.NetworkLocationNotFound):
+            NetworkClient.build_for_address("https://attacker.qqq/")
 
     @mock.patch.object(
         requests.Session, "request", mock_happy_request("https://url.qqq/")

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -407,3 +407,26 @@ class NetworkClientTestCase(TestCase):
             with mock.patch.object(NetworkClient, "get", return_value=response):
                 with NetworkClient("http://url.qqq/") as nc:
                     nc.connect()
+
+    def _redirect_response(self, url, location):
+        response = requests.Response()
+        response.url = url
+        response.status_code = 302
+        response.headers["Location"] = location
+        return response
+
+    def test_get_redirect_target__cross_host_blocked(self):
+        response = self._redirect_response(
+            "http://peer.qqq/api/info/", "http://attacker.qqq/"
+        )
+        with NetworkClient("http://peer.qqq/") as nc:
+            self.assertIsNone(nc.get_redirect_target(response))
+
+    def test_get_redirect_target__same_host_followed(self):
+        response = self._redirect_response(
+            "http://peer.qqq/api/info/", "http://peer.qqq/api/info"
+        )
+        with NetworkClient("http://peer.qqq/") as nc:
+            self.assertEqual(
+                nc.get_redirect_target(response), "http://peer.qqq/api/info"
+            )

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -66,6 +66,26 @@ class NetworkClient(SameHostSession):
         return (DEFAULT_CONNECT_TIMEOUT, DEFAULT_SYNC_READ_TIMEOUT)
 
     @classmethod
+    def known_location_for_address(cls, address):
+        """
+        Looks up the NetworkLocation matching `address` exactly or via a normalized variation.
+
+        :param address: The address to look up in the allowlist
+        :return: The matching NetworkLocation, or None if malformed or not in the allowlist
+        :rtype: NetworkLocation|None
+        """
+        try:
+            variations = get_normalized_url_variations(address)
+        except errors.URLParseError:
+            return None
+        # Variations always end in `/`, but stored base_urls may or may not — e.g.
+        # `connect()` strips the trailing slash before persisting. Match both forms
+        # so a path-less peer is found regardless of which shape was stored.
+        candidates = set(variations)
+        candidates.update(url.rstrip("/") for url in variations)
+        return NetworkLocation.objects.filter(base_url__in=candidates).first()
+
+    @classmethod
     def build_for_address(cls, address, timeout=None):
         """
         Builds a NetworkClient for an address that already corresponds to a known peer.
@@ -79,10 +99,7 @@ class NetworkClient(SameHostSession):
         if timeout is None:
             timeout = cls._default_timeout()
 
-        candidates = [address] + list(get_normalized_url_variations(address))
-        network_location = NetworkLocation.objects.filter(
-            base_url__in=candidates
-        ).first()
+        network_location = cls.known_location_for_address(address)
         if network_location is None:
             raise errors.NetworkLocationNotFound()
 

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -60,57 +60,80 @@ class NetworkClient(SameHostSession):
         )
 
     @classmethod
+    def _default_timeout(cls):
+        if get_current_job() is not None:
+            return (DEFAULT_CONNECT_TIMEOUT, DEFAULT_ASYNC_READ_TIMEOUT)
+        return (DEFAULT_CONNECT_TIMEOUT, DEFAULT_SYNC_READ_TIMEOUT)
+
+    @classmethod
     def build_for_address(cls, address, timeout=None):
         """
+        Builds a NetworkClient for an address that already corresponds to a known peer.
+        Raises NetworkLocationNotFound if no NetworkLocation matches.
+
+        :param address: The address to look up in the allowlist
+        :param timeout: A timeout value in seconds or tuple for (connect, read)
+        :return: A NetworkClient with a verified connection
+        :rtype: NetworkClient|cls
+        """
+        if timeout is None:
+            timeout = cls._default_timeout()
+
+        candidates = [address] + list(get_normalized_url_variations(address))
+        network_location = NetworkLocation.objects.filter(
+            base_url__in=candidates
+        ).first()
+        if network_location is None:
+            raise errors.NetworkLocationNotFound()
+
+        with cls(network_location.base_url, timeout=timeout) as client:
+            last_accessed = network_location.last_accessed
+            if (
+                last_accessed
+                and (timezone.now() - last_accessed)
+                < timedelta(seconds=NETWORK_LOCATION_KEEP_ALIVE_TIMEOUT)
+                and network_location.connection_status == ConnectionStatus.Okay
+            ):
+                # If we know this location is okay and its been accessed recently,
+                # use it without calling connect() to save some resources
+                return client
+
+            if client.connect(raise_if_unavailable=False):
+                network_location.last_accessed = timezone.now()
+                network_location.connection_status = ConnectionStatus.Okay
+                network_location.save()
+                return client
+        raise errors.NetworkLocationNotFound()
+
+    @classmethod
+    def discover_from_address(cls, address, timeout=None):
+        """
         Normalizes the address URL and tries a number of variations until we find one
-        that's able to connect
+        that's able to connect. Use only from trusted entry points (discovery
+        validation, CLI management commands, internal re-probing).
 
         :param address: The address of which to try variations of
         :param timeout: A timeout value in seconds or tuple for (connect, read)
         :return: A NetworkClient with a verified connection
         :rtype: NetworkClient|cls
         """
+        if timeout is None:
+            timeout = cls._default_timeout()
+        try:
+            return cls.build_for_address(address, timeout=timeout)
+        except errors.NetworkLocationNotFound:
+            pass
+
         logger.info(
             "Attempting connections to variations of the URL: {}".format(address)
         )
-        if timeout is None:
-            if get_current_job() is not None:
-                # when we're within a job, then we can use longer timeouts
-                timeout = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_ASYNC_READ_TIMEOUT)
-            else:
-                # if we're within a request thread, then we limit it for an overall time
-                timeout = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_SYNC_READ_TIMEOUT)
         _, self_urls = get_urls()
-
-        # Check if the address is already known
-        network_location = NetworkLocation.objects.filter(base_url=address).first()
-        if network_location:
-            with cls(network_location.base_url, timeout=timeout) as client:
-                last_accessed = network_location.last_accessed
-                if (
-                    last_accessed
-                    and (timezone.now() - last_accessed)
-                    < timedelta(seconds=NETWORK_LOCATION_KEEP_ALIVE_TIMEOUT)
-                    and network_location.connection_status == ConnectionStatus.Okay
-                ):
-                    # If we know this location is okay and its been accessed recently,
-                    # use it without calling connect() to save some resources
-                    return client
-
-                if client.connect(raise_if_unavailable=False):
-                    network_location.last_accessed = timezone.now()
-                    network_location.connection_status = ConnectionStatus.Okay
-                    network_location.save()
-                    return client
-
-        # If we haven't found a known location, try variations
         for url in get_normalized_url_variations(address):
             if url in self_urls:
                 continue  # exclude our own URLs
             with cls(url, timeout=timeout) as client:
                 if client.connect(raise_if_unavailable=False):
                     return client
-        # we weren't able to connect to any of the URL variations, so all we can do is throw
         raise errors.NetworkLocationNotFound()
 
     @classmethod
@@ -130,7 +153,7 @@ class NetworkClient(SameHostSession):
             network_location.location_type is LocationTypes.Dynamic
             and network_location.connection_status == ConnectionStatus.Unknown
         ):
-            return cls.build_for_address(network_location.base_url, timeout=timeout)
+            return cls.discover_from_address(network_location.base_url, timeout=timeout)
         return cls(network_location.base_url, timeout=timeout)
 
     def head(self, path, **kwargs):

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -15,6 +15,7 @@ from kolibri.core.discovery.models import LocationTypes
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.urls import join_url
+from kolibri.utils.http_session import SameHostSession
 from kolibri.utils.server import get_urls
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ NETWORK_LOCATION_KEEP_ALIVE_TIMEOUT = 5
 DEFAULT_SYNC_READ_TIMEOUT = DEFAULT_READ_TIMEOUT / (len(HTTP_PORTS) + len(HTTPS_PORTS))
 
 
-class NetworkClient(requests.Session):
+class NetworkClient(SameHostSession):
     __slots__ = ("base_url", "timeout", "session", "device_info", "remote_ip")
 
     def __init__(self, base_url, timeout=None):

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
 from rest_framework import decorators
+from rest_framework import serializers
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
@@ -33,6 +34,10 @@ class HasPermissionDuringLODSetup(BasePermission):
         return get_device_setting("subset_of_users_device")
 
 
+class _PublicSignupErrorSerializer(serializers.Serializer):
+    id = serializers.CharField()
+
+
 @method_decorator(csrf_protect, name="dispatch")
 class SetupWizardResource(ViewSet):
     """
@@ -62,7 +67,16 @@ class SetupWizardResource(ViewSet):
             r = client.post(api_url, data=payload)
         except NetworkLocationResponseFailure as e:
             r = e.response
-        return Response({"status": r.status_code, "data": r.content})
+        errors = []
+        if r.status_code != 201:
+            try:
+                upstream = r.json()
+            except ValueError:
+                upstream = None
+            serializer = _PublicSignupErrorSerializer(data=upstream, many=True)
+            if serializer.is_valid():
+                errors = serializer.data
+        return Response({"status": r.status_code, "errors": errors})
 
 
 @method_decorator(csrf_protect, name="dispatch")

--- a/kolibri/plugins/setup_wizard/frontend/views/LodJoinFacility.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/LodJoinFacility.vue
@@ -68,7 +68,7 @@
           baseurl: baseurl.slice(0, -1),
           ...user,
         }).then(response => {
-          const { status, data } = response.data;
+          const { status, errors } = response.data;
 
           if (status == 201) {
             const task_name = 'kolibri.core.auth.tasks.peeruserimport';
@@ -87,8 +87,7 @@
                 this.handleApiError({ error: err });
               });
           } else {
-            const errorData = JSON.parse(data);
-            if (errorData.find(error => error.id === ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS)) {
+            if (errors.find(error => error.id === ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS)) {
               this.caughtErrors = [ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS];
             }
             this.loading = false;

--- a/kolibri/plugins/setup_wizard/test/test_api.py
+++ b/kolibri/plugins/setup_wizard/test/test_api.py
@@ -1,4 +1,7 @@
+import uuid
+
 from django.urls import reverse
+from mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
@@ -153,3 +156,63 @@ class CSRFProtectedSetupTestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class CreateUserOnRemoteTestCase(APITestCase):
+    url = "kolibri:kolibri.plugins.setup_wizard:setupwizard-createuseronremote"
+
+    def setUp(self):
+        clear_process_cache()
+
+    def _post(self, upstream_status, upstream_json, json_raises=None):
+        with patch("kolibri.plugins.setup_wizard.api.NetworkClient") as NetworkClient:
+            client = NetworkClient.build_for_address.return_value
+            client.post.return_value.status_code = upstream_status
+            if json_raises is not None:
+                client.post.return_value.json.side_effect = json_raises
+            else:
+                client.post.return_value.json.return_value = upstream_json
+            return self.client.post(
+                reverse(self.url),
+                {
+                    "baseurl": "http://remote.example",
+                    "facility_id": uuid.uuid4().hex,
+                    "username": "alice",
+                    "password": "p",
+                    "full_name": "Alice",
+                },
+                format="json",
+            )
+
+    def test_success_response_does_not_reflect_remote_body(self):
+        response = self._post(
+            201, {"id": uuid.uuid4().hex, "username": "alice", "secret": "AKIA..."}
+        )
+        self.assertEqual(response.data, {"status": 201, "errors": []})
+
+    def test_error_response_is_sanitized_to_id_only(self):
+        response = self._post(
+            400,
+            [
+                {
+                    "id": "USERNAME_ALREADY_EXISTS",
+                    "metadata": {"smuggled": "AKIA..."},
+                }
+            ],
+        )
+        self.assertEqual(
+            response.data,
+            {"status": 400, "errors": [{"id": "USERNAME_ALREADY_EXISTS"}]},
+        )
+
+    def test_non_list_error_response_returns_empty_errors(self):
+        response = self._post(500, {"detail": "leaked", "secret": "AKIA..."})
+        self.assertEqual(response.data, {"status": 500, "errors": []})
+
+    def test_any_invalid_error_item_rejects_whole_response(self):
+        response = self._post(400, [{"id": "USERNAME_ALREADY_EXISTS"}, "not a dict"])
+        self.assertEqual(response.data, {"status": 400, "errors": []})
+
+    def test_non_json_response_returns_empty_errors(self):
+        response = self._post(500, None, json_raises=ValueError("not JSON"))
+        self.assertEqual(response.data, {"status": 500, "errors": []})

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -19,6 +19,8 @@ from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 
+from kolibri.utils.http_session import SameHostSession
+
 
 try:
     # Pre-empt the PanicException that importing cryptography can cause
@@ -772,9 +774,10 @@ class FileDownload(Transfer):
         full_ranges=True,
     ):
 
-        # allow an existing requests.Session instance to be passed in, so it can be reused for speed
-        # initialize a fresh requests session, if one wasn't provided
-        self.session = session or requests.Session()
+        # Allow an existing requests.Session to be passed in, so it can be
+        # reused for speed. The default blocks cross-host redirects so a
+        # caller-supplied baseurl can't pivot us onto another host.
+        self.session = session or SameHostSession()
 
         # A flag to allow the download to remain in the chunked file directory
         # for easier clean up when it is just a temporary download.

--- a/kolibri/utils/http_session.py
+++ b/kolibri/utils/http_session.py
@@ -1,0 +1,34 @@
+"""
+HTTP utilities shared across Kolibri's remote-fetching code paths.
+"""
+import logging
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _host(url):
+    """The hostname of a URL, lowercased for comparison."""
+    hostname = urlparse(url).hostname
+    return hostname.lower() if hostname else None
+
+
+class SameHostSession(requests.Session):
+    """A :class:`requests.Session` that refuses cross-host redirects."""
+
+    def get_redirect_target(self, resp):
+        target = super().get_redirect_target(resp)
+        if target is None:
+            return None
+        absolute_target = urljoin(resp.url, target)
+        if _host(absolute_target) != _host(resp.url):
+            logger.info(
+                "Refusing cross-host redirect from %s to %s",
+                resp.url,
+                absolute_target,
+            )
+            return None
+        return target

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -21,8 +21,8 @@ from whitenoise.responders import Response
 from whitenoise.responders import StaticFile
 from whitenoise.string_utils import decode_path_info
 
+from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.utils.file_transfer import RemoteFile
-from kolibri.utils.urls import validator
 
 
 compressed_file_extensions = ("gz",)
@@ -279,7 +279,6 @@ class StreamingStaticFile(EndRangeStaticFile):
             return NOT_ALLOWED_RESPONSE
         if method != "HEAD":
             try:
-                validator(self.remote_url)
                 file_handle = RemoteFile(
                     self.path,
                     self.remote_url,
@@ -364,6 +363,11 @@ class DynamicWhiteNoise(WhiteNoise):
         remote_baseurl = parse_qs(environ.get("QUERY_STRING", "")).get(
             "baseurl", [None]
         )[0]
+        if (
+            remote_baseurl is not None
+            and NetworkClient.known_location_for_address(remote_baseurl) is None
+        ):
+            remote_baseurl = None
         if self.autorefresh:
             static_file = self.find_file(path)
         else:

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -591,7 +591,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
     def test_remote_file_iterator(self):
         output = b""
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -609,7 +609,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
     def test_remote_file_iterator_repeated(self):
         output = b""
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -626,7 +626,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
 
         output = b""
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -643,7 +643,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
         data_out = b""
 
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -661,7 +661,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
         end_range = self.file_size // 3 * 2
 
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -695,7 +695,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
         end_range = self.file_size // 3 * 2
 
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -725,7 +725,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
         ]
 
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             for start_range, end_range in ranges:
@@ -761,7 +761,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
         ]
 
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             for start_range, end_range in ranges:
@@ -797,7 +797,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
 
     def test_remote_file_seek_and_tell(self):
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -807,7 +807,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
     def test_remote_file_finalized_during_read(self):
         self.set_test_data(finished=True)
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)
@@ -820,7 +820,7 @@ class TestTransferNoFullRangesDownloadByteRangeSupport(
     def test_remote_file_cleaned_up_during_read(self):
         self.set_test_data(finished=True)
         with patch(
-            "kolibri.utils.file_transfer.requests.Session",
+            "kolibri.utils.file_transfer.SameHostSession",
             return_value=self.mock_session,
         ):
             rf = RemoteFile(self.dest, self.source)

--- a/kolibri/utils/tests/test_http_session.py
+++ b/kolibri/utils/tests/test_http_session.py
@@ -1,0 +1,75 @@
+import requests
+from django.test import TestCase
+
+from kolibri.utils.http_session import SameHostSession
+
+
+def _redirect_response(url, location, status_code=302):
+    """Build a Response whose .url and Location header trigger redirect logic."""
+    response = requests.Response()
+    response.url = url
+    response.status_code = status_code
+    response.headers["Location"] = location
+    return response
+
+
+class SameHostSessionTestCase(TestCase):
+    def setUp(self):
+        self.session = SameHostSession()
+
+    def test_same_host_redirect_is_followed(self):
+        resp = _redirect_response(
+            "http://peer.example/api/info/", "http://peer.example/api/info"
+        )
+        self.assertEqual(
+            self.session.get_redirect_target(resp), "http://peer.example/api/info"
+        )
+
+    def test_https_upgrade_on_same_host_is_followed(self):
+        resp = _redirect_response(
+            "http://peer.example/api/info/", "https://peer.example/api/info/"
+        )
+        self.assertEqual(
+            self.session.get_redirect_target(resp),
+            "https://peer.example/api/info/",
+        )
+
+    def test_relative_redirect_is_followed(self):
+        resp = _redirect_response("http://peer.example/api/info/", "/new/")
+        self.assertEqual(self.session.get_redirect_target(resp), "/new/")
+
+    def test_cross_host_redirect_is_blocked(self):
+        resp = _redirect_response(
+            "http://peer.example/api/info/", "http://attacker.example/"
+        )
+        self.assertIsNone(self.session.get_redirect_target(resp))
+
+    def test_redirect_to_cloud_metadata_is_blocked(self):
+        resp = _redirect_response(
+            "http://peer.example/api/info/",
+            "http://169.254.169.254/latest/meta-data/",
+        )
+        self.assertIsNone(self.session.get_redirect_target(resp))
+
+    def test_same_host_different_port_is_followed(self):
+        resp = _redirect_response(
+            "http://peer.example:80/api/info/", "http://peer.example:8080/api/info/"
+        )
+        self.assertEqual(
+            self.session.get_redirect_target(resp),
+            "http://peer.example:8080/api/info/",
+        )
+
+    def test_hostname_comparison_is_case_insensitive(self):
+        resp = _redirect_response(
+            "http://PEER.example/api/info/", "http://peer.example/new/"
+        )
+        self.assertEqual(
+            self.session.get_redirect_target(resp), "http://peer.example/new/"
+        )
+
+    def test_non_redirect_response_returns_none(self):
+        response = requests.Response()
+        response.url = "http://peer.example/"
+        response.status_code = 200
+        self.assertIsNone(self.session.get_redirect_target(response))

--- a/kolibri/utils/urls.py
+++ b/kolibri/utils/urls.py
@@ -1,7 +1,0 @@
-from django.core.validators import URLValidator
-
-validator = URLValidator(schemes=["http", "https"])
-# Need to do this as the default message is a lazily translated string
-# which then tries to invoke the Django settings, so would not work
-# outside of a Django setup context.
-validator.message = "Invalid URL"


### PR DESCRIPTION
## Summary

Tightens the API endpoints that fetch from a caller-supplied remote URL:

- **Response shape validation** — `remotefacilityuser`, `remotefacilityauthenticateduserinfo`, `NetworkLocationFacilitiesView`, and the setup-wizard `createuseronremote` proxy now validate upstream JSON against a DRF schema and refuse to reflect non-matching responses. `createuseronremote` returns `{status, errors: [{id}]}` instead of the raw body.
- **Permission classes** — `remotefacilityuser` / `remotefacilityauthenticateduserinfo` move from `AllowAny` to `IsAuthenticated | NotProvisionedHasPermission`, matching `NetworkLocationFacilitiesView`.
- **Redirect handling** — `SameHostSession` blocks cross-host 30x on `NetworkClient`, `FileDownload`'s default session, and the channel-import session. Port changes and HTTP→HTTPS upgrades still work.
- **Peer allowlist** — `NetworkClient.build_for_address` resolves only to addresses already registered as a `NetworkLocation`; discovery / CLI / re-probing keep variation-probing via a separate `discover_from_address`. The zipcontent WSGI handler and DynamicWhiteNoise's dynamic-file resolver are gated on the same allowlist via `known_location_for_address`. Studio and KDP are seeded as Reserved rows so `CENTRAL_CONTENT_BASE_URL` keeps working.
- **Cleanup** — remove the now-redundant `validator(baseurl)` preamble in front of `build_for_address` calls, and delete `kolibri.utils.urls`.

## Reviewer guidance

Areas worth scrutiny:

- **Auth tightening on `remotefacilityuser` viewsets** (`kolibri/core/auth/api.py`) — verify the setup wizard, admin import, and profile flows still reach these endpoints with the new `IsAuthenticated | NotProvisionedHasPermission` gate.
- **Peer allowlist on `build_for_address`** (`kolibri/core/discovery/utils/network/client.py`) — content import from a registered peer must still hit the keep-alive fast path; CLI / discovery paths route through `discover_from_address` and must still accept new addresses.
- **Reserved seed rows** — Studio and KDP are seeded as `NetworkLocation` rows so `CENTRAL_CONTENT_BASE_URL` resolves through the allowlist. Worth confirming the seeding runs idempotently and that a custom `CENTRAL_CONTENT_BASE_URL` is honoured.
- **`kolibri.utils.urls` deletion** — module is gone; the callers it had are converted, but worth a `grep` over the diff for any straggler import.

Suggested manual run-throughs:

- Run through setup wizard against a peer, including the LOD flow.
- Import content from a registered peer (channel + resources)
- Browse remote content in Learn, both regular resources and zipcontent.
- Register a new peer via the discovery UI (e.g. kolibri-demo) and confirm you can import content from it.

## Manual verification

LOD setup-wizard walkthrough against a freshly-provisioned peer, end to end:

| Step | Screenshot |
|------|------------|
| Adding a peer (exercises `discover_from_address`) | ![Add peer](https://i.imgur.com/t7hji9p.png) |
| Create-account form after peer / facility list resolved | ![Create account](https://i.imgur.com/tqWy81W.png) |
| Sync completion (`createuseronremote` + sanitized response path) | ![Complete](https://i.imgur.com/1sj9fVY.png) |

Direct API smoke tests against the provisioned primary also confirmed `GET /api/auth/remotefacilityuser`, `POST /api/auth/remotefacilityauthenticateduserinfo`, and `GET /api/discovery/networklocation_facilities/{id}/` all return validated payloads under the new auth gate.

## AI usage

Used Claude Code to draft commits, serializer schemas, and tests, working from a short brief per area. Reviewed every diff hunk, rejected verbose error handling and unnecessary abstractions, and ran the full Python test suite locally before each push.