### PR TITLE
Authorization scopes with enhanced test coverage

### DIFF
--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -6,10 +6,13 @@ backends are checked in the order they're listed.
 import abc
 
 from django.contrib.sessions.backends.db import SessionStore as DBStore
+from django.db.models import Exists
+from django.db.models import OuterRef
 from django.utils.functional import cached_property
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import Role
 from kolibri.core.auth.models import Session
 from kolibri.core.device.utils import is_full_facility_import
 
@@ -61,7 +64,11 @@ class FacilityAuthScope(abc.ABC):
         qs = FacilityUser.objects.all()
         if self.dataset_id:
             qs = qs.filter(dataset_id=self.dataset_id)
-        return qs
+        # users who have the most roles could be more active than users who have less, but instead
+        # of trying to authenticate them first, through ordering, we just prioritize by date joined
+        return qs.annotate(
+            has_roles=Exists(Role.objects.filter(user_id=OuterRef("pk"))),
+        ).order_by("-has_roles", "date_joined")
 
     @abc.abstractmethod
     def matches_credentials(self, user):
@@ -104,7 +111,7 @@ class UsernameAuthScope(FacilityAuthScope):
         return (
             self.dataset_id
             and user.dataset.learner_can_login_with_no_password
-            and not user.roles.count()
+            and not user.has_roles
             and (not user.is_superuser or self.is_subset_of_users_device)
         )
 
@@ -133,7 +140,7 @@ class PicturePasswordAuthScope(FacilityAuthScope):
         return (
             self.dataset_id
             and user.dataset.picture_password_settings is not None
-            and not user.roles.count()
+            and not user.has_roles
             and (not user.is_superuser or self.is_subset_of_users_device)
         )
 

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -3,15 +3,139 @@ Implements custom auth backends as described in the Django docs, for our custom 
 The appropriate classes should be listed in the AUTHENTICATION_BACKENDS. Note that authentication
 backends are checked in the order they're listed.
 """
+import abc
+
 from django.contrib.sessions.backends.db import SessionStore as DBStore
-from django.db.models import Q
+from django.utils.functional import cached_property
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Session
+from kolibri.core.device.utils import is_full_facility_import
 
 
 FACILITY_CREDENTIAL_KEY = "facility"
+
+
+class FacilityAuthScope(abc.ABC):
+    """Base facility scope for authentication"""
+
+    def __init__(self, facility_or_id):
+        """
+        :param facility_or_id: The facility ID string or a Facility object
+        """
+        self.facility_or_id = facility_or_id
+
+    @cached_property
+    def dataset_id(self):
+        """
+        Resolves a facility string ID or object to its dataset ID.
+        See FacilityUserBackend.authenticate on how it accepts either
+
+        :return: The facility dataset ID
+        """
+        if not self.facility_or_id:
+            return None
+
+        # Resolve dataset_id to leverage the (dataset, picture_password) unique
+        # index. facility may be a Facility object or a raw pk/UUID.
+        if isinstance(self.facility_or_id, Facility):
+            return self.facility_or_id.dataset_id
+
+        try:
+            return Facility.objects.values_list("dataset_id", flat=True).get(
+                pk=self.facility_or_id
+            )
+        except Facility.DoesNotExist:
+            return None
+
+    @cached_property
+    def is_subset_of_users_device(self):
+        return self.dataset_id and not is_full_facility_import(self.dataset_id)
+
+    def get_candidate_users(self):
+        """
+        Determines candidate users for checking authorization
+        :return: A queryset of FacilityUser objects
+        """
+        qs = FacilityUser.objects.all()
+        if self.dataset_id:
+            qs = qs.filter(dataset_id=self.dataset_id)
+        return qs
+
+    @abc.abstractmethod
+    def matches_credentials(self, user):
+        """
+        Determines whether this user is authorized
+        :param user: A FacilityUser object
+        :return: A boolean indicating authorization
+        """
+        pass
+
+
+class UsernameAuthScope(FacilityAuthScope):
+    """Auth scope for username/password authentication"""
+
+    def __init__(self, facility_or_id, username=None, password=None):
+        super().__init__(facility_or_id)
+        self.username = username
+        self.password = password
+        self.case_sensitive = True
+
+    def set_case_insensitive(self):
+        self.case_sensitive = False
+
+    def get_candidate_users(self):
+        qs = super().get_candidate_users()
+        if self.case_sensitive:
+            return qs.filter(username=self.username)
+        return qs.filter(username__iexact=self.username)
+
+    def matches_credentials(self, user):
+        """
+        Either the provided password matches the user, or the user is a learner and the facility
+        configuration allows passwordless sign-in.
+        :param user: A FacilityUser object
+        :return: Whether the user is authorized
+        """
+        if user.check_password(self.password):
+            return True
+
+        return (
+            self.dataset_id
+            and user.dataset.learner_can_login_with_no_password
+            and not user.roles.count()
+            and (not user.is_superuser or self.is_subset_of_users_device)
+        )
+
+
+class PicturePasswordAuthScope(FacilityAuthScope):
+    """Auth scope for picture password authentication"""
+
+    def __init__(self, facility_or_id, picture_password=None):
+        super().__init__(facility_or_id)
+        self.picture_password = picture_password
+
+    def get_candidate_users(self):
+        if not self.dataset_id:
+            return FacilityUser.objects.none()
+        return (
+            super().get_candidate_users().filter(picture_password=self.picture_password)
+        )
+
+    def matches_credentials(self, user):
+        """
+        Validates that the user is a learner and that the facility configuration allows picture
+        password sign-in.
+        :param user: A FacilityUser object
+        :return: Whether the user is authorized
+        """
+        return (
+            self.dataset_id
+            and user.dataset.picture_password_settings is not None
+            and not user.roles.count()
+            and (not user.is_superuser or self.is_subset_of_users_device)
+        )
 
 
 class FacilityUserBackend:
@@ -38,70 +162,25 @@ class FacilityUserBackend:
         # The None check is load-bearing: filter(picture_password=None) would
         # match rows where the column IS NULL, returning an arbitrary learner.
         if picture_password is not None:
-            return self._authenticate_picture_password(picture_password, facility)
+            auth_scope = PicturePasswordAuthScope(facility, picture_password)
+            return self._run(auth_scope)
 
         # First, attempt case-sensitive login
-        user = self.authenticate_case_sensitive(username, password, facility)
+        auth_scope = UsernameAuthScope(facility, username=username, password=password)
+
+        user = self._run(auth_scope)
         if user:
             return user
 
         # If case-sensitive login fails, attempt case-insensitive login
-        user = self.authenticate_case_insensitive(username, password, facility)
-        return user
+        auth_scope.set_case_insensitive()
+        return self._run(auth_scope)
 
-    def _authenticate_picture_password(self, picture_password, facility):
-        if not facility:
-            return None
-        # Resolve dataset_id to leverage the (dataset, picture_password) unique
-        # index. facility may be a Facility object or a raw pk/UUID.
-        if hasattr(facility, "dataset_id"):
-            dataset_id = facility.dataset_id
-        else:
-            try:
-                dataset_id = Facility.objects.values_list("dataset_id", flat=True).get(
-                    pk=facility
-                )
-            except Facility.DoesNotExist:
-                return None
-        return (
-            FacilityUser.objects.filter(
-                picture_password=picture_password,
-                dataset_id=dataset_id,
-                # Restrict to learners only (no facility roles).
-                roles__isnull=True,
-            )
-            .filter(
-                # Exclude device superusers; allow users with no devicepermissions row.
-                Q(devicepermissions__is_superuser=False)
-                | Q(devicepermissions__isnull=True)
-            )
-            .first()
-        )
-
-    def _authenticate_users(self, users, password, facility):
-        if facility:
-            users = users.filter(facility=facility)
-        for user in users:
-            if user.check_password(password):
-                return user
-            # Allow login without password for learners for facilities that allow this.
-            # Must specify the facility, to prevent accidental logins
-            elif (
-                facility
-                and user.dataset.learner_can_login_with_no_password
-                and not user.roles.count()
-                and not user.is_superuser
-            ):
+    def _run(self, auth_scope):
+        for user in auth_scope.get_candidate_users():
+            if auth_scope.matches_credentials(user):
                 return user
         return None
-
-    def authenticate_case_sensitive(self, username, password, facility):
-        users = FacilityUser.objects.filter(username=username)
-        return self._authenticate_users(users, password, facility)
-
-    def authenticate_case_insensitive(self, username, password, facility):
-        users = FacilityUser.objects.filter(username__iexact=username)
-        return self._authenticate_users(users, password, facility)
 
     def get_user(self, user_id):
         """

--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -45,6 +45,25 @@ def setup_device():
     return facility, superuser
 
 
+def enable_picture_password(facility):
+    dataset = facility.dataset
+    dataset.learner_can_login_with_no_password = True
+    dataset.learner_can_edit_password = False
+    dataset.picture_password_settings = {
+        "icon_style": "standard",
+        "show_icon_text": True,
+    }
+    dataset.save()
+
+
+def disable_picture_password(facility, passwordless=False):
+    dataset = facility.dataset
+    dataset.learner_can_login_with_no_password = passwordless
+    dataset.learner_can_edit_password = not passwordless
+    dataset.picture_password_settings = None
+    dataset.save()
+
+
 def create_dummy_facility_data(
     allow_sign_ups=False, classroom_count=2, learnergroup_count=2
 ):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -35,7 +35,9 @@ from ..constants.facility_presets import mappings
 from ..models import Facility
 from ..serializers import _prepare_for_bulk_create
 from .helpers import create_superuser
+from .helpers import disable_picture_password
 from .helpers import DUMMY_PASSWORD
+from .helpers import enable_picture_password
 from .helpers import provision_device
 from .helpers import setup_device
 from kolibri.core import error_constants
@@ -1871,6 +1873,10 @@ class PicturePasswordLoginTestCase(APITestCase):
         cls.learner.picture_password = "1.2.3"
         cls.learner.save(update_fields=["picture_password"])
 
+    def setUp(self):
+        enable_picture_password(self.facility)
+        enable_picture_password(self.other_facility)
+
     def test_valid_picture_password_creates_session(self):
         response = self.client.post(
             reverse("kolibri:core:session-list"),
@@ -1882,6 +1888,21 @@ class PicturePasswordLoginTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["user_id"], self.learner.id)
+
+    def test_picture_password_not_enabled(self):
+        disable_picture_password(self.facility, passwordless=True)
+
+        response = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "picture_password": "1.2.3",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(response.data[0]["id"], error_constants.NOT_FOUND)
 
     def test_picture_password_wrong_facility_returns_not_found(self):
         response = self.client.post(
@@ -2013,30 +2034,6 @@ class PicturePasswordLoginTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["user_id"], self.learner.id)
-
-
-class PicturePasswordPasswordlessLoginTestCase(APITestCase):
-    """Passwordless login must still work when picture-password feature is enabled."""
-
-    databases = "__all__"
-
-    @classmethod
-    def setUpTestData(cls):
-        provision_device()
-        cls.facility = FacilityFactory.create()
-        cls.facility.dataset.learner_can_login_with_no_password = True
-        cls.facility.dataset.learner_can_edit_password = False
-        cls.facility.dataset.save()
-
-    def test_passwordless_login_unaffected_by_picture_password_feature(self):
-        learner = FacilityUserFactory.create(facility=self.facility)
-        response = self.client.post(
-            reverse("kolibri:core:session-list"),
-            data={"username": learner.username, "facility": self.facility.id},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["user_id"], learner.id)
 
 
 class SignUpBase:
@@ -4072,6 +4069,9 @@ class PicturePasswordPrevalidateTestCase(APITestCase):
         cls.learner = FacilityUserFactory.create(facility=cls.facility)
         cls.learner.picture_password = "1.2.3"
         cls.learner.save(update_fields=["picture_password"])
+
+    def setUp(self):
+        enable_picture_password(self.facility)
 
     def _url(self):
         return reverse("kolibri:core:session-list") + "?prevalidate=true"

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -1,7 +1,9 @@
 import uuid
+from datetime import timedelta
 
 import mock
 from django.test import TestCase
+from django.utils import timezone
 
 from ..backends import FacilityAuthScope
 from ..backends import FacilityUserBackend
@@ -41,6 +43,8 @@ class FacilityUserBackendTestCase(TestCase):
             facility=cls.facility,
             picture_password="1.2.3",
         )
+        cls.picture_user.set_password("foo")
+        cls.picture_user.save()
 
         cls.request = mock.Mock()
 
@@ -86,14 +90,14 @@ class FacilityUserBackendTestCase(TestCase):
             ),
         )
 
-    def test_authenticate__returns_first_case_insensitive_match_after_case_sensitive_miss(
+    def test_authenticate__returns_unambiguous_case_insensitive_match_after_case_sensitive_miss(
         self,
     ):
         self.assertEqual(
-            self.user,
+            self.picture_user,
             FacilityUserBackend().authenticate(
                 self.request,
-                username="MIKE",
+                username="PIC-USER",
                 password="foo",
                 facility=self.facility,
             ),
@@ -374,6 +378,46 @@ class FacilityAuthScopeTestCase(TestCase):
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
         self.assertEqual(list(auth_scope.get_candidate_users()), [scoped_user])
 
+    def test_get_candidate_users__orders_users_by_has_roles_then_date_joined(self):
+        base_time = timezone.now()
+        learner_old = FacilityUser.objects.create(
+            username="learner-old",
+            facility=self.facility,
+        )
+        coach_new = FacilityUser.objects.create(
+            username="coach-new",
+            facility=self.facility,
+        )
+        coach_old = FacilityUser.objects.create(
+            username="coach-old",
+            facility=self.facility,
+        )
+        learner_new = FacilityUser.objects.create(
+            username="learner-new",
+            facility=self.facility,
+        )
+        self.facility.add_coach(coach_new)
+        self.facility.add_coach(coach_old)
+
+        FacilityUser.objects.filter(pk=learner_old.pk).update(
+            date_joined=base_time + timedelta(seconds=1)
+        )
+        FacilityUser.objects.filter(pk=coach_new.pk).update(
+            date_joined=base_time + timedelta(seconds=4)
+        )
+        FacilityUser.objects.filter(pk=coach_old.pk).update(
+            date_joined=base_time + timedelta(seconds=2)
+        )
+        FacilityUser.objects.filter(pk=learner_new.pk).update(
+            date_joined=base_time + timedelta(seconds=3)
+        )
+
+        auth_scope = _NoMatchFacilityAuthScope(self.facility)
+        self.assertEqual(
+            list(auth_scope.get_candidate_users()),
+            [coach_old, coach_new, learner_old, learner_new],
+        )
+
 
 class PicturePasswordAuthScopeTestCase(TestCase):
     @classmethod
@@ -394,6 +438,7 @@ class PicturePasswordAuthScopeTestCase(TestCase):
             facility=cls.facility,
             picture_password="1.2.3",
         )
+        cls._set_has_roles(cls.learner)
 
     def setUp(self):
         dataset_id_patcher = mock.patch(
@@ -402,6 +447,12 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         self.is_full_facility_import = dataset_id_patcher.start()
         self.is_full_facility_import.return_value = True
         self.addCleanup(dataset_id_patcher.stop)
+
+    @classmethod
+    def _set_has_roles(cls, user):
+        """This is annotated by the auth scope querysets"""
+        setattr(user, "has_roles", user.roles.count() > 0)
+        return user
 
     def test_authenticate__returns_learner_for_valid_picture_password(self):
         auth_scope = PicturePasswordAuthScope(self.facility, "1.2.3")
@@ -429,7 +480,7 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         self.facility.add_coach(coach)
 
         auth_scope = PicturePasswordAuthScope(self.facility, "4.5.6")
-        self.assertFalse(auth_scope.matches_credentials(coach))
+        self.assertFalse(auth_scope.matches_credentials(self._set_has_roles(coach)))
 
     def test_matches_credentials__returns_false_for_device_superuser_when_full_import(
         self,
@@ -439,7 +490,7 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         superuser.save(update_fields=["picture_password"])
 
         auth_scope = PicturePasswordAuthScope(self.facility, "2.4.6")
-        self.assertFalse(auth_scope.matches_credentials(superuser))
+        self.assertFalse(auth_scope.matches_credentials(self._set_has_roles(superuser)))
 
     def test_matches_credentials__returns_true_for_device_superuser_when_single_user_on_device(
         self,
@@ -450,7 +501,7 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         superuser.save(update_fields=["picture_password"])
 
         auth_scope = PicturePasswordAuthScope(self.facility, "2.4.6")
-        self.assertTrue(auth_scope.matches_credentials(superuser))
+        self.assertTrue(auth_scope.matches_credentials(self._set_has_roles(superuser)))
 
 
 class UsernameAuthScopeTestCase(TestCase):
@@ -460,6 +511,12 @@ class UsernameAuthScopeTestCase(TestCase):
         cls.user = FacilityUser(username="Mike", facility=cls.facility)
         cls.user.set_password("foo")
         cls.user.save()
+
+    @classmethod
+    def _set_has_roles(cls, user):
+        """This is annotated by the auth scope querysets"""
+        setattr(user, "has_roles", user.roles.count() > 0)
+        return user
 
     def test_get_candidate_users__filters_by_case_sensitive_username_when_enabled(self):
         auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
@@ -480,3 +537,21 @@ class UsernameAuthScopeTestCase(TestCase):
     def test_matches_credentials__returns_true_for_matching_password(self):
         auth_scope = UsernameAuthScope(self.facility, username="Mike", password="foo")
         self.assertTrue(auth_scope.matches_credentials(self.user))
+
+    def test_matches_credentials__returns_true_for_passwordless_learner_with_role_count_zero(
+        self,
+    ):
+        disable_picture_password(self.facility, passwordless=True)
+        auth_scope = UsernameAuthScope(self.facility, username="Mike", password="wrong")
+        self.assertTrue(auth_scope.matches_credentials(self._set_has_roles(self.user)))
+
+    def test_matches_credentials__returns_false_for_passwordless_coach_with_nonzero_role_count(
+        self,
+    ):
+        disable_picture_password(self.facility, passwordless=True)
+        coach = FacilityUser.objects.create(username="coach", facility=self.facility)
+        self.facility.add_coach(coach)
+        auth_scope = UsernameAuthScope(
+            self.facility, username="coach", password="wrong"
+        )
+        self.assertFalse(auth_scope.matches_credentials(self._set_has_roles(coach)))

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -1,82 +1,105 @@
+import uuid
+
 import mock
 from django.test import TestCase
 
+from ..backends import FacilityAuthScope
 from ..backends import FacilityUserBackend
+from ..backends import PicturePasswordAuthScope
+from ..backends import UsernameAuthScope
 from ..models import Facility
 from ..models import FacilityUser
 from .helpers import create_superuser
+from .helpers import disable_picture_password
+from .helpers import DUMMY_PASSWORD
+from .helpers import enable_picture_password
+
+
+class _NoMatchFacilityAuthScope(FacilityAuthScope):
+    def matches_credentials(self, user):
+        return False
 
 
 class FacilityUserBackendTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.facility = Facility.objects.create()
+        cls.other_facility = Facility.objects.create()
+
+        cls.dataset = cls.facility.dataset
+
         cls.user = FacilityUser(username="Mike", facility=cls.facility)
         cls.user.set_password("foo")
         cls.user.save()
-        cls.user_other_mike = FacilityUser.objects.create(
-            username="mike", facility=cls.facility
-        )
+
+        cls.user_other_mike = FacilityUser(username="mike", facility=cls.facility)
         cls.user_other_mike.set_password("foo")
         cls.user_other_mike.save()
+
+        cls.picture_user = FacilityUser.objects.create(
+            username="pic-user",
+            facility=cls.facility,
+            picture_password="1.2.3",
+        )
+
         cls.request = mock.Mock()
 
-    def test_facility_user_authenticated(self):
+    def setUp(self):
+        dataset_id_patcher = mock.patch(
+            "kolibri.core.auth.backends.is_full_facility_import"
+        )
+        self.is_full_facility_import = dataset_id_patcher.start()
+        self.is_full_facility_import.return_value = True
+        self.addCleanup(dataset_id_patcher.stop)
+
+        disable_picture_password(self.facility, passwordless=False)
+
+    def test_authenticate__returns_user_for_valid_facility_object_credentials(self):
         self.assertEqual(
             self.user,
             FacilityUserBackend().authenticate(
-                self.request, username="Mike", password="foo", facility=self.facility
+                self.request,
+                username="Mike",
+                password="foo",
+                facility=self.facility,
             ),
         )
 
-    def test_facility_user_other_mike_authenticated(self):
-        self.assertEqual(
-            self.user_other_mike,
-            FacilityUserBackend().authenticate(
-                self.request, username="mike", password="foo", facility=self.facility
-            ),
-        )
-
-    def test_facility_user_authenticated__facility_id(self):
+    def test_authenticate__returns_user_for_valid_facility_pk_credentials(self):
         self.assertEqual(
             self.user,
             FacilityUserBackend().authenticate(
-                self.request, username="Mike", password="foo", facility=self.facility.pk
+                self.request,
+                username="Mike",
+                password="foo",
+                facility=self.facility.pk,
             ),
         )
 
-    def test_facility_user_other_mike_authenticated__facility_id(self):
-        self.assertEqual(
-            self.user_other_mike,
-            FacilityUserBackend().authenticate(
-                self.request, username="mike", password="foo", facility=self.facility.pk
-            ),
-        )
-
-    def test_facility_user_authentication_does_not_require_facility(self):
+    def test_authenticate__returns_user_without_facility_when_credentials_match(self):
         self.assertEqual(
             self.user,
             FacilityUserBackend().authenticate(
-                self.request, username="Mike", password="foo"
+                self.request,
+                username="Mike",
+                password="foo",
             ),
         )
 
-    def test_facility_user_other_mike_authentication_does_not_require_facility(self):
+    def test_authenticate__returns_first_case_insensitive_match_after_case_sensitive_miss(
+        self,
+    ):
         self.assertEqual(
-            self.user_other_mike,
+            self.user,
             FacilityUserBackend().authenticate(
-                self.request, username="mike", password="foo"
+                self.request,
+                username="MIKE",
+                password="foo",
+                facility=self.facility,
             ),
         )
 
-    def test_device_owner_not_authenticated(self):
-        self.assertIsNone(
-            FacilityUserBackend().authenticate(
-                self.request, username="Chuck", password="foobar"
-            )
-        )
-
-    def test_incorrect_password_does_not_authenticate(self):
+    def test_authenticate__returns_none_for_wrong_password(self):
         self.assertIsNone(
             FacilityUserBackend().authenticate(
                 self.request,
@@ -86,123 +109,374 @@ class FacilityUserBackendTestCase(TestCase):
             )
         )
 
-    def test_get_facility_user(self):
+    def test_authenticate__returns_none_for_missing_user(self):
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="not-a-user",
+                password="bar",
+            )
+        )
+
+    def test_authenticate__allows_learner_passwordless_login_with_facility(self):
+        disable_picture_password(self.facility, passwordless=True)
+
+        self.assertEqual(
+            self.user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="Mike",
+                facility=self.facility,
+            ),
+        )
+
+    def test_authenticate__does_not_allow_coach_passwordless_login(self):
+        coach = FacilityUser.objects.create(
+            username="coach",
+            facility=self.facility,
+            picture_password="4.5.6",
+        )
+        coach.set_password(DUMMY_PASSWORD)
+        coach.save()
+        self.facility.add_coach(coach)
+        disable_picture_password(self.facility, passwordless=True)
+
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="coach",
+                facility=self.facility,
+            )
+        )
+
+    def test_authenticate__allows_superuser_with_valid_password(self):
+        superuser = create_superuser(self.facility, username="superuser")
+
+        self.assertEqual(
+            superuser,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username=superuser.username,
+                password=DUMMY_PASSWORD,
+            ),
+        )
+
+    def test_authenticate__does_not_allow_superuser_passwordless_when_full_import(self):
+        superuser = create_superuser(self.facility, username="superuser")
+        disable_picture_password(self.facility, passwordless=True)
+
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                username=superuser.username,
+                facility=self.facility,
+            )
+        )
+
+    def test_authenticate__allows_superuser_passwordless_when_single_user_on_device(
+        self,
+    ):
+        superuser = create_superuser(self.facility, username="superuser")
+        self.is_full_facility_import.return_value = False
+        disable_picture_password(self.facility, passwordless=True)
+
+        self.assertEqual(
+            superuser,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username=superuser.username,
+                facility=self.facility,
+            ),
+        )
+
+    def test_authenticate__uses_username_path_when_picture_password_is_none(self):
+        self.assertEqual(
+            self.user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="Mike",
+                password="foo",
+                picture_password=None,
+                facility=self.facility,
+            ),
+        )
+
+    def test_authenticate__returns_user_for_valid_picture_password_with_facility(self):
+        enable_picture_password(self.facility)
+
+        self.assertEqual(
+            self.picture_user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="1.2.3",
+                facility=self.facility,
+            ),
+        )
+
+    def test_authenticate__returns_user_for_valid_picture_password_with_facility_pk(
+        self,
+    ):
+        enable_picture_password(self.facility)
+
+        self.assertEqual(
+            self.picture_user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="1.2.3",
+                facility=self.facility.pk,
+            ),
+        )
+
+    def test_authenticate__returns_user_for_valid_username(
+        self,
+    ):
+        """
+        With picture passwords enabled, passwordless sign-in is always enabled
+        """
+        enable_picture_password(self.facility)
+
+        self.assertEqual(
+            self.picture_user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="pic-user",
+                picture_password=None,
+                facility=self.facility.pk,
+            ),
+        )
+
+    def test_authenticate__returns_user_for_valid_username_password_meaningless(
+        self,
+    ):
+        """
+        With picture passwords enabled, passwordless sign-in is always enabled, but auth does not
+        reject the attempt if a password is provided
+        """
+        enable_picture_password(self.facility)
+
+        self.assertEqual(
+            self.picture_user,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username="pic-user",
+                password="wrongpassword",
+                picture_password=None,
+                facility=self.facility.pk,
+            ),
+        )
+
+    def test_authenticate__returns_none_for_picture_password_without_facility(self):
+        enable_picture_password(self.facility)
+
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="1.2.3",
+            )
+        )
+
+    def test_authenticate__returns_none_for_picture_password_with_wrong_facility(self):
+        disable_picture_password(self.other_facility)
+
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="1.2.3",
+                facility=self.other_facility,
+            )
+        )
+
+    def test_authenticate__returns_none_for_non_matching_picture_password(self):
+        enable_picture_password(self.facility)
+
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="9.9.9",
+                facility=self.facility,
+            )
+        )
+
+    def test_authenticate__allows_superuser_picture_password_when_single_user_on_device(
+        self,
+    ):
+        superuser = create_superuser(self.facility, username="superuser")
+        superuser.picture_password = "2.4.6"
+        superuser.save(update_fields=["picture_password"])
+        self.is_full_facility_import.return_value = False
+        enable_picture_password(self.facility)
+
+        self.assertEqual(
+            superuser,
+            FacilityUserBackend().authenticate(
+                self.request,
+                picture_password="2.4.6",
+                facility=self.facility,
+            ),
+        )
+
+    def test_get_user__returns_user_for_existing_id(self):
         self.assertEqual(self.user, FacilityUserBackend().get_user(self.user.id))
 
-    def test_nonexistent_user_returns_none(self):
+    def test_get_user__returns_none_for_nonexistent_id(self):
         self.assertIsNone(
             FacilityUserBackend().get_user("8acf96e56d0d4ab49fab3fbf3f716bc2")
         )
 
-    def test_authenticate_nonexistent_user_returns_none(self):
-        self.assertIsNone(
-            FacilityUserBackend().authenticate(self.request, "foo", "bar")
-        )
 
-    def test_authenticate_with_wrong_password_returns_none(self):
-        self.assertIsNone(
-            FacilityUserBackend().authenticate(self.request, "Mike", "goo")
-        )
-
-
-class PicturePasswordBackendTestCase(TestCase):
+class FacilityAuthScopeTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.facility = Facility.objects.create(name="Pic Facility")
+        cls.facility = Facility.objects.create(name="Scoped Facility")
+        cls.other_facility = Facility.objects.create(name="Other Facility")
+
+    def setUp(self):
+        dataset_id_patcher = mock.patch(
+            "kolibri.core.auth.backends.is_full_facility_import"
+        )
+        self.is_full_facility_import = dataset_id_patcher.start()
+        self.is_full_facility_import.return_value = True
+        self.addCleanup(dataset_id_patcher.stop)
+
+    def test_dataset_id__returns_dataset_id_for_facility_object(self):
+        auth_scope = _NoMatchFacilityAuthScope(self.facility)
+        self.assertEqual(self.facility.dataset_id, auth_scope.dataset_id)
+
+    def test_dataset_id__returns_dataset_id_for_facility_pk(self):
+        auth_scope = _NoMatchFacilityAuthScope(self.facility.pk)
+        self.assertEqual(self.facility.dataset_id, auth_scope.dataset_id)
+
+    def test_dataset_id__returns_none_for_missing_facility_pk(self):
+        auth_scope = _NoMatchFacilityAuthScope(str(uuid.uuid4()))
+        self.assertIsNone(auth_scope.dataset_id)
+
+    def test_is_subset_of_users_device__returns_false_for_full_facility_import(self):
+        auth_scope = _NoMatchFacilityAuthScope(self.facility)
+        self.assertFalse(auth_scope.is_subset_of_users_device)
+
+    def test_is_subset_of_users_device__returns_true_for_partial_facility_import(self):
+        self.is_full_facility_import.return_value = False
+        auth_scope = _NoMatchFacilityAuthScope(self.facility)
+        self.assertTrue(auth_scope.is_subset_of_users_device)
+
+    def test_get_candidate_users__filters_users_by_dataset_scope(self):
+        scoped_user = FacilityUser.objects.create(
+            username="scoped-user",
+            facility=self.facility,
+            picture_password="1.1.1",
+        )
+        FacilityUser.objects.create(
+            username="other-user",
+            facility=self.other_facility,
+            picture_password="2.2.2",
+        )
+
+        auth_scope = _NoMatchFacilityAuthScope(self.facility)
+        self.assertEqual(list(auth_scope.get_candidate_users()), [scoped_user])
+
+
+class PicturePasswordAuthScopeTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="Picture Facility")
+        cls.dataset = cls.facility.dataset
+        cls.dataset.learner_can_login_with_no_password = True
+        cls.dataset.learner_can_edit_password = False
+        cls.dataset.picture_password_settings = {
+            "icon_style": "standard",
+            "show_icon_text": True,
+        }
+        cls.dataset.save()
+
         cls.other_facility = Facility.objects.create(name="Other Facility")
         cls.learner = FacilityUser.objects.create(
             username="learner",
             facility=cls.facility,
             picture_password="1.2.3",
         )
-        cls.request = mock.Mock()
 
-    def test_valid_picture_password_returns_learner(self):
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="1.2.3",
-            facility=self.facility,
+    def setUp(self):
+        dataset_id_patcher = mock.patch(
+            "kolibri.core.auth.backends.is_full_facility_import"
         )
-        self.assertEqual(user, self.learner)
+        self.is_full_facility_import = dataset_id_patcher.start()
+        self.is_full_facility_import.return_value = True
+        self.addCleanup(dataset_id_patcher.stop)
 
-    def test_valid_picture_password_with_facility_pk_returns_learner(self):
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="1.2.3",
-            facility=self.facility.pk,
-        )
-        self.assertEqual(user, self.learner)
+    def test_authenticate__returns_learner_for_valid_picture_password(self):
+        auth_scope = PicturePasswordAuthScope(self.facility, "1.2.3")
+        self.assertTrue(auth_scope.matches_credentials(self.learner))
 
-    def test_picture_password_wrong_facility_returns_none(self):
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="1.2.3",
-            facility=self.other_facility,
-        )
-        self.assertIsNone(user)
+    def test_get_candidate_users__returns_empty_queryset_without_dataset_scope(self):
+        auth_scope = PicturePasswordAuthScope(None, "1.2.3")
+        self.assertEqual(list(auth_scope.get_candidate_users()), [])
 
-    def test_picture_password_no_match_returns_none(self):
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="9.9.9",
-            facility=self.facility,
-        )
-        self.assertIsNone(user)
+    def test_matches_credentials__returns_false_when_picture_password_settings_not_configured(
+        self,
+    ):
+        self.dataset.picture_password_settings = None
+        self.dataset.save()
 
-    def test_picture_password_no_facility_returns_none(self):
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="1.2.3",
-        )
-        self.assertIsNone(user)
+        auth_scope = PicturePasswordAuthScope(self.facility, "1.2.3")
+        self.assertFalse(auth_scope.matches_credentials(self.learner))
 
-    def test_coach_not_returned_by_picture_password(self):
+    def test_matches_credentials__returns_false_for_coach(self):
         coach = FacilityUser.objects.create(
             username="coach",
             facility=self.facility,
             picture_password="4.5.6",
         )
         self.facility.add_coach(coach)
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="4.5.6",
-            facility=self.facility,
-        )
-        self.assertIsNone(user)
 
-    def test_admin_not_returned_by_picture_password(self):
-        admin = FacilityUser.objects.create(
-            username="admin",
-            facility=self.facility,
-            picture_password="7.8.9",
-        )
-        self.facility.add_admin(admin)
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="7.8.9",
-            facility=self.facility,
-        )
-        self.assertIsNone(user)
+        auth_scope = PicturePasswordAuthScope(self.facility, "4.5.6")
+        self.assertFalse(auth_scope.matches_credentials(coach))
 
-    def test_device_superuser_not_returned_by_picture_password(self):
+    def test_matches_credentials__returns_false_for_device_superuser_when_full_import(
+        self,
+    ):
         superuser = create_superuser(self.facility, username="superuser")
         superuser.picture_password = "2.4.6"
         superuser.save(update_fields=["picture_password"])
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            picture_password="2.4.6",
-            facility=self.facility,
-        )
-        self.assertIsNone(user)
 
-    def test_picture_password_none_does_not_use_picture_path(self):
-        # When picture_password is None, falls through to username/password path
-        # (which returns None for non-existent username)
-        user = FacilityUserBackend().authenticate(
-            self.request,
-            username="nobody",
-            password="wrong",
-            picture_password=None,
-            facility=self.facility,
-        )
-        self.assertIsNone(user)
+        auth_scope = PicturePasswordAuthScope(self.facility, "2.4.6")
+        self.assertFalse(auth_scope.matches_credentials(superuser))
+
+    def test_matches_credentials__returns_true_for_device_superuser_when_single_user_on_device(
+        self,
+    ):
+        self.is_full_facility_import.return_value = False
+        superuser = create_superuser(self.facility, username="superuser")
+        superuser.picture_password = "2.4.6"
+        superuser.save(update_fields=["picture_password"])
+
+        auth_scope = PicturePasswordAuthScope(self.facility, "2.4.6")
+        self.assertTrue(auth_scope.matches_credentials(superuser))
+
+
+class UsernameAuthScopeTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="Username Facility")
+        cls.user = FacilityUser(username="Mike", facility=cls.facility)
+        cls.user.set_password("foo")
+        cls.user.save()
+
+    def test_get_candidate_users__filters_by_case_sensitive_username_when_enabled(self):
+        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
+        self.assertEqual(list(auth_scope.get_candidate_users()), [])
+
+    def test_get_candidate_users__filters_by_case_insensitive_username_when_disabled(
+        self,
+    ):
+        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
+        auth_scope.set_case_insensitive()
+        self.assertEqual(list(auth_scope.get_candidate_users()), [self.user])
+
+    def test_set_case_insensitive__disables_case_sensitive_matching(self):
+        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
+        auth_scope.set_case_insensitive()
+        self.assertFalse(auth_scope.case_sensitive)
+
+    def test_matches_credentials__returns_true_for_matching_password(self):
+        auth_scope = UsernameAuthScope(self.facility, username="Mike", password="foo")
+        self.assertTrue(auth_scope.matches_credentials(self.user))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = test/ kolibri/
-norecursedirs = dist tmp* .svn .*
+norecursedirs = dist tmp* .svn .* node_modules
 # Settings for pytest-django
 django_find_project = false
 DJANGO_SETTINGS_MODULE = kolibri.deployment.default.settings.test


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Primary functionality change is to allow superusers to sign-in when the facility is determined to be a subset of a full facility
- Refactors the authentication into scopes to create clear patterns for the common auth handling
- Increases test coverage on passwordless sign-in, and cleans the backend tests up
- Applies ordering to `FacilityUser` querysets for gathering candidates, particularly for `username__iexact` filter

## References
<!--
 * references to related issues and PRs
-->
https://learningequality.slack.com/archives/C0AAJ1CSYFN/p1778776443037939?thread_ts=1778773541.743669&cid=C0AAJ1CSYFN

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Test coverage is sufficient?

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Mostly human. The changes were implemented, and tests updated, by me. One I was satisfied with that, I had AI refactor the tests, to increase clarity on the scenarios being tested.