### PR TITLE
Fix fork-PR lookup in findPrByHeadSha

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -302,28 +302,42 @@ async function postNpmVersionComment(github, context, prNumber, body) {
 }
 
 /**
- * Look up the open PR for a workflow_run event using the head SHA.
- * Returns the PR number, or null if no open PR is found.
- * Disambiguates multiple matches by comparing head.repo.full_name
- * against workflow_run.head_repository.full_name.
+ * Look up the PR for a workflow_run event.
+ *
+ * Uses pulls.list with a `head: "owner:branch"` filter rather than
+ * listPullRequestsAssociatedWithCommit — the latter only knows commits in
+ * the base repo's own git tree, so returns [] for fork PRs (the primary
+ * case). The workflow_run payload exposes the source branch and source
+ * (fork) repo for pull_request-triggered workflows, which is what we
+ * need here.
+ *
+ * Returns the PR number, or null if no PR is found.
  */
 async function findPrByHeadSha(github, context) {
-  const headSha = context.payload.workflow_run.head_sha;
-  const headRepoFullName = context.payload.workflow_run.head_repository.full_name;
+  const wr = context.payload.workflow_run;
+  if (!wr || !wr.head_repository || !wr.head_branch) {
+    return null;
+  }
 
-  const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+  const headOwner = wr.head_repository.owner.login;
+  const headBranch = wr.head_branch;
+  const headSha = wr.head_sha;
+
+  const { data: prs } = await github.rest.pulls.list({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    commit_sha: headSha,
+    head: `${headOwner}:${headBranch}`,
+    state: 'all',
+    per_page: 100,
+    sort: 'updated',
+    direction: 'desc',
   });
 
-  const matched = prs.find(
-    pr =>
-      pr.state === 'open' &&
-      pr.head.sha === headSha &&
-      pr.head.repo.full_name === headRepoFullName
-  );
-
+  // Prefer exact head-SHA match; fall back to the most-recently-updated
+  // PR for this head (covers rebases / force-pushes between the upstream
+  // run and the comment workflow firing).
+  const exact = prs.find(pr => pr.head.sha === headSha);
+  const matched = exact || prs[0] || null;
   return matched ? matched.number : null;
 }
 


### PR DESCRIPTION
## Summary

`findPrByHeadSha` used `listPullRequestsAssociatedWithCommit`, which only knows about commits in the base repo's git tree. Fork-PR head commits live in the fork's tree until merged, so the lookup returned `[]` for fork PRs (the primary case) and the comment workflows silently skipped on every one of them.

Switch to `pulls.list` with a `head: "owner:branch"` filter — works for both same-repo and fork PRs. Also drop the `state === 'open'` requirement so recently-merged PRs still get commented on, and add a fallback to the most-recently-updated matching PR for rebase / force-push cases.

## References

- Regression introduced by #14715 (which implemented #14708 — workflow_run hardening).

## Reviewer guidance

Verified locally with `gh api` calls against a real fork PR's head SHA; can't exercise the workflow on this PR itself since `workflow_run` runs from the default branch.

## AI usage

Diagnosed the regression with Claude, verified the root cause and the fix empirically via `gh api` calls against a real fork PR, then applied the change.