### PR TITLE
Bypass facility ID filter for superusers, but require it for all other users

### DIFF
--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -4,6 +4,7 @@ The appropriate classes should be listed in the AUTHENTICATION_BACKENDS. Note th
 backends are checked in the order they're listed.
 """
 import abc
+import logging
 
 from django.contrib.sessions.backends.db import SessionStore as DBStore
 from django.db.models import Exists
@@ -18,9 +19,32 @@ from kolibri.core.device.utils import is_full_facility_import
 
 
 FACILITY_CREDENTIAL_KEY = "facility"
+logger = logging.getLogger(__name__)
 
 
-class FacilityAuthScope(abc.ABC):
+class AuthScope(abc.ABC):
+    @abc.abstractmethod
+    def get_candidate_users(self):
+        """
+        Determines candidate users for checking authorization
+        :return: A queryset of FacilityUser objects
+        """
+        pass
+
+    @abc.abstractmethod
+    def matches_credentials(self, user):
+        """
+        Determines whether this user is authorized
+        :param user: A FacilityUser object
+        :return: A boolean indicating authorization
+        """
+        pass
+
+    def __str__(self):
+        return self.__class__.__name__
+
+
+class FacilityAuthScope(AuthScope, abc.ABC):
     """Base facility scope for authentication"""
 
     def __init__(self, facility_or_id):
@@ -53,7 +77,7 @@ class FacilityAuthScope(abc.ABC):
             return None
 
     @cached_property
-    def is_subset_of_users_device(self):
+    def is_full_facility_import(self):
         return self.dataset_id and not is_full_facility_import(self.dataset_id)
 
     def get_candidate_users(self):
@@ -70,14 +94,39 @@ class FacilityAuthScope(abc.ABC):
             has_roles=Exists(Role.objects.filter(user_id=OuterRef("pk"))),
         ).order_by("-has_roles", "date_joined")
 
-    @abc.abstractmethod
+    def __str__(self):
+        suffix = ""
+        if self.facility_or_id:
+            suffix = f"<{self.facility_or_id}>"
+        return f"{super().__str__()}{suffix}"
+
+
+class SuperuserAuthScope(AuthScope):
+    """
+    Auth scope for superuser authentication, which does not need to align with a specific facility,
+    but requires superuser device permissions
+    """
+
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+
+    def get_candidate_users(self):
+        """
+        Only return superusers with matching username
+        :return: A queryset of FacilityUser objects
+        """
+        return FacilityUser.objects.filter(
+            username=self.username, devicepermissions__is_superuser=True
+        )
+
     def matches_credentials(self, user):
         """
-        Determines whether this user is authorized
+        Superuser's password must be verified
         :param user: A FacilityUser object
-        :return: A boolean indicating authorization
+        :return: Whether the user is authorized
         """
-        pass
+        return user.check_password(self.password)
 
 
 class UsernameAuthScope(FacilityAuthScope):
@@ -112,7 +161,7 @@ class UsernameAuthScope(FacilityAuthScope):
             self.dataset_id
             and user.dataset.learner_can_login_with_no_password
             and not user.has_roles
-            and (not user.is_superuser or self.is_subset_of_users_device)
+            and (not user.is_superuser or self.is_full_facility_import)
         )
 
 
@@ -141,7 +190,7 @@ class PicturePasswordAuthScope(FacilityAuthScope):
             self.dataset_id
             and user.dataset.picture_password_settings is not None
             and not user.has_roles
-            and (not user.is_superuser or self.is_subset_of_users_device)
+            and (not user.is_superuser or self.is_full_facility_import)
         )
 
 
@@ -181,11 +230,28 @@ class FacilityUserBackend:
 
         # If case-sensitive login fails, attempt case-insensitive login
         auth_scope.set_case_insensitive()
-        return self._run(auth_scope)
+        user = self._run(auth_scope)
+        if user:
+            return user
+
+        if username and password:
+            superuser_scope = SuperuserAuthScope(username, password)
+            user = self._run(superuser_scope)
+            if user:
+                return user
+
+        return None
 
     def _run(self, auth_scope):
+        """
+        :param auth_scope: The auth scope to validate against
+        :type auth_scope: AuthScope
+        :return:
+        """
         for user in auth_scope.get_candidate_users():
+            logger.debug(f"Using {auth_scope} to check user {user.id}")
             if auth_scope.matches_credentials(user):
+                logger.debug(f"{auth_scope} authorized user {user.id}")
                 return user
         return None
 

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -7,6 +7,7 @@ import abc
 import logging
 
 from django.contrib.sessions.backends.db import SessionStore as DBStore
+from django.core.exceptions import PermissionDenied
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django.utils.functional import cached_property
@@ -23,11 +24,17 @@ logger = logging.getLogger(__name__)
 
 
 class AuthScope(abc.ABC):
+    def get_queryset(self):
+        """
+        :return: A queryset of FacilityUser objects
+        """
+        return FacilityUser.objects.select_related("dataset")
+
     @abc.abstractmethod
-    def get_candidate_users(self):
+    def iter_candidate_users(self):
         """
         Determines candidate users for checking authorization
-        :return: A queryset of FacilityUser objects
+        :return: An iterator over candidate FacilityUser objects
         """
         pass
 
@@ -42,6 +49,48 @@ class AuthScope(abc.ABC):
 
     def __str__(self):
         return self.__class__.__name__
+
+    def __repr__(self):
+        return str(self)
+
+
+class UsernameAuthScope(AuthScope, abc.ABC):
+    """Auth scope for username based authentication"""
+
+    def __init__(self, username):
+        super().__init__()
+        self.username = username
+
+    def iter_candidate_users(self):
+        """
+        First iters over users with exactly matching usernames, then those with an inexact match
+        """
+        qs = self.get_queryset()
+        for user in qs.filter(username=self.username):
+            yield user
+
+        for user in qs.filter(username__iexact=self.username):
+            yield user
+
+
+class SuperuserAuthScope(UsernameAuthScope):
+    """
+    Auth scope for superuser authentication, which does not need to align with a specific facility,
+    but requires superuser device permissions
+    """
+
+    def __init__(self, username, password):
+        super().__init__(username)
+        self.password = password
+
+    def get_queryset(self):
+        return FacilityUser.objects.filter(devicepermissions__is_superuser=True)
+
+    def matches_credentials(self, user):
+        """
+        Superuser's password must be verified
+        """
+        return user.check_password(self.password)
 
 
 class FacilityAuthScope(AuthScope, abc.ABC):
@@ -61,9 +110,6 @@ class FacilityAuthScope(AuthScope, abc.ABC):
 
         :return: The facility dataset ID
         """
-        if not self.facility_or_id:
-            return None
-
         # Resolve dataset_id to leverage the (dataset, picture_password) unique
         # index. facility may be a Facility object or a raw pk/UUID.
         if isinstance(self.facility_or_id, Facility):
@@ -74,20 +120,18 @@ class FacilityAuthScope(AuthScope, abc.ABC):
                 pk=self.facility_or_id
             )
         except Facility.DoesNotExist:
-            return None
+            # if we cannot find the requested facility, we'll just fail fast
+            raise PermissionDenied("Invalid credentials")
 
     @cached_property
     def is_full_facility_import(self):
         return self.dataset_id and not is_full_facility_import(self.dataset_id)
 
-    def get_candidate_users(self):
+    def get_queryset(self):
         """
         Determines candidate users for checking authorization
-        :return: A queryset of FacilityUser objects
         """
-        qs = FacilityUser.objects.all()
-        if self.dataset_id:
-            qs = qs.filter(dataset_id=self.dataset_id)
+        qs = super().get_queryset().filter(dataset_id=self.dataset_id)
         # users who have the most roles could be more active than users who have less, but instead
         # of trying to authenticate them first, through ordering, we just prioritize by date joined
         return qs.annotate(
@@ -95,71 +139,27 @@ class FacilityAuthScope(AuthScope, abc.ABC):
         ).order_by("-has_roles", "date_joined")
 
     def __str__(self):
-        suffix = ""
-        if self.facility_or_id:
-            suffix = f"<{self.facility_or_id}>"
-        return f"{super().__str__()}{suffix}"
+        return f"{super().__str__()}<{self.facility_or_id}>"
 
 
-class SuperuserAuthScope(AuthScope):
-    """
-    Auth scope for superuser authentication, which does not need to align with a specific facility,
-    but requires superuser device permissions
-    """
-
-    def __init__(self, username, password):
-        self.username = username
-        self.password = password
-
-    def get_candidate_users(self):
-        """
-        Only return superusers with matching username
-        :return: A queryset of FacilityUser objects
-        """
-        return FacilityUser.objects.filter(
-            username=self.username, devicepermissions__is_superuser=True
-        )
-
-    def matches_credentials(self, user):
-        """
-        Superuser's password must be verified
-        :param user: A FacilityUser object
-        :return: Whether the user is authorized
-        """
-        return user.check_password(self.password)
-
-
-class UsernameAuthScope(FacilityAuthScope):
+class BasicUserAuthScope(FacilityAuthScope, UsernameAuthScope):
     """Auth scope for username/password authentication"""
 
-    def __init__(self, facility_or_id, username=None, password=None):
+    def __init__(self, facility_or_id, username, password=None):
         super().__init__(facility_or_id)
-        self.username = username
+        UsernameAuthScope.__init__(self, username)
         self.password = password
-        self.case_sensitive = True
-
-    def set_case_insensitive(self):
-        self.case_sensitive = False
-
-    def get_candidate_users(self):
-        qs = super().get_candidate_users()
-        if self.case_sensitive:
-            return qs.filter(username=self.username)
-        return qs.filter(username__iexact=self.username)
 
     def matches_credentials(self, user):
         """
         Either the provided password matches the user, or the user is a learner and the facility
         configuration allows passwordless sign-in.
-        :param user: A FacilityUser object
-        :return: Whether the user is authorized
         """
         if user.check_password(self.password):
             return True
 
         return (
-            self.dataset_id
-            and user.dataset.learner_can_login_with_no_password
+            user.dataset.learner_can_login_with_no_password
             and not user.has_roles
             and (not user.is_superuser or self.is_full_facility_import)
         )
@@ -172,23 +172,23 @@ class PicturePasswordAuthScope(FacilityAuthScope):
         super().__init__(facility_or_id)
         self.picture_password = picture_password
 
-    def get_candidate_users(self):
-        if not self.dataset_id:
-            return FacilityUser.objects.none()
-        return (
-            super().get_candidate_users().filter(picture_password=self.picture_password)
-        )
+    def get_queryset(self):
+        return super().get_queryset().filter(picture_password=self.picture_password)
+
+    def iter_candidate_users(self):
+        """
+        We expect only one user with the dataset and picture password filters
+        """
+        for user in self.get_queryset():
+            yield user
 
     def matches_credentials(self, user):
         """
         Validates that the user is a learner and that the facility configuration allows picture
         password sign-in.
-        :param user: A FacilityUser object
-        :return: Whether the user is authorized
         """
         return (
-            self.dataset_id
-            and user.dataset.picture_password_settings is not None
+            user.dataset.picture_password_settings is not None
             and not user.has_roles
             and (not user.is_superuser or self.is_full_facility_import)
         )
@@ -214,29 +214,23 @@ class FacilityUserBackend:
         facility = kwargs.get(FACILITY_CREDENTIAL_KEY, None)
         picture_password = kwargs.get("picture_password", None)
 
+        scopes = []
+
         # Picture password authentication path.
         # The None check is load-bearing: filter(picture_password=None) would
         # match rows where the column IS NULL, returning an arbitrary learner.
         if picture_password is not None:
-            auth_scope = PicturePasswordAuthScope(facility, picture_password)
-            return self._run(auth_scope)
+            if not facility:
+                # we cannot run picture password auth without it
+                raise PermissionDenied("Invalid credentials")
+            scopes.append(PicturePasswordAuthScope(facility, picture_password))
+        else:
+            if facility:
+                scopes.append(BasicUserAuthScope(facility, username, password))
+            scopes.append(SuperuserAuthScope(username, password))
 
-        # First, attempt case-sensitive login
-        auth_scope = UsernameAuthScope(facility, username=username, password=password)
-
-        user = self._run(auth_scope)
-        if user:
-            return user
-
-        # If case-sensitive login fails, attempt case-insensitive login
-        auth_scope.set_case_insensitive()
-        user = self._run(auth_scope)
-        if user:
-            return user
-
-        if username and password:
-            superuser_scope = SuperuserAuthScope(username, password)
-            user = self._run(superuser_scope)
+        for auth_scope in scopes:
+            user = self._run(auth_scope)
             if user:
                 return user
 
@@ -248,7 +242,7 @@ class FacilityUserBackend:
         :type auth_scope: AuthScope
         :return:
         """
-        for user in auth_scope.get_candidate_users():
+        for user in auth_scope.iter_candidate_users():
             logger.debug(f"Using {auth_scope} to check user {user.id}")
             if auth_scope.matches_credentials(user):
                 logger.debug(f"{auth_scope} authorized user {user.id}")

--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -3,6 +3,9 @@ Helper functions for use across the user/auth/permission-related tests.
 """
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
+from rest_framework.test import APIClient
+from rest_framework.test import APITestCase
+from rest_framework.test import APITransactionTestCase
 
 from ..models import Classroom
 from ..models import Facility
@@ -35,6 +38,32 @@ def create_superuser(facility, username="superuser"):
     superuser.save()
     DevicePermissions.objects.create(user=superuser, is_superuser=True)
     return superuser
+
+
+class KolibriAPIClient(APIClient):
+    """
+    Test API client that infers facility for username/password login when omitted.
+    """
+
+    def login(self, **credentials):
+        if "facility" not in credentials:
+            username = credentials.get("username")
+            password = credentials.get("password")
+            if username and password is not None:
+                candidates = FacilityUser.objects.filter(username__iexact=username)
+                for user in candidates:
+                    if user.check_password(password):
+                        credentials["facility"] = user.facility
+                        break
+        return super().login(**credentials)
+
+
+class KolibriAPITestCase(APITestCase):
+    client_class = KolibriAPIClient
+
+
+class KolibriAPITransactionTestCase(APITransactionTestCase):
+    client_class = KolibriAPIClient
 
 
 def setup_device():

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -26,8 +26,6 @@ from morango.models import TransferSession
 from morango.sync.controller import MorangoProfileController
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework.test import APITestCase
-from rest_framework.test import APITransactionTestCase
 
 from .. import models
 from ..constants import role_kinds
@@ -38,6 +36,8 @@ from .helpers import create_superuser
 from .helpers import disable_picture_password
 from .helpers import DUMMY_PASSWORD
 from .helpers import enable_picture_password
+from .helpers import KolibriAPITestCase as APITestCase
+from .helpers import KolibriAPITransactionTestCase as APITransactionTestCase
 from .helpers import provision_device
 from .helpers import setup_device
 from kolibri.core import error_constants
@@ -1037,7 +1037,9 @@ class UserUpdateTestCase(APITestCase):
         )
         self.client.logout()
         response = self.client.login(
-            username=self.user.username, password=new_password, facility=self.facility
+            username=self.user.username,
+            password=new_password,
+            facility=self.facility,
         )
         self.assertTrue(response)
 
@@ -1050,7 +1052,9 @@ class UserUpdateTestCase(APITestCase):
         )
         self.client.logout()
         response = self.client.login(
-            username=self.user.username, password=new_password, facility=self.facility
+            username=self.user.username,
+            password=new_password,
+            facility=self.facility,
         )
         self.assertTrue(response)
 
@@ -1442,7 +1446,9 @@ class UserRetrieveTestCase(APITestCase):
     def _make_request(self, user=None, url=None, params=None):
         if user:
             self.client.login(
-                username=user.username, password=DUMMY_PASSWORD, facility=self.facility
+                username=user.username,
+                password=DUMMY_PASSWORD,
+                facility=self.facility,
             )
 
         if url is None:

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -165,6 +165,21 @@ class FacilityUserBackendTestCase(TestCase):
             ),
         )
 
+    def test_authenticate__allows_superuser_with_valid_password_regardless_of_facility(
+        self,
+    ):
+        superuser = create_superuser(self.facility, username="superuser")
+
+        self.assertEqual(
+            superuser,
+            FacilityUserBackend().authenticate(
+                self.request,
+                username=superuser.username,
+                password=DUMMY_PASSWORD,
+                facility=self.other_facility.pk,
+            ),
+        )
+
     def test_authenticate__does_not_allow_superuser_passwordless_when_full_import(self):
         superuser = create_superuser(self.facility, username="superuser")
         disable_picture_password(self.facility, passwordless=True)
@@ -356,12 +371,12 @@ class FacilityAuthScopeTestCase(TestCase):
 
     def test_is_subset_of_users_device__returns_false_for_full_facility_import(self):
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
-        self.assertFalse(auth_scope.is_subset_of_users_device)
+        self.assertFalse(auth_scope.is_full_facility_import)
 
     def test_is_subset_of_users_device__returns_true_for_partial_facility_import(self):
         self.is_full_facility_import.return_value = False
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
-        self.assertTrue(auth_scope.is_subset_of_users_device)
+        self.assertTrue(auth_scope.is_full_facility_import)
 
     def test_get_candidate_users__filters_users_by_dataset_scope(self):
         scoped_user = FacilityUser.objects.create(

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -2,13 +2,14 @@ import uuid
 from datetime import timedelta
 
 import mock
+from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.utils import timezone
 
+from ..backends import BasicUserAuthScope
 from ..backends import FacilityAuthScope
 from ..backends import FacilityUserBackend
 from ..backends import PicturePasswordAuthScope
-from ..backends import UsernameAuthScope
 from ..models import Facility
 from ..models import FacilityUser
 from .helpers import create_superuser
@@ -18,6 +19,9 @@ from .helpers import enable_picture_password
 
 
 class _NoMatchFacilityAuthScope(FacilityAuthScope):
+    def iter_candidate_users(self):
+        return iter(self.get_queryset())
+
     def matches_credentials(self, user):
         return False
 
@@ -80,14 +84,13 @@ class FacilityUserBackendTestCase(TestCase):
             ),
         )
 
-    def test_authenticate__returns_user_without_facility_when_credentials_match(self):
-        self.assertEqual(
-            self.user,
+    def test_authenticate__returns_none_for_basic_user_without_facility(self):
+        self.assertIsNone(
             FacilityUserBackend().authenticate(
                 self.request,
                 username="Mike",
                 password="foo",
-            ),
+            )
         )
 
     def test_authenticate__returns_unambiguous_case_insensitive_match_after_case_sensitive_miss(
@@ -284,15 +287,16 @@ class FacilityUserBackendTestCase(TestCase):
             ),
         )
 
-    def test_authenticate__returns_none_for_picture_password_without_facility(self):
+    def test_authenticate__raises_permission_denied_for_picture_password_without_facility(
+        self,
+    ):
         enable_picture_password(self.facility)
 
-        self.assertIsNone(
+        with self.assertRaises(PermissionDenied):
             FacilityUserBackend().authenticate(
                 self.request,
                 picture_password="1.2.3",
             )
-        )
 
     def test_authenticate__returns_none_for_picture_password_with_wrong_facility(self):
         disable_picture_password(self.other_facility)
@@ -365,9 +369,10 @@ class FacilityAuthScopeTestCase(TestCase):
         auth_scope = _NoMatchFacilityAuthScope(self.facility.pk)
         self.assertEqual(self.facility.dataset_id, auth_scope.dataset_id)
 
-    def test_dataset_id__returns_none_for_missing_facility_pk(self):
+    def test_dataset_id__raises_permission_denied_for_missing_facility_pk(self):
         auth_scope = _NoMatchFacilityAuthScope(str(uuid.uuid4()))
-        self.assertIsNone(auth_scope.dataset_id)
+        with self.assertRaises(PermissionDenied):
+            auth_scope.dataset_id
 
     def test_is_subset_of_users_device__returns_false_for_full_facility_import(self):
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
@@ -378,7 +383,7 @@ class FacilityAuthScopeTestCase(TestCase):
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
         self.assertTrue(auth_scope.is_full_facility_import)
 
-    def test_get_candidate_users__filters_users_by_dataset_scope(self):
+    def test_iter_candidate_users__filters_users_by_dataset_scope(self):
         scoped_user = FacilityUser.objects.create(
             username="scoped-user",
             facility=self.facility,
@@ -391,9 +396,9 @@ class FacilityAuthScopeTestCase(TestCase):
         )
 
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
-        self.assertEqual(list(auth_scope.get_candidate_users()), [scoped_user])
+        self.assertEqual(list(auth_scope.iter_candidate_users()), [scoped_user])
 
-    def test_get_candidate_users__orders_users_by_has_roles_then_date_joined(self):
+    def test_iter_candidate_users__orders_users_by_has_roles_then_date_joined(self):
         base_time = timezone.now()
         learner_old = FacilityUser.objects.create(
             username="learner-old",
@@ -429,7 +434,7 @@ class FacilityAuthScopeTestCase(TestCase):
 
         auth_scope = _NoMatchFacilityAuthScope(self.facility)
         self.assertEqual(
-            list(auth_scope.get_candidate_users()),
+            list(auth_scope.iter_candidate_users()),
             [coach_old, coach_new, learner_old, learner_new],
         )
 
@@ -473,9 +478,10 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         auth_scope = PicturePasswordAuthScope(self.facility, "1.2.3")
         self.assertTrue(auth_scope.matches_credentials(self.learner))
 
-    def test_get_candidate_users__returns_empty_queryset_without_dataset_scope(self):
+    def test_iter_candidate_users__raises_permission_denied_without_dataset_scope(self):
         auth_scope = PicturePasswordAuthScope(None, "1.2.3")
-        self.assertEqual(list(auth_scope.get_candidate_users()), [])
+        with self.assertRaises(PermissionDenied):
+            list(auth_scope.iter_candidate_users())
 
     def test_matches_credentials__returns_false_when_picture_password_settings_not_configured(
         self,
@@ -519,7 +525,7 @@ class PicturePasswordAuthScopeTestCase(TestCase):
         self.assertTrue(auth_scope.matches_credentials(self._set_has_roles(superuser)))
 
 
-class UsernameAuthScopeTestCase(TestCase):
+class BasicUserAuthScopeTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.facility = Facility.objects.create(name="Username Facility")
@@ -533,31 +539,23 @@ class UsernameAuthScopeTestCase(TestCase):
         setattr(user, "has_roles", user.roles.count() > 0)
         return user
 
-    def test_get_candidate_users__filters_by_case_sensitive_username_when_enabled(self):
-        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
-        self.assertEqual(list(auth_scope.get_candidate_users()), [])
-
-    def test_get_candidate_users__filters_by_case_insensitive_username_when_disabled(
+    def test_iter_candidate_users__returns_case_insensitive_match(
         self,
     ):
-        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
-        auth_scope.set_case_insensitive()
-        self.assertEqual(list(auth_scope.get_candidate_users()), [self.user])
-
-    def test_set_case_insensitive__disables_case_sensitive_matching(self):
-        auth_scope = UsernameAuthScope(self.facility, username="mike", password="foo")
-        auth_scope.set_case_insensitive()
-        self.assertFalse(auth_scope.case_sensitive)
+        auth_scope = BasicUserAuthScope(self.facility, username="mike", password="foo")
+        self.assertEqual(list(auth_scope.iter_candidate_users()), [self.user])
 
     def test_matches_credentials__returns_true_for_matching_password(self):
-        auth_scope = UsernameAuthScope(self.facility, username="Mike", password="foo")
+        auth_scope = BasicUserAuthScope(self.facility, username="Mike", password="foo")
         self.assertTrue(auth_scope.matches_credentials(self.user))
 
     def test_matches_credentials__returns_true_for_passwordless_learner_with_role_count_zero(
         self,
     ):
         disable_picture_password(self.facility, passwordless=True)
-        auth_scope = UsernameAuthScope(self.facility, username="Mike", password="wrong")
+        auth_scope = BasicUserAuthScope(
+            self.facility, username="Mike", password="wrong"
+        )
         self.assertTrue(auth_scope.matches_credentials(self._set_has_roles(self.user)))
 
     def test_matches_credentials__returns_false_for_passwordless_coach_with_nonzero_role_count(
@@ -566,7 +564,7 @@ class UsernameAuthScopeTestCase(TestCase):
         disable_picture_password(self.facility, passwordless=True)
         coach = FacilityUser.objects.create(username="coach", facility=self.facility)
         self.facility.add_coach(coach)
-        auth_scope = UsernameAuthScope(
+        auth_scope = BasicUserAuthScope(
             self.facility, username="coach", password="wrong"
         )
         self.assertFalse(auth_scope.matches_credentials(self._set_has_roles(coach)))

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -12,7 +12,6 @@ import os
 import unittest
 import uuid
 
-import requests
 from django.core.management import call_command
 from django.db import connections
 from django.test import TestCase
@@ -161,27 +160,6 @@ class CertificateAuthenticationTestCase(MultipleServerTestCase):
 
         controller = MorangoProfileController(PROFILE_FACILITY_DATA)
         network_connection = controller.create_network_connection(server.baseurl)
-
-        # facility mismatch for superuser 1
-        with self.assertRaises(requests.exceptions.HTTPError):
-            get_client_and_server_certs(
-                superuser_1.username,
-                "superuser_1",
-                facility_1.dataset_id,
-                network_connection,
-                facility_id=facility_2.id,
-                noninteractive=True,
-            )
-        # facility mismatch for superuser 2
-        with self.assertRaises(requests.exceptions.HTTPError):
-            get_client_and_server_certs(
-                superuser_2.username,
-                "superuser_2",
-                facility_2.dataset_id,
-                network_connection,
-                facility_id=facility_1.id,
-                noninteractive=True,
-            )
 
         client_cert, server_cert, username = get_client_and_server_certs(
             superuser_1.username,

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -18,13 +18,13 @@ from le_utils.constants import content_kinds
 from le_utils.constants import library as library_constants
 from le_utils.constants import modalities
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from kolibri.core import error_constants
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content import models as content
 from kolibri.core.content.test.helpers import ChannelBuilder

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -3,7 +3,6 @@ import uuid
 from django.urls import reverse
 from le_utils.constants import modalities
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from .. import models
 from kolibri.core.auth.constants import collection_kinds
@@ -12,6 +11,7 @@ from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from .. import models
 from kolibri.core import error_constants
@@ -13,6 +12,7 @@ from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.exams.constants import MAX_QUESTIONS_PER_QUIZ_SECTION
 from kolibri.core.logger.models import ContentSummaryLog

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from .. import models
 from kolibri.core import error_constants
@@ -9,6 +8,7 @@ from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode

--- a/kolibri/core/lessons/test/test_lesson_create.py
+++ b/kolibri/core/lessons/test/test_lesson_create.py
@@ -1,11 +1,11 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons.models import Lesson

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -8,10 +8,10 @@ from mock import patch
 from rest_framework import serializers
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.test_api import FacilityUserFactory
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -2,11 +2,11 @@ from django.conf import settings
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from mock import patch
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_superuser
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
 from kolibri.core.auth.test.test_api import FacilityFactory

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -4,11 +4,11 @@ import uuid
 from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
-from rest_framework.test import APITestCase
 
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons import models
@@ -147,7 +147,8 @@ class ClassSummaryTestCase(EvaluationMixin, APITestCase):
 
     def test_another_classroom_coach_cannot_access_detail(self):
         self.client.login(
-            username=self.another_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.another_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(self.detail_name, kwargs={"pk": self.classroom.id})

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 
 from django.db.utils import DatabaseError
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 
 
@@ -71,7 +71,8 @@ class ClassroomNotificationsTestCase(APITestCase):
 
     def test_another_classroom_coach_cannot_access_list(self):
         self.client.login(
-            username=self.another_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.another_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(self.list_name), {"classroom_id": self.classroom.id}

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -3,13 +3,13 @@ from datetime import timedelta
 from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
-from rest_framework.test import APITestCase
 
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.exams.models import Exam
@@ -131,7 +131,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
 
     def test_coach_classroom_id_required(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -143,7 +144,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_classroom_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -156,7 +158,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_lesson_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -169,7 +172,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_group_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -220,7 +224,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_classroom_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -236,7 +241,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_lesson_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -257,7 +263,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         )
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -273,7 +280,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_group_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -299,7 +307,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             item="nottest",
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -327,7 +336,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             item="nottest",
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -358,7 +368,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         )
         LessonAssignment.objects.all().delete()
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -383,7 +394,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         )
         LessonAssignment.objects.all().delete()
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -408,7 +420,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
         self.classroom.add_member(learner2)
         self._set_one_difficult(learner2)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -440,7 +453,8 @@ class ExerciseDifficultQuestionTestCase(APITestCase):
             collection=self.group,
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -521,7 +535,8 @@ class QuizDifficultQuestionTestCase(APITestCase):
 
     def _login_as_coach(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
 
     def test_learner_cannot_access(self):
@@ -875,7 +890,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
 
     def test_coach_classroom_id_required(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -887,7 +903,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_classroom_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -900,7 +917,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_lesson_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -913,7 +931,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
 
     def test_coach_no_progress_by_group_id(self):
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -980,7 +999,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_classroom_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -998,7 +1018,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self._set_one_difficult(self.classroom_group_learner)
         self._set_one_difficult(self.classroom_group_learner, complete=False)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1016,7 +1037,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self._set_one_difficult(self.classroom_group_learner)
         self._set_one_difficult(self.classroom_group_learner, difficult=False)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1053,7 +1075,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self._set_one_difficult(other_learner, complete=False)
         self._set_one_difficult(other_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1075,7 +1098,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self.masterylog.complete = False
         self.masterylog.save()
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1091,7 +1115,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_lesson_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1112,7 +1137,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         )
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1128,7 +1154,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
     def test_coach_one_difficult_by_group_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1154,7 +1181,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
             item="nottest",
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1182,7 +1210,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
             item="nottest",
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1213,7 +1242,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         )
         LessonAssignment.objects.all().delete()
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1238,7 +1268,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         )
         LessonAssignment.objects.all().delete()
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1263,7 +1294,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self.classroom.add_member(learner2)
         self._set_one_difficult(learner2)
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1295,7 +1327,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
             collection=self.group,
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(
@@ -1326,7 +1359,8 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
             item="nottest",
         )
         self.client.login(
-            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.facility_and_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         response = self.client.get(
             reverse(

--- a/kolibri/plugins/coach/test/test_lesson_report.py
+++ b/kolibri/plugins/coach/test/test_lesson_report.py
@@ -1,11 +1,11 @@
 import datetime
 
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons.models import Lesson
@@ -164,7 +164,8 @@ class LessonReportTestCase(APITestCase):
 
     def test_another_classroom_coach_cannot_access_detail(self):
         self.client.login(
-            username=self.another_classroom_coach.username, password=DUMMY_PASSWORD
+            username=self.another_classroom_coach.username,
+            password=DUMMY_PASSWORD,
         )
         get_response = self.client.get(
             reverse(

--- a/kolibri/plugins/coach/test/test_unit_lesson_progress.py
+++ b/kolibri/plugins/coach/test/test_unit_lesson_progress.py
@@ -5,11 +5,11 @@ from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
 from le_utils.constants import modalities
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -7,11 +7,11 @@ from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
 from le_utils.constants import modalities
-from rest_framework.test import APITestCase
 
 from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import ContentNode

--- a/kolibri/plugins/device/test/test_api.py
+++ b/kolibri/plugins/device/test/test_api.py
@@ -3,10 +3,10 @@ import uuid
 import mock
 from django.db.models import Q
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 import kolibri.plugins.device.api
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import setup_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode

--- a/kolibri/plugins/learn/test/test_learner_classroom.py
+++ b/kolibri/plugins/learn/test/test_learner_classroom.py
@@ -4,13 +4,13 @@ from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
 from le_utils.constants import modalities
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import clear_process_cache
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession

--- a/kolibri/plugins/learn/test/test_learner_course.py
+++ b/kolibri/plugins/learn/test/test_learner_course.py
@@ -4,13 +4,13 @@ from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
 from le_utils.constants import modalities
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import clear_process_cache
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
@@ -48,7 +48,7 @@ class LearnerCourseTestCase(APITestCase):
                 parent=lesson,
                 available=True,
                 kind=content_kinds.VIDEO,
-                title=f"Resource {i+1}",
+                title=f"Resource {i + 1}",
                 description="",
             )
             ContentSummaryLog.objects.create(
@@ -75,7 +75,7 @@ class LearnerCourseTestCase(APITestCase):
         )
         new_lessons = []
         for i in range(lessons):
-            lesson = self._create_lesson(unit, f"Lesson {i+1}", resources)
+            lesson = self._create_lesson(unit, f"Lesson {i + 1}", resources)
             new_lessons.append(lesson)
 
         return unit, new_lessons
@@ -110,7 +110,7 @@ class LearnerCourseTestCase(APITestCase):
             unit = self._create_unit(
                 course_session=course_session,
                 course=course,
-                title=f"Unit {i+1}",
+                title=f"Unit {i + 1}",
                 lessons=lessons,
                 resources=resources,
             )

--- a/kolibri/plugins/learn/test/test_learner_lesson.py
+++ b/kolibri/plugins/learn/test/test_learner_lesson.py
@@ -1,11 +1,11 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import clear_process_cache
+from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Previously, a superuser would only be validated if the request sent the facility that matched their user record, or sent no facility. If they sent a different facility, this would fail, hence the issue with importing a different facility with superuser credentials. 

This PR changes authentication to always allow superusers to authenticate regardless of the facility ID. It also now requires that facility ID is used for basic user authentication.

- Adds iterator to `AuthScope` API for ultimate flexibility in defining auth approaches
- Separates username filtering and candidate user iterating into base auth scope
- Defines a new `SuperuserAuthScope` that strictly authorizes superusers regardless of facility
- Fails fast when a requested facility is not found (`PermissionDenied` is treated like returning `None`)
- Adds logging when auth scopes are evaluated
- Adds new API Client for testcases to automatically add facility to the login request

## References
<!--
 * references to related issues and PRs
-->
fixes https://github.com/learningequality/kolibri/issues/14727

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Can you still log into http://localhost:8000/api_explorer/
- Can you create a new facility and then import it from a different device using super user credentials?


<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI reviewed my changes, gave me feedback, updated tests, and did the heavy lifting on migrating all the tests.