### PR TITLE
Fix: Handle empty strings synchronously in RegisterFacilityModal

### DIFF
--- a/packages/kolibri-common/components/syncComponentSet/RegisterFacilityModal.vue
+++ b/packages/kolibri-common/components/syncComponentSet/RegisterFacilityModal.vue
@@ -84,8 +84,11 @@
         this.$emit('skip', this.facility);
       },
       validateToken() {
-        // TODO synchronously handle empty strings
-        const strippedToken = this.token.replace('-', '');
+        const strippedToken = (this.token || '').replace(/-/g, '').trim();
+        if (!strippedToken) {
+          this.invalid = true;
+          return;
+        }
         this.submitting = true;
         PortalResource.validateToken(strippedToken)
           .then(response => {


### PR DESCRIPTION
## Summary
This PR resolves an open `TODO` in `RegisterFacilityModal.vue` regarding synchronously handling empty strings for the project token before dispatching the validation request to the backend.

Previously, `validateToken` used `this.token.replace('-', '')`, which only replaced the first hyphen and would throw an error if `this.token` was falsy. Furthermore, if a user inputted a string of hyphens or whitespace, it would result in an empty string being sent to the `PortalResource.validateToken` API, causing unnecessary network requests.

**Changes made:**
- Safely replace all hyphens by using the global regex `/-/g`.
- Trim whitespace from the token.
- Synchronously check if the resulting `strippedToken` is empty. If it is empty, set `this.invalid = true` and return early, saving an unnecessary API request.

**Manual verification:**
- Verified the updated frontend regex correctly replaces multiple hyphens.
- Verified that submitting empty tokens or tokens consisting only of spaces/hyphens halts execution synchronously and triggers the invalid UI state.

## References
Closes #[Insert Issue Number Here]

## Reviewer guidance
To test these changes:
1. Navigate to the UI where you can sync facility data and enter a project token.
2. Try submitting an empty token, a token with multiple hyphens like `---`, or a string of just spaces.
3. Observe that it synchronously triggers the "Invalid token" error state without making a network request to the backend.
4. Try submitting a valid token with multiple hyphens (e.g. `abc-def-ghi`) and verify the backend request is sent correctly as `abcdefghi`.

## AI usage
I used an AI coding assistant to help find and resolve this good first issue. The assistant pointed out the incomplete hyphen replacement and the unhandled empty string logic in the `RegisterFacilityModal` component. I used the AI to write the initial fix, and then I reviewed the code manually to ensure the regex `/-/g` functioned as expected, and confirmed that the early return logic correctly bypassed the network request while setting the proper invalid state.
