### PR TITLE
Use class summary password settings instead of useFacility

### DIFF
--- a/kolibri/plugins/coach/frontend/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/OverviewBlock.vue
@@ -26,7 +26,7 @@
         :layout4="{ span: 2, alignment: 'right' }"
       >
         <KRouterLink
-          v-if="facilityConfig.picture_password_settings && learnerNames.length"
+          v-if="picture_password_settings && learnerNames.length"
           :text="viewPasswordsAction$()"
           appearance="raised-button"
           :to="{
@@ -84,11 +84,10 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useFacilities from 'kolibri-common/composables/useFacilities';
-  import useFacility from 'kolibri-common/composables/useFacility';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { ref } from 'vue';
   import { ClassesPageNames } from '../../../../../learn/frontend/constants';
@@ -102,12 +101,10 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { userIsMultiFacilityAdmin } = useFacilities();
-      const { facilityConfig } = useFacility();
       const { viewPasswordsAction$ } = picturePasswordStrings;
       const userList = ref([]);
       return {
         userIsMultiFacilityAdmin,
-        facilityConfig,
         viewPasswordsAction$,
         userList,
         PageNames,
@@ -116,6 +113,7 @@
     },
     computed: {
       ...mapGetters(['classListPageEnabled']),
+      ...mapState('classSummary', ['picture_password_settings']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
       },

--- a/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/OverviewBlock.spec.js
+++ b/kolibri/plugins/coach/frontend/views/home/HomePage/__tests__/OverviewBlock.spec.js
@@ -1,15 +1,12 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import { ref } from 'vue';
 import VueRouter from 'vue-router';
-import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import makeStore from '../../../../__tests__/utils/makeStore';
 import OverviewBlock from '../OverviewBlock.vue';
 
 const { viewPasswordsAction$ } = picturePasswordStrings;
 
-jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri-common/composables/useFacilities');
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../../composables/fetchClassSyncStatus');
@@ -34,17 +31,13 @@ const routes = [
 const MOCK_LEARNER = { id: 'learner-1', name: 'Learner One', username: 'learner1' };
 
 function renderComponent({ picturePasswordSettings, learners = [] } = {}) {
-  useFacility.mockImplementation(() =>
-    useFacilityMock({
-      facilityConfig: ref({ picture_password_settings: picturePasswordSettings }),
-    }),
-  );
   const store = makeStore();
   const learnerMap = {};
   learners.forEach(l => {
     learnerMap[l.id] = l;
   });
   store.state.classSummary.learnerMap = learnerMap;
+  store.state.classSummary.picture_password_settings = picturePasswordSettings;
   return render(OverviewBlock, { store, routes });
 }
 

--- a/kolibri/plugins/coach/frontend/views/learners/LearnersRootPage.vue
+++ b/kolibri/plugins/coach/frontend/views/learners/LearnersRootPage.vue
@@ -7,7 +7,7 @@
       >
         <template #actions>
           <KRouterLink
-            v-if="facilityConfig.picture_password_settings && learners.length"
+            v-if="picture_password_settings && learners.length"
             :text="viewPasswordsAction$()"
             appearance="raised-button"
             :to="{
@@ -77,10 +77,10 @@
 
 <script>
 
+  import { mapState } from 'vuex';
   import sortBy from 'lodash/sortBy';
   import ElapsedTime from 'kolibri-common/components/ElapsedTime';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
-  import useFacility from 'kolibri-common/composables/useFacility';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import { ref } from 'vue';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
@@ -105,7 +105,6 @@
     mixins: [commonCoach, commonCoreStrings],
     setup() {
       const { entireClassLabel$ } = coachStrings;
-      const { facilityConfig } = useFacility();
       const { viewPasswordsAction$ } = picturePasswordStrings;
 
       const recipientSelected = ref({
@@ -116,7 +115,6 @@
       return {
         pageLoading,
         entireClassLabel$,
-        facilityConfig,
         viewPasswordsAction$,
         recipientSelected,
         PageNames,
@@ -124,6 +122,7 @@
       };
     },
     computed: {
+      ...mapState('classSummary', ['picture_password_settings']),
       table() {
         const sorted = sortBy(this.learners, ['name']);
 

--- a/kolibri/plugins/coach/frontend/views/learners/__tests__/LearnersRootPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/learners/__tests__/LearnersRootPage.spec.js
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import { ref } from 'vue';
-import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 import makeStore from '../../../__tests__/utils/makeStore';
@@ -9,7 +7,6 @@ import LearnersRootPage from '../LearnersRootPage.vue';
 
 const { viewPasswordsAction$ } = picturePasswordStrings;
 
-jest.mock('kolibri-common/composables/useFacility');
 jest.mock('kolibri-common/composables/usePageLoading');
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../composables/fetchClassSyncStatus');
@@ -28,17 +25,13 @@ const routes = [
 const MOCK_LEARNER = { id: 'learner-1', name: 'Learner One', username: 'learner1' };
 
 function renderComponent({ picturePasswordSettings, learners = [] } = {}) {
-  useFacility.mockImplementation(() =>
-    useFacilityMock({
-      facilityConfig: ref({ picture_password_settings: picturePasswordSettings }),
-    }),
-  );
   const store = makeStore();
   const learnerMap = {};
   learners.forEach(l => {
     learnerMap[l.id] = l;
   });
   store.state.classSummary.learnerMap = learnerMap;
+  store.state.classSummary.picture_password_settings = picturePasswordSettings;
   return render(LearnersRootPage, { store, routes });
 }
 


### PR DESCRIPTION
## Summary
* Use class summary password settings on coach instead of the `facilityConfig` object returned by `useFacility` (This was also happening on the learners root page.
  * The error is because when we reload the page, we do not fetch the current facility data, because we do not go through the "select facility" page, so the `facilityConfig` object is inaccurate. Given that we already return this config from the classSummary endpoint, we can just use it instead.


https://github.com/user-attachments/assets/41b3213e-3402-4e97-b4c3-e866fc30e303


## References
Closes #14736.

## Reviewer guidance
Replicate #14736.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Used Claude to update the tests.