### PR TITLE
Gate picture-password UI on isPictureLoginFeatureEnabled

### DIFF
--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/index.vue
@@ -68,6 +68,20 @@
               :label="enableMarkAttendance$()"
               data-testid="enable_mark_attendance"
             />
+            <template v-if="!isPictureLoginFeatureEnabled">
+              <KCheckbox
+                :checked="signInOption === OptionsForSignIn.USERNAME_PASSWORD"
+                :label="learnerNeedPasswordToLogin$()"
+                data-testid="learner_can_login_with_no_password"
+                @change="handleNoPicturePasswordSignInOptionToggle"
+              />
+              <KCheckbox
+                v-model="settings.learner_can_edit_password"
+                :disabled="signInOption !== OptionsForSignIn.USERNAME_PASSWORD"
+                :label="learnerCanEditPassword$()"
+                data-testid="learner_can_edit_password"
+              />
+            </template>
           </div>
         </section>
 
@@ -84,7 +98,10 @@
         </section>
 
         <!-- How learners sign in Section -->
-        <section class="facility-settings learner-signin">
+        <section
+          v-if="isPictureLoginFeatureEnabled"
+          class="facility-settings learner-signin"
+        >
           <h3>{{ howLearnersSignIn$() }}</h3>
           <div class="settings">
             <KRadioButtonGroup>
@@ -109,55 +126,51 @@
                 :data-testid="OptionsForSignIn.USERNAME_ONLY"
               />
 
-              <template v-if="isPictureLoginFeatureEnabled">
-                <div class="radio-button-and-info-wrapper">
-                  <KRadioButton
-                    v-model="signInOption"
-                    :label="picturePassword$()"
-                    :buttonValue="OptionsForSignIn.PICTURE_PASSWORD"
-                    :disabled="picturePasswordDisabled"
-                    :data-testid="OptionsForSignIn.PICTURE_PASSWORD"
-                  />
-                  <KIconButton
-                    icon="info"
-                    size="mini"
-                    :color="$themeTokens.primary"
-                    :ariaLabel="picturePasswordInfoLabel$()"
-                    @click.stop="showPicturePasswordInfoModal = true"
-                  />
-                </div>
-                <div
-                  class="radio-description"
-                  :style="{
-                    color: picturePasswordDisabled
-                      ? $themeTokens.textDisabled
-                      : $themeTokens.annotation,
-                  }"
-                >
-                  {{ picturePasswordDescription$() }}
-                </div>
-                <div
-                  v-if="picturePasswordDisabled"
-                  class="exhausted-explanation nested-settings"
-                >
-                  <KIcon
-                    icon="warning"
-                    :style="{ fill: $themePalette.yellow.v_600 }"
-                  />
-                  <span>{{ picturePasswordUnavailableExplanation$() }}</span>
-                  <KIconButton
-                    icon="info"
-                    size="mini"
-                    :color="$themeTokens.primary"
-                    :ariaLabel="picturePasswordUnavailableExplanation$()"
-                    @click="showPicturePasswordUnavailableModal = true"
-                  />
-                </div>
-              </template>
+              <div class="radio-button-and-info-wrapper">
+                <KRadioButton
+                  v-model="signInOption"
+                  :label="picturePassword$()"
+                  :buttonValue="OptionsForSignIn.PICTURE_PASSWORD"
+                  :disabled="picturePasswordDisabled"
+                  :data-testid="OptionsForSignIn.PICTURE_PASSWORD"
+                />
+                <KIconButton
+                  icon="info"
+                  size="mini"
+                  :color="$themeTokens.primary"
+                  :ariaLabel="picturePasswordInfoLabel$()"
+                  @click.stop="showPicturePasswordInfoModal = true"
+                />
+              </div>
+              <div
+                class="radio-description"
+                :style="{
+                  color: picturePasswordDisabled
+                    ? $themeTokens.textDisabled
+                    : $themeTokens.annotation,
+                }"
+              >
+                {{ picturePasswordDescription$() }}
+              </div>
+              <div
+                v-if="picturePasswordDisabled"
+                class="exhausted-explanation nested-settings"
+              >
+                <KIcon
+                  icon="warning"
+                  :style="{ fill: $themePalette.yellow.v_600 }"
+                />
+                <span>{{ picturePasswordUnavailableExplanation$() }}</span>
+                <KIconButton
+                  icon="info"
+                  size="mini"
+                  :color="$themeTokens.primary"
+                  :ariaLabel="picturePasswordUnavailableExplanation$()"
+                  @click="showPicturePasswordUnavailableModal = true"
+                />
+              </div>
               <KRadioButtonGroup
-                v-if="
-                  isPictureLoginFeatureEnabled && signInOption === OptionsForSignIn.PICTURE_PASSWORD
-                "
+                v-if="signInOption === OptionsForSignIn.PICTURE_PASSWORD"
                 class="nested-settings picture-password-settings"
                 :aria-label="iconStyle$()"
               >
@@ -343,7 +356,6 @@
   import useTaskPolling from 'kolibri-common/composables/useTaskPolling';
   import { TaskStatuses } from 'kolibri-common/utils/syncTaskUtils';
   import { pageLoading } from 'kolibri-common/composables/usePageLoading';
-  import { createTranslator } from 'kolibri/utils/i18n';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
 
   import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
@@ -357,86 +369,7 @@
   import PicturePasswordInfoModal from './PicturePasswordInfoModal';
   import ChildFriendlyIconsModal from './ChildFriendlyIconsModal';
   import PicturePasswordUnavailableModal from './PicturePasswordUnavailableModal';
-
-  /**
-   * Using the createTranslator to aid concatenation
-   * of strings missed before string freeze. This only a workaround
-   */
-  const deviceSettingsPageStrings = createTranslator('DeviceSettingsPage', {
-    changeLocation: {
-      message: 'Change',
-      context: 'Label to change primary storage location',
-    },
-  });
-  const pinAuthenticationModalStrings = createTranslator('PinAuthenticationModal', {
-    pinPlaceholder: {
-      message: 'PIN',
-      context: 'Placeholder label for a PIN input',
-    },
-  });
-  const facilityConfigPageStrings = createTranslator('FacilityConfigPage', {
-    learnerCanEditUsername: {
-      message: 'Allow learners to edit their username',
-      context: "Option on 'Facility settings' page.",
-    },
-    learnerCanEditName: {
-      message: 'Allow learners to edit their full name',
-      context: "Option on 'Facility settings' page.",
-    },
-    learnerCanSignUp: {
-      message: 'Allow learners to create accounts',
-      context: "Option on 'Facility settings' page.",
-    },
-    learnerCanEditPassword: {
-      message: 'Allow learners to edit their password when signed in',
-      context: "Option on 'Facility settings' page.",
-    },
-    showDownloadButtonInLearn: {
-      message: "Show 'download' button with resources",
-      context: "Option on 'Facility settings' page.\n",
-    },
-    enableMarkAttendance: {
-      message: 'Allow coaches to take attendance (English only)',
-      context: "Option on 'Facility settings' page.",
-    },
-    saveFailure: {
-      message: 'There was a problem saving your settings',
-      context: 'Status report after the facility change operation.',
-    },
-    saveSuccess: {
-      message: 'Facility settings updated',
-      context: 'Status report after the facility change operation.',
-    },
-    pageDescription: {
-      message: 'Configure facility settings here.',
-      context: 'Interpret as "[You can] configure facility settings here"',
-    },
-    deviceSettings: {
-      message: 'You can also configure device settings',
-      context: 'Text link on Facility settings page.',
-    },
-    pageHeader: {
-      message: 'Facility settings',
-      context: 'Title of the Facility > Settings page.',
-    },
-    documentTitle: {
-      message: 'Facility Settings',
-      context: 'Title of page where user can configure facility settings.',
-    },
-    deviceManagementPin: {
-      message: 'Device management PIN',
-      context: 'The title for the device management PIN',
-    },
-    deviceManagementDescription: {
-      message:
-        'This 4-digit PIN allows users to manage content and other settings on learn-only devices',
-      context: 'Description for the device management',
-    },
-    createPinBtn: {
-      message: 'Create PIN',
-      context: 'Button for the create PIN',
-    },
-  });
+  import facilityConfigPageStrings from './strings';
 
   export default {
     name: 'FacilityConfigPage',
@@ -495,11 +428,14 @@
         showDownloadButtonInLearn$,
         enableMarkAttendance$,
         learnerCanEditPassword$,
+        learnerNeedPasswordToLogin$,
         deviceManagementPin$,
         deviceManagementDescription$,
         createPinBtn$,
         saveSuccess$,
         saveFailure$,
+        pinPlaceholder$,
+        changeLocation$,
       } = facilityConfigPageStrings;
       const {
         howLearnersSignIn$,
@@ -515,8 +451,6 @@
         iconStyle$,
         picturePasswordUnavailableExplanation$,
       } = picturePasswordStrings;
-      const { pinPlaceholder$ } = pinAuthenticationModalStrings;
-      const { changeLocation$ } = deviceSettingsPageStrings;
 
       // state
       const showEditFacilityModal = ref(false);
@@ -632,6 +566,16 @@
         }
       }
 
+      const handleNoPicturePasswordSignInOptionToggle = () => {
+        // When picture password is disabled in the UI, just treat it
+        // being enabled as 'USERNAME_ONLY' to avoid ambiguous state.
+        if (signInOption.value !== OptionsForSignIn.USERNAME_PASSWORD) {
+          signInOption.value = OptionsForSignIn.USERNAME_PASSWORD;
+        } else {
+          signInOption.value = OptionsForSignIn.USERNAME_ONLY;
+        }
+      };
+
       const { tasks: facilityTasks } = useTaskPolling('facility_task');
       const pictureLoginTaskLoading = ref(false);
 
@@ -697,6 +641,7 @@
         handleRemovePinSubmit,
         handleCreatePin,
         handleSelect,
+        handleNoPicturePasswordSignInOptionToggle,
 
         // Strings
         pageHeader$,
@@ -707,6 +652,7 @@
         learnerCanSignUp$,
         enableMarkAttendance$,
         learnerCanEditPassword$,
+        learnerNeedPasswordToLogin$,
         showDownloadButtonInLearn$,
         deviceManagementPin$,
         deviceManagementDescription$,

--- a/kolibri/plugins/facility/frontend/views/FacilityConfigPage/strings.js
+++ b/kolibri/plugins/facility/frontend/views/FacilityConfigPage/strings.js
@@ -1,0 +1,77 @@
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export default createTranslator('FacilityConfigPage', {
+  learnerCanEditUsername: {
+    message: 'Allow learners to edit their username',
+    context: "Option on 'Facility settings' page.",
+  },
+  learnerCanEditName: {
+    message: 'Allow learners to edit their full name',
+    context: "Option on 'Facility settings' page.",
+  },
+  learnerCanSignUp: {
+    message: 'Allow learners to create accounts',
+    context: "Option on 'Facility settings' page.",
+  },
+  learnerNeedPasswordToLogin: {
+    message: 'Require password for learners',
+    context: "Option on 'Facility settings' page.",
+  },
+  learnerCanEditPassword: {
+    message: 'Allow learners to edit their password when signed in',
+    context: "Option on 'Facility settings' page.",
+  },
+  showDownloadButtonInLearn: {
+    message: "Show 'download' button with resources",
+    context: "Option on 'Facility settings' page.\n",
+  },
+  enableMarkAttendance: {
+    message: 'Allow coaches to take attendance (English only)',
+    context: "Option on 'Facility settings' page.",
+  },
+  saveFailure: {
+    message: 'There was a problem saving your settings',
+    context: 'Status report after the facility change operation.',
+  },
+  saveSuccess: {
+    message: 'Facility settings updated',
+    context: 'Status report after the facility change operation.',
+  },
+  pageDescription: {
+    message: 'Configure facility settings here.',
+    context: 'Interpret as "[You can] configure facility settings here"',
+  },
+  deviceSettings: {
+    message: 'You can also configure device settings',
+    context: 'Text link on Facility settings page.',
+  },
+  pageHeader: {
+    message: 'Facility settings',
+    context: 'Title of the Facility > Settings page.',
+  },
+  documentTitle: {
+    message: 'Facility Settings',
+    context: 'Title of page where user can configure facility settings.',
+  },
+  deviceManagementPin: {
+    message: 'Device management PIN',
+    context: 'The title for the device management PIN',
+  },
+  deviceManagementDescription: {
+    message:
+      'This 4-digit PIN allows users to manage content and other settings on learn-only devices',
+    context: 'Description for the device management',
+  },
+  createPinBtn: {
+    message: 'Create PIN',
+    context: 'Button for the create PIN',
+  },
+  changeLocation: {
+    message: 'Change',
+    context: 'Label to change primary storage location',
+  },
+  pinPlaceholder: {
+    message: 'PIN',
+    context: 'Placeholder label for a PIN input',
+  },
+});

--- a/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/frontend/views/__tests__/facility-config-page.spec.js
@@ -8,6 +8,7 @@ import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-di
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line
 import { OptionsForSignIn, PicturePasswordIconStyle } from 'kolibri-common/constants/Auth';
 import useFacilityEditor from '../../composables/useFacilityEditor';
+import facilityConfigPageStrings from '../FacilityConfigPage/strings';
 import ConfigPage from '../FacilityConfigPage';
 
 const {
@@ -15,9 +16,12 @@ const {
   picturePasswordInfoBody$,
   childFriendlyIconsInfoLabel$,
   childFriendlyIcons$,
+  howLearnersSignIn$,
   picturePasswordUnavailableExplanation$,
   picturePasswordUnavailableTitle$,
 } = picturePasswordStrings;
+
+const { learnerNeedPasswordToLogin$, learnerCanEditPassword$ } = facilityConfigPageStrings;
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('../../../../device/frontend/views/DeviceSettingsPage/api.js', () => ({
@@ -384,6 +388,79 @@ describe('facility config page view', () => {
       renderExhausted({ signInOption: OptionsForSignIn.PICTURE_PASSWORD });
       expect(screen.getByTestId('child_friendly_icons').querySelector('input')).toBeDisabled();
       expect(screen.getByTestId('standard_icons').querySelector('input')).toBeDisabled();
+    });
+  });
+
+  describe('when the picture login feature is disabled', () => {
+    function renderDisabled(extra = {}) {
+      return renderPage({
+        mockFacilityConfig: {
+          isPictureLoginFeatureEnabled: ref(false),
+          ...extra,
+        },
+      });
+    }
+
+    function getUsersSection() {
+      return screen.getByRole('heading', { name: coreString('usersLabel') }).closest('section');
+    }
+
+    it('hides the "how learners sign in" section', () => {
+      renderDisabled();
+      expect(screen.queryByRole('heading', { name: howLearnersSignIn$() })).not.toBeInTheDocument();
+    });
+
+    it('shows the legacy require-password checkbox inside the Users section, reflecting the inverted setting', () => {
+      const settings = ref({ learner_can_login_with_no_password: false });
+      renderDisabled({ settings });
+      const checkbox = within(getUsersSection()).getByRole('checkbox', {
+        name: learnerNeedPasswordToLogin$(),
+      });
+      expect(checkbox).toBeChecked();
+    });
+
+    it('switches signInOption to USERNAME_ONLY when the require-password checkbox is unchecked', async () => {
+      const mockFacilityConfig = createMockFacilityConfig({
+        isPictureLoginFeatureEnabled: ref(false),
+      });
+      renderPage({ mockFacilityConfig });
+      await userEvent.click(screen.getByRole('checkbox', { name: learnerNeedPasswordToLogin$() }));
+      expect(mockFacilityConfig.signInOption.value).toBe(OptionsForSignIn.USERNAME_ONLY);
+    });
+
+    it('shows the edit-password checkbox inside the Users section regardless of signInOption', () => {
+      // With signInOption=USERNAME_ONLY this checkbox would normally be hidden by
+      // the signin-section template; once the section is gone it must remain visible.
+      renderDisabled({ signInOption: OptionsForSignIn.USERNAME_ONLY });
+      expect(
+        within(getUsersSection()).getByRole('checkbox', { name: learnerCanEditPassword$() }),
+      ).toBeInTheDocument();
+    });
+
+    it('disables the edit-password checkbox when password is not required', () => {
+      renderDisabled({ signInOption: OptionsForSignIn.USERNAME_ONLY });
+      expect(screen.getByRole('checkbox', { name: learnerCanEditPassword$() })).toBeDisabled();
+    });
+
+    describe('when picture-password is already selected in settings', () => {
+      it('shows the require-password checkbox unchecked', () => {
+        renderDisabled({ signInOption: OptionsForSignIn.PICTURE_PASSWORD });
+        expect(
+          screen.getByRole('checkbox', { name: learnerNeedPasswordToLogin$() }),
+        ).not.toBeChecked();
+      });
+
+      it('switches signInOption to USERNAME_PASSWORD when the require-password checkbox is checked', async () => {
+        const mockFacilityConfig = createMockFacilityConfig({
+          isPictureLoginFeatureEnabled: ref(false),
+          signInOption: OptionsForSignIn.PICTURE_PASSWORD,
+        });
+        renderPage({ mockFacilityConfig });
+        await userEvent.click(
+          screen.getByRole('checkbox', { name: learnerNeedPasswordToLogin$() }),
+        );
+        expect(mockFacilityConfig.signInOption.value).toBe(OptionsForSignIn.USERNAME_PASSWORD);
+      });
     });
   });
 });

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/__tests__/UserCreateSidePanel.spec.js
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/__tests__/UserCreateSidePanel.spec.js
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/vue';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import useFacility from 'kolibri-common/composables/useFacility';
 import { useFacilityMock } from 'kolibri-common/composables/__mocks__/useFacility';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
@@ -32,6 +32,7 @@ function setup({
   pictureLogin = false,
   exhausted = false,
   learnerCanLoginWithNoPassword = false,
+  pictureLoginFeatureEnabled = true,
 } = {}) {
   useFacility.mockImplementation(() =>
     useFacilityMock({
@@ -41,6 +42,7 @@ function setup({
         extra_fields: null,
       }),
       selectedFacility: ref({ picture_passwords_exhausted: exhausted }),
+      isPictureLoginFeatureEnabled: computed(() => pictureLoginFeatureEnabled),
       setFacilityId: jest.fn().mockResolvedValue(undefined),
     }),
   );
@@ -287,6 +289,51 @@ describe('UserCreateSidePanel', () => {
       await fillRequired();
       await fireEvent.click(saveAndCloseButton());
       expect(FacilityUserResource.saveModel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the picture login feature is disabled (non-English locale)', () => {
+    it('hides the picture password info block even when the facility has picture passwords configured', async () => {
+      setup({ pictureLogin: true, pictureLoginFeatureEnabled: false });
+      await waitForFormReady();
+      expect(screen.queryByTestId('picture-password-info')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: picturePasswordStrings.signingInHeading$() }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the password input for learners even when the facility has picture passwords configured', async () => {
+      setup({ pictureLogin: true, pictureLoginFeatureEnabled: false });
+      await waitForFormReady();
+      expect(screen.getByLabelText(coreStrings.passwordLabel$())).toHaveValue('');
+    });
+
+    it('hides the learner-limit-exhausted warning and keeps the submit buttons enabled', async () => {
+      setup({ pictureLogin: true, exhausted: true, pictureLoginFeatureEnabled: false });
+      await waitForFormReady();
+      expect(
+        screen.queryByText(picturePasswordStrings.learnerCreationDisabled$()),
+      ).not.toBeInTheDocument();
+      expect(saveAndCloseButton()).toBeEnabled();
+      expect(saveAndAddAnotherButton()).toBeEnabled();
+    });
+
+    it('submits the form with the user-supplied password when the facility has picture passwords configured', async () => {
+      FacilityUserResource.saveModel.mockResolvedValue({ id: 'new-user-id', facility: 'fac-1' });
+      setup({ pictureLogin: true, pictureLoginFeatureEnabled: false });
+      await waitForFormReady();
+      await fillRequired();
+      await setPassword('secret123');
+      await fireEvent.click(saveAndCloseButton());
+
+      await waitFor(() => {
+        expect(FacilityUserResource.saveModel).toHaveBeenCalledTimes(1);
+      });
+      expect(FacilityUserResource.saveModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ password: 'secret123' }),
+        }),
+      );
     });
   });
 });

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/UserCreate/index.vue
@@ -242,7 +242,13 @@
       const router = useRouter();
       const instance = getCurrentInstance();
       const $refs = instance.proxy.$refs;
-      const { facilityConfig, selectedFacility, facilityId, fetchFacilities } = useFacility();
+      const {
+        facilityConfig,
+        selectedFacility,
+        facilityId,
+        fetchFacilities,
+        isPictureLoginFeatureEnabled,
+      } = useFacility();
       const picturePasswordSettings = computed(
         () => facilityConfig.value?.picture_password_settings || null,
       );
@@ -250,7 +256,9 @@
 
       const showLearnerLimitModal = ref(false);
 
-      const isPictureLoginActive = computed(() => picturePasswordSettings.value != null);
+      const isPictureLoginActive = computed(
+        () => isPictureLoginFeatureEnabled.value && picturePasswordSettings.value != null,
+      );
       const learnerLimitReached = computed(
         () => isPictureLoginActive.value && selectedFacility.value?.picture_passwords_exhausted,
       );


### PR DESCRIPTION
## Summary

- **Facility Settings**: when `isPictureLoginFeatureEnabled` is false, hide the "How learners sign in" section and show the pre-refactor require-password / edit-password checkboxes under Users instead.
- **New user side panel**: when `isPictureLoginFeatureEnabled` is false, hide the picture-password info block, the "Signing in" heading, and the 1300-learner-limit warning.

## References

Fixes #14738

## Reviewer guidance

Reproduce in a non-English locale (e.g. `/ar/`) against a facility that has picture passwords configured:

1. Facility › Settings — confirm "How learners sign in" is gone and the legacy "Require password for learners" / "Allow learners to edit their password" checkboxes render under Users.
2. Users › New user — confirm the picture-password info block and 1300-learner warning are gone.
3. Switch back to `/en/` — both pages should be unchanged from before.

## Screenshots

| Page | English | Arabic |
|------|---------|--------|
| Facility › Settings | ![EN settings](https://i.imgur.com/BWc1uqp.png) | ![AR settings](https://i.imgur.com/fpDtYzV.png) |
| Users › New user | ![EN new user](https://i.imgur.com/PL5qFev.png) | ![AR new user](https://i.imgur.com/6TBKKRf.png) |

axe-core audit (WCAG AA, moderate+) on all four pages above: **0 violations**.

## AI usage

Used Claude Code (Opus 4.7) end-to-end: clarified the gating approach with me through questions, wrote failing tests first then the implementation, and drove a headless browser against the dev server in English and Arabic to confirm the disabled-state behaviour matches the issue's repro.