### PR TITLE
Add visible error notification for wrong picture password

### DIFF
--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -8,6 +8,12 @@
     @submit.prevent="handleSubmit"
   >
     <div
+      ref="errorFocusRef"
+      tabindex="-1"
+      class="visuallyhidden"
+      aria-hidden="true"
+    ></div>
+    <div
       class="icon-grid"
       :style="{
         gridTemplateColumns: `repeat(${columns}, 1fr)`,
@@ -128,8 +134,9 @@
       // Internal selection state: up to 3 integer IDs in order of selection.
       const sequence = ref([]);
 
-      // Template ref for the form element (used for programmatic focus)
+      // Template refs for programmatic focus
       const formRef = ref(null);
+      const errorFocusRef = ref(null);
 
       const resolveIconToken = entry =>
         props.iconStyle === 'standard' ? entry.iconStandard : entry.iconColorful;
@@ -327,6 +334,19 @@
         }
       };
 
+      /**
+       * @public
+       * Moves focus to the visually-hidden sentinel at the top of the form.
+       * Focusing the form itself causes screen readers to announce every picture
+       * password icon, so this aria-hidden sentinel absorbs focus without
+       * triggering that full grid read-out.
+       */
+      const focusErrorTarget = () => {
+        if (errorFocusRef.value) {
+          errorFocusRef.value.focus();
+        }
+      };
+
       return {
         icons,
         columns,
@@ -342,7 +362,9 @@
         handleSubmit,
         formAriaLabel$,
         formRef,
+        errorFocusRef,
         focus, // eslint-disable-line vue/no-unused-properties
+        focusErrorTarget, // eslint-disable-line vue/no-unused-properties
         sequence, // eslint-disable-line vue/no-unused-properties
         playSuccessAnimation, // eslint-disable-line vue/no-unused-properties
       };

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -8,7 +8,7 @@
     @submit.prevent="handleSubmit"
   >
     <div
-      ref="errorFocusRef"
+      ref="sentinelRef"
       tabindex="-1"
       class="visuallyhidden"
       aria-hidden="true"
@@ -136,7 +136,7 @@
 
       // Template refs for programmatic focus
       const formRef = ref(null);
-      const errorFocusRef = ref(null);
+      const sentinelRef = ref(null);
 
       const resolveIconToken = entry =>
         props.iconStyle === 'standard' ? entry.iconStandard : entry.iconColorful;
@@ -336,14 +336,13 @@
 
       /**
        * @public
-       * Moves focus to the visually-hidden sentinel at the top of the form.
-       * Focusing the form itself causes screen readers to announce every picture
-       * password icon, so this aria-hidden sentinel absorbs focus without
-       * triggering that full grid read-out.
+       * Moves focus to the visually-hidden sentinel at the top of the form,
+       * e.g. after a failed sign-in attempt, so that screen readers land
+       * inside the grid without announcing every picture password icon.
        */
-      const focusErrorTarget = () => {
-        if (errorFocusRef.value) {
-          errorFocusRef.value.focus();
+      const focusSentinel = () => {
+        if (sentinelRef.value) {
+          sentinelRef.value.focus();
         }
       };
 
@@ -362,9 +361,9 @@
         handleSubmit,
         formAriaLabel$,
         formRef,
-        errorFocusRef,
+        sentinelRef,
         focus, // eslint-disable-line vue/no-unused-properties
-        focusErrorTarget, // eslint-disable-line vue/no-unused-properties
+        focusSentinel, // eslint-disable-line vue/no-unused-properties
         sequence, // eslint-disable-line vue/no-unused-properties
         playSuccessAnimation, // eslint-disable-line vue/no-unused-properties
       };

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordGrid.vue
@@ -224,6 +224,7 @@
         }
 
         sequence.value = [...sequence.value, id];
+        emit('select', sequence.value.length);
 
         const position = sequence.value.length;
         sendPoliteMessage(ORDINAL_STRING_MAP[position]({ icon: iconLabelFor(id) }));

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -70,7 +70,6 @@
   import { useFacilitySelect } from 'kolibri-common/composables/useFacility';
   import useSnackbar from 'kolibri/composables/useSnackbar';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
@@ -103,7 +102,6 @@
       const { login } = useUser();
       const { createSnackbar } = useSnackbar();
       const { windowIsLandscape } = useKResponsiveWindow();
-      const { sendAssertiveMessage } = useKLiveRegion();
       const { wrongPicturesTryAgain$ } = picturePasswordStrings;
       const { nextParam, defaultRoute, getFacilitySelectionRoute } = useAuthRouter(route);
       const {
@@ -180,7 +178,6 @@
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;
-            sendAssertiveMessage(wrongPicturesTryAgain$());
             passwordGridRef.value?.focus();
           }
         } catch (error) {
@@ -212,7 +209,6 @@
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;
-            sendAssertiveMessage(wrongPicturesTryAgain$());
             passwordGridRef.value?.focus();
           } else {
             showConfirmModal.value = false;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -175,10 +175,10 @@
             showConfirmModal.value = true; // Then show modal
           } else if (error) {
             await authBaseRef.value.shake();
+            passwordGridRef.value?.focusErrorTarget();
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;
-            passwordGridRef.value?.focus();
           }
         } catch (error) {
           createSnackbar({
@@ -206,10 +206,10 @@
             submittedPicturePassword.value = '';
             confirmedLearnerName.value = '';
             await authBaseRef.value.shake();
+            passwordGridRef.value?.focusErrorTarget();
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;
-            passwordGridRef.value?.focus();
           } else {
             showConfirmModal.value = false;
             redirectBrowser(nextParam.value || undefined);

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -175,7 +175,7 @@
             showConfirmModal.value = true; // Then show modal
           } else if (error) {
             await authBaseRef.value.shake();
-            passwordGridRef.value?.focusErrorTarget();
+            passwordGridRef.value?.focusSentinel();
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;
@@ -206,7 +206,7 @@
             submittedPicturePassword.value = '';
             confirmedLearnerName.value = '';
             await authBaseRef.value.shake();
-            passwordGridRef.value?.focusErrorTarget();
+            passwordGridRef.value?.focusSentinel();
             clearSequence.value = true;
             await nextTick();
             wrongPictures.value = true;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -43,6 +43,7 @@
       :showIconText="picturePasswordShowIconText"
       :clearSequence.sync="clearSequence"
       :landscapeLayout="landscapeLayout"
+      @select="onGridSelect"
       @submit="prevalidate"
     />
     <PicturePasswordConfirmModal
@@ -232,6 +233,12 @@
         clearSequence.value = true;
       }
 
+      function onGridSelect(len) {
+        if (len === 1 && wrongPictures.value) {
+          wrongPictures.value = false;
+        }
+      }
+
       return {
         // state
         busy,
@@ -252,6 +259,7 @@
         prevalidate,
         handleConfirm,
         handleCancel,
+        onGridSelect,
         // strings
         wrongPicturesTryAgain$,
       };

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignInPage.vue
@@ -26,6 +26,15 @@
       :backTo="backTo"
     />
 
+    <UiAlert
+      v-if="wrongPictures"
+      class="error-alert"
+      type="error"
+      :dismissible="false"
+    >
+      {{ wrongPicturesTryAgain$() }}
+    </UiAlert>
+
     <PicturePasswordGrid
       ref="passwordGridRef"
       class="picture-grid"
@@ -63,6 +72,7 @@
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { isTouchDevice } from 'kolibri/utils/browserInfo';
   import { picturePasswordStrings } from 'kolibri-common/strings/picturePasswords';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import AuthBase from '../AuthBase';
   import useAuthFlow from '../../composables/useAuthFlow';
   import useAuthWatcher from '../../composables/useAuthWatcher';
@@ -83,6 +93,7 @@
       AuthContextHeading,
       PicturePasswordGrid,
       PicturePasswordConfirmModal,
+      UiAlert,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -109,6 +120,7 @@
       const showConfirmModal = ref(false);
       const confirmedLearnerName = ref('');
       const submittedPicturePassword = ref('');
+      const wrongPictures = ref(false);
 
       // Template refs for calling public methods on child components
       const authBaseRef = ref(null);
@@ -149,6 +161,7 @@
        */
       async function prevalidate(picturePassword) {
         busy.value = true;
+        wrongPictures.value = false;
         setSelectedFacilityId(facilityId.value);
         try {
           const { data, error } = await login(
@@ -165,6 +178,7 @@
             await authBaseRef.value.shake();
             clearSequence.value = true;
             await nextTick();
+            wrongPictures.value = true;
             sendAssertiveMessage(wrongPicturesTryAgain$());
             passwordGridRef.value?.focus();
           }
@@ -196,6 +210,7 @@
             await authBaseRef.value.shake();
             clearSequence.value = true;
             await nextTick();
+            wrongPictures.value = true;
             sendAssertiveMessage(wrongPicturesTryAgain$());
             passwordGridRef.value?.focus();
           } else {
@@ -225,6 +240,7 @@
         showConfirmModal,
         confirmedLearnerName,
         submittedPicturePassword,
+        wrongPictures,
         backTo,
         picturePasswordStyle,
         picturePasswordShowIconText,
@@ -236,6 +252,8 @@
         prevalidate,
         handleConfirm,
         handleCancel,
+        // strings
+        wrongPicturesTryAgain$,
       };
     },
     $trs: {
@@ -250,6 +268,11 @@
 
 
 <style lang="scss" scoped>
+
+  .error-alert {
+    margin-top: 16px;
+    text-align: start;
+  }
 
   .picture-grid {
     margin-top: 20px;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -270,7 +270,7 @@ describe('PictureSignInPage', () => {
   });
 
   describe('error handling and accessibility', () => {
-    it('returns focus to the form after a failed prevalidate', async () => {
+    it('returns focus to the error sentinel inside the grid after a failed prevalidate', async () => {
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       const { container } = renderComponent();
 
@@ -279,17 +279,13 @@ describe('PictureSignInPage', () => {
       await userEvent.click(checkbox(moon()));
       await userEvent.click(screen.getByTestId('submit-button'));
 
-      // Wait for the sequence to clear after shake resolves
       await waitFor(() => {
-        expect(checkbox(bee())).not.toBeChecked();
+        const sentinel = container.querySelector('form [aria-hidden="true"]');
+        expect(sentinel).toHaveFocus();
       });
-
-      // Focus should be on the form
-      const form = container.querySelector('form');
-      expect(form).toHaveFocus();
     });
 
-    it('returns focus to the form after confirm login fails', async () => {
+    it('returns focus to the error sentinel inside the grid after confirm login fails', async () => {
       mockLogin
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
@@ -304,13 +300,10 @@ describe('PictureSignInPage', () => {
 
       await userEvent.click(screen.getByRole('button', { name: confirmLabel() }));
 
-      // Wait for the sequence to clear after shake resolves
       await waitFor(() => {
-        expect(checkbox(bee())).not.toBeChecked();
+        const sentinel = container.querySelector('form [aria-hidden="true"]');
+        expect(sentinel).toHaveFocus();
       });
-
-      const form = container.querySelector('form');
-      expect(form).toHaveFocus();
     });
 
     it('shows a visible error notification after a failed prevalidate', async () => {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -367,6 +367,29 @@ describe('PictureSignInPage', () => {
       });
     });
 
+    it('clears the error notification when the first icon of a new sequence is selected', async () => {
+      mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
+      renderComponent();
+
+      // First failed attempt — error notification appears
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+        ).toBeInTheDocument();
+      });
+
+      // Selecting the first icon of the next sequence clears the error immediately
+      await userEvent.click(checkbox(bee()));
+      expect(
+        screen.queryByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+      ).not.toBeInTheDocument();
+    });
+
     it('clears the visible error notification on the next submission attempt', async () => {
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       renderComponent();

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -329,5 +329,71 @@ describe('PictureSignInPage', () => {
         picturePasswordStrings.wrongPicturesTryAgain$(),
       );
     });
+
+    it('shows a visible error notification after a failed prevalidate', async () => {
+      mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
+      renderComponent();
+
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows a visible error notification after confirm login fails', async () => {
+      mockLogin
+        .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
+        .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
+
+      renderComponent();
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+
+      await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
+      await userEvent.click(screen.getByRole('button', { name: confirmLabel() }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('clears the visible error notification on the next submission attempt', async () => {
+      mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
+      renderComponent();
+
+      // First failed attempt
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+        ).toBeInTheDocument();
+      });
+
+      // Second attempt — error should clear immediately on submit
+      await userEvent.click(checkbox(bee()));
+      await userEvent.click(checkbox(star()));
+      await userEvent.click(checkbox(moon()));
+      await userEvent.click(screen.getByTestId('submit-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -28,20 +28,11 @@ jest.mock('kolibri-plugin-data', () => ({
 }));
 const mockLogin = jest.fn();
 const mockRouterPush = jest.fn();
-const mockSendPoliteMessage = jest.fn();
-const mockSendAssertiveMessage = jest.fn();
 
 jest.mock('../../../composables/useAuthFlow');
 jest.mock('../../../composables/useAuthRouter');
 jest.mock('../../../composables/useAuthWatcher');
 jest.mock('vue-router/composables');
-jest.mock('kolibri-design-system/lib/composables/useKLiveRegion', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    sendPoliteMessage: mockSendPoliteMessage,
-    sendAssertiveMessage: mockSendAssertiveMessage,
-  })),
-}));
 const bee = () => picturePasswordStrings.bee$();
 const star = () => picturePasswordStrings.star$();
 const moon = () => picturePasswordStrings.moon$();
@@ -103,8 +94,6 @@ describe('PictureSignInPage', () => {
   beforeEach(() => {
     mockLogin.mockReset();
     mockRouterPush.mockReset();
-    mockSendPoliteMessage.mockReset();
-    mockSendAssertiveMessage.mockReset();
     redirectBrowser.mockReset();
     window.matchMedia = jest.fn().mockImplementation(query => ({
       matches: false,
@@ -281,7 +270,7 @@ describe('PictureSignInPage', () => {
   });
 
   describe('error handling and accessibility', () => {
-    it('sends an assertive message and returns focus to the form after a failed prevalidate', async () => {
+    it('returns focus to the form after a failed prevalidate', async () => {
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       const { container } = renderComponent();
 
@@ -295,22 +284,17 @@ describe('PictureSignInPage', () => {
         expect(checkbox(bee())).not.toBeChecked();
       });
 
-      // Assertive message should have been sent with the error string
-      expect(mockSendAssertiveMessage).toHaveBeenCalledWith(
-        picturePasswordStrings.wrongPicturesTryAgain$(),
-      );
-
       // Focus should be on the form
       const form = container.querySelector('form');
       expect(form).toHaveFocus();
     });
 
-    it('sends an assertive message and returns focus to the form after confirm login fails', async () => {
+    it('returns focus to the form after confirm login fails', async () => {
       mockLogin
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
 
-      renderComponent();
+      const { container } = renderComponent();
       await userEvent.click(checkbox(bee()));
       await userEvent.click(checkbox(star()));
       await userEvent.click(checkbox(moon()));
@@ -325,9 +309,8 @@ describe('PictureSignInPage', () => {
         expect(checkbox(bee())).not.toBeChecked();
       });
 
-      expect(mockSendAssertiveMessage).toHaveBeenCalledWith(
-        picturePasswordStrings.wrongPicturesTryAgain$(),
-      );
+      const form = container.querySelector('form');
+      expect(form).toHaveFocus();
     });
 
     it('shows a visible error notification after a failed prevalidate', async () => {

--- a/packages/kolibri-common/strings/picturePasswords.js
+++ b/packages/kolibri-common/strings/picturePasswords.js
@@ -101,7 +101,7 @@ export const picturePasswordStrings = createTranslator('PicturePasswordStrings',
   wrongPicturesTryAgain: {
     message: 'Wrong pictures, try again!',
     context:
-      'Assertive screen reader announcement when the learner submits an incorrect picture password sequence.',
+      'Error notification and assertive screen reader announcement when the learner submits an incorrect picture password sequence.',
   },
 
   learnerLimitReachedHeading: {


### PR DESCRIPTION
## Summary

When a learner submits an incorrect picture password sequence, only a shake animation and an `aria-live` screen reader announcement were shown — no visible error text for sighted users. This adds a `UiAlert` error notification ("Wrong pictures, try again!") above the picture grid, consistent with the "Incorrect password" alert on the regular sign-in page. This is a follow-up from #14690

**Changes:**
- `PictureSignInPage`: Adds a `wrongPictures` ref that shows a `UiAlert` on failed login and clears on the next submission attempt. Applied in both the prevalidation path and the confirm-modal path.
- Error text is left-aligned with extra top margin for visual separation from the facility heading.
- 3 new tests: error visible after failed prevalidate, error visible after confirm fails, error clears on next submit.

https://github.com/user-attachments/assets/5e2aca1f-4090-461b-a5ee-4116d1484281

## References

Closes #14740

## Reviewer guidance

To test manually:
1. Enable picture password for a facility in Facility settings.
2. Open the picture sign-in page and submit an incorrect 3-picture sequence.
3. Confirm "Wrong pictures, try again!" appears above the grid after the shake.
4. Select a new sequence and submit — the alert disappears at the start of the next attempt.

## AI usage

Implemented with Claude Code. I reviewed the output, verified test coverage for all error states, and recorded the screen capture independently.