### PR TITLE
Prevent untracked files complicating worktree removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ kolibri/locale/.crowdin-download-marker
 .junie/
 .aiassistant/
 .aiignore
+.codex*
+.qwen/
+.vibe/
+.aider.config.yml
 
 # Complexity
 output/*.html

--- a/kolibri/core/content/test/test_sqlalchemy_bridge.py
+++ b/kolibri/core/content/test/test_sqlalchemy_bridge.py
@@ -95,6 +95,12 @@ class SQLAlchemyBridgeSQLAlchemyFunctionsTestCase(TestCase):
     def test_sqlite_string(self):
         self.assertEqual("sqlite:///test", sqlite_connection_string("test"))
 
+    def test_sqlite_uri_string(self):
+        self.assertEqual(
+            "sqlite:///file:memorydb_default?mode=memory&cache=shared&uri=true",
+            sqlite_connection_string("file:memorydb_default?mode=memory&cache=shared"),
+        )
+
     def test_get_engine(self):
         self.assertEqual(type(get_engine("sqlite:///")), Engine)
 
@@ -204,11 +210,26 @@ class SQLAlchemyBridgeDefaultDBStringTestCase(TestCase):
     @pytest.mark.filterwarnings("ignore:Overriding setting DATABASES")
     @override_settings(
         DATABASES={
-            "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "test.sqlite3"}
+            "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "test.sqlite3"},
         }
     )
     def test_sqlite(self):
         self.assertEqual(get_default_db_string(), "sqlite:///test.sqlite3")
+
+    @pytest.mark.filterwarnings("ignore:Overriding setting DATABASES")
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": "file:memorydb_default?mode=memory&cache=shared",
+            },
+        }
+    )
+    def test_sqlite_uri(self):
+        self.assertEqual(
+            get_default_db_string(),
+            "sqlite:///file:memorydb_default?mode=memory&cache=shared&uri=true",
+        )
 
     @pytest.mark.filterwarnings("ignore:Overriding setting DATABASES")
     @override_settings(

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -81,6 +81,13 @@ class SharingPool(NullPool):
 
 
 def sqlite_connection_string(db_path):
+    # shortcut db_paths like `file:memorydb_default?mode=memory&cache=shared`
+    # to ensure they have `uri=true` so sqlite treats it as in-memory
+    if db_path.startswith("file:"):
+        separator = "&" if "?" in db_path else "?"
+        return "sqlite:///{db_path}{separator}uri=true".format(
+            db_path=db_path, separator=separator
+        )
     # Call normpath to ensure that Windows paths are properly formatted
     return "sqlite://{db_path}".format(
         db_path="" if db_path == ":memory:" else "/" + os.path.normpath(db_path)


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Adds more `.gitignore` rules for various AI harnesses that sometimes create local project files
- Prevents `test_enumerate_channel.py` from creating untracked file `file:memorydb_default` in project root


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Tests pass?

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I had AI investigate the untracked file. Based off the name, it seems the intent was to have that be in-memory. AI found that `file:memorydb_default?mode=memory&cache=shared` was generated as a DB path and eventually went through the content plugin's sqlite handling code, and got formatted to `sqlite:///file:memorydb_default?mode=memory&cache=shared`. AI determined the missing `uri=true` was problematic.