### PR TITLE
Bump kolibri-app workflow refs to v0.5.1

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -22,10 +22,10 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.5.0
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.5.1
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v0.5.0
+      ref: v0.5.1
   deb:
     name: Build DEB file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -58,11 +58,11 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.5.0
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.5.1
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v0.5.0
+      ref: v0.5.1
     secrets:
       KOLIBRI_MAC_APP_IDENTITY: ${{ secrets.KOLIBRI_MAC_APP_IDENTITY }}
       KOLIBRI_MAC_APP_CERTIFICATE: ${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE }}


### PR DESCRIPTION
## Summary

Bumps the `kolibri-app` workflow refs from `v0.5.0` to `v0.5.1`.

## References

Fixes #14674
Release notes: https://github.com/learningequality/kolibri-app/releases/tag/v0.5.1

## Reviewer guidance

Download the DMG built by the `dmg` job on this PR and verify the "On my own" setup completes without the provisioning error from #14674.

## AI usage

Used Claude Code to bump the `kolibri-app` workflow refs from `v0.5.0` to `v0.5.1` after I asked it to find the latest release; verified the v0.5.1 diff didn't change the `build_mac.yml` interface before pushing.