### PR TITLE
Use KListbox

### DIFF
--- a/kolibri/plugins/coach/frontend/views/reports/__tests__/__snapshots__/ReportsLearnersTable.spec.js.snap
+++ b/kolibri/plugins/coach/frontend/views/reports/__tests__/__snapshots__/ReportsLearnersTable.spec.js.snap
@@ -20,7 +20,7 @@ exports[`ReportsLearnersTable doesn't render groups information when show groups
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-testid="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #000000; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_psanzm link" data-testid="learner-link"><!----> <span class="link-text">learner1</span>
+        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #000000; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a data-testid="learner-link" dir="auto" class="KRouterLink-noKey-0_psanzm link"><!----> <span class="link-text">learner1</span>
           <!----></a></span></span> <span class="icon-after"><!----></span></span>
         </td>
         <td>
@@ -41,7 +41,7 @@ exports[`ReportsLearnersTable doesn't render groups information when show groups
   </span></td>
       </tr>
       <tr data-testid="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #000000; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_psanzm link" data-testid="learner-link"><!----> <span class="link-text">learner2</span>
+        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #000000; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a data-testid="learner-link" dir="auto" class="KRouterLink-noKey-0_psanzm link"><!----> <span class="link-text">learner2</span>
           <!----></a></span></span> <span class="icon-after"><!----></span></span>
         </td>
         <td>

--- a/kolibri/plugins/facility/frontend/views/common/SelectableList.vue
+++ b/kolibri/plugins/facility/frontend/views/common/SelectableList.vue
@@ -27,12 +27,12 @@
     <KListbox
       :id="listboxId"
       :value="value"
-      :aria-labelledby="ariaLabelledby"
+      :ariaLabelledBy="ariaLabelledby"
       :messages="messages"
       :style="maxHeight ? { maxHeight } : {}"
       @input="$emit('input', $event)"
     >
-      <template #selectAll="{ allSelected, someSelected, toggle }">
+      <template #selectAll="{ allSelected, someSelected, setAllSelected }">
         <div
           class="select-all"
           :style="{ borderColor: $themeTokens.fineLine }"
@@ -44,7 +44,7 @@
             :indeterminate="someSelected"
             :disabled="!filteredOptions.length"
             :aria-controls="listboxId"
-            @change="toggle"
+            @change="setAllSelected"
           >
             <slot name="selectAllLabel"></slot>
           </KCheckbox>
@@ -111,7 +111,13 @@
         if (!filterText.value) {
           return options.value;
         }
-        return fuse.value.search(filterText.value).map(result => result.item);
+        return (
+          fuse.value
+            .search(filterText.value)
+            // Sort by Fuse's built-in original index reference to prevent re-sorting by score
+            .sort((a, b) => a.refIndex - b.refIndex)
+            .map(result => result.item)
+        );
       });
 
       const { sendPoliteMessage } = useKLiveRegion();

--- a/kolibri/plugins/facility/frontend/views/common/SelectableList.vue
+++ b/kolibri/plugins/facility/frontend/views/common/SelectableList.vue
@@ -24,70 +24,46 @@
         }"
       />
     </div>
-    <div
-      class="select-all-checkbox-container"
-      :class="$computedClass(rowStyles)"
-      @click.self="changeSelectAll(!selectAllChecked)"
-    >
-      <KCheckbox
-        :label="selectAllLabel"
-        :checked="selectAllChecked"
-        :indeterminate="selectAllIndeterminate"
-        :disabled="!filteredOptions.length"
-        :aria-controls="listboxId"
-        @change="changeSelectAll"
-      >
-        <slot name="selectAllLabel"></slot>
-      </KCheckbox>
-    </div>
-    <p
-      :id="ariaDescribedById"
-      class="visuallyhidden"
-    >
-      {{ clickableOptionsDescription$() }}
-    </p>
-    <ul
-      v-show="filteredOptions.length"
+    <KListbox
       :id="listboxId"
-      class="list-options"
-      tabindex="0"
-      role="listbox"
-      data-focus="true"
-      aria-multiselectable="true"
-      :style="{ outline: 'none', maxHeight: maxHeight }"
+      :value="value"
       :aria-labelledby="ariaLabelledby"
-      :aria-describedby="ariaDescribedById"
-      :aria-activedescendant="getElementOptionId(focusedOption)"
-      @focus="onListFocus"
-      @blur="onListBlur"
-      @keydown="handleKeydown"
+      :messages="messages"
+      :style="maxHeight ? { maxHeight } : {}"
+      @input="$emit('input', $event)"
     >
-      <li
-        v-for="option in filteredOptions"
-        :id="getElementOptionId(option)"
-        :key="option.id"
-        role="option"
-        :class="
-          $computedClass({
-            ...rowStyles,
-            ...(isOptionFocused(option) ? { ...$coreOutline, outlineOffset: '-2px' } : {}),
-          })
-        "
-        :aria-selected="isOptionSelected(option).toString()"
-        @click="toggleOption(option)"
-      >
-        <KCheckbox
-          presentational
-          :checked="isOptionSelected(option)"
-          :label="option.label"
+      <template #selectAll="{ allSelected, someSelected, toggle }">
+        <div
+          class="select-all"
+          :style="{ borderColor: $themeTokens.fineLine }"
         >
-          <slot
-            :option="option"
-            name="option"
-          ></slot>
-        </KCheckbox>
-      </li>
-    </ul>
+          <KCheckbox
+            :label="selectAllLabel"
+            class="select-all-checkbox"
+            :checked="allSelected"
+            :indeterminate="someSelected"
+            :disabled="!filteredOptions.length"
+            :aria-controls="listboxId"
+            @change="toggle"
+          >
+            <slot name="selectAllLabel"></slot>
+          </KCheckbox>
+        </div>
+      </template>
+      <KListboxOption
+        v-for="option in filteredOptions"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+        :style="{ borderColor: $themeTokens.fineLine }"
+        class="option"
+      >
+        <slot
+          name="option"
+          :option="option"
+        ></slot>
+      </KListboxOption>
+    </KListbox>
     <p
       v-if="!filteredOptions.length"
       role="status"
@@ -103,39 +79,25 @@
 <script>
 
   import Fuse from 'fuse.js';
-  import uniq from 'lodash/uniq';
   import { validateObject } from 'kolibri/utils/objectSpecs';
   import FilterTextbox from 'kolibri/components/FilterTextbox';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-  import { ref, computed, toRefs, getCurrentInstance, watch } from 'vue';
+  import { ref, computed, watch, toRefs } from 'vue';
   import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
-  import { themePalette, themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import { searchAndFilterStrings } from 'kolibri-common/strings/searchAndFilterStrings';
+
+  let _uid = 0;
 
   export default {
     name: 'SelectableList',
     components: {
       FilterTextbox,
     },
-    setup(props, { emit }) {
-      const { value, options } = toRefs(props);
+    setup(props) {
+      const { options } = toRefs(props);
       const filterText = ref('');
-      const focusedIndex = ref(null);
 
-      const instance = getCurrentInstance();
-      const uid = instance.proxy._uid;
-
-      const listboxId = computed(() => `selectable-listbox-${uid}`);
-      const ariaDescribedById = computed(() => `selectable-listbox-description-${uid}`);
-
-      const selectedOptions = computed({
-        get() {
-          return value.value;
-        },
-        set(newValue) {
-          emit('input', newValue);
-        },
-      });
+      const listboxId = `listbox-${_uid++}`;
 
       const fuse = computed(() => {
         return new Fuse(options.value, {
@@ -152,150 +114,6 @@
         return fuse.value.search(filterText.value).map(result => result.item);
       });
 
-      const focusedOption = computed(() => {
-        if (focusedIndex.value === null || !filteredOptions.value.length) {
-          return null;
-        }
-        return filteredOptions.value[focusedIndex.value];
-      });
-
-      function setFocusedIndex(index) {
-        focusedIndex.value = index;
-
-        if (instance.proxy.$inputModality === 'keyboard') {
-          const optionElement = document.getElementById(getElementOptionId(focusedOption.value));
-          if (optionElement) {
-            optionElement.scrollIntoView({
-              block: 'nearest',
-              inline: 'nearest',
-            });
-          }
-        }
-      }
-
-      function isOptionSelected(option) {
-        return selectedOptions.value.includes(option.id);
-      }
-
-      function isOptionFocused(option) {
-        return focusedOption.value?.id === option.id;
-      }
-
-      function toggleOption(option) {
-        if (!option) {
-          return;
-        }
-
-        const { deselectedLabel$ } = coreStrings;
-
-        if (isOptionSelected(option)) {
-          selectedOptions.value = value.value.filter(id => id !== option.id);
-          sendPoliteMessage(deselectedLabel$());
-        } else {
-          selectedOptions.value = [...value.value, option.id];
-        }
-
-        if (focusedOption.value?.id !== option.id) {
-          setFocusedIndex(filteredOptions.value.findIndex(opt => opt.id === option.id));
-        }
-      }
-
-      function getElementOptionId(option) {
-        if (!option?.id) {
-          return null;
-        }
-
-        return `sl-option-${uid}-${option.id}`;
-      }
-
-      const selectAllChecked = computed(() => {
-        return (
-          filteredOptions.value.length > 0 &&
-          filteredOptions.value.every(option => isOptionSelected(option))
-        );
-      });
-
-      const selectAllIndeterminate = computed(() => {
-        return (
-          !selectAllChecked.value && filteredOptions.value.some(option => isOptionSelected(option))
-        );
-      });
-
-      function changeSelectAll(checked) {
-        const { allNOptionsSelectedLabel$, noOptionsSelectedLabel$ } = coreStrings;
-        if (checked) {
-          selectedOptions.value = uniq([
-            ...selectedOptions.value,
-            ...filteredOptions.value.map(option => option.id),
-          ]);
-          sendPoliteMessage(allNOptionsSelectedLabel$({ count: filteredOptions.value.length }));
-        } else {
-          selectedOptions.value = selectedOptions.value.filter(
-            id => !filteredOptions.value.some(option => option.id === id),
-          );
-          sendPoliteMessage(noOptionsSelectedLabel$());
-        }
-      }
-
-      function onListFocus() {
-        if (!filteredOptions.value.length) {
-          return;
-        }
-        setFocusedIndex(0);
-      }
-
-      function onListBlur() {
-        focusedIndex.value = null;
-      }
-
-      function handleFocusNavigation(key) {
-        const diff = key === 'ArrowDown' ? 1 : -1;
-        // adding options.length and using modulo to wrap around
-        // enables circular navigation
-        const newFocusedIndex =
-          (focusedIndex.value + diff + filteredOptions.value.length) % filteredOptions.value.length;
-        setFocusedIndex(newFocusedIndex);
-      }
-
-      function handleKeydown(event) {
-        if (!filteredOptions.value.length) {
-          return;
-        }
-
-        const { key } = event;
-
-        switch (key) {
-          case 'ArrowDown':
-          case 'ArrowUp':
-            handleFocusNavigation(key);
-            break;
-          case 'Home':
-            setFocusedIndex(0);
-            break;
-          case 'End':
-            setFocusedIndex(filteredOptions.value.length - 1);
-            break;
-          case ' ':
-            toggleOption(focusedOption.value);
-            break;
-          // Cntrl + A for select all
-          case 'a':
-          case 'A':
-            if (!event.ctrlKey && !event.metaKey) {
-              return;
-            }
-            if (!selectAllChecked.value) {
-              changeSelectAll(true);
-            }
-            break;
-          default:
-            // Early return for unsupported keys so that we don't prevent default behavior
-            return;
-        }
-
-        event.preventDefault();
-      }
-
       const { sendPoliteMessage } = useKLiveRegion();
       const { resultsCount$ } = searchAndFilterStrings;
 
@@ -303,40 +121,27 @@
         sendPoliteMessage(resultsCount$({ count: newOptions.length }));
       });
 
-      const rowStyles = computed(() => ({
-        ':hover': {
-          backgroundColor: filteredOptions.value.length ? themePalette().grey.v_100 : 'transparent',
-        },
-        ':not(:last-child)': {
-          borderBottom: `1px solid ${themeTokens().fineLine}`,
-        },
-        padding: '0 10px',
-        cursor: filteredOptions.value.length ? 'pointer' : 'default',
-        display: 'flex',
-        alignItems: 'center',
-      }));
-
-      const { noResultsLabel$, clickableOptionsDescription$ } = coreStrings;
-
-      return {
-        rowStyles,
-        listboxId,
-        onListBlur,
-        filterText,
-        onListFocus,
-        toggleOption,
-        focusedOption,
-        filteredOptions,
-        selectAllChecked,
-        ariaDescribedById,
-        selectAllIndeterminate,
-        changeSelectAll,
-        isOptionFocused,
-        isOptionSelected,
-        getElementOptionId,
-        handleKeydown,
+      const {
         noResultsLabel$,
         clickableOptionsDescription$,
+        deselectedLabel$,
+        allNOptionsSelectedLabel$,
+        noOptionsSelectedLabel$,
+      } = coreStrings;
+
+      const messages = {
+        clickable: clickableOptionsDescription$(),
+        allOptionsSelected: allNOptionsSelectedLabel$(),
+        allOptionsDeselected: noOptionsSelectedLabel$(),
+        optionDeselected: deselectedLabel$(),
+      };
+
+      return {
+        messages,
+        listboxId,
+        filterText,
+        filteredOptions,
+        noResultsLabel$,
       };
     },
     props: {
@@ -396,11 +201,25 @@
     border-radius: 4px;
   }
 
-  .list-options {
-    padding: 0;
-    margin: 0;
-    overflow: auto;
-    list-style: none;
+  .select-all,
+  .select-all-checkbox {
+    width: 100%;
+  }
+
+  .option,
+  .select-all {
+    padding-right: 10px;
+    padding-left: 10px;
+    border-bottom: 1px solid;
+  }
+
+  .option {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  .option:last-child {
+    border-bottom: 0;
   }
 
   .list-no-options {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 0.2.16
       version: 0.2.16
     kolibri-design-system:
-      specifier: 5.6.1
-      version: 5.6.1
+      specifier: 5.7.0
+      version: 5.7.0
     lodash:
       specifier: ^4.17.23
       version: 4.17.23
@@ -183,7 +183,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-sandbox:
         specifier: workspace:*
         version: link:../../../packages/kolibri-sandbox
@@ -219,7 +219,7 @@ importers:
         version: 0.2.16
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -295,7 +295,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -350,7 +350,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-viewer:
         specifier: workspace:*
         version: link:../../../packages/kolibri-viewer
@@ -417,7 +417,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -457,7 +457,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-sandbox:
         specifier: workspace:*
         version: link:../../../packages/kolibri-sandbox
@@ -496,7 +496,7 @@ importers:
         version: 0.2.16
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -560,7 +560,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-viewer:
         specifier: workspace:*
         version: link:../../../packages/kolibri-viewer
@@ -602,7 +602,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -747,7 +747,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -820,7 +820,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-plugin-data:
         specifier: workspace:*
         version: link:../../../packages/kolibri-plugin-data
@@ -847,7 +847,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -874,7 +874,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-viewer:
         specifier: workspace:*
         version: link:../../../packages/kolibri-viewer
@@ -908,7 +908,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../../../packages/kolibri-logging
@@ -957,7 +957,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-viewer:
         specifier: workspace:*
         version: link:../../../packages/kolibri-viewer
@@ -987,7 +987,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-plugin-data:
         specifier: workspace:*
         version: link:../../../packages/kolibri-plugin-data
@@ -1033,7 +1033,7 @@ importers:
         version: link:../../../packages/kolibri-common
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       lodash:
         specifier: 'catalog:'
         version: 4.17.23
@@ -1103,7 +1103,7 @@ importers:
         version: 0.2.16
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../kolibri-logging
@@ -1302,7 +1302,7 @@ importers:
         version: 0.2.16
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../kolibri-logging
@@ -1562,7 +1562,7 @@ importers:
         version: link:../kolibri
       kolibri-design-system:
         specifier: 'catalog:'
-        version: 5.6.1
+        version: 5.7.0
       kolibri-logging:
         specifier: workspace:*
         version: link:../kolibri-logging
@@ -6763,8 +6763,8 @@ packages:
   kolibri-constants@0.2.16:
     resolution: {integrity: sha512-z2tH+Sl8vBX1Y7O3BYTfwQs33Ozp6QRKZIHhl66A8sZkxUVBFFKOR+SgGOt0U0Q7pT/PH4yfCZ5mu6u8J641zQ==}
 
-  kolibri-design-system@5.6.1:
-    resolution: {integrity: sha512-Uxnhq5maQWO76IrVktrzGOwuyI5NU3GyzpcNith9vKq5bM70f8PLEbV48T23vmeJsQqApac/oOWP2u7wxNZ6Kw==}
+  kolibri-design-system@5.7.0:
+    resolution: {integrity: sha512-+ol8VBIfTbSbLGmSvtGehZUhEFejWJDAzGNujRL62DHs9NhDjpmjBGehvk/y7BV13FwxFR4tOFhW9RxnYx7eBg==}
 
   launch-editor-middleware@2.12.0:
     resolution: {integrity: sha512-SgU5QWoR+Grq1sQedvS/RlfoyO6bdvrztpP+2RRg8UzE7Jz2Yup5J4jiFfm2J9dYBCQYD26AbJVbjnvgwdL6Pw==}
@@ -15437,7 +15437,7 @@ snapshots:
 
   kolibri-constants@0.2.16: {}
 
-  kolibri-design-system@5.6.1:
+  kolibri-design-system@5.7.0:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   xhr-mock: ^2.5.1
   core-js: ^3.47.0
   kolibri-constants: 0.2.16
-  kolibri-design-system: 5.6.1
+  kolibri-design-system: 5.7.0
   lodash: ^4.17.23
   vue: 2.7.16
   vue-meta: ^2.4.0


### PR DESCRIPTION
_Supersedes #14695 by pushing a few last changes to match the latest updates_

## Summary

Uses KListbox in SelectableList. A companion to https://github.com/learningequality/kolibri-design-system/pull/1247.

`SelectableList` is used for filtering & bulk operations in _Facility > Users._

## Before/after

| | Before | After |
| -- | -- | -- |
| Filter |  <img width="1109" height="1044" alt="filter-users-before" src="https://github.com/user-attachments/assets/f9d320ff-c9a9-4dc7-bf86-64828f2dc772" /> | <img width="1109" height="1044" alt="filter-users-after" src="https://github.com/user-attachments/assets/a4c0d18f-9957-4408-93d1-0ae9e0fe6a9f" /> |
| Assign coaches | <img width="1109" height="1044" alt="assign-coach-before" src="https://github.com/user-attachments/assets/3a1c9bf6-f02e-4e33-b62a-c6c8a4fc7912" /> | <img width="1109" height="1044" alt="assign-coach-after" src="https://github.com/user-attachments/assets/585f6708-8b3e-4a6d-9bc7-02b1533d7376" /> |
| Enroll in class |<img width="1109" height="1044" alt="enroll-learners-before" src="https://github.com/user-attachments/assets/9b96fa26-04d3-4b13-b436-3b5629392e26" /> | <img width="1109" height="1044" alt="enroll-learners-after" src="https://github.com/user-attachments/assets/920ebd5b-e3e4-4bcd-94a4-5d42b0cb8b30" /> |
| Remove from class | <img width="1109" height="1044" alt="remove-from-class-before" src="https://github.com/user-attachments/assets/481877a8-9e0d-4b78-81f6-191eb1cac972" /> | <img width="1109" height="1044" alt="remove-from-class-after" src="https://github.com/user-attachments/assets/f1590d3c-dd5f-4b65-b288-66096a585e91" /> |

## Reviewer guidance

Go to facility users and do bulk operations

- Filter
- Assign coach
- Enroll in class
- Remove from class

## AI usage

Claude generated draft. I reviewed & adjusted code. Tested manually all affected places.