### PR TITLE
Set prop for import modal to ensure devices have facilities

### DIFF
--- a/kolibri/plugins/device/frontend/views/FacilitiesPage/ImportFacilityModalGroup.vue
+++ b/kolibri/plugins/device/frontend/views/FacilitiesPage/ImportFacilityModalGroup.vue
@@ -4,6 +4,7 @@
     <!-- Select Network Address Step -->
     <SelectDeviceModalGroup
       v-if="atSelectAddress"
+      :filterByHasFacilities="true"
       @submit="handleAddressSubmit"
       @cancel="closeModal"
     />


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Sets `filterByHasFacilities` for Import modal to only show devices that have facilities (can't import a facility without a facility!). This flag was already set in the setup wizard. Syncing flows:
- Setup wizard: already set, and unprovisioned devices aren't visible
- Import facility: this is the fix
- Sync a particular facility: this filters devices for those that have the facility, which inherently filters unprovisioned devices out
- Sync all: only syncs to KDP

## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/kolibri/issues/14726

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Run 2 or more devices, one of them not yet provisioned
2. Verify the unprovisioned devices do not show up in device selection from other devices
3. Verify that once the device is provisioned, it shows up, without needing to restart Kolibri

Note: the devices may still show up in channel import, because unprovisioned devices could still have content preloaded.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Free range, gluten-free human implemented