### PR TITLE
Fix picture password icons broken on Coach page refresh

### DIFF
--- a/kolibri/plugins/coach/frontend/app.js
+++ b/kolibri/plugins/coach/frontend/app.js
@@ -7,6 +7,7 @@ import KolibriApp from 'kolibri-app';
 import { handleApiError } from 'kolibri/utils/appError';
 import useSnackbar from 'kolibri/composables/useSnackbar';
 import useFacilities from 'kolibri-common/composables/useFacilities';
+import useFacility from 'kolibri-common/composables/useFacility';
 import { pageLoading } from 'kolibri-common/composables/usePageLoading';
 import { PageNames } from './constants';
 import routes from './routes';
@@ -14,6 +15,7 @@ import pluginModule from './modules/pluginModule';
 import HomeActivityPage from './views/home/HomeActivityPage';
 
 const { fetchFacilities, facilities } = useFacilities();
+const { fetchFacilityConfig } = useFacility();
 
 function _channelListState(data) {
   return data.map(channel => ({
@@ -44,7 +46,7 @@ export function setChannelInfo(store) {
 
 class CoachToolsModule extends KolibriApp {
   get stateSetters() {
-    return [setChannelInfo];
+    return [setChannelInfo, () => fetchFacilityConfig().catch(() => {})];
   }
   get routes() {
     return routes;

--- a/kolibri/plugins/coach/frontend/app.js
+++ b/kolibri/plugins/coach/frontend/app.js
@@ -44,9 +44,13 @@ export function setChannelInfo(store) {
   );
 }
 
+function initFacilityConfig() {
+  return fetchFacilityConfig().catch(() => {});
+}
+
 class CoachToolsModule extends KolibriApp {
   get stateSetters() {
-    return [setChannelInfo, () => fetchFacilityConfig().catch(() => {})];
+    return [setChannelInfo, initFacilityConfig];
   }
   get routes() {
     return routes;


### PR DESCRIPTION
## Summary

When a coach refreshes directly to any Coach page (Class home, Learners, or All Passwords), the picture password icons were broken — displaying nothing instead of the correct icons.

**Root cause:** `UserPicturePassword` falls back to `useFacility()` for `iconStyle` and `showIconText` when those props are not explicitly passed. On a fresh page load the Coach SPA never called `fetchFacilityConfig()`, so `facilityConfig` was an empty object. `getPicturePasswordIcons` received `null` as `iconStyle` and returned icon objects without an `iconName`, causing `KIcon` to render nothing.

**Fix:** Import `useFacility` in `kolibri/plugins/coach/frontend/app.js` and add `fetchFacilityConfig` to `stateSetters`, so it is called once at SPA initialisation — exactly as the Facility plugin already does in its `beforeEach` guard (`kolibri/plugins/facility/frontend/app.js:49`).

> **Note:** This fix addresses the same underlying problem that #14737 worked around by reading `picture_password_settings` directly from the `classSummary` Vuex module instead of `useFacility`. Now that `facilityConfig` is reliably populated on load, #14737 may be a candidate for revert so that the codebase returns to the canonical `useFacility` pattern throughout the Coach plugin (as pointed out by @bjester in his [comment](https://github.com/learningequality/kolibri/pull/14737#issuecomment-4499542002))

https://github.com/user-attachments/assets/1fde2e20-c690-4784-9981-307e7b95348a


## References

Closes #14750
See also: #14737 (may be revertable), #14736

## Reviewer guidance

1. Enable Picture Password sign-in in Facility > Settings, enrol learners in a class and assign them picture passwords.
2. Navigate to **Coach > Class home → View passwords** — icons should display correctly.
3. **Refresh the page** — icons must still display correctly (this was the regression).
4. Repeat from **Coach > Learners → View passwords** and refresh.
5. Open the print dialog and confirm the preview card also shows icons after a refresh.

## AI usage

Implemented with Claude Code. I reviewed the diff, verified the approach matches the Facility plugin's existing pattern, and confirmed the pre-commit hooks pass.