### PR TITLE
ensure picture password modal appears on LOD join

### DIFF
--- a/kolibri/plugins/learn/frontend/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/frontend/views/LearnIndex.vue
@@ -38,8 +38,8 @@
       PicturePasswordAssignedModal,
     },
     setup() {
-      const { isUserLoggedIn, isAppContext, currentUserId } = useUser();
-      const { fetchFacilityConfig } = useFacility();
+      const { isUserLoggedIn, isAppContext, currentUserId, isLearner } = useUser();
+      const { fetchFacilityConfig, facilityConfig } = useFacility();
       const picturePasswordPending = useSessionStorage(
         PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING,
         false,
@@ -59,7 +59,7 @@
         if (user.picture_password) {
           assignedPicturePassword.value = user.picture_password;
           showPicturePasswordModal.value = true;
-        } else {
+        } else if (!facilityConfig.value?.picture_password_settings || !isLearner.value) {
           picturePasswordPending.value = false;
         }
       });

--- a/kolibri/plugins/learn/frontend/views/__tests__/learn-index.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/learn-index.spec.js
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { render, screen, fireEvent, within } from '@testing-library/vue';
 import FacilityUserResource from 'kolibri-common/apiResources/FacilityUserResource';
 import useFacility, { useFacilityMock } from 'kolibri-common/composables/useFacility'; // eslint-disable-line import-x/named
@@ -16,11 +17,16 @@ async function flushUi() {
   await global.flushPromises();
 }
 
-function renderComponent() {
+function renderComponent({ facilityConfig, isLearner = true } = {}) {
   useFacility.mockReturnValue(
-    useFacilityMock({ fetchFacilityConfig: jest.fn().mockResolvedValue({}) }),
+    useFacilityMock({
+      fetchFacilityConfig: jest.fn().mockResolvedValue({}),
+      ...(facilityConfig ? { facilityConfig } : {}),
+    }),
   );
-  useUser.mockReturnValue(useUserMock({ currentUserId: 'user-1', isUserLoggedIn: true }));
+  useUser.mockReturnValue(
+    useUserMock({ currentUserId: 'user-1', isUserLoggedIn: true, isLearner }),
+  );
   return render(LearnIndex, {
     routes: [{ path: '/', component: { template: '<div />' } }],
   });
@@ -68,6 +74,33 @@ describe('LearnIndex picture password modal', () => {
     await flushUi();
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps the flag set when picture_password is null but facility has picture passwords enabled', async () => {
+    sessionStorage.setItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING, 'true');
+    FacilityUserResource.fetchModel.mockResolvedValue({ picture_password: null });
+
+    renderComponent({
+      facilityConfig: ref({ picture_password_settings: { icon_style: 'standard' } }),
+    });
+    await flushUi();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(sessionStorage.getItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING)).toBe('true');
+  });
+
+  it('clears the flag when picture_password is null and user is not a learner, even if facility has picture passwords enabled', async () => {
+    sessionStorage.setItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING, 'true');
+    FacilityUserResource.fetchModel.mockResolvedValue({ picture_password: null });
+
+    renderComponent({
+      facilityConfig: ref({ picture_password_settings: { icon_style: 'standard' } }),
+      isLearner: false,
+    });
+    await flushUi();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(sessionStorage.getItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING)).not.toBe('true');
   });
 
   it('does not fetch user data when the flag is not set', async () => {

--- a/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/frontend/views/onboarding-forms/SettingUpKolibri.vue
@@ -38,6 +38,7 @@
 
   import omitBy from 'lodash/omitBy';
   import get from 'lodash/get';
+  import { useSessionStorage } from '@vueuse/core';
   import useUser from 'kolibri/composables/useUser';
   import { error as coreError, handleApiError, clearError } from 'kolibri/utils/appError';
   import pluginData from 'kolibri-plugin-data';
@@ -50,6 +51,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { Presets } from 'kolibri/constants';
   import Lockr from 'lockr';
+  import { PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING } from 'kolibri-common/constants/Auth';
   import { DeviceTypePresets } from '../../constants';
 
   const PROVISION_TASK_QUEUE = 'device_provision';
@@ -61,7 +63,11 @@
     mixins: [commonCoreStrings],
     setup() {
       const { isAppContext, login } = useUser();
-      return { isAppContext, login, coreError, handleApiError, clearError };
+      const picturePasswordPending = useSessionStorage(
+        PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING,
+        false,
+      );
+      return { isAppContext, login, coreError, handleApiError, clearError, picturePasswordPending };
     },
     computed: {
       facilityData() {
@@ -228,6 +234,12 @@
 
             this.clearPollingTasks();
             this.wrapOnboarding();
+            const selectedFacility = this.wizardContext('selectedFacility');
+            if (selectedFacility?.picture_password_settings) {
+              // picturePasswordPending is a ref returned from setup(); Vue 2.7 auto-unwraps
+              // refs on the component instance so assigning via `this` sets .value correctly.
+              this.picturePasswordPending = true;
+            }
             if (this.deviceProvisioningData.superuser || this.userBasedOnOs) {
               const { password } = this.deviceProvisioningData.superuser || {};
               const { error } = await this.login({

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/MergeFacility.vue
@@ -290,7 +290,10 @@
           method: 'POST',
           data: params,
         }).then(response => {
-          if (response.data?.picture_password) {
+          if (
+            response.data?.picture_password ||
+            state.value.targetFacility?.picture_password_settings
+          ) {
             picturePasswordPending.value = true;
           }
           redirectBrowser();

--- a/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
+++ b/kolibri/plugins/user_profile/frontend/views/ChangeFacility/__tests__/MergeFacility.spec.js
@@ -136,7 +136,10 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
     expect(sessionStorage.getItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING)).toBe('true');
   });
 
-  it('redirects without storing in sessionStorage when picture password is null after facility change', async () => {
+  // Previously (before the picture-password fix) this case did NOT set the flag — that was the bug.
+  // The facility has picture_password_settings but the user's picture_password hasn't synced yet;
+  // the flag must stay set so the modal can appear after the next sync.
+  it('stores picture password pending in sessionStorage when picture passwords are enabled but not yet synced', async () => {
     TaskResource.fetchModel.mockResolvedValue(completedTask);
     client.mockResolvedValue({ data: { picture_password: null } });
     renderComponent({
@@ -147,6 +150,17 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
         picture_password_settings: { icon_style: 'colorful', show_icon_text: true },
       },
     });
+    await flushUi();
+    await fireEvent.click(screen.getByTestId('finishButton'));
+    await flushUi();
+    expect(redirectBrowser).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(PICTURE_PASSWORD_ASSIGNED_MODAL_PENDING)).toBe('true');
+  });
+
+  it('redirects without storing in sessionStorage when picture password is null and picture passwords are not enabled', async () => {
+    TaskResource.fetchModel.mockResolvedValue(completedTask);
+    client.mockResolvedValue({ data: { picture_password: null } });
+    renderComponent();
     await flushUi();
     await fireEvent.click(screen.getByTestId('finishButton'));
     await flushUi();

--- a/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/frontend/views/ProfilePage/index.vue
@@ -260,7 +260,7 @@
       const { fetchPoints, totalPoints } = useTotalProgress();
       const { facilities } = useFacilities();
       const { facilityConfig, fetchFacilities, updateFacilityConfig } = useFacility();
-      const userPermissions = computed(() => pickBy(_userPermissions));
+      const userPermissions = computed(() => pickBy(_userPermissions.value));
 
       return {
         pageLoading,
@@ -311,10 +311,13 @@
         return '';
       },
       showPicturePasswordRow() {
-        return (
-          this.userKind === UserKinds.LEARNER &&
-          this.facilityConfig?.picture_password_settings != null
-        );
+        if (this.facilityConfig?.picture_password_settings == null) {
+          return false;
+        }
+        if (this.isSuperuser && this.isLearnerOnlyImport) {
+          return true;
+        }
+        return this.userKind === UserKinds.LEARNER;
       },
       canEditPassword() {
         const learner_can_edit =


### PR DESCRIPTION
## Summary
This PR updates some frontend logic to ensure that when an LOD user is joining a facility that has picture password enabled, either via the setup wizard or through a merge, they see the modal that "introduces" their picture password. 

## References
Fixes [#14742 ](https://github.com/learningequality/kolibri/issues/14742)


https://github.com/user-attachments/assets/ed6fa1b2-9402-49be-990d-b8be0b1f2416



## Reviewer guidance
Code review: 
1. Is there context I am missing about why this might not be the best approach, or faulty logic? I did several rounds of brainstorming and exploring with Claude, and just looking over the code, but I was definitely feeling my lack of context in moments 🙃 
2. Are there any other paths that might not be covered by this that we can predict?

QA: 
Reproduce the issue outlined in 14742 (originally reported by Peter)


## AI usage
Debugged and implementation with Claude used mainly to understand the code context more quickly. Implementation using TDD Claude-led: write failing tests first, update implementation, tests passing. Manual QA and self-code review.