### PR TITLE
Bundle colorama so Click works on Windows

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,6 +23,10 @@ redis==3.5.3
 html5lib==1.1
 zeroconf-py2compat==0.19.17
 Click==8.0.4
+# Windows-only transitive dependency of Click and colorlog. The dist is built on
+# Linux, where the platform marker excludes it, so it must be listed explicitly to
+# be bundled. Pinned to 0.4.5 as 0.4.6 drops Python 3.6 (our build) support.
+colorama==0.4.5
 whitenoise==5.3.0
 idna==3.7
 ifaddr==0.1.7  # Pin as version 0.2.0 only supports Python 3.7 and above


### PR DESCRIPTION
## Summary
- Bundle `colorama` so Click works on Windows.

## References
- Fixes #14755

## Reviewer guidance
- Pinned `0.4.5`, not `0.4.6`: 0.4.6 drops Python 3.6, which the dist build container (`python:3.6-buster`) still uses.
- colorama was the only gap — I audited every transitive dep in `base.txt` for platform/version-gated packages the Linux build would drop.

## AI usage
Used Claude Code (Opus 4.7) to trace the root cause through the build pipeline, verify the Python 3.6 version constraint, and audit `base.txt` for similar gaps. I reviewed the diagnosis and the one-line fix before committing.