### PR TITLE
Set up Django app registry before building WSGI applications

### DIFF
--- a/kolibri/deployment/default/alt_wsgi.py
+++ b/kolibri/deployment/default/alt_wsgi.py
@@ -4,10 +4,10 @@ sandboxed content
 """
 import os
 
+import django
+
 import kolibri.core.content
 from kolibri.core.content.utils import paths
-from kolibri.core.content.zip_wsgi import get_application
-from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
@@ -15,6 +15,13 @@ os.environ.setdefault(
 
 
 def generate_alt_wsgi_application():
+    django.setup(set_prefix=False)
+
+    # Defer these imports until after django setup has run
+    # as both depend on the NetworkClient (which depends on Django models)
+    from kolibri.core.content.zip_wsgi import get_application
+    from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
+
     alt_content_path = "/" + paths.get_content_url(
         paths.zip_content_path_prefix()
     ).lstrip("/")

--- a/kolibri/deployment/default/tests/test_wsgi.py
+++ b/kolibri/deployment/default/tests/test_wsgi.py
@@ -1,0 +1,57 @@
+"""
+Initialization tests for the WSGI entrypoints in this deployment.
+
+uWSGI loads these modules in a fresh interpreter that has *not* run
+``django.setup()`` -- see kolibri-server's ``uwsgi.ini`` and ``hashi_uwsgi.ini``,
+which point at ``wsgi:application`` and ``alt_wsgi:alt_application``. Importing
+the module must therefore not touch the ORM at import time: if it does, the
+worker crashes at load with ``AppRegistryNotReady: Apps aren't loaded yet.`` and
+no app is served (``*** no app loaded. GAME OVER ***``).
+
+Each test reproduces that fresh-interpreter load in a subprocess, so the suite
+catches any model-touching import that creeps back into the module top level
+(for example a transitive ``NetworkClient`` import pulling in
+``kolibri.core.discovery.models``).
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+# (importable module path, attribute that must hold the WSGI application)
+WSGI_ENTRYPOINTS = [
+    ("kolibri.deployment.default.wsgi", "application"),
+    ("kolibri.deployment.default.alt_wsgi", "alt_application"),
+]
+
+
+@pytest.mark.parametrize("module_path,app_attribute", WSGI_ENTRYPOINTS)
+def test_wsgi_entrypoint_imports_without_django_setup(module_path, app_attribute):
+    """
+    Importing the entrypoint in a clean interpreter (as uWSGI does) must succeed
+    and expose its application callable, without a prior ``django.setup()``.
+    """
+    code = (
+        f"import {module_path}; "
+        f"app = getattr({module_path}, {app_attribute!r}); "
+        "assert app is not None"
+    )
+
+    env = os.environ.copy()
+    env.setdefault("DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base")
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        f"Importing {module_path} in a fresh interpreter (as uWSGI does) failed. "
+        "The module likely touches the ORM at import time, before django.setup() "
+        f"has run:\n\n{result.stdout}"
+    )

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -16,7 +16,6 @@ from django.db.utils import OperationalError
 
 from kolibri.core.content.utils import paths
 from kolibri.utils import conf
-from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +30,10 @@ def generate_wsgi_application():
         conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
     ).lstrip("/")
     content_dirs = [paths.get_content_dir_path()] + paths.get_content_fallback_paths()
+
+    # Must be imported after get_wsgi_application is called
+    # as this depends on the NetworkClient (which depends on Django models)
+    from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
 
     # Mount static files
     return DynamicWhiteNoise(


### PR DESCRIPTION
## Summary

- Defer the model-touching imports (`NetworkClient`, via `zip_wsgi` / `kolibri_whitenoise`) into the WSGI app factories, and call `django.setup()` in `alt_wsgi` — so uWSGI no longer crashes with `AppRegistryNotReady` when it loads them before Django is set up.
- Add subprocess init tests for both entrypoints that import them in a fresh interpreter, guarding against model-touching imports creeping back to the module top level.

## References

Reported against 0.19.4rc0. No tracking issue.

## Reviewer guidance

- Reproduce in a fresh interpreter (as uWSGI does): `DJANGO_SETTINGS_MODULE=kolibri.deployment.default.settings.base python -c "import kolibri.deployment.default.alt_wsgi"`. Succeeds with this change; raises `AppRegistryNotReady` without it. The new `test_wsgi.py` automates this for both entrypoints.
- `alt_wsgi.py:18` now calls `django.setup()`, so the alternate-origin (zip/hashi) server process initializes the full Django app registry — which it didn't before. Worth confirming that's acceptable for that process.

## AI usage

Used Claude Code to diagnose the root cause, reproduce the crash in a clean interpreter, and write the subprocess init tests. I wrote the code fix myself and confirmed the tests fail without it and pass with it.
