### PR TITLE
Add animations to picture password confirmation modal

### DIFF
--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -122,6 +122,7 @@
   import { themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
 
+  // Must match the transition durations in the component's CSS (0.5s).
   const ANIMATION_DURATION_MS = 500;
   const PRESSED_CANCEL = 'cancel';
   const PRESSED_CONFIRM = 'confirm';
@@ -338,6 +339,10 @@
     &.gap-collapsed {
       gap: 0;
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 
   .btn-bg {
@@ -353,6 +358,10 @@
     &.btn-collapsed {
       max-width: 0;
       opacity: 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
     }
 
     /deep/ button {

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -122,7 +122,7 @@
   import { themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
 
-  // Must match the transition durations in the component's CSS (0.5s).
+  // Must match both .action-buttons and .btn-bg transition durations in the component's CSS (0.5s)
   const ANIMATION_DURATION_MS = 500;
   const PRESSED_CANCEL = 'cancel';
   const PRESSED_CONFIRM = 'confirm';

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/PicturePasswordConfirmModal.vue
@@ -58,37 +58,44 @@
               />
             </div>
 
-            <div class="action-buttons">
+            <div
+              class="action-buttons"
+              :class="{ 'gap-collapsed': isAnyPressed }"
+            >
               <div
                 class="btn-bg"
-                :class="
+                :class="[
                   $computedClass({
                     backgroundColor: cancelBg,
                     ':hover': { backgroundColor: cancelBgHover },
-                  })
-                "
+                  }),
+                  { 'btn-collapsed': isConfirmPressed },
+                ]"
               >
                 <KIconButton
                   icon="close"
                   :ariaLabel="noGoBackAction$()"
-                  @click="$emit('cancel')"
+                  :disabled="isAnyPressed"
+                  @click="handleCancel"
                 />
               </div>
               <div
                 class="btn-bg"
-                :class="
+                :class="[
                   $computedClass({
                     backgroundColor: confirmBg,
                     ':hover': { backgroundColor: confirmBgHover },
-                  })
-                "
+                  }),
+                  { 'btn-collapsed': isCancelPressed },
+                ]"
               >
                 <KIconButton
                   ref="confirmBtn"
                   icon="check"
                   :color="$themePalette.white"
                   :ariaLabel="yesConfirmAction$()"
-                  @click="$emit('confirm')"
+                  :disabled="isAnyPressed"
+                  @click="handleConfirm"
                 />
               </div>
             </div>
@@ -115,17 +122,27 @@
   import { themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { darken1 } from 'kolibri-design-system/lib/styles/darkenColors';
 
+  const ANIMATION_DURATION_MS = 500;
+  const PRESSED_CANCEL = 'cancel';
+  const PRESSED_CONFIRM = 'confirm';
+
+  function getPrefersReduced() {
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  }
+
   export default {
     name: 'PicturePasswordConfirmModal',
 
     components: { KFocusTrap, KOverlay, Backdrop },
 
-    setup(props) {
+    setup(props, { emit }) {
       useReturnFocusOnUnmount();
       const confirmBtn = ref(null);
       const modalTitle = ref(null);
       const modalCard = ref(null);
       const naturalCardHeight = ref(0);
+      const pressed = ref(null);
+      let animationTimer = null;
       const { height: windowHeight } = useWindowSize();
 
       const cardScale = computed(() => {
@@ -154,6 +171,36 @@
         return yourPasswordIs$({ labels });
       });
 
+      const isCancelPressed = computed(() => pressed.value === PRESSED_CANCEL);
+      const isConfirmPressed = computed(() => pressed.value === PRESSED_CONFIRM);
+      const isAnyPressed = computed(() => isCancelPressed.value || isConfirmPressed.value);
+
+      function handleCancel() {
+        if (isAnyPressed.value) return;
+        if (getPrefersReduced()) {
+          emit('cancel');
+          return;
+        }
+        pressed.value = PRESSED_CANCEL;
+        animationTimer = setTimeout(() => {
+          animationTimer = null;
+          emit('cancel');
+        }, ANIMATION_DURATION_MS);
+      }
+
+      function handleConfirm() {
+        if (isAnyPressed.value) return;
+        if (getPrefersReduced()) {
+          emit('confirm');
+          return;
+        }
+        pressed.value = PRESSED_CONFIRM;
+        animationTimer = setTimeout(() => {
+          animationTimer = null;
+          emit('confirm');
+        }, ANIMATION_DURATION_MS);
+      }
+
       onMounted(() => {
         document.documentElement.style.overflow = 'hidden';
         naturalCardHeight.value = modalCard.value.scrollHeight;
@@ -162,6 +209,7 @@
 
       onUnmounted(() => {
         document.documentElement.style.overflow = '';
+        clearTimeout(animationTimer);
       });
 
       return {
@@ -178,6 +226,11 @@
         cancelBgHover,
         confirmBg,
         confirmBgHover,
+        isCancelPressed,
+        isConfirmPressed,
+        isAnyPressed,
+        handleCancel,
+        handleConfirm,
       };
     },
 
@@ -280,12 +333,27 @@
     gap: 22px;
     justify-content: center;
     padding: 0 32px 32px;
+    transition: gap 0.5s ease;
+
+    &.gap-collapsed {
+      gap: 0;
+    }
   }
 
   .btn-bg {
     flex: 1;
     min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
     border-radius: 8px;
+    transition:
+      max-width 0.5s ease,
+      opacity 0.5s ease;
+
+    &.btn-collapsed {
+      max-width: 0;
+      opacity: 0;
+    }
 
     /deep/ button {
       width: 100% !important;

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
@@ -84,6 +84,49 @@ describe('PicturePasswordConfirmModal', () => {
     });
   });
 
+  describe('prefers-reduced-motion', () => {
+    beforeEach(() => {
+      window.matchMedia = jest.fn(q => ({
+        matches: q === '(prefers-reduced-motion: reduce)',
+        media: q,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+    });
+
+    afterEach(() => {
+      window.matchMedia = undefined;
+    });
+
+    it('emits cancel immediately without a timer when reduced motion is preferred', async () => {
+      const { emitted } = renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
+      );
+      expect(emitted()['cancel']).toBeTruthy();
+    });
+
+    it('emits confirm immediately without a timer when reduced motion is preferred', async () => {
+      const { emitted } = renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.yesConfirmAction$() }),
+      );
+      expect(emitted()['confirm']).toBeTruthy();
+    });
+
+    it('does not apply animation classes when reduced motion is preferred', async () => {
+      renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
+      );
+      expect(document.body.querySelector('.action-buttons')).not.toHaveClass('gap-collapsed');
+    });
+  });
+
   describe('button animations', () => {
     it('disables both buttons after one is pressed', async () => {
       renderComponent();

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/PictureSignIn/__tests__/PicturePasswordConfirmModal.spec.js
@@ -53,20 +53,77 @@ describe('PicturePasswordConfirmModal', () => {
   });
 
   describe('events', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function createUser() {
+      return userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+    }
+
     it('emits confirm when the confirm button is clicked', async () => {
       const { emitted } = renderComponent();
-      await userEvent.click(
+      await createUser().click(
         screen.getByRole('button', { name: picturePasswordStrings.yesConfirmAction$() }),
       );
+      jest.runAllTimers();
       expect(emitted()['confirm']).toBeTruthy();
     });
 
     it('emits cancel when the cancel button is clicked', async () => {
       const { emitted } = renderComponent();
+      await createUser().click(
+        screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
+      );
+      jest.runAllTimers();
+      expect(emitted()['cancel']).toBeTruthy();
+    });
+  });
+
+  describe('button animations', () => {
+    it('disables both buttons after one is pressed', async () => {
+      renderComponent();
+      const cancelBtn = screen.getByRole('button', {
+        name: picturePasswordStrings.noGoBackAction$(),
+      });
+      await userEvent.click(cancelBtn);
+      expect(
+        screen.getByRole('button', { name: picturePasswordStrings.yesConfirmAction$() }),
+      ).toBeDisabled();
+      expect(cancelBtn).toBeDisabled();
+    });
+
+    it('applies btn-collapsed to the confirm button when cancel is pressed', async () => {
+      renderComponent();
       await userEvent.click(
         screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
       );
-      expect(emitted()['cancel']).toBeTruthy();
+      // KOverlay portals into document.body; query from there
+      const btnBgs = document.body.querySelectorAll('.btn-bg');
+      expect(btnBgs[1]).toHaveClass('btn-collapsed');
+      expect(btnBgs[0]).not.toHaveClass('btn-collapsed');
+    });
+
+    it('applies btn-collapsed to the cancel button when confirm is pressed', async () => {
+      renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.yesConfirmAction$() }),
+      );
+      const btnBgs = document.body.querySelectorAll('.btn-bg');
+      expect(btnBgs[0]).toHaveClass('btn-collapsed');
+      expect(btnBgs[1]).not.toHaveClass('btn-collapsed');
+    });
+
+    it('applies gap-collapsed to the action-buttons container when a button is pressed', async () => {
+      renderComponent();
+      await userEvent.click(
+        screen.getByRole('button', { name: picturePasswordStrings.noGoBackAction$() }),
+      );
+      expect(document.body.querySelector('.action-buttons')).toHaveClass('gap-collapsed');
     });
   });
 

--- a/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
+++ b/kolibri/plugins/user_auth/frontend/views/SignInPage/__tests__/PictureSignInPage.spec.js
@@ -41,6 +41,10 @@ const cancelLabel = () => picturePasswordStrings.noGoBackAction$();
 const confirmLabel = () => picturePasswordStrings.yesConfirmAction$();
 const checkbox = name => screen.getByRole('checkbox', { name });
 
+function createUser() {
+  return userEvent.setup({ advanceTimers: jest.advanceTimersByTime.bind(jest) });
+}
+
 const MOCK_LEARNER_NAME = 'Alice Example';
 
 function renderComponent() {
@@ -91,13 +95,13 @@ function renderComponent() {
 }
 
 describe('PictureSignInPage', () => {
+  // Suppress all animation timers so event handlers and state transitions resolve
+  // in fake time. Animation timing is tested in PicturePasswordConfirmModal.spec.js.
   beforeEach(() => {
-    mockLogin.mockReset();
-    mockRouterPush.mockReset();
-    redirectBrowser.mockReset();
-    window.matchMedia = jest.fn().mockImplementation(query => ({
-      matches: false,
-      media: query,
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    window.matchMedia = jest.fn(q => ({
+      matches: q === '(prefers-reduced-motion: reduce)',
+      media: q,
       onchange: null,
       addListener: jest.fn(),
       removeListener: jest.fn(),
@@ -105,15 +109,24 @@ describe('PictureSignInPage', () => {
       removeEventListener: jest.fn(),
       dispatchEvent: jest.fn(),
     }));
+    mockLogin.mockReset();
+    mockRouterPush.mockReset();
+    redirectBrowser.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    window.matchMedia = undefined;
   });
 
   it('submitting a sequence calls login with prevalidate=true, not a real login', async () => {
+    const user = createUser();
     mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     renderComponent();
-    await userEvent.click(checkbox(bee()));
-    await userEvent.click(checkbox(star()));
-    await userEvent.click(checkbox(moon()));
-    await userEvent.click(screen.getByTestId('submit-button'));
+    await user.click(checkbox(bee()));
+    await user.click(checkbox(star()));
+    await user.click(checkbox(moon()));
+    await user.click(screen.getByTestId('submit-button'));
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith(
@@ -125,14 +138,15 @@ describe('PictureSignInPage', () => {
   });
 
   it('a failed response clears the grid selection after shake ends', async () => {
+    const user = createUser();
     mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     renderComponent();
-    await userEvent.click(checkbox(bee()));
-    await userEvent.click(checkbox(star()));
-    await userEvent.click(checkbox(moon()));
-    await userEvent.click(screen.getByTestId('submit-button'));
+    await user.click(checkbox(bee()));
+    await user.click(checkbox(star()));
+    await user.click(checkbox(moon()));
+    await user.click(screen.getByTestId('submit-button'));
 
-    // Grid is still filled while the shake is active
+    // Grid is still filled while the shake timer is pending
     expect(checkbox(bee())).toBeChecked();
     expect(checkbox(star())).toBeChecked();
     expect(checkbox(moon())).toBeChecked();
@@ -145,12 +159,13 @@ describe('PictureSignInPage', () => {
   });
 
   it('applies shaking class on a failed sequence and removes it after shake() resolves', async () => {
+    const user = createUser();
     mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
     const { container } = renderComponent();
-    await userEvent.click(checkbox(bee()));
-    await userEvent.click(checkbox(star()));
-    await userEvent.click(checkbox(moon()));
-    await userEvent.click(screen.getByTestId('submit-button'));
+    await user.click(checkbox(bee()));
+    await user.click(checkbox(star()));
+    await user.click(checkbox(moon()));
+    await user.click(screen.getByTestId('submit-button'));
 
     await waitFor(() => {
       expect(container.querySelector('.shaking')).toBeTruthy();
@@ -166,16 +181,17 @@ describe('PictureSignInPage', () => {
       mockLogin.mockResolvedValue({ data: { full_name: MOCK_LEARNER_NAME }, error: null });
     });
 
-    async function submitSequence() {
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+    async function submitSequence(user) {
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
     }
 
     it('shows the confirmation modal with learner name after successful prevalidation', async () => {
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => {
         expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument();
@@ -184,8 +200,9 @@ describe('PictureSignInPage', () => {
     });
 
     it('does not redirect immediately after a successful prevalidation', async () => {
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => {
         expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument();
@@ -195,13 +212,14 @@ describe('PictureSignInPage', () => {
     });
 
     it('calls login when confirm is clicked', async () => {
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
 
       const confirmButton = screen.getByRole('button', { name: confirmLabel() });
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         expect(mockLogin).toHaveBeenCalledWith(
@@ -217,13 +235,14 @@ describe('PictureSignInPage', () => {
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: null });
 
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
 
       const confirmButton = screen.getByRole('button', { name: confirmLabel() });
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         expect(redirectBrowser).toHaveBeenCalledTimes(1);
@@ -235,13 +254,14 @@ describe('PictureSignInPage', () => {
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
 
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
 
       const confirmButton = screen.getByRole('button', { name: confirmLabel() });
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         expect(screen.queryByText(MOCK_LEARNER_NAME)).not.toBeInTheDocument();
@@ -252,13 +272,14 @@ describe('PictureSignInPage', () => {
     });
 
     it('hides the modal and clears grid when cancel is clicked, without making a delete request', async () => {
+      const user = createUser();
       renderComponent();
-      await submitSequence();
+      await submitSequence(user);
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
 
       const cancelButton = screen.getByRole('button', { name: cancelLabel() });
-      await userEvent.click(cancelButton);
+      await user.click(cancelButton);
 
       await waitFor(() => {
         expect(screen.queryByText(MOCK_LEARNER_NAME)).not.toBeInTheDocument();
@@ -271,13 +292,14 @@ describe('PictureSignInPage', () => {
 
   describe('error handling and accessibility', () => {
     it('returns focus to the error sentinel inside the grid after a failed prevalidate', async () => {
+      const user = createUser();
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       const { container } = renderComponent();
 
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => {
         const sentinel = container.querySelector('form [aria-hidden="true"]');
@@ -290,15 +312,16 @@ describe('PictureSignInPage', () => {
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
 
+      const user = createUser();
       const { container } = renderComponent();
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
 
-      await userEvent.click(screen.getByRole('button', { name: confirmLabel() }));
+      await user.click(screen.getByRole('button', { name: confirmLabel() }));
 
       await waitFor(() => {
         const sentinel = container.querySelector('form [aria-hidden="true"]');
@@ -307,13 +330,14 @@ describe('PictureSignInPage', () => {
     });
 
     it('shows a visible error notification after a failed prevalidate', async () => {
+      const user = createUser();
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       renderComponent();
 
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => {
         expect(
@@ -327,14 +351,15 @@ describe('PictureSignInPage', () => {
         .mockResolvedValueOnce({ data: { full_name: MOCK_LEARNER_NAME }, error: null })
         .mockResolvedValueOnce({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
 
+      const user = createUser();
       renderComponent();
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => expect(screen.getByText(MOCK_LEARNER_NAME)).toBeInTheDocument());
-      await userEvent.click(screen.getByRole('button', { name: confirmLabel() }));
+      await user.click(screen.getByRole('button', { name: confirmLabel() }));
 
       await waitFor(() => {
         expect(
@@ -344,14 +369,15 @@ describe('PictureSignInPage', () => {
     });
 
     it('clears the error notification when the first icon of a new sequence is selected', async () => {
+      const user = createUser();
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       renderComponent();
 
       // First failed attempt — error notification appears
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => {
         expect(
@@ -360,21 +386,22 @@ describe('PictureSignInPage', () => {
       });
 
       // Selecting the first icon of the next sequence clears the error immediately
-      await userEvent.click(checkbox(bee()));
+      await user.click(checkbox(bee()));
       expect(
         screen.queryByText(picturePasswordStrings.wrongPicturesTryAgain$()),
       ).not.toBeInTheDocument();
     });
 
     it('clears the visible error notification on the next submission attempt', async () => {
+      const user = createUser();
       mockLogin.mockResolvedValue({ data: null, error: LoginErrors.INVALID_CREDENTIALS });
       renderComponent();
 
       // First failed attempt
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
       await waitFor(() => {
         expect(
@@ -382,17 +409,15 @@ describe('PictureSignInPage', () => {
         ).toBeInTheDocument();
       });
 
-      // Second attempt — error should clear immediately on submit
-      await userEvent.click(checkbox(bee()));
-      await userEvent.click(checkbox(star()));
-      await userEvent.click(checkbox(moon()));
-      await userEvent.click(screen.getByTestId('submit-button'));
+      // Second attempt — prevalidate clears wrongPictures before the shake timer fires
+      await user.click(checkbox(bee()));
+      await user.click(checkbox(star()));
+      await user.click(checkbox(moon()));
+      await user.click(screen.getByTestId('submit-button'));
 
-      await waitFor(() => {
-        expect(
-          screen.queryByText(picturePasswordStrings.wrongPicturesTryAgain$()),
-        ).not.toBeInTheDocument();
-      });
+      expect(
+        screen.queryByText(picturePasswordStrings.wrongPicturesTryAgain$()),
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

* Adds button transition animations to picture password confirmation modal.

https://github.com/user-attachments/assets/1c58bf24-0532-45e8-b290-b5e557e3e340



## References
Closes https://github.com/learningequality/kolibri/issues/14564

## Reviewer guidance

Follow instructions in #14564.

## AI usage

Used Claude code to get the initial implementation, and polished the implementation several times.