### PR TITLE
Pass DOCKERHUB_TOKEN to the container image publish reusable workflow

### DIFF
--- a/.github/workflows/container_image_publish.yml
+++ b/.github/workflows/container_image_publish.yml
@@ -11,6 +11,9 @@ on:
         description: Tag the image as 'latest'
         required: false
         type: boolean
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch:
     inputs: *workflow_inputs
 

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -266,3 +266,5 @@ jobs:
     with:
       release-tag: ${{ github.event.release.tag_name }}
       tag-latest: ${{ needs.latest_release.outputs.is_latest_release == 'true' }}
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Reusable workflows don't inherit the caller's secrets
- Docker Hub login got an empty password → `Password required`
- Declare `DOCKERHUB_TOKEN` in `workflow_call`, pass it from the release workflow

## References

- Failed run: https://github.com/learningequality/kolibri/actions/runs/26472105042/job/78073775811

## Reviewer guidance

- Same secret-passing pattern as `pypi_upload` and `android_release`

## AI usage

- Claude Code diagnosed the failure from CI logs and wrote the fix; I reviewed it.