### PR TITLE
Update Raspberry Pi image build to v1.1.0

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -50,10 +50,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.0.0
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.0
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v1.0.0
+      ref: v1.1.0
   browser_smoke_test:
     name: Browser smoke test
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -110,10 +110,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.0.0
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.0
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v1.0.0
+      ref: v1.1.0
   upload_zip:
     uses: ./.github/workflows/upload_github_release_asset.yml
     needs: zip


### PR DESCRIPTION
## Summary
- Pin `kolibri-image-pi` build workflow to `v1.1.0`.
- Updates both release and PR-build workflows.
- Bumps `uses:` ref and `ref:` input together.

## References
- Latest `kolibri-image-pi` release: `v1.1.0` (2026-05-27).

## Reviewer guidance
- Test Raspberry Pi image asset

## AI usage
- Used Claude Code to locate and bump pins; verified the release tag.