### PR TITLE
Refactor arbitrary size values in SelectContentPage.spec.js tests for clarity

### DIFF
--- a/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
+++ b/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
@@ -43,13 +43,16 @@ const allChannels = [
   },
 ];
 
+// The transferredChannel used by makeSelectContentPageStore, exported so tests can
+// derive expected display values (resource counts, file sizes) from the same source of truth.
+export const selectContentTransferredChannel = {
+  ...allChannels[0],
+  on_device_resources: 2000,
+  on_device_file_size: 95189556, // about 95 MB
+};
+
 const channelsOnDevice = [
-  {
-    ...allChannels[0],
-    on_device_resources: 2000,
-    on_device_file_size: 95189556, // about 95 MB
-    available: true,
-  },
+  { ...selectContentTransferredChannel, available: true },
   {
     ...allChannels[1],
     on_device_resources: 0,
@@ -92,14 +95,6 @@ export function makeAvailableChannelsPageStore({ channelList } = {}) {
   });
   return store;
 }
-
-// The transferredChannel used by makeSelectContentPageStore, exported so tests can
-// derive expected display values (resource counts, file sizes) from the same source of truth.
-export const selectContentTransferredChannel = {
-  ...allChannels[0],
-  on_device_resources: 2000,
-  on_device_file_size: 95189556, // about 95 MB
-};
 
 // Use for selectContentPage and all children:
 // contentTreeViewer

--- a/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
+++ b/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
@@ -93,6 +93,14 @@ export function makeAvailableChannelsPageStore({ channelList } = {}) {
   return store;
 }
 
+// The transferredChannel used by makeSelectContentPageStore, exported so tests can
+// derive expected display values (resource counts, file sizes) from the same source of truth.
+export const selectContentTransferredChannel = {
+  ...allChannels[0],
+  on_device_resources: 2000,
+  on_device_file_size: 95189556, // about 95 MB
+};
+
 // Use for selectContentPage and all children:
 // contentTreeViewer
 export function makeSelectContentPageStore() {
@@ -105,11 +113,7 @@ export function makeSelectContentPageStore() {
   Object.assign(store.state.manageContent.wizard, {
     availableChannels: [...allChannels],
     transferType: 'localimport',
-    transferredChannel: {
-      ...allChannels[0],
-      on_device_resources: 2000,
-      on_device_file_size: 95189556, // about 95 MB
-    },
+    transferredChannel: { ...selectContentTransferredChannel },
     currentTopicNode: contentNodeGranularPayload(),
   });
   return store;

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -82,7 +82,7 @@ describe('SelectContentPage', () => {
     });
     renderComponent({ store });
     expect(screen.getAllByRole('row')[2]).toHaveTextContent(
-      `${summaryTr.$tr('onDeviceRow')} ${onDeviceResources.toString()} ${bytesForHumans(onDeviceFileSize)}`,
+      `${summaryTr.$tr('onDeviceRow')} ${onDeviceResources.toLocaleString()} ${bytesForHumans(onDeviceFileSize)}`,
     );
   });
 

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -57,16 +57,16 @@ describe('SelectContentPage', () => {
   });
 
   it('shows the total size of the channel', () => {
-    renderComponent({ store });
     const { total_resources, total_file_size } = selectContentTransferredChannel;
+    renderComponent({ store });
     expect(screen.getAllByRole('row')[1]).toHaveTextContent(
       `${summaryTr.$tr('totalSizeRow')} ${total_resources.toLocaleString()} ${bytesForHumans(total_file_size)}`,
     );
   });
 
   it('shows the total size of any resources on the device', () => {
-    renderComponent({ store });
     const { on_device_resources, on_device_file_size } = selectContentTransferredChannel;
+    renderComponent({ store });
     expect(screen.getAllByRole('row')[2]).toHaveTextContent(
       `${summaryTr.$tr('onDeviceRow')} ${on_device_resources.toLocaleString()} ${bytesForHumans(on_device_file_size)}`,
     );
@@ -105,7 +105,7 @@ describe('SelectContentPage', () => {
   });
 
   describe('draft channel (installed version = 0)', () => {
-    const newerVersion = 5;
+    const newerVersion = 15;
 
     function setInstalledVersion(store, version) {
       const existing = store.state.manageContent.channelList[0];

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/vue';
 import { createTranslator, i18nSetup } from 'kolibri/utils/i18n';
+import bytesForHumans from 'kolibri/uiText/bytesForHumans';
 import SelectContentPage from '../SelectContentPage';
-import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
+import {
+  makeSelectContentPageStore,
+  selectContentTransferredChannel,
+} from '../../__tests__/utils/makeStore';
 import ChannelContentsSummary from '../SelectContentPage/ChannelContentsSummary';
 import ContentTreeViewer from '../SelectContentPage/ContentTreeViewer';
 import NewChannelVersionBanner from '../ManageContentPage/NewChannelVersionBanner';
@@ -56,27 +60,31 @@ describe('SelectContentPage', () => {
 
   it('shows the total size of the channel', () => {
     renderComponent({ store });
+    const { total_resources, total_file_size } = selectContentTransferredChannel;
     expect(screen.getAllByRole('row')[1]).toHaveTextContent(
-      `${summaryTr.$tr('totalSizeRow')} 1,000 5 GB`,
+      `${summaryTr.$tr('totalSizeRow')} ${total_resources.toLocaleString()} ${bytesForHumans(total_file_size)}`,
     );
   });
 
   it('shows the total size of any resources on the device', () => {
     renderComponent({ store });
+    const { on_device_resources, on_device_file_size } = selectContentTransferredChannel;
     expect(screen.getAllByRole('row')[2]).toHaveTextContent(
-      `${summaryTr.$tr('onDeviceRow')} 2,000 95 MB`,
+      `${summaryTr.$tr('onDeviceRow')} ${on_device_resources.toLocaleString()} ${bytesForHumans(on_device_file_size)}`,
     );
   });
 
   it('shows size and resources as 0 if channel is not on device', () => {
+    const onDeviceResources = 0;
+    const onDeviceFileSize = 0;
     updateMetaChannel(store, {
       id: 'not_awesome_channel',
-      on_device_resources: 0,
-      on_device_file_size: 0,
+      on_device_resources: onDeviceResources,
+      on_device_file_size: onDeviceFileSize,
     });
     renderComponent({ store });
     expect(screen.getAllByRole('row')[2]).toHaveTextContent(
-      `${summaryTr.$tr('onDeviceRow')} 0 0 B`,
+      `${summaryTr.$tr('onDeviceRow')} ${onDeviceResources.toString()} ${bytesForHumans(onDeviceFileSize)}`,
     );
   });
 

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -46,15 +46,13 @@ describe('SelectContentPage', () => {
   });
 
   it('shows the thumbnail, title, descripton, and version of the channel', () => {
-    const heading = 'Awesome Channel';
-    const version = '10';
-    const description = 'An awesome channel';
+    const { name, version, description } = selectContentTransferredChannel;
     const fakeImage = 'data:image/png;base64,abcd1234';
     updateMetaChannel(store, { thumbnail: fakeImage });
     renderComponent({ store });
     expect(screen.getByRole('img')).toHaveAttribute('src', fakeImage);
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(heading);
-    expect(screen.getByText(summaryTr.$tr('version', { version: version }))).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(name);
+    expect(screen.getByText(summaryTr.$tr('version', { version }))).toBeInTheDocument();
     expect(screen.getByText(description)).toBeInTheDocument();
   });
 
@@ -89,25 +87,26 @@ describe('SelectContentPage', () => {
   });
 
   it('shows a update notification if a new version is available', () => {
-    updateMetaChannel(store, { version: 1000 });
+    const newVersion = 1000;
+    updateMetaChannel(store, { version: newVersion });
     renderComponent({ store });
-    const NEW_VERSION = '1000';
     expect(
-      screen.getByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+      screen.getByText(bannerTr.$tr('versionAvailable', { version: newVersion })),
     ).toBeInTheDocument();
   });
 
   it('if a new version is not available, then no notification/button appear', () => {
-    updateMetaChannel(store, { version: 10 }); // same version
+    const { version } = selectContentTransferredChannel;
+    updateMetaChannel(store, { version });
     renderComponent({ store });
-    const NEW_VERSION = '1000';
     expect(
-      screen.queryByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+      screen.queryByText(bannerTr.$tr('versionAvailable', { version })),
     ).not.toBeInTheDocument();
   });
 
-  //Add translations strings to these tests & test these & commit the changes.
   describe('draft channel (installed version = 0)', () => {
+    const draftNewerVersion = 5;
+
     function setInstalledVersion(store, version) {
       const existing = store.state.manageContent.channelList[0];
       store.commit('manageContent/SET_CHANNEL_LIST', [{ ...existing, version }]);
@@ -115,7 +114,7 @@ describe('SelectContentPage', () => {
 
     it('shows ContentTreeViewer when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: 5 });
+      updateMetaChannel(store, { version: draftNewerVersion });
       renderComponent({ store });
       expect(
         screen.getByRole('checkbox', {
@@ -126,17 +125,16 @@ describe('SelectContentPage', () => {
 
     it('shows NewChannelVersionBanner when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: 5 });
+      updateMetaChannel(store, { version: draftNewerVersion });
       renderComponent({ store });
-      const NEW_VERSION = 5;
       expect(
-        screen.getByText(bannerTr.$tr('versionAvailable', { version: NEW_VERSION })),
+        screen.getByText(bannerTr.$tr('versionAvailable', { version: draftNewerVersion })),
       ).toBeInTheDocument();
     });
 
     it('shows SelectionBottomBar when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: 5 });
+      updateMetaChannel(store, { version: draftNewerVersion });
       renderComponent({ store });
       expect(
         screen.getByRole('button', { name: bottomBarTr.$tr('importAction') }),
@@ -144,8 +142,8 @@ describe('SelectContentPage', () => {
     });
 
     it('hides ContentTreeViewer when installed version > 0 and newer version available on Studio', () => {
-      // Preserve existing non-draft behavior
-      updateMetaChannel(store, { version: 1000 });
+      const newerVersion = 1000;
+      updateMetaChannel(store, { version: newerVersion });
       renderComponent({ store });
       expect(
         screen.queryByRole('checkbox', {

--- a/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js
@@ -105,7 +105,7 @@ describe('SelectContentPage', () => {
   });
 
   describe('draft channel (installed version = 0)', () => {
-    const draftNewerVersion = 5;
+    const newerVersion = 5;
 
     function setInstalledVersion(store, version) {
       const existing = store.state.manageContent.channelList[0];
@@ -114,7 +114,7 @@ describe('SelectContentPage', () => {
 
     it('shows ContentTreeViewer when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: draftNewerVersion });
+      updateMetaChannel(store, { version: newerVersion });
       renderComponent({ store });
       expect(
         screen.getByRole('checkbox', {
@@ -125,16 +125,16 @@ describe('SelectContentPage', () => {
 
     it('shows NewChannelVersionBanner when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: draftNewerVersion });
+      updateMetaChannel(store, { version: newerVersion });
       renderComponent({ store });
       expect(
-        screen.getByText(bannerTr.$tr('versionAvailable', { version: draftNewerVersion })),
+        screen.getByText(bannerTr.$tr('versionAvailable', { version: newerVersion })),
       ).toBeInTheDocument();
     });
 
     it('shows SelectionBottomBar when installed version is 0 and Studio has newer version', () => {
       setInstalledVersion(store, 0);
-      updateMetaChannel(store, { version: draftNewerVersion });
+      updateMetaChannel(store, { version: newerVersion });
       renderComponent({ store });
       expect(
         screen.getByRole('button', { name: bottomBarTr.$tr('importAction') }),
@@ -142,8 +142,7 @@ describe('SelectContentPage', () => {
     });
 
     it('hides ContentTreeViewer when installed version > 0 and newer version available on Studio', () => {
-      const newerVersion = 1000;
-      updateMetaChannel(store, { version: newerVersion });
+      updateMetaChannel(store, { version: 1000 });
       renderComponent({ store });
       expect(
         screen.queryByRole('checkbox', {


### PR DESCRIPTION
## Summary

`SelectContentPage.spec.js` contained hard-coded size strings (`1,000 5 GB`, `2,000 95 MB`, `0 0 B`) with no visible connection to the store data that produces them, making the tests hard to understand and maintain.

This PR:
- Exports `selectContentTransferredChannel` from `makeStore.js` as a named constant so it serves as a single source of truth for both the store factory and test assertions
- Replaces the opaque size literals with values derived from that constant via `bytesForHumans` and `.toLocaleString()` / `.toString()`
- Cleans up the remaining test assertions: named variables for version numbers (removing post-render `NEW_VERSION` declarations), fixes a silent bug where the negative version test was asserting against `'1000'` instead of the actual channel version, introduces `draftNewerVersion` to name the repeated `5` across the draft-channel tests, and removes a stale TODO comment

All 10 tests pass unchanged.

## References

Closes #14781
Related to #14656

## Reviewer guidance

Tests only — no production code was modified.

To verify: `pnpm test-jest kolibri/plugins/device/frontend/views/__tests__/SelectContentPage.spec.js`

## AI usage

Claude Code (Sonnet 4.6) was used to implement the refactor. I reviewed each change for correctness, engaged critically with the approach (e.g. choosing `bytesForHumans` over hard-coded strings, catching the wrong-version bug in the negative test), and ran the test suite after each step to verify nothing broke.