### PR TITLE
Update versions of postgres used in dev and CI

### DIFF
--- a/.github/workflows/morango_integration.yml
+++ b/.github/workflows/morango_integration.yml
@@ -111,7 +111,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:12
+        image: postgres:16
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        postgres-version: [9, 10, 11, 12, 13]
+        postgres-version: [13, 14, 15, 16, 17]
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -115,7 +115,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:12
+        image: postgres:16
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,9 @@ test-all:
 	function _on_interrupt() { docker compose down; }; \
 	trap _on_interrupt SIGINT SIGTERM SIGKILL ERR; \
 	docker compose up --detach; \
-	until docker compose logs --tail=1 postgres | grep -q "database system is ready to accept connections"; do \
-		echo "$(date) - waiting for postgres..."; \
+	container_id=$$(docker compose ps -q postgres); \
+	until [ "$$(docker inspect --format='{{.State.Health.Status}}' $$container_id)" = "healthy" ]; do \
+		echo "$(date) - waiting for postgres (health=$$(docker inspect --format='{{.State.Health.Status}}' $$container_id))..."; \
 		sleep 1; \
 	done; \
 	$(MAKE) -e $(subst -with-postgres,,$@); \

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ test-all:
 	@echo "CI runs tests across all supported Python versions."
 	uv run pytest
 
+test-morango-integ:
+	export INTEGRATION_TEST=1; \
+	python -O -m pytest kolibri/core/auth/test/test_morango_integration.py
+
 %-with-postgres:
 	@echo -e "\e[33mWARNING: for testing purposes only; postgresql database backend is ephemeral\e[0m"
 	@echo -e "\e[36mINFO: run 'docker compose -v' to remove the database volume\e[0m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,18 @@
 version: '3.4'
 services:
   postgres:
-    image: postgres:12
+    image: postgres:16
     ports:
       - "15432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: default
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d default"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
     volumes:
       - kolibri-pg:/var/lib/postgresql/data
 #    command: "postgres -c log_statement=all -c log_line_prefix='%t %d '"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ kolibri = "kolibri.utils.cli:main"
 "kolibri.plugins.safe_html5_viewer" = "kolibri.plugins.safe_html5_viewer"
 
 [project.optional-dependencies]
-postgres = ["psycopg2-binary==2.9.9; python_version >= '3.7'"]
+postgres = ["psycopg2-binary==2.9.10; python_version >= '3.8' and python_version < '3.14'"]
 storages = ["django-storages[google]==1.14.5; python_version >= '3.8'", "google-auth==2.38.0; python_version >= '3.8'"]
 
 [dependency-groups]


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Updates default postgres version to v16 for dev and CI
- Upgrades `psycopg2` to 2.9.10 which supports python 3.8-3.13 and postgres up to v17
- Updates `%-with-postgres` recipe to use health-check instead of grepping logs for readiness probing
- Adds make recipe for explicitly running Morango integration tests, useful in conjunction with `%-with-postgres` (e.g. `make test-morango-integ-with-postgres`)
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Does CI pass?
- Do tests pass locally?
  - `make test-with-postgres` (pre-existing issue with it hanging at one particular test for me)
  - `make test-morango-integ-with-postgres`

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Used AI to update `-with-postgres` to use health-check.