### PR TITLE
Replace m2r2 with myst-parser for docs builds

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,3 +1,4 @@
 .. _changelog:
 
-.. mdinclude:: ../CHANGELOG.md
+.. include:: ../CHANGELOG.md
+   :parser: myst_parser.sphinx_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ def process_docstring(app, what, name, obj, options, lines):
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
-    "m2r2",
+    "myst_parser",
     "notfound.extension",
     "sphinx_llm.txt",
 ]

--- a/docs/contributing/authors.rst
+++ b/docs/contributing/authors.rst
@@ -1,1 +1,2 @@
-.. mdinclude:: ../../AUTHORS.md
+.. include:: ../../AUTHORS.md
+   :parser: myst_parser.sphinx_

--- a/docs/contributing/code_of_conduct.rst
+++ b/docs/contributing/code_of_conduct.rst
@@ -4,7 +4,8 @@ Code of Conduct
 ===============
 
 
-.. mdinclude:: ../../CODE_OF_CONDUCT.md
+.. include:: ../../CODE_OF_CONDUCT.md
+   :parser: myst_parser.sphinx_
 
 
 Reporting Guidelines

--- a/docs/howtos/working_with_urls_and_api_endpoints.md
+++ b/docs/howtos/working_with_urls_and_api_endpoints.md
@@ -500,7 +500,7 @@ const response = await MyResource.accessDetailEndpoint(
 
 ## Related Documentation
 
-- Frontend Architecture: [Core Functionality](/docs/frontend_architecture/core.rst)
-- Backend Architecture: [Plugins](/docs/backend_architecture/plugins.rst)
+- Frontend Architecture: [Core Functionality](../frontend_architecture/core.rst)
+- Backend Architecture: [Plugins](../backend_architecture/plugins.rst)
 - Django Documentation: [URL namespaces](https://docs.djangoproject.com/en/stable/topics/http/urls/#url-namespaces)
 - Django REST Framework: [Routers](https://www.django-rest-framework.org/api-guide/routers/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ docs = [
     "sphinx-intl; python_version >= '3.9'",
     "sphinx-rtd-theme~=3.0; python_version >= '3.9'",
     "sphinx-autobuild; python_version >= '3.9'",
-    "m2r2; python_version >= '3.9'",
+    "myst-parser; python_version >= '3.9'",
     "sphinx-notfound-page; python_version >= '3.9'",
     "sphinx-llm[gen]==0.4.1; python_version >= '3.9'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -15,12 +15,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-18T00:55:14.658968919Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-le-utils = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-morango = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+le-utils = { timestamp = "2026-06-25T00:55:14.658988947Z", span = "PT0S" }
+morango = { timestamp = "2026-06-25T00:55:14.659010578Z", span = "PT0S" }
 
 [[package]]
 name = "alabaster"
@@ -2660,9 +2660,10 @@ docs = [
     { name = "json-schema-validator" },
     { name = "jsonfield" },
     { name = "le-utils" },
-    { name = "m2r2", marker = "python_full_version >= '3.9'" },
     { name = "magicbus" },
     { name = "morango" },
+    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "redis" },
@@ -2894,9 +2895,9 @@ docs = [
     { name = "json-schema-validator", specifier = "==2.4.1" },
     { name = "jsonfield", specifier = "==3.1.0" },
     { name = "le-utils", specifier = "==0.2.17" },
-    { name = "m2r2", marker = "python_full_version >= '3.9'" },
     { name = "magicbus", specifier = "==4.1.2" },
     { name = "morango", specifier = "==0.8.13" },
+    { name = "myst-parser", marker = "python_full_version >= '3.9'" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "pytz", specifier = "==2024.1" },
     { name = "redis", specifier = "==3.5.3" },
@@ -3226,25 +3227,24 @@ wheels = [
 ]
 
 [[package]]
-name = "m2r2"
-version = "0.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.9'" },
-    { name = "mistune", marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/a9/ab03ff21972cfb2e6ea766b1dc015c2c081af70f8f956806e948c62044ba/m2r2-0.3.4.tar.gz", hash = "sha256:e278f5f337e9aa7b2080fcc3e94b051bda9615b02e36c6fb3f23ff019872f043", size = 17082, upload-time = "2025-05-01T16:55:53.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/50/5b1d70de548fb1e11e15ea9ebec0480365462d202f98b66ad7e154284327/m2r2-0.3.4-py3-none-any.whl", hash = "sha256:1a445514af8a229496bfb1380c52da8dd38313e48600359ee92b2c9d2e4df34a", size = 11199, upload-time = "2025-05-01T16:55:51.87Z" },
-]
-
-[[package]]
 name = "magicbus"
 version = "4.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/37/5ba414c9275b8d9aa3f7527b66714902874946b662c0b682b5970499fc20/MagicBus-4.1.2.tar.gz", hash = "sha256:14cb645d9980e5e693a966b0012ac957a9a34cc66dc7ea5483d6cde8d2160113", size = 34459, upload-time = "2020-03-11T20:38:01.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/c9/ca1d033e9fe1ea2a056b260503f2b4eb011c375b44b7bec96cc4462da460/MagicBus-4.1.2-py2.py3-none-any.whl", hash = "sha256:8f98747b1063f6c198863da2c5bfed29ad9f7096022df1722321f29d5dfb099d", size = 37912, upload-time = "2020-03-11T20:38:00.359Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
@@ -3457,12 +3457,46 @@ wheels = [
 ]
 
 [[package]]
-name = "mistune"
-version = "0.8.4"
+name = "mdit-py-plugins"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/a4/509f6e7783ddd35482feda27bc7f72e65b5e7dc910eca4ab2164daf9c577/mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e", size = 58322, upload-time = "2018-10-11T06:59:27.908Z" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "markdown-it-py", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/ec/4b43dae793655b7d8a25f76119624350b4d65eb663459eb9603d7f1f0345/mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4", size = 16220, upload-time = "2018-10-11T06:59:26.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -3706,6 +3740,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/6a/07f3e10ed4503045b882ef7bf8512d01d8a9e25056950a977bd5f50df1c2/msgpack-1.1.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6bde749afe671dc44893f8d08e83bf475a1a14570d67c4bb5cec5573463c8833", size = 397516, upload-time = "2025-10-08T09:15:51.646Z" },
     { url = "https://files.pythonhosted.org/packages/76/9b/a86828e75986c12a3809c1e5062f5eba8e0cae3dfa2bf724ed2b1bb72b4c/msgpack-1.1.2-cp39-cp39-win32.whl", hash = "sha256:ad09b984828d6b7bb52d1d1d0c9be68ad781fa004ca39216c8a1e63c0f34ba3c", size = 64863, upload-time = "2025-10-08T09:15:53.118Z" },
     { url = "https://files.pythonhosted.org/packages/14/a7/b1992b4fb3da3b413f5fb78a63bad42f256c3be2352eb69273c3789c2c96/msgpack-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:67016ae8c8965124fdede9d3769528ad8284f14d635337ffa6a713a580f6c030", size = 71540, upload-time = "2025-10-08T09:15:55.573Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "docutils", marker = "python_full_version == '3.9.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.9.*'" },
+    { name = "markdown-it-py", marker = "python_full_version == '3.9.*'" },
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pyyaml", marker = "python_full_version == '3.9.*'" },
+    { name = "sphinx", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163, upload-time = "2024-04-28T20:22:39.985Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "docutils", marker = "python_full_version >= '3.10'" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
+    { name = "mdit-py-plugins", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
+    { name = "sphinx", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces unmaintained `m2r2` with `myst-parser` for the docs build, dropping `mistune` (whose security update it was blocking in #14794) from the dependency tree entirely.

## References

Supersedes #14794, where the reviewer suggested this replacement.

## Reviewer guidance

Check the docs CI job and the readthedocs build pass and produce valid output. Pages touched by this change to spot-check in the readthedocs preview: changelog, contributing/authors, contributing/code_of_conduct, and howtos/working_with_urls_and_api_endpoints (link targets at the bottom).

## AI usage

Implemented with Claude Code; it verified the change with strict `-W` docs builds on Python 3.9 and 3.11 locally, and I reviewed the diff.