### PR TITLE
Add fan-in summary job to Python tests workflow for branch protection

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -246,3 +246,22 @@ jobs:
         run: |
           uv run python -O -m pytest kolibri --color=no
           uv run python -O -m pytest --color=no -p no:django test
+  # Single stable check for branch protection. Skipped matrix jobs don't
+  # produce per-version check runs, so matrix-suffixed required checks hang
+  # as "Expected" on PRs that skip the tests; require this job instead.
+  required_checks:
+    name: Python tests
+    needs:
+      - pre_job
+      - unit_test
+      - unit_test_eol_python
+      - postgres
+      - postgres_ssl
+      - macos
+      - windows
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

Since #14457 the path-match skip is at job level, so skipped matrix jobs report one bare-named check run instead of per-version ones, leaving the matrix-suffixed required checks stuck on "Expected". This adds a single stable "Python tests" fan-in check for branch protection to require instead.

## References

Regression introduced in #14457.

## Reviewer guidance

This PR touches Python test paths, so the new "Python tests" check should report success on a full run here. After merge, branch protection needs updating to require "Python tests" and drop the per-version checks.

## AI usage

Diagnosed and written with Claude Code — it compared check run reporting on skipped vs running PRs to confirm the missing matrix expansion, and drafted the workflow change, which I reviewed.