### PR TITLE
Add supervisor heartbeat and ownership fencing for distributed jobs

### DIFF
--- a/docs/backend_architecture/tasks.rst
+++ b/docs/backend_architecture/tasks.rst
@@ -198,3 +198,32 @@ The response will be a list of enqueued jobs like:
     ]
 
 However, if any task fails validation, all tasks in the request will be rejected. Validation happens prior to enqueuing, so tasks will not be partially started in the bulk case.
+
+
+Job execution and worker supervision
+------------------------------------
+
+Enqueued jobs are persisted in the job storage database (``kolibri.core.tasks.storage``) and executed by a ``WorkerSupervisor`` (``kolibri.core.tasks.worker``). Each supervisor runs a job checker thread that claims the next eligible ``QUEUED`` job and dispatches it to a thread pool of worker executors. Several supervisors - in separate processes, or on separate hosts sharing a postgres database - can serve the same job storage concurrently; the claim is made exactly once because it is serialized at the database level (``SELECT ... FOR UPDATE SKIP LOCKED`` on postgres, ``BEGIN IMMEDIATE`` transactions on SQLite).
+
+On Android there is no ``WorkerSupervisor``; the platform's WorkManager dispatches executions directly through ``execute_job``, passing its own ``supervisor_id``.
+
+Job ownership
+~~~~~~~~~~~~~
+
+While a job is in one of the supervised states - ``SELECTED``, ``RUNNING`` or ``CANCELING`` - it is owned by the supervisor responsible for its execution, recorded as ``supervisor_id`` on the job row. Ownership is stamped in the same database update that claims the job, and cleared again when the job reaches a terminal state or is requeued. Supervisors restrict themselves to their own jobs: a supervisor only cancels and finalizes jobs it owns (plus unowned ``CANCELING`` jobs, which were canceled before pickup and are idempotent to finalize).
+
+Supervisor liveness and reconciliation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A supervisor that dies leaves its jobs stuck in supervised states, so each supervisor registers itself in a supervisor registry and updates a heartbeat timestamp at a third of the ``SUPERVISOR_STALE_THRESHOLD`` interval (a ``Tasks`` option, 30 seconds by default - three heartbeats must be missed before a supervisor is considered dead). Heartbeats are written and compared using database time, so liveness never depends on clock synchronization between processes or hosts.
+
+On startup and on every heartbeat, each supervisor reconciles stalled jobs: ``SELECTED`` and ``RUNNING`` jobs whose owner has no fresh heartbeat (or no owner at all) are requeued, and such ``CANCELING`` jobs are finalized as ``CANCELED``, since their owner can never finalize them. On Android, where WorkManager already knows which dispatchers are alive, reconciliation is instead passed the live set explicitly.
+
+A supervisor can be *wrongly* declared dead - for example when its heartbeat thread is delayed - while its execution is still running. Its heartbeat re-registers it, but its jobs may already have been requeued and reclaimed by a peer. Execution is therefore **at least once**, and task functions should be written to be idempotent.
+
+Ownership fencing
+~~~~~~~~~~~~~~~~~
+
+To keep the at-least-once overlap from corrupting job state, every storage write made from a job execution carries the execution's ``supervisor_id`` as the expected owner. The comparison happens under a row lock, atomically with the write: if the job is no longer owned by the writer's supervisor - it was requeued, or reclaimed by a peer - the write is discarded and logged, so the disowned execution cannot overwrite the newer state, and its completion cannot reschedule a repeating job into a duplicate run. Ownership loss is also treated as a cancel signal, so a disowned cancellable execution stops at its next cancellation checkpoint rather than running a duplicate to completion.
+
+Writes made outside of an execution - for example API code updating a job's metadata - carry no expected owner and are unaffected by the fence.

--- a/kolibri/core/tasks/constants.py
+++ b/kolibri/core/tasks/constants.py
@@ -1,5 +1,9 @@
 DEFAULT_QUEUE = "kolibri"
 
+# Sentinel default for parameters where None is a semantic value (e.g. an
+# unowned job's supervisor_id), so "not provided" needs a distinct marker.
+NO_VALUE = object()
+
 
 class Priority:
     """

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -5,6 +5,7 @@ import traceback
 import uuid
 from collections import namedtuple
 
+from kolibri.core.tasks.constants import NO_VALUE
 from kolibri.core.tasks.constants import (  # noqa F401 - imported for backwards compatibility
     Priority,
 )
@@ -69,11 +70,20 @@ class State:
         PENDING,
         SCHEDULED,
         QUEUED,
+        SELECTED,
         RUNNING,
         FAILED,
         CANCELING,
         CANCELED,
         COMPLETED,
+    }
+
+    # States in which a supervisor may hold the job - ownership only exists
+    # while the job is in one of these states.
+    SUPERVISED_STATES = {
+        SELECTED,
+        RUNNING,
+        CANCELING,
     }
 
 
@@ -230,6 +240,10 @@ class Job:
         self.args = args
         self.kwargs = kwargs or {}
         self._storage = None
+        # This execution's fence token (see execute) - the no-check sentinel
+        # outside of execution, so that instances inflated from storage (e.g.
+        # in API code) can update an owned job freely.
+        self._supervisor_id = NO_VALUE
         self.func = callable_to_import_path(func)
 
     def _check_storage_attached(self):
@@ -248,7 +262,7 @@ class Job:
         self._storage = value
 
     def save_meta(self):
-        self.storage.save_job_meta(self)
+        self.storage.save_job_meta(self, expected_supervisor_id=self._supervisor_id)
 
     def _update_meta(self, **kwargs):
         for key, value in kwargs.items():
@@ -286,6 +300,7 @@ class Job:
                 progress,
                 total_progress,
                 extra_metadata=self.extra_metadata,
+                expected_supervisor_id=self._supervisor_id,
             )
             self._last_saved_progress = self.progress
             self._last_saved_total_progress = self.total_progress
@@ -301,11 +316,14 @@ class Job:
             process=process,
             thread=thread,
             extra=extra,
+            expected_supervisor_id=self._supervisor_id,
         )
 
     def check_for_cancel(self):
         if self.cancellable:
-            if self.storage.check_job_canceled(self.job_id):
+            if self.storage.check_job_canceled(
+                self.job_id, expected_supervisor_id=self._supervisor_id
+            ):
                 raise UserCancelledError()
 
     def is_cancelled(self):
@@ -320,7 +338,11 @@ class Job:
         if self.cancellable == cancellable:
             return
         self.cancellable = cancellable
-        self.storage.save_job_as_cancellable(self.job_id, cancellable=cancellable)
+        self.storage.save_job_as_cancellable(
+            self.job_id,
+            cancellable=cancellable,
+            expected_supervisor_id=self._supervisor_id,
+        )
 
     def retry_in(self, dt, **kwargs):
         if getattr(current_state_tracker, "job", None) is not self:
@@ -348,10 +370,19 @@ class Job:
 
         self._retry_in_kwargs = kwargs
 
-    def execute(self):
+    def execute(self, supervisor_id=None):
         self._check_storage_attached()
 
-        self.storage.mark_job_as_running(self.job_id)
+        # This execution's fence token, carried as the expected owner on every
+        # write back to storage. None means unowned direct execution, not a
+        # no-check.
+        self._supervisor_id = supervisor_id
+
+        # Mark RUNNING for worker contexts that call execute() directly (e.g.
+        # Android's WorkManager); preserves an owner set by a dispatcher.
+        self.storage.mark_job_as_running(
+            self.job_id, expected_supervisor_id=self._supervisor_id
+        )
 
         setattr(current_state_tracker, "job", self)
 
@@ -368,9 +399,13 @@ class Job:
             # First check whether the job has been cancelled
             self.check_for_cancel()
             result = func(*args, **kwargs)
-            self.storage.complete_job(self.job_id, result=result)
+            accepted = self.storage.complete_job(
+                self.job_id, result=result, expected_supervisor_id=self._supervisor_id
+            )
         except UserCancelledError:
-            self.storage.mark_job_as_canceled(self.job_id)
+            accepted = self.storage.mark_job_as_canceled(
+                self.job_id, expected_supervisor_id=self._supervisor_id
+            )
         except Exception as e:
             exception = e
             # If any error occurs, mark the job as failed and save the exception
@@ -379,13 +414,21 @@ class Job:
             logger.error(
                 "Job {} raised an exception: {}".format(self.job_id, traceback_str)
             )
-            self.storage.mark_job_as_failed(self.job_id, e, traceback_str)
-        self.storage.reschedule_finished_job_if_needed(
-            self.job_id,
-            delay=self._retry_in_delay,
-            exception=exception,
-            **self._retry_in_kwargs,
-        )
+            accepted = self.storage.mark_job_as_failed(
+                self.job_id,
+                e,
+                traceback_str,
+                expected_supervisor_id=self._supervisor_id,
+            )
+        if accepted:
+            # A rejected terminal write means another worker now supervises
+            # this job; don't requeue.
+            self.storage.reschedule_finished_job_if_needed(
+                self.job_id,
+                delay=self._retry_in_delay,
+                exception=exception,
+                **self._retry_in_kwargs,
+            )
         setattr(current_state_tracker, "job", None)
 
     @property

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -120,8 +120,16 @@ class Job:
     to the workers.
     """
 
-    UPDATEABLE_KEYS = {
+    # Stored in their own ORM column (the source of truth), not in saved_job;
+    # restored from the row on inflation. See Storage._orm_to_job.
+    PROJECTED_KEYS = {
+        "job_id",
+        "func",
         "state",
+    }
+
+    # Mutable fields a storage update may write through _update_job's kwargs.
+    UPDATEABLE_KEYS = {
         "exception",
         "traceback",
         "track_progress",
@@ -134,10 +142,9 @@ class Job:
         "kwargs",
     }
 
+    # Fields with no column of their own, persisted only in the saved_job JSON.
     JSON_KEYS = UPDATEABLE_KEYS | {
-        "job_id",
         "facility_id",
-        "func",
         "long_running",
     }
 
@@ -162,13 +169,23 @@ class Job:
         return string_result
 
     @classmethod
-    def from_json(cls, json_string):
-        working_dictionary = json.loads(json_string)
+    def from_orm(cls, orm_job):
+        """
+        Reconstruct a Job from an ORM row: PROJECTED_KEYS come from their
+        columns, the rest from the saved_job JSON. Stale copies of the
+        projected keys in legacy payloads are dropped.
+        """
+        working_dictionary = json.loads(orm_job.saved_job)
 
-        # func is required for a Job so it will always be in working_dictionary
-        func = working_dictionary.pop("func")
+        for projected in cls.PROJECTED_KEYS:
+            working_dictionary.pop(projected, None)
 
-        return Job(func, **working_dictionary)
+        return cls(
+            orm_job.func,
+            job_id=orm_job.id,
+            state=orm_job.state,
+            **working_dictionary,
+        )
 
     @classmethod
     def from_job(cls, job, **kwargs):

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -3,7 +3,7 @@ import logging
 from django.utils.functional import SimpleLazyObject
 
 from kolibri.core.tasks.storage import Storage
-from kolibri.core.tasks.worker import Worker
+from kolibri.core.tasks.worker import WorkerSupervisor
 from kolibri.utils import conf
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ job_storage = SimpleLazyObject(__job_storage)
 
 def initialize_workers():
     logger.info("Starting async task workers.")
-    return Worker(
+    return WorkerSupervisor(
         regular_workers=conf.OPTIONS["Tasks"]["REGULAR_PRIORITY_WORKERS"],
         high_workers=conf.OPTIONS["Tasks"]["HIGH_PRIORITY_WORKERS"],
     )

--- a/kolibri/core/tasks/migrations/0004_add_supervisor_registry.py
+++ b/kolibri/core/tasks/migrations/0004_add_supervisor_registry.py
@@ -1,0 +1,34 @@
+# Adds the supervisor registry table and the supervisor_id column on jobs,
+# used to detect dead supervisors and requeue their orphaned jobs.
+import morango.models.fields.uuids
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("kolibritasks", "0003_convert_datetime_to_timestamptz"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Supervisor",
+            fields=[
+                (
+                    "id",
+                    morango.models.fields.uuids.UUIDField(
+                        primary_key=True, serialize=False
+                    ),
+                ),
+                ("host", models.CharField(max_length=100)),
+                ("process", models.CharField(max_length=50)),
+                ("thread", models.CharField(max_length=50)),
+                ("last_seen", models.DateTimeField(blank=True, null=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name="job",
+            name="supervisor_id",
+            field=morango.models.fields.uuids.UUIDField(blank=True, null=True),
+        ),
+    ]

--- a/kolibri/core/tasks/models.py
+++ b/kolibri/core/tasks/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from morango.models import UUIDField
 
 from kolibri.core.utils.model_router import KolibriModelRouter
 from kolibri.deployment.default.sqlite_db_names import JOB_STORAGE
@@ -41,6 +42,8 @@ class Job(models.Model):
 
     # Optional references to the worker host, process and thread that are running this job,
     # and any extra metadata that can be used by specific worker implementations.
+    # Note that this is the identity of the executor thread actually running the job's
+    # function; the supervisor that dispatched it is recorded in supervisor_id below.
     worker_host = models.CharField(max_length=100, null=True, blank=True)
     worker_process = models.CharField(max_length=50, null=True, blank=True)
     worker_thread = models.CharField(max_length=50, null=True, blank=True)
@@ -51,6 +54,10 @@ class Job(models.Model):
     retries = models.IntegerField(null=True, blank=True)
     # Maximum number of retries allowed for the job
     max_retries = models.IntegerField(null=True, blank=True)
+
+    # References the supervisor currently responsible for this job.
+    # No FK constraint to avoid complexity with supervisor cleanup.
+    supervisor_id = UUIDField(null=True, blank=True)
 
     class Meta:
         db_table = "jobs"
@@ -64,11 +71,35 @@ class Job(models.Model):
         return f"Job {self.id} - {self.func} ({self.state})"
 
 
+class Supervisor(models.Model):
+    """
+    Registry of active supervisors for distributed job processing.
+    Used to detect dead supervisors and requeue their orphaned jobs.
+    """
+
+    # The hex UUID generated for the supervisor instance upon registration.
+    id = UUIDField(primary_key=True)
+
+    # Worker identity, recorded for logging and debugging only - liveness is
+    # determined solely by heartbeat staleness on last_seen. Deliberately not
+    # unique: host/pid/thread tuples can collide across pid namespaces, and a
+    # wrongly-deleted supervisor must be able to re-register by id even if
+    # another record holds the same tuple.
+    host = models.CharField(max_length=100)
+    process = models.CharField(max_length=50)
+    thread = models.CharField(max_length=50)
+
+    last_seen = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self):
+        return f"Supervisor {self.id} - {self.host}/{self.process}/{self.thread}"
+
+
 class KolibriTasksRouter(KolibriModelRouter):
     """
     Determine how to route database calls for the kolibritasks app.
     All other models will be routed to the default database.
     """
 
-    MODEL_CLASSES = {Job}
+    MODEL_CLASSES = {Job, Supervisor}
     DB_NAME = JOB_STORAGE

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -1,12 +1,17 @@
 import logging
+import uuid
 from datetime import datetime
 from datetime import timedelta
 
 from django.db import connections
 from django.db import transaction
+from django.db.models import DateTimeField
+from django.db.models import ExpressionWrapper
 from django.db.models import Q
+from django.db.models.functions import Now
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.constants import NO_VALUE
 from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
@@ -15,6 +20,7 @@ from kolibri.core.tasks.hooks import JobHook
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.models import Job as ORMJob
+from kolibri.core.tasks.models import Supervisor as ORMSupervisor
 from kolibri.core.tasks.validation import validate_exception
 from kolibri.core.tasks.validation import validate_interval
 from kolibri.core.tasks.validation import validate_priority
@@ -24,9 +30,6 @@ from kolibri.deployment.default.sqlite_db_names import JOB_STORAGE
 from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
-
-
-NO_VALUE = object()
 
 
 class Storage:
@@ -194,20 +197,30 @@ class Storage:
             retry_interval=retry_interval,
         )
 
-    def mark_job_as_canceled(self, job_id):
+    def mark_job_as_canceled(self, job_id, expected_supervisor_id=NO_VALUE):
         """
         Mark the job as canceled. Does not actually try to cancel a running job.
-        """
-        self._update_job(job_id, State.CANCELED)
 
-    def mark_job_as_canceling(self, job_id):
+        Returns:
+            bool: True if applied (or already canceled), False if discarded by
+                the fence or the job is gone.
+        """
+        return self._update_job(
+            job_id,
+            State.CANCELED,
+            expected_supervisor_id=expected_supervisor_id,
+        )
+
+    def mark_job_as_canceling(self, job_id, expected_supervisor_id=NO_VALUE):
         """
         Mark the job as requested for canceling. Does not actually try to cancel a running job.
 
         :param job_id: the job to be marked as canceling.
         :return: None
         """
-        self._update_job(job_id, State.CANCELING)
+        self._update_job(
+            job_id, State.CANCELING, expected_supervisor_id=expected_supervisor_id
+        )
 
     def _filter_next_query(self, queryset, priority):
         now = self._now()
@@ -215,7 +228,7 @@ class Storage:
             Q(scheduled_time__lte=now), state=State.QUEUED, priority__lte=priority
         ).order_by("priority", "scheduled_time", "time_created")
 
-    def _postgres_next_queued_job(self, priority):
+    def _postgres_next_queued_job(self, priority, supervisor_id):
         """
         For postgres we are doing our best to ensure that the selected job
         is not then also selected by another potentially concurrent worker controller
@@ -233,41 +246,68 @@ class Storage:
 
             if next_job:
                 next_job.state = State.SELECTED
+                next_job.supervisor_id = supervisor_id
                 next_job.save()
                 return next_job
         return None
 
-    def _sqlite_next_queued_job(self, priority):
+    def _sqlite_next_queued_job(self, priority, supervisor_id):
         """
-        Due to the difficulty in appropriately locking the task row
-        we do not support multiple task runners potentially duelling
-        to lock tasks for SQLite, so here we just do a minimal
-        best effort to mark the job as selected for running.
+        SQLite cannot lock individual rows, but Kolibri's custom SQLite
+        backend opens every transaction with BEGIN IMMEDIATE, taking the
+        database-wide write lock up front - so running the selection query
+        inside the transaction that marks the job SELECTED guarantees that
+        concurrent claimants cannot both claim the same job. The unlocked
+        peek keeps the frequent idle polls of the job checker read-only,
+        rather than contending for the write lock on every poll.
         """
-        orm_job = self._filter_next_query(ORMJob.objects.all(), priority).first()
+        if not self._filter_next_query(ORMJob.objects.all(), priority).exists():
+            return None
+        with transaction.atomic(using=self._get_job_database_alias()):
+            orm_job = self._filter_next_query(ORMJob.objects.all(), priority).first()
+            if orm_job:
+                orm_job.state = State.SELECTED
+                orm_job.supervisor_id = supervisor_id
+                orm_job.save()
+            return orm_job
 
-        if orm_job:
-            orm_job.state = State.SELECTED
-            orm_job.save()
-        return orm_job
-
-    def get_next_queued_job(self, priority=Priority.REGULAR):
+    def get_next_queued_job(self, priority=Priority.REGULAR, supervisor_id=None):
+        """
+        Select the next queued job to run, stamping ownership in the same
+        update that marks it SELECTED, so a supervisor dying between pick-up
+        and start does not leave the job unowned in a non-QUEUED state.
+        """
         db_backend = connections[ORMJob.objects.db].vendor
 
         if db_backend == "sqlite":
-            orm_job = self._sqlite_next_queued_job(priority)
+            orm_job = self._sqlite_next_queued_job(priority, supervisor_id)
         else:
-            orm_job = self._postgres_next_queued_job(priority)
+            orm_job = self._postgres_next_queued_job(priority, supervisor_id)
 
         if orm_job:
             return self._orm_to_job(orm_job)
         return None
 
     def filter_jobs(
-        self, queue=None, queues=None, state=None, repeating=None, func=None
+        self,
+        queue=None,
+        queues=None,
+        state=None,
+        repeating=None,
+        func=None,
+        supervisor_id=NO_VALUE,
+        include_unowned=False,
     ):
+        """
+        Because supervisor_id is nullable, None is a semantic value (unowned
+        jobs), so the no-filtering default is the NO_VALUE sentinel.
+        include_unowned widens an owner filter to also match unowned jobs.
+        """
         if queue and queues:
             raise ValueError("Cannot specify both queue and queues")
+
+        if include_unowned and supervisor_id is NO_VALUE:
+            raise ValueError("include_unowned requires a supervisor_id filter")
 
         queryset = ORMJob.objects.all()
 
@@ -291,16 +331,42 @@ class Storage:
         if func:
             queryset = queryset.filter(func=func)
 
+        queryset = self._filter_owner(queryset, supervisor_id, include_unowned)
+
         return [self._orm_to_job(o) for o in queryset]
 
-    def get_canceling_jobs(self, queues=None):
-        return self.get_jobs_by_state(state=State.CANCELING, queues=queues)
+    def _filter_owner(self, queryset, supervisor_id, include_unowned):
+        if supervisor_id is NO_VALUE:
+            return queryset
+        owner_filter = Q(supervisor_id=supervisor_id)
+        if include_unowned:
+            owner_filter |= Q(supervisor_id__isnull=True)
+        return queryset.filter(owner_filter)
 
-    def get_running_jobs(self, queues=None):
-        return self.get_jobs_by_state(state=State.RUNNING, queues=queues)
+    def get_canceling_jobs(
+        self, queues=None, supervisor_id=NO_VALUE, include_unowned=False
+    ):
+        return self.get_jobs_by_state(
+            state=State.CANCELING,
+            queues=queues,
+            supervisor_id=supervisor_id,
+            include_unowned=include_unowned,
+        )
 
-    def get_jobs_by_state(self, state, queues=None):
-        return self.filter_jobs(state=state, queues=queues)
+    def get_running_jobs(self, queues=None, supervisor_id=NO_VALUE):
+        return self.get_jobs_by_state(
+            state=State.RUNNING, queues=queues, supervisor_id=supervisor_id
+        )
+
+    def get_jobs_by_state(
+        self, state, queues=None, supervisor_id=NO_VALUE, include_unowned=False
+    ):
+        return self.filter_jobs(
+            state=state,
+            queues=queues,
+            supervisor_id=supervisor_id,
+            include_unowned=include_unowned,
+        )
 
     def get_all_jobs(self, queue=None, repeating=None):
         return self.filter_jobs(queue=queue, repeating=repeating)
@@ -342,10 +408,15 @@ class Storage:
                 "Cannot restart job with state={}".format(job_to_restart.state)
             )
 
-    def check_job_canceled(self, job_id):
+    def check_job_canceled(self, job_id, expected_supervisor_id=NO_VALUE):
         try:
-            job = self.get_job(job_id)
+            job, orm_job = self._get_job_and_orm_job(job_id)
         except JobNotFound:
+            return True
+
+        if self._is_disowned_write(orm_job, expected_supervisor_id):
+            # Lost ownership: signal cancel so the disowned execution stops at
+            # its next checkpoint.
             return True
 
         return job.state == State.CANCELED or job.state == State.CANCELING
@@ -361,6 +432,8 @@ class Storage:
         if job.state == State.QUEUED:
             self.clear(job_id=job_id, force=True)
         else:
+            # Cancellation can originate outside a supervisor context, so no
+            # supervisor id needed.
             self.mark_job_as_canceling(job_id)
 
     def cancel_if_exists(self, job_id):
@@ -419,7 +492,12 @@ class Storage:
             queryset.delete()
 
     def update_job_progress(
-        self, job_id, progress, total_progress, extra_metadata=None
+        self,
+        job_id,
+        progress,
+        total_progress,
+        extra_metadata=None,
+        expected_supervisor_id=NO_VALUE,
     ):
         """
         Update the job given by job_id's progress info.
@@ -437,40 +515,90 @@ class Storage:
         }
         if extra_metadata is not None:
             kwargs["extra_metadata"] = extra_metadata
-        self._update_job(job_id, **kwargs)
+        self._update_job(
+            job_id, expected_supervisor_id=expected_supervisor_id, **kwargs
+        )
 
-    def mark_job_as_failed(self, job_id, exception, traceback):
+    def mark_job_as_failed(
+        self, job_id, exception, traceback, expected_supervisor_id=NO_VALUE
+    ):
         """
         Mark the job as failed, and record the traceback and exception.
+
         Args:
             job_id: The job_id of the job that failed.
             exception: The exception object thrown by the job.
-            traceback: The traceback, if any. Note (aron): Not implemented yet. We need to find a way
-            for the conncurrent.futures workers to throw back the error to us.
+            traceback: The traceback, if any.
 
-        Returns: None
-
+        Returns:
+            bool: True if applied, False if discarded by the fence or the job
+                is gone.
         """
         exception = type(exception).__name__
-        self._update_job(job_id, State.FAILED, exception=exception, traceback=traceback)
+        return self._update_job(
+            job_id,
+            State.FAILED,
+            exception=exception,
+            traceback=traceback,
+            expected_supervisor_id=expected_supervisor_id,
+        )
 
-    def mark_job_as_running(self, job_id):
-        self._update_job(job_id, State.RUNNING)
+    def mark_job_as_running(
+        self, job_id, supervisor_id=None, expected_supervisor_id=NO_VALUE
+    ):
+        """
+        Returns:
+            bool: True if applied (including a no-op re-mark or CANCELING kept
+                for the writer), False if discarded by the fence or the job is
+                gone.
+        """
+        return self._update_job(
+            job_id,
+            State.RUNNING,
+            supervisor_id=supervisor_id,
+            expected_supervisor_id=expected_supervisor_id,
+        )
 
     def mark_job_as_queued(self, job_id):
         self._update_job(job_id, State.QUEUED)
 
-    def complete_job(self, job_id, result=None):
-        self._update_job(job_id, State.COMPLETED, result=result)
+    def complete_job(self, job_id, result=None, expected_supervisor_id=NO_VALUE):
+        """
+        Returns:
+            bool: True if applied, False if discarded by the fence or the job
+                is gone.
+        """
+        return self._update_job(
+            job_id,
+            State.COMPLETED,
+            result=result,
+            expected_supervisor_id=expected_supervisor_id,
+        )
 
-    def save_job_meta(self, job):
-        self._update_job(job.job_id, extra_metadata=job.extra_metadata)
+    def save_job_meta(self, job, expected_supervisor_id=NO_VALUE):
+        self._update_job(
+            job.job_id,
+            extra_metadata=job.extra_metadata,
+            expected_supervisor_id=expected_supervisor_id,
+        )
 
-    def save_job_as_cancellable(self, job_id, cancellable=True):
-        self._update_job(job_id, cancellable=cancellable)
+    def save_job_as_cancellable(
+        self, job_id, cancellable=True, expected_supervisor_id=NO_VALUE
+    ):
+        self._update_job(
+            job_id,
+            cancellable=cancellable,
+            expected_supervisor_id=expected_supervisor_id,
+        )
 
     def save_worker_info(
-        self, job_id, host=None, process=None, thread=None, extra=None
+        self,
+        job_id,
+        host=None,
+        process=None,
+        thread=None,
+        extra=None,
+        expected_supervisor_id=NO_VALUE,
     ):
         """
         Generally we only want to capture/update, not erase, any of this information so we only
@@ -482,7 +610,18 @@ class Storage:
 
         with transaction.atomic(using=self._get_job_database_alias()):
             try:
-                _, orm_job = self._get_job_and_orm_job(job_id)
+                # Lock the row so the fence comparison below is atomic with
+                # the write, as in _update_job.
+                _, orm_job = self._get_job_and_orm_job(job_id, for_update=True)
+                if self._is_disowned_write(orm_job, expected_supervisor_id):
+                    # Don't let a disowned execution misattribute the job's
+                    # worker identity to itself.
+                    logger.info(
+                        f"Discarding worker info update of job {job_id} from a "
+                        f"disowned execution (expected owner: {expected_supervisor_id}, "
+                        f"actual owner: {orm_job.supervisor_id})"
+                    )
+                    return
                 if host is not None:
                     orm_job.worker_host = host
                 if process is not None:
@@ -494,7 +633,7 @@ class Storage:
                 orm_job.save()
             except JobNotFound:
                 logger.error(
-                    "Tried to update job with id {} but it was not found".format(job_id)
+                    f"Tried to update job with id {job_id} but it was not found"
                 )
 
     # Turning off the complexity warning for this function as moving the conditional validation checks
@@ -614,43 +753,131 @@ class Storage:
 
         return True
 
-    def _update_job(self, job_id, state=None, **kwargs):
+    def _lock_rows(self, queryset):
+        """
+        Lock the selected job rows until the transaction commits. Only postgres
+        needs (and supports) this; SQLite's BEGIN IMMEDIATE already serializes
+        whole transactions.
+        """
+        if connections[ORMJob.objects.db].vendor == "postgresql":
+            return queryset.select_for_update()
+        return queryset
+
+    def _is_identical_re_mark(self, orm_job, state, supervisor_id, kwargs):
+        """
+        An identical re-mark (e.g. Job.execute re-marking RUNNING after the
+        dispatching supervisor already did) is a no-op, so hooks observe
+        exactly one event per state transition.
+        """
+        return (
+            state is not None
+            and state == orm_job.state
+            and not kwargs
+            and (supervisor_id is None or supervisor_id == orm_job.supervisor_id)
+        )
+
+    def _is_disowned_write(self, orm_job, expected_supervisor_id):
+        """
+        A write is disowned when the writer's expected owner no longer
+        matches: a peer declared the writer's supervisor dead and requeued
+        (and possibly reclaimed) the job.
+        """
+        return (
+            expected_supervisor_id is not NO_VALUE
+            and orm_job.supervisor_id != expected_supervisor_id
+        )
+
+    def _update_job(
+        self,
+        job_id,
+        state=None,
+        supervisor_id=None,
+        expected_supervisor_id=NO_VALUE,
+        **kwargs,
+    ):
+        """
+        Returns:
+            bool: True if applied (including a no-op re-mark or CANCELING kept
+                for the writer), False if discarded by the fence or the job is
+                gone.
+        """
         with transaction.atomic(using=self._get_job_database_alias()):
             try:
-                job, orm_job = self._get_job_and_orm_job(job_id)
-                if state is not None:
-                    orm_job.state = job.state = state
-                for kwarg in kwargs:
-                    if kwarg in Job.UPDATEABLE_KEYS:
-                        setattr(job, kwarg, kwargs[kwarg])
-                    else:
-                        logger.error(
-                            "Tried to update job with id {} with non-updateable key {}".format(
-                                job.job_id, kwarg
-                            )
-                        )
-                orm_job.saved_job = job.to_json()
-                orm_job.save()
-                for hook in self._hooks:
-                    hook.update(job, orm_job, state=state, **kwargs)
-                return job, orm_job
+                # Lock the row so concurrent updates serialize and the guards
+                # below see the winner's write.
+                job, orm_job = self._get_job_and_orm_job(job_id, for_update=True)
             except JobNotFound:
-                if state:
-                    logger.error(
-                        "Tried to update job with id {} with state {} but it was not found".format(
-                            job_id, state
-                        )
-                    )
-                else:
-                    logger.error(
-                        "Tried to update job with id {} but it was not found".format(
-                            job_id
-                        )
-                    )
+                self._log_missing_job(job_id, state)
+                return False
 
-    def _get_job_and_orm_job(self, job_id):
+            handled, result = self._short_circuit_update(
+                orm_job, state, supervisor_id, expected_supervisor_id, kwargs
+            )
+            if handled:
+                return result
+
+            self._write_job_update(job, orm_job, state, supervisor_id, kwargs)
+            for hook in self._hooks:
+                hook.update(job, orm_job, state=state, **kwargs)
+            return True
+
+    def _short_circuit_update(
+        self, orm_job, state, supervisor_id, expected_supervisor_id, kwargs
+    ):
+        """
+        Returns (handled, result): if handled, the update is skipped and result
+        is what _update_job should return; otherwise proceed with the write.
+        """
+        # Checked before the fence so a claim re-mark stays silent on the python
+        # worker path, where ownership is already stamped.
+        if self._is_identical_re_mark(orm_job, state, supervisor_id, kwargs):
+            return True, True
+        if state == State.RUNNING and orm_job.state == State.CANCELING:
+            # Keep CANCELING if a cancel landed between dispatch and the re-mark.
+            return True, True
+        if self._is_disowned_write(orm_job, expected_supervisor_id):
+            logger.info(
+                f"Discarding update of job {orm_job.id} to state {state} from a "
+                f"disowned execution (current state: {orm_job.state}, expected "
+                f"owner: {expected_supervisor_id}, actual owner: {orm_job.supervisor_id})"
+            )
+            return True, False
+        return False, None
+
+    def _write_job_update(self, job, orm_job, state, supervisor_id, kwargs):
+        if state is not None:
+            orm_job.state = job.state = state
+            # Ownership exists only in supervised states; a bare re-mark
+            # preserves the owner, a terminal state clears it.
+            if state in State.SUPERVISED_STATES:
+                if supervisor_id is not None:
+                    orm_job.supervisor_id = supervisor_id
+            else:
+                orm_job.supervisor_id = None
+        for kwarg in kwargs:
+            if kwarg in Job.UPDATEABLE_KEYS:
+                setattr(job, kwarg, kwargs[kwarg])
+            else:
+                logger.error(
+                    f"Tried to update job with id {job.job_id} with non-updateable key {kwarg}"
+                )
+        orm_job.saved_job = job.to_json()
+        orm_job.save()
+
+    def _log_missing_job(self, job_id, state):
+        if state:
+            logger.error(
+                f"Tried to update job with id {job_id} with state {state} but it was not found"
+            )
+        else:
+            logger.error(f"Tried to update job with id {job_id} but it was not found")
+
+    def _get_job_and_orm_job(self, job_id, for_update=False):
+        queryset = ORMJob.objects.all()
+        if for_update:
+            queryset = self._lock_rows(queryset)
         try:
-            orm_job = ORMJob.objects.get(id=job_id)
+            orm_job = queryset.get(id=job_id)
         except ORMJob.DoesNotExist:
             raise JobNotFound()
         job = self._orm_to_job(orm_job)
@@ -749,6 +976,8 @@ class Storage:
             orm_job_data = {
                 "id": job.job_id,
                 "state": job.state,
+                # Clear any stale owner (e.g. a re-scheduled CANCELING job).
+                "supervisor_id": None,
                 "func": job.func,
                 "priority": priority,
                 "queue": queue,
@@ -780,3 +1009,160 @@ class Storage:
 
     def _now(self):
         return local_now()
+
+    def register_supervisor(self, host, process, thread):
+        """
+        Register a supervisor under a freshly generated id.
+
+        Returns:
+            str: the supervisor id.
+        """
+        supervisor_id = uuid.uuid4().hex
+        ORMSupervisor.objects.create(
+            id=supervisor_id,
+            host=host,
+            process=process,
+            thread=thread,
+            # Liveness timestamps use database time (see reconcile_stalled_jobs).
+            last_seen=Now(),
+        )
+        return supervisor_id
+
+    def unregister_supervisor(self, supervisor_id):
+        """
+        Remove a supervisor from the registry.
+        """
+        ORMSupervisor.objects.filter(id=supervisor_id).delete()
+
+    def heartbeat_supervisor(self, supervisor_id, host, process, thread):
+        """
+        Bump last_seen, re-registering if the record is missing (a peer may have
+        wrongly reconciled it away while it was still running jobs).
+        """
+        ORMSupervisor.objects.update_or_create(
+            id=supervisor_id,
+            defaults={
+                "host": host,
+                "process": process,
+                "thread": thread,
+                # Liveness timestamps use database time (see reconcile_stalled_jobs).
+                "last_seen": Now(),
+            },
+        )
+
+    def _transition_jobs_with_dead_owner(self, owner_filter, transitions):
+        """
+        Apply per-state transitions (state -> (callable, log template)) to jobs
+        matching owner_filter, which must select only jobs without a live owner.
+        Each job transitions in its own transaction, in id order.
+        """
+        candidate_filter = Q(state__in=list(transitions)) & owner_filter
+        dead_jobs = list(
+            ORMJob.objects.filter(candidate_filter)
+            .order_by("id")
+            .values_list("id", "supervisor_id")
+        )
+        for job_id, owner_id in dead_jobs:
+            try:
+                with transaction.atomic(using=self._get_job_database_alias()):
+                    # Re-check under lock: the owner may have moved the job on
+                    # since the candidate read, and its current state picks the
+                    # transition.
+                    still_orphaned = self._lock_rows(
+                        ORMJob.objects.filter(
+                            candidate_filter, id=job_id, supervisor_id=owner_id
+                        )
+                    )
+                    orm_job = still_orphaned.first()
+                    if orm_job is None:
+                        continue
+                    transition, log_template = transitions[orm_job.state]
+                    logger.info(log_template.format(job_id, owner_id))
+                    # Unfenced: the locked re-read already confirmed owner and
+                    # state.
+                    transition(job_id)
+            except Exception:
+                # One bad transition must not abort the pass; it rolled back, so
+                # log and let a later pass retry it.
+                logger.exception(
+                    f"Failed to transition job {job_id} with no live supervisor"
+                )
+
+    def reconcile_stalled_jobs(
+        self,
+        supervisor_stale_threshold=None,
+        live_supervisor_ids=None,
+    ):
+        """
+        Requeue SELECTED/RUNNING jobs and finalize CANCELING jobs whose owner is
+        not live. Execution is at-least-once, so tasks must be idempotent.
+
+        Pass exactly one of:
+            supervisor_stale_threshold: seconds before a supervisor counts as
+                dead; the live set is derived from registry heartbeats.
+            live_supervisor_ids: the live set supplied directly (e.g. Android
+                WorkManager), in which case the registry is unused.
+        """
+        if (supervisor_stale_threshold is None) == (live_supervisor_ids is None):
+            raise ValueError(
+                "Exactly one of supervisor_stale_threshold or live_supervisor_ids must be provided"
+            )
+
+        cutoff = None
+        if supervisor_stale_threshold is not None:
+            cutoff, live_supervisor_ids = self._live_supervisors(
+                supervisor_stale_threshold
+            )
+
+        # NOT IN never matches NULL, so the isnull clause is needed too.
+        no_live_owner = Q(supervisor_id__isnull=True) | ~Q(
+            supervisor_id__in=live_supervisor_ids
+        )
+        self._transition_jobs_with_dead_owner(
+            no_live_owner, self._stalled_job_transitions()
+        )
+
+        # After the job transitions, so a mid-reconcile crash leaves records for
+        # a later pass.
+        self._delete_stale_supervisors(cutoff)
+
+    def _live_supervisors(self, stale_threshold):
+        """
+        Returns the staleness cutoff and the ids of supervisors heartbeating
+        more recently than it. Evaluated in database time, so liveness never
+        depends on clock synchronization between processes or hosts.
+        """
+        cutoff = ExpressionWrapper(
+            Now() - timedelta(seconds=stale_threshold),
+            output_field=DateTimeField(),
+        )
+        live = ORMSupervisor.objects.filter(last_seen__gte=cutoff).values_list(
+            "id", flat=True
+        )
+        return cutoff, live
+
+    def _stalled_job_transitions(self):
+        requeue = (
+            self.mark_job_as_queued,
+            "Requeuing job {} with no live supervisor (owner: {})",
+        )
+        return {
+            State.SELECTED: requeue,
+            State.RUNNING: requeue,
+            State.CANCELING: (
+                self.mark_job_as_canceled,
+                "Finalizing canceling job {} with no live supervisor (owner: {})",
+            ),
+        }
+
+    def _delete_stale_supervisors(self, cutoff):
+        if cutoff is not None:
+            # Negated gte so a null last_seen also counts as stale.
+            deleted_count, _ = ORMSupervisor.objects.filter(
+                ~Q(last_seen__gte=cutoff)
+            ).delete()
+        else:
+            # Explicit-live-set mode: the registry is unused cruft.
+            deleted_count, _ = ORMSupervisor.objects.all().delete()
+        if deleted_count:
+            logger.info(f"Removed {deleted_count} stale supervisors")

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -60,12 +60,10 @@ class Storage:
 
     def _orm_to_job(self, orm_job):
         """
-        Extracts a Job object from the saved_job string column of ORMJob
-
-        Sets the storage attribute on the job so the job can persist
-        state updates to the database.
+        Build a Job from an ORM row, attaching this storage so the job can
+        persist its own state updates.
         """
-        job = Job.from_json(orm_job.saved_job)
+        job = Job.from_orm(orm_job)
 
         job.storage = self
         return job

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -10,12 +10,12 @@ from kolibri.core.tasks.job import State
 from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.tasks.utils import import_path_to_callable
-from kolibri.core.tasks.worker import Worker
+from kolibri.core.tasks.worker import WorkerSupervisor
 
 
 @pytest.fixture
 def storage_fixture():
-    e = Worker()
+    e = WorkerSupervisor()
     b = e.storage
     b.clear(force=True)
     yield b

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -252,6 +252,12 @@ class TestBackend:
             len(defaultbackend.get_canceling_jobs(queues=[DEFAULT_QUEUE, QUEUE])) == 3
         )
 
+    def test_filter_jobs_include_unowned_requires_owner_filter(self, defaultbackend):
+        # include_unowned widens an owner filter; without one it would be
+        # silently ignored, so reject it instead.
+        with pytest.raises(ValueError):
+            defaultbackend.filter_jobs(include_unowned=True)
+
     def test_get_jobs_by_state(self, defaultbackend):
         # Schedule jobs
         schedule_time = local_now() + datetime.timedelta(hours=1)

--- a/kolibri/core/tasks/test/taskrunner/test_supervisor.py
+++ b/kolibri/core/tasks/test/taskrunner/test_supervisor.py
@@ -1,0 +1,1346 @@
+import datetime
+import threading
+import time
+import uuid
+
+import mock
+import pytest
+from django.db import connections
+
+from kolibri.core.tasks.hooks import JobHook
+from kolibri.core.tasks.job import Job
+from kolibri.core.tasks.job import State
+from kolibri.core.tasks.models import Job as ORMJob
+from kolibri.core.tasks.models import Supervisor as ORMSupervisor
+from kolibri.core.tasks.storage import Storage
+from kolibri.core.tasks.utils import get_current_job
+from kolibri.core.tasks.worker import execute_job
+from kolibri.core.tasks.worker import WorkerSupervisor
+from kolibri.utils.conf import OPTIONS
+from kolibri.utils.time_utils import local_now
+
+QUEUE = "pytest"
+
+
+def _assert_running():
+    job = get_current_job()
+    if job.storage.get_job(job.job_id).state != State.RUNNING:
+        raise AssertionError("Job was not marked RUNNING during execution")
+
+
+def _assert_owner(expected_supervisor_id):
+    job = get_current_job()
+    if ORMJob.objects.get(id=job.job_id).supervisor_id != expected_supervisor_id:
+        raise AssertionError("Job was not owned by the expected supervisor")
+
+
+# Tokens recorded by job functions that ran past a point an ownership-fenced
+# execution should never reach.
+_executed_past_checkpoint = []
+
+
+def _record_token(token):
+    _executed_past_checkpoint.append(token)
+
+
+def _simulate_peer_reclaim(new_supervisor_id):
+    # Stand-in for a peer wrongly declaring this job's supervisor dead while
+    # the job is still running: reconcile requeues the job, then the peer
+    # claims it under its own id.
+    job = get_current_job()
+    job.storage.mark_job_as_queued(job.job_id)
+    job.storage.mark_job_as_running(job.job_id, supervisor_id=new_supervisor_id)
+
+
+def _reclaimed_mid_run(new_supervisor_id, token):
+    _simulate_peer_reclaim(new_supervisor_id)
+    get_current_job().check_for_cancel()
+    _record_token(token)
+
+
+@pytest.fixture
+def defaultbackend():
+    b = Storage()
+    b.clear(force=True)
+    ORMSupervisor.objects.all().delete()
+    yield b
+    b.clear(force=True)
+    ORMSupervisor.objects.all().delete()
+
+
+@pytest.fixture
+def simplejob():
+    return Job(id)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSupervisorRegistry:
+    def test_register_supervisor_creates_new_record(self, defaultbackend):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+
+        assert supervisor_id is not None
+        supervisor = ORMSupervisor.objects.get(id=supervisor_id)
+        assert supervisor.host == "testhost"
+        assert supervisor.process == "1234"
+        assert supervisor.thread == "5678"
+        assert supervisor.last_seen is not None
+
+    def test_register_supervisor_issues_fresh_id_for_same_identity(
+        self, defaultbackend
+    ):
+        # Identity is probe data, not a key - same-identity records
+        # coexist under distinct ids.
+        supervisor_id1 = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        supervisor_id2 = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+
+        assert supervisor_id1 != supervisor_id2
+        assert ORMSupervisor.objects.count() == 2
+
+    def test_register_supervisor_creates_new_for_different_identity(
+        self, defaultbackend
+    ):
+        supervisor_id1 = defaultbackend.register_supervisor(
+            host="testhost1", process="1234", thread="5678"
+        )
+        supervisor_id2 = defaultbackend.register_supervisor(
+            host="testhost2", process="1234", thread="5678"
+        )
+
+        assert supervisor_id1 != supervisor_id2
+        assert ORMSupervisor.objects.count() == 2
+
+    def test_unregister_supervisor_removes_record(self, defaultbackend):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+        defaultbackend.unregister_supervisor(supervisor_id)
+        assert not ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_heartbeat_supervisor_updates_last_seen(self, defaultbackend):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        stale_time = local_now() - datetime.timedelta(seconds=120)
+        ORMSupervisor.objects.filter(id=supervisor_id).update(last_seen=stale_time)
+
+        defaultbackend.heartbeat_supervisor(
+            supervisor_id, host="testhost", process="1234", thread="5678"
+        )
+
+        supervisor = ORMSupervisor.objects.get(id=supervisor_id)
+        assert supervisor.last_seen > stale_time
+
+    def test_heartbeat_supervisor_recreates_missing_record(self, defaultbackend):
+        # If another supervisor's reconcile wrongly declared us dead and
+        # deleted our record, the heartbeat must re-register us, otherwise
+        # every job we own is requeued while we are still running it.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        ORMSupervisor.objects.filter(id=supervisor_id).delete()
+
+        defaultbackend.heartbeat_supervisor(
+            supervisor_id, host="testhost", process="1234", thread="5678"
+        )
+
+        supervisor = ORMSupervisor.objects.get(id=supervisor_id)
+        assert supervisor.host == "testhost"
+        assert supervisor.process == "1234"
+        assert supervisor.thread == "5678"
+        assert supervisor.last_seen is not None
+
+    def test_heartbeat_supervisor_reregisters_alongside_same_identity_record(
+        self, defaultbackend
+    ):
+        # A wrongly-deleted supervisor must be able to re-register even
+        # while another record holds the same identity tuple (e.g. a
+        # cross-namespace twin with colliding host/pid/thread).
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        twin_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        ORMSupervisor.objects.filter(id=supervisor_id).delete()
+
+        defaultbackend.heartbeat_supervisor(
+            supervisor_id, host="testhost", process="1234", thread="5678"
+        )
+
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+        assert ORMSupervisor.objects.filter(id=twin_id).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReconcileStalledJobs:
+    def test_reconcile_requeues_jobs_from_stale_supervisors(
+        self, defaultbackend, simplejob
+    ):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+
+        # Make the supervisor's heartbeat stale.
+        ORMSupervisor.objects.filter(id=supervisor_id).update(
+            last_seen=local_now() - datetime.timedelta(seconds=300)
+        )
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        job = defaultbackend.get_job(job_id)
+        assert job.state == State.QUEUED
+        # supervisor_id is cleared and the inflated state stays consistent.
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.supervisor_id is None
+        assert orm_job.state == State.QUEUED
+        # The dead supervisor record has been removed.
+        assert not ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_reconcile_cleans_up_stale_supervisors(self, defaultbackend):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        ORMSupervisor.objects.filter(id=supervisor_id).update(
+            last_seen=local_now() - datetime.timedelta(seconds=300)
+        )
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert ORMSupervisor.objects.count() == 0
+
+    def test_reconcile_requeues_orphaned_jobs_with_no_supervisor_id(
+        self, defaultbackend, simplejob
+    ):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id)
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.QUEUED
+
+    def test_reconcile_requeues_jobs_with_nonexistent_supervisor(
+        self, defaultbackend, simplejob
+    ):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=uuid.uuid4().hex)
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.QUEUED
+        assert ORMJob.objects.get(id=job_id).supervisor_id is None
+
+    def test_reconcile_requeues_selected_jobs_with_dead_supervisor(
+        self, defaultbackend, simplejob
+    ):
+        # A supervisor can die between picking a job (SELECTED) and starting
+        # it (RUNNING); reconciliation must requeue those jobs too.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.get_next_queued_job(supervisor_id=uuid.uuid4().hex)
+        assert ORMJob.objects.get(id=job_id).state == State.SELECTED
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.QUEUED
+        assert orm_job.supervisor_id is None
+
+    def test_reconcile_requeues_orphaned_selected_jobs(self, defaultbackend, simplejob):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.get_next_queued_job()
+        assert ORMJob.objects.get(id=job_id).state == State.SELECTED
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert ORMJob.objects.get(id=job_id).state == State.QUEUED
+
+    def test_reconcile_finalizes_canceling_jobs_of_dead_supervisors(
+        self, defaultbackend, simplejob
+    ):
+        # A dead supervisor can never finalize its CANCELING jobs, and live
+        # peers skip CANCELING jobs they do not own, so reconciliation must
+        # finalize them or they are stuck in CANCELING forever.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=uuid.uuid4().hex)
+        defaultbackend.mark_job_as_canceling(job_id)
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.CANCELED
+
+    def test_reconcile_finalizes_unowned_canceling_jobs(
+        self, defaultbackend, simplejob
+    ):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_canceling(job_id)
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.CANCELED
+
+    def test_reconcile_does_not_finalize_live_supervisors_canceling_jobs(
+        self, defaultbackend, simplejob
+    ):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+        defaultbackend.mark_job_as_canceling(job_id)
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.CANCELING
+
+    def test_reconcile_with_explicit_live_set(self, defaultbackend):
+        # An external liveness authority (e.g. WorkManager on Android) passes
+        # the live set directly instead of relying on registry heartbeats.
+        live_id = uuid.uuid4().hex
+        dead_id = uuid.uuid4().hex
+        live_job = defaultbackend.enqueue_job(Job(id), QUEUE)
+        dead_job = defaultbackend.enqueue_job(Job(id), QUEUE)
+        orphan_job = defaultbackend.enqueue_job(Job(id), QUEUE)
+        defaultbackend.mark_job_as_running(live_job, supervisor_id=live_id)
+        defaultbackend.mark_job_as_running(dead_job, supervisor_id=dead_id)
+        defaultbackend.mark_job_as_running(orphan_job)
+        registered_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+
+        defaultbackend.reconcile_stalled_jobs(live_supervisor_ids=[live_id])
+
+        assert defaultbackend.get_job(live_job).state == State.RUNNING
+        assert defaultbackend.get_job(dead_job).state == State.QUEUED
+        assert defaultbackend.get_job(orphan_job).state == State.QUEUED
+        # The two modes are mutually exclusive per deployment, so any registry
+        # record in this mode is stale cruft from a previous registry-mode
+        # deployment and is deleted.
+        assert not ORMSupervisor.objects.filter(id=registered_id).exists()
+
+    def test_reconcile_with_empty_live_set_requeues_all(self, defaultbackend):
+        job_id = defaultbackend.enqueue_job(Job(id), QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=uuid.uuid4().hex)
+
+        defaultbackend.reconcile_stalled_jobs(live_supervisor_ids=[])
+
+        assert defaultbackend.get_job(job_id).state == State.QUEUED
+
+    def test_reconcile_requires_exactly_one_liveness_source(self, defaultbackend):
+        with pytest.raises(ValueError):
+            defaultbackend.reconcile_stalled_jobs()
+        with pytest.raises(ValueError):
+            defaultbackend.reconcile_stalled_jobs(
+                supervisor_stale_threshold=60, live_supervisor_ids=[]
+            )
+
+    def test_reconcile_does_not_requeue_job_finished_during_reconcile(
+        self, defaultbackend
+    ):
+        # A supervisor wrongly declared dead may finish its job between
+        # reconcile reading its candidates and requeuing them. Simulate the
+        # interleaving with a hook that completes the other candidate during
+        # the first requeue - the finished job must not be resurrected.
+        job1 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        job2 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        defaultbackend.mark_job_as_running(job1, supervisor_id=uuid.uuid4().hex)
+        defaultbackend.mark_job_as_running(job2, supervisor_id=uuid.uuid4().hex)
+
+        hook = mock.MagicMock()
+        finished = {}
+
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+
+            def complete_other(job, orm_job, state=None, **kwargs):
+                if state == State.QUEUED and not finished:
+                    finished["job_id"] = job2 if job.job_id == job1 else job1
+                    backend.complete_job(finished["job_id"])
+
+            hook.update.side_effect = complete_other
+            backend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        requeued = job1 if finished["job_id"] == job2 else job2
+        assert defaultbackend.get_job(finished["job_id"]).state == State.COMPLETED
+        assert defaultbackend.get_job(requeued).state == State.QUEUED
+
+    def test_reconcile_does_not_cancel_canceling_job_finished_during_reconcile(
+        self, defaultbackend
+    ):
+        # A supervisor wrongly declared dead may finish its CANCELING job
+        # (the function ran to completion before noticing the cancel request)
+        # between reconcile reading its candidates and finalizing them.
+        # Simulate the interleaving with a hook that completes the other
+        # candidate during the first finalization - the finished job's
+        # terminal state must not be overwritten with CANCELED.
+        job1 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        job2 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        defaultbackend.mark_job_as_running(job1, supervisor_id=uuid.uuid4().hex)
+        defaultbackend.mark_job_as_running(job2, supervisor_id=uuid.uuid4().hex)
+        defaultbackend.mark_job_as_canceling(job1)
+        defaultbackend.mark_job_as_canceling(job2)
+
+        hook = mock.MagicMock()
+        finished = {}
+
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+
+            def complete_other(job, orm_job, state=None, **kwargs):
+                if state == State.CANCELED and not finished:
+                    finished["job_id"] = job2 if job.job_id == job1 else job1
+                    backend.complete_job(finished["job_id"])
+
+            hook.update.side_effect = complete_other
+            backend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        canceled = job1 if finished["job_id"] == job2 else job2
+        assert defaultbackend.get_job(finished["job_id"]).state == State.COMPLETED
+        assert defaultbackend.get_job(canceled).state == State.CANCELED
+
+    def test_reconcile_continues_past_failing_job_transition(self, defaultbackend):
+        # A single job whose transition raises (e.g. a broken job hook) must
+        # not abort the whole reconcile - the remaining orphans still get
+        # requeued and the stale registry records still get cleaned up.
+        # Otherwise one poison job blocks reconciliation forever, since each
+        # heartbeat retries the candidates in the same id order.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job1 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        job2 = defaultbackend.enqueue_job(Job(id), QUEUE)
+        defaultbackend.mark_job_as_running(job1, supervisor_id=supervisor_id)
+        defaultbackend.mark_job_as_running(job2, supervisor_id=supervisor_id)
+        ORMSupervisor.objects.filter(id=supervisor_id).update(
+            last_seen=local_now() - datetime.timedelta(seconds=300)
+        )
+        # Poison the job that is first in the id-ordered pass, so the test
+        # proves the pass continues past a failure rather than merely
+        # finishing before one.
+        poison_job = min(job1, job2)
+        healthy_job = job1 if poison_job == job2 else job2
+
+        hook = mock.MagicMock()
+
+        def raise_for_poison(job, orm_job, state=None, **kwargs):
+            if job.job_id == poison_job:
+                raise RuntimeError("boom")
+
+        hook.update.side_effect = raise_for_poison
+
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+            backend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(healthy_job).state == State.QUEUED
+        # The poisoned transition rolled back whole, leaving the job intact
+        # for a later reconcile to retry.
+        orm_job = ORMJob.objects.get(id=poison_job)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == supervisor_id
+        assert not ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_reconcile_ignores_local_clock_skew(self, defaultbackend, simplejob):
+        # Liveness timestamps are written and compared using database time,
+        # so a skewed local clock on the reconciling process must not
+        # condemn a supervisor with a fresh heartbeat.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        with mock.patch.object(
+            Storage, "_now", return_value=local_now() + datetime.timedelta(hours=1)
+        ):
+            defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_heartbeat_timestamp_ignores_local_clock_skew(
+        self, defaultbackend, simplejob
+    ):
+        # The writer's local clock must not matter either - a heartbeat
+        # written moments ago by a supervisor with a skewed clock is fresh.
+        with mock.patch.object(
+            Storage, "_now", return_value=local_now() - datetime.timedelta(hours=1)
+        ):
+            supervisor_id = defaultbackend.register_supervisor(
+                host="testhost", process="1234", thread="5678"
+            )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_reconcile_does_not_affect_fresh_supervisor_jobs(
+        self, defaultbackend, simplejob
+    ):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        defaultbackend.reconcile_stalled_jobs(supervisor_stale_threshold=60)
+
+        assert defaultbackend.get_job(job_id).state == State.RUNNING
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestJobSupervisorId:
+    def test_get_next_queued_job_stamps_supervisor_id(self, defaultbackend, simplejob):
+        # Ownership starts at SELECTED time, not RUNNING - otherwise a
+        # supervisor dying between pick-up and start leaves the job unowned
+        # in a non-QUEUED state.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        job = defaultbackend.get_next_queued_job(supervisor_id=supervisor_id)
+
+        assert job.job_id == job_id
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.SELECTED
+        assert orm_job.supervisor_id == supervisor_id
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_get_next_queued_job_claims_job_exactly_once_across_threads(
+        self, defaultbackend
+    ):
+        # Two supervisors racing to pick up the same job must not both claim
+        # it - the loser of the race gets nothing. The unsafe interleaving is
+        # timing dependent, so repeat the race to give it a chance to occur.
+        for _ in range(10):
+            job_id = defaultbackend.enqueue_job(Job(id), QUEUE)
+            barrier = threading.Barrier(2, timeout=10)
+            results = {}
+
+            def claim(supervisor_id):
+                barrier.wait()
+                try:
+                    results[supervisor_id] = defaultbackend.get_next_queued_job(
+                        supervisor_id=supervisor_id
+                    )
+                finally:
+                    connections.close_all()
+
+            supervisor_ids = [uuid.uuid4().hex, uuid.uuid4().hex]
+            threads = [
+                threading.Thread(target=claim, args=(supervisor_id,))
+                for supervisor_id in supervisor_ids
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            claimed = {
+                supervisor_id: job
+                for supervisor_id, job in results.items()
+                if job is not None
+            }
+            assert len(claimed) == 1
+            winner = next(iter(claimed))
+            assert ORMJob.objects.get(id=job_id).supervisor_id == winner
+            defaultbackend.clear(force=True)
+
+    def test_get_next_queued_job_without_supervisor_id_leaves_unowned(
+        self, defaultbackend, simplejob
+    ):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        defaultbackend.get_next_queued_job()
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.SELECTED
+        assert orm_job.supervisor_id is None
+
+    def test_mark_job_as_running_with_supervisor_id(self, defaultbackend, simplejob):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id == supervisor_id
+
+    def test_mark_job_as_running_without_supervisor_id(self, defaultbackend, simplejob):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id is None
+
+    def test_mark_job_as_running_again_preserves_supervisor_id(
+        self, defaultbackend, simplejob
+    ):
+        # A bare re-mark (e.g. Job.execute in a non-supervisor worker context)
+        # must not clear the owner set by the dispatching supervisor.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+        defaultbackend.mark_job_as_running(job_id)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id == supervisor_id
+
+    def test_mark_job_as_running_again_emits_single_hook_event(self, defaultbackend):
+        # The dispatching supervisor marks RUNNING, then Job.execute re-marks
+        # it (so external dispatchers like Android's WorkManager still get the
+        # transition); the re-mark is idempotent and must not emit a second
+        # hook event.
+        hook = mock.MagicMock()
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+            supervisor_id = uuid.uuid4().hex
+            job_id = backend.enqueue_job(Job(id), QUEUE)
+            backend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+            backend.mark_job_as_running(job_id)
+
+        running_events = [
+            c for c in hook.update.call_args_list if c[1].get("state") == State.RUNNING
+        ]
+        assert len(running_events) == 1
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_concurrent_identical_re_marks_emit_single_hook_event(self, defaultbackend):
+        # Two live peers may race to finalize the same unowned CANCELING job
+        # (WorkerSupervisor.check_jobs finalizes unowned jobs on every pass);
+        # the loser must observe the winner's write and no-op, so hooks see
+        # exactly one CANCELED event per transition. The unsafe interleaving
+        # is timing dependent, so repeat the race to give it a chance to occur.
+        hook = mock.MagicMock()
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+            for _ in range(10):
+                job_id = backend.enqueue_job(Job(id), QUEUE)
+                backend.mark_job_as_canceling(job_id)
+                hook.reset_mock()
+                barrier = threading.Barrier(2, timeout=10)
+
+                def finalize():
+                    barrier.wait()
+                    try:
+                        backend.mark_job_as_canceled(job_id)
+                    finally:
+                        connections.close_all()
+
+                threads = [threading.Thread(target=finalize) for _ in range(2)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+
+                canceled_events = [
+                    c
+                    for c in hook.update.call_args_list
+                    if c[1].get("state") == State.CANCELED
+                ]
+                assert len(canceled_events) == 1
+                backend.clear(force=True)
+
+    def test_execute_marks_job_running_without_a_supervisor(self, defaultbackend):
+        # Worker contexts that call execute() directly without a supervisor
+        # (e.g. Android's WorkManager) rely on execute() itself transitioning
+        # the job to RUNNING.
+        job_id = defaultbackend.enqueue_job(Job(_assert_running), QUEUE)
+
+        defaultbackend.get_job(job_id).execute()
+
+        assert defaultbackend.get_job(job_id).state == State.COMPLETED
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_execute_job_with_supervisor_id_stamps_owner(self, defaultbackend):
+        # External dispatchers (e.g. Android's WorkManager) pass their own
+        # identity so the job is owned for the duration of its execution.
+        # transaction=True because execute_job closes the django connection
+        # when it finishes - on postgres that is the same connection the test
+        # runs on, which breaks the default test transaction wrapper.
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(
+            Job(_assert_owner, args=(supervisor_id,)), QUEUE
+        )
+
+        execute_job(job_id, supervisor_id=supervisor_id)
+
+        assert defaultbackend.get_job(job_id).state == State.COMPLETED
+
+    @pytest.mark.parametrize(
+        "leave_supervised_state",
+        [
+            lambda backend, job_id: backend.complete_job(job_id),
+            lambda backend, job_id: backend.mark_job_as_failed(
+                job_id, RuntimeError("boom"), "traceback"
+            ),
+            lambda backend, job_id: backend.mark_job_as_canceled(job_id),
+            lambda backend, job_id: backend.mark_job_as_queued(job_id),
+        ],
+        ids=["complete", "failed", "canceled", "queued"],
+    )
+    def test_leaving_supervised_state_clears_supervisor_id(
+        self, defaultbackend, simplejob, leave_supervised_state
+    ):
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        leave_supervised_state(defaultbackend, job_id)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id is None
+
+    def test_schedule_clears_supervisor_id(self, defaultbackend, simplejob):
+        # CANCELING keeps its owner and can be re-scheduled.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+        defaultbackend.mark_job_as_canceling(job_id)
+        assert ORMJob.objects.get(id=job_id).supervisor_id == supervisor_id
+
+        job = defaultbackend.get_job(job_id)
+        defaultbackend.schedule(local_now(), job, QUEUE)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id is None
+
+    def _reclaimed_job(self, backend, job, old_id, new_id):
+        # A supervisor wrongly declared dead while still executing: reconcile
+        # requeues its job, then a peer claims it under a new id.
+        job_id = backend.enqueue_job(job, QUEUE)
+        backend.mark_job_as_running(job_id, supervisor_id=old_id)
+        backend.mark_job_as_queued(job_id)
+        backend.mark_job_as_running(job_id, supervisor_id=new_id)
+        return job_id
+
+    def test_fenced_write_applied_when_owner_matches(self, defaultbackend, simplejob):
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        accepted = defaultbackend.complete_job(
+            job_id, expected_supervisor_id=supervisor_id
+        )
+
+        assert accepted is True
+        assert defaultbackend.get_job(job_id).state == State.COMPLETED
+
+    def test_fenced_write_discarded_when_job_claimed_by_another_supervisor(
+        self, defaultbackend, simplejob
+    ):
+        # The disowned executor's late terminal write must not clobber the
+        # reclaiming peer's RUNNING state or its ownership.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        accepted = defaultbackend.complete_job(job_id, expected_supervisor_id=old_id)
+
+        assert accepted is False
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    def test_fenced_write_discarded_when_job_requeued_and_unclaimed(
+        self, defaultbackend, simplejob
+    ):
+        # The fence is an exact match, so a requeued-but-unclaimed (unowned)
+        # job is off limits too - an unowned QUEUED job is indistinguishable
+        # from one rescheduled after a peer already finished a duplicate run,
+        # and completing that one would kill its scheduled next run.
+        old_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+        defaultbackend.mark_job_as_queued(job_id)
+
+        accepted = defaultbackend.complete_job(job_id, expected_supervisor_id=old_id)
+
+        assert accepted is False
+        assert ORMJob.objects.get(id=job_id).state == State.QUEUED
+
+    def test_fenced_write_with_expected_none_applies_when_unowned(
+        self, defaultbackend, simplejob
+    ):
+        # None is a real expectation (unowned direct execution), not a
+        # no-check default.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id)
+
+        accepted = defaultbackend.complete_job(job_id, expected_supervisor_id=None)
+
+        assert accepted is True
+        assert defaultbackend.get_job(job_id).state == State.COMPLETED
+
+    def test_fenced_write_with_expected_none_discarded_when_owned(
+        self, defaultbackend, simplejob
+    ):
+        # An unowned execution loses its job the moment a supervisor claims
+        # it; its writes are then discarded like any other disowned writer's.
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        accepted = defaultbackend.complete_job(job_id, expected_supervisor_id=None)
+
+        assert accepted is False
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == supervisor_id
+
+    def test_fenced_mark_running_does_not_steal_claimed_job(
+        self, defaultbackend, simplejob
+    ):
+        # The claim execute_job makes for external dispatchers (own id with
+        # expected None) must not re-stamp ownership over a peer's claim.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        defaultbackend.mark_job_as_running(
+            job_id, supervisor_id=old_id, expected_supervisor_id=None
+        )
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id == new_id
+
+    def test_mark_job_as_running_reports_applied_write(self, defaultbackend, simplejob):
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        applied = defaultbackend.mark_job_as_running(
+            job_id, supervisor_id=supervisor_id, expected_supervisor_id=None
+        )
+
+        assert applied is True
+
+    def test_mark_job_as_running_reports_discarded_write(
+        self, defaultbackend, simplejob
+    ):
+        # Callers that dispatch an execution off the back of this mark (e.g.
+        # WorkerSupervisor.start_next_job) need to know the job is no longer
+        # theirs to run.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        applied = defaultbackend.mark_job_as_running(
+            job_id, supervisor_id=old_id, expected_supervisor_id=old_id
+        )
+
+        assert applied is False
+
+    def test_fenced_progress_update_discarded_after_ownership_loss(
+        self, defaultbackend, simplejob
+    ):
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        defaultbackend.update_job_progress(job_id, 5, 10, expected_supervisor_id=old_id)
+
+        assert defaultbackend.get_job(job_id).progress == 0
+
+    def test_fenced_metadata_save_discarded_after_ownership_loss(
+        self, defaultbackend, simplejob
+    ):
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+        job = defaultbackend.get_job(job_id)
+        job.extra_metadata["stale"] = True
+
+        defaultbackend.save_job_meta(job, expected_supervisor_id=old_id)
+
+        assert "stale" not in defaultbackend.get_job(job_id).extra_metadata
+
+    def test_fenced_cancellable_save_discarded_after_ownership_loss(
+        self, defaultbackend, simplejob
+    ):
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        defaultbackend.save_job_as_cancellable(
+            job_id, cancellable=True, expected_supervisor_id=old_id
+        )
+
+        assert defaultbackend.get_job(job_id).cancellable is False
+
+    def test_fenced_mark_canceling_discarded_after_ownership_loss(
+        self, defaultbackend, simplejob
+    ):
+        # WorkerSupervisor.shutdown_workers marks its own jobs CANCELING fenced
+        # on its id; a job reclaimed by a peer must not be dragged into
+        # CANCELING by the disowned supervisor.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        defaultbackend.mark_job_as_canceling(job_id, expected_supervisor_id=old_id)
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    def test_fenced_worker_info_discarded_after_ownership_loss(
+        self, defaultbackend, simplejob
+    ):
+        # Worker identity fields exist to attribute an execution; a fenced-off
+        # duplicate execution is exactly when they get read, so a disowned
+        # writer must not misattribute the job to itself.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        defaultbackend.save_worker_info(
+            job_id, host="stale-host", expected_supervisor_id=old_id
+        )
+
+        assert ORMJob.objects.get(id=job_id).worker_host != "stale-host"
+
+    def test_fenced_worker_info_applied_when_owner_matches(
+        self, defaultbackend, simplejob
+    ):
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        defaultbackend.save_worker_info(
+            job_id, host="live-host", expected_supervisor_id=supervisor_id
+        )
+
+        assert ORMJob.objects.get(id=job_id).worker_host == "live-host"
+
+    def test_discarded_write_emits_no_hook_events(self, defaultbackend):
+        # A discarded write must be invisible to hooks - otherwise observers
+        # see state transitions that never happened.
+        hook = mock.MagicMock()
+        with mock.patch.dict(JobHook._registered_hooks, {"test-hook": hook}):
+            backend = Storage()
+            old_id = uuid.uuid4().hex
+            new_id = uuid.uuid4().hex
+            job_id = self._reclaimed_job(backend, Job(id), old_id, new_id)
+            hook.reset_mock()
+
+            backend.complete_job(job_id, expected_supervisor_id=old_id)
+
+        assert hook.update.call_count == 0
+
+    def test_check_job_canceled_after_ownership_loss(self, defaultbackend, simplejob):
+        # Ownership loss is a cancel signal: there is precedent, since a
+        # deleted job is already treated as canceled. This bounds the
+        # at-least-once overlap - the disowned execution stops at its next
+        # cancellation checkpoint instead of running to completion.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = self._reclaimed_job(defaultbackend, simplejob, old_id, new_id)
+
+        assert (
+            defaultbackend.check_job_canceled(job_id, expected_supervisor_id=old_id)
+            is True
+        )
+
+    def test_check_job_canceled_with_matching_owner(self, defaultbackend, simplejob):
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+
+        assert (
+            defaultbackend.check_job_canceled(
+                job_id, expected_supervisor_id=supervisor_id
+            )
+            is False
+        )
+
+    def test_execute_does_not_overwrite_cancel_requested_before_start(
+        self, defaultbackend
+    ):
+        # A cancel can arrive between the dispatching supervisor marking the
+        # job RUNNING and the executor thread starting; the executor's
+        # RUNNING re-mark must not overwrite CANCELING, or the cancel signal
+        # is lost and the job runs to completion.
+        supervisor_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(Job(id, args=(9,), cancellable=True), QUEUE)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=supervisor_id)
+        defaultbackend.mark_job_as_canceling(job_id)
+
+        defaultbackend.get_job(job_id).execute(supervisor_id=supervisor_id)
+
+        assert defaultbackend.get_job(job_id).state == State.CANCELED
+
+    def test_disowned_cancellable_execution_stops_at_checkpoint(self, defaultbackend):
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(
+            Job(_reclaimed_mid_run, args=(new_id, token), cancellable=True), QUEUE
+        )
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+
+        defaultbackend.get_job(job_id).execute(supervisor_id=old_id)
+
+        assert token not in _executed_past_checkpoint
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    def test_disowned_execution_does_not_reschedule_repeating_job(self, defaultbackend):
+        # reschedule_finished_job_if_needed runs unconditionally after every
+        # execution; for a repeating job a disowned executor re-scheduling
+        # means QUEUED and a third claim - duplicates compound rather than
+        # converge.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = defaultbackend.schedule(
+            local_now(),
+            Job(_simulate_peer_reclaim, args=(new_id,)),
+            QUEUE,
+            interval=600,
+            repeat=None,
+        )
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+
+        defaultbackend.get_job(job_id).execute(supervisor_id=old_id)
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_execute_job_does_not_steal_job_claimed_by_another_supervisor(
+        self, defaultbackend
+    ):
+        # A job requeued and reclaimed by a peer between dispatch and the
+        # executor thread starting must not be re-stamped or run.
+        # transaction=True because execute_job closes the django connection
+        # when it finishes - on postgres that is the same connection the test
+        # runs on, which breaks the default test transaction wrapper.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(
+            Job(_record_token, args=(token,), cancellable=True), QUEUE
+        )
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+        defaultbackend.mark_job_as_queued(job_id)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=new_id)
+
+        execute_job(job_id, supervisor_id=old_id)
+
+        assert token not in _executed_past_checkpoint
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_execute_job_does_not_run_reclaimed_non_cancellable_job(
+        self, defaultbackend
+    ):
+        # A non-cancellable job has no checkpoint at which to notice it was
+        # disowned, so a failed claim must abort the execution outright rather
+        # than let the function run a duplicate to completion.
+        # transaction=True because execute_job closes the django connection
+        # when it finishes - on postgres that is the same connection the test
+        # runs on, which breaks the default test transaction wrapper.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(
+            Job(_record_token, args=(token,), cancellable=False), QUEUE
+        )
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+        defaultbackend.mark_job_as_queued(job_id)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=new_id)
+
+        execute_job(job_id, supervisor_id=old_id)
+
+        assert token not in _executed_past_checkpoint
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == new_id
+
+    @pytest.mark.django_db(databases="__all__", transaction=True)
+    def test_execute_job_does_not_overwrite_worker_info_of_reclaiming_peer(
+        self, defaultbackend
+    ):
+        # The worker identity recorded by execute_job must be fenced like any
+        # other execution write - a disowned executor's identity would
+        # misattribute the peer's run.
+        # transaction=True because execute_job closes the django connection
+        # when it finishes - on postgres that is the same connection the test
+        # runs on, which breaks the default test transaction wrapper.
+        old_id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        job_id = defaultbackend.enqueue_job(
+            Job(_record_token, args=(uuid.uuid4().hex,), cancellable=True), QUEUE
+        )
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=old_id)
+        defaultbackend.mark_job_as_queued(job_id)
+        defaultbackend.mark_job_as_running(job_id, supervisor_id=new_id)
+        defaultbackend.save_worker_info(job_id, host="peer-host")
+
+        execute_job(job_id, worker_host="stale-host", supervisor_id=old_id)
+
+        assert ORMJob.objects.get(id=job_id).worker_host == "peer-host"
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+class TestWorkerSupervisor:
+    @pytest.fixture
+    def worker(self):
+        w = WorkerSupervisor(regular_workers=1, high_workers=1)
+        w.storage.clear(force=True)
+        yield w
+        w.storage.clear(force=True)
+        w.shutdown()
+
+    def test_supervisor_registers_on_startup(self, worker):
+        assert worker.supervisor_id is not None
+        assert ORMSupervisor.objects.filter(id=worker.supervisor_id).exists()
+
+    def test_supervisor_thread_is_running(self, worker):
+        assert worker.supervisor_thread is not None
+        assert worker.supervisor_thread.is_alive()
+
+    def test_heartbeat_reconciles_dead_supervisors(self, worker):
+        # Reconciliation must happen on every heartbeat, not only at startup.
+        dead_id = worker.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        job = Job(id, args=(9,))
+        job_id = worker.storage.enqueue_job(job, QUEUE)
+        worker.storage.mark_job_as_running(job_id, supervisor_id=dead_id)
+        ORMSupervisor.objects.filter(id=dead_id).update(
+            last_seen=local_now() - datetime.timedelta(seconds=300)
+        )
+
+        worker._do_supervisor_heartbeat()
+
+        # The live worker may already have picked the job back up, so assert
+        # it is no longer owned by the dead supervisor rather than a state.
+        assert not ORMSupervisor.objects.filter(id=dead_id).exists()
+        assert ORMJob.objects.get(id=job_id).supervisor_id != dead_id
+
+    def test_heartbeat_reregisters_after_record_deleted(self, worker):
+        # A supervisor wrongly declared dead by a peer must restore its
+        # registration on its next heartbeat.
+        ORMSupervisor.objects.filter(id=worker.supervisor_id).delete()
+
+        worker._do_supervisor_heartbeat()
+
+        assert ORMSupervisor.objects.filter(id=worker.supervisor_id).exists()
+
+    def test_heartbeat_interval_derived_from_stale_threshold(self):
+        # The heartbeat cadence is derived from the stale threshold rather
+        # than separately configurable, so the two can never be misconfigured
+        # relative to each other.
+        with mock.patch.dict(OPTIONS["Tasks"], {"SUPERVISOR_STALE_THRESHOLD": 90}):
+            w = WorkerSupervisor(regular_workers=1, high_workers=1)
+            try:
+                assert w._heartbeat_interval == 30
+            finally:
+                w.storage.clear(force=True)
+                w.shutdown()
+
+    def test_supervisor_unregisters_on_shutdown(self):
+        w = WorkerSupervisor(regular_workers=1, high_workers=1)
+        supervisor_id = w.supervisor_id
+        assert ORMSupervisor.objects.filter(id=supervisor_id).exists()
+        w.storage.clear(force=True)
+        w.shutdown()
+        assert not ORMSupervisor.objects.filter(id=supervisor_id).exists()
+
+    def test_shutdown_keeps_heartbeat_until_workers_drained(self):
+        # While workers drain, the loop must keep running (heartbeating) with
+        # claiming paused, or a job that outlasts the stale threshold lets a
+        # peer declare this supervisor dead and requeue its still-running jobs.
+        w = WorkerSupervisor(regular_workers=1, high_workers=1)
+        w.storage.clear(force=True)
+        observed = {}
+        original_shutdown_workers = w.shutdown_workers
+
+        def spy(wait=True):
+            observed["loop_running"] = not w.supervisor_thread.shutdown_event.is_set()
+            observed["draining"] = w._draining.is_set()
+            return original_shutdown_workers(wait=wait)
+
+        w.shutdown_workers = spy
+        w.shutdown()
+
+        assert observed["loop_running"] is True
+        assert observed["draining"] is True
+        ORMSupervisor.objects.all().delete()
+
+    def test_shutdown_does_not_cancel_other_supervisors_running_jobs(self):
+        # A supervisor shutting down must only cancel its own jobs - a peer's
+        # running jobs are not its business (orphans belong to reconcile).
+        w = WorkerSupervisor(regular_workers=1, high_workers=1)
+        other_id = w.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        # Schedule in the future so this worker's job checker cannot pick it
+        # up before we assign it to the other supervisor.
+        job_id = w.storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        w.storage.mark_job_as_running(job_id, supervisor_id=other_id)
+
+        w.shutdown()
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == other_id
+        w.storage.clear(force=True)
+        ORMSupervisor.objects.all().delete()
+
+    def test_start_next_job_does_not_steal_job_reclaimed_by_peer(self, worker):
+        # The dispatch-time RUNNING mark must be fenced on our own claim -
+        # if we were wrongly declared dead between claim and dispatch and a
+        # peer reclaimed the job, stamping ourselves back over its ownership
+        # is a steal, not a claim.
+        peer_id = worker.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        # Schedule in the future so this worker's job checker cannot claim it
+        # independently of the start_next_job call under test.
+        job_id = worker.storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        job = worker.storage.get_job(job_id)
+        worker.storage.mark_job_as_running(job_id, supervisor_id=peer_id)
+
+        worker.start_next_job(job)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id == peer_id
+
+    def test_start_next_job_skips_dispatch_when_job_no_longer_owned(self, worker):
+        # Dispatching anyway would start an execution we already know is
+        # disowned - for a non-cancellable job, a guaranteed duplicate run.
+        peer_id = worker.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        job_id = worker.storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        job = worker.storage.get_job(job_id)
+        worker.storage.mark_job_as_running(job_id, supervisor_id=peer_id)
+
+        future = worker.start_next_job(job)
+
+        assert future is None
+        assert job_id not in worker.future_job_mapping
+
+    def test_check_jobs_does_not_finalize_other_supervisors_canceling_jobs(
+        self, worker
+    ):
+        # A CANCELING job owned by a live peer is that peer's to finalize -
+        # it may still be actively cancelling the future.
+        other_id = worker.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        job_id = worker.storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        worker.storage.mark_job_as_running(job_id, supervisor_id=other_id)
+        worker.storage.mark_job_as_canceling(job_id)
+
+        worker.check_jobs()
+
+        assert ORMJob.objects.get(id=job_id).state == State.CANCELING
+
+    def test_check_jobs_finalizes_unowned_canceling_jobs(self, worker):
+        # Unowned CANCELING means canceled before pickup - any supervisor may
+        # finalize it promptly (idempotent across peers).
+        job_id = worker.storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        worker.storage.mark_job_as_canceling(job_id)
+
+        worker.check_jobs()
+
+        assert ORMJob.objects.get(id=job_id).state == State.CANCELED
+
+    def test_worker_execution_writes_are_fenced(self, worker):
+        # The fence token must flow from the dispatching supervisor through
+        # to the executing job, so that a job reclaimed by a peer mid-run has
+        # its terminal write discarded rather than clobbering the peer's
+        # claim.
+        peer_id = worker.storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        job_id = worker.storage.enqueue_job(
+            Job(_simulate_peer_reclaim, args=(peer_id,)), QUEUE
+        )
+
+        deadline = time.time() + 30
+        while (
+            ORMJob.objects.get(id=job_id).supervisor_id != peer_id
+            or job_id in worker.future_job_mapping
+        ):
+            assert time.time() < deadline, "Job execution did not finish in time"
+            time.sleep(0.1)
+        # Give any unfenced straggler writes a chance to land before
+        # asserting they did not.
+        time.sleep(0.5)
+
+        orm_job = ORMJob.objects.get(id=job_id)
+        assert orm_job.state == State.RUNNING
+        assert orm_job.supervisor_id == peer_id
+
+    def test_completed_job_has_supervisor_id_cleared(self, worker):
+        job = Job(id, args=(9,))
+        job_id = worker.storage.enqueue_job(job, QUEUE)
+
+        deadline = time.time() + 30
+        while worker.storage.get_job(job_id).state != State.COMPLETED:
+            assert time.time() < deadline, "Job did not complete within 30 seconds"
+            time.sleep(0.1)
+
+        assert ORMJob.objects.get(id=job_id).supervisor_id is None
+
+    def test_startup_requeues_jobs_of_stale_supervisor(self):
+        # A crashed predecessor's record goes quiet; once it passes the stale
+        # threshold, a freshly started supervisor requeues its jobs at startup.
+        storage = Storage()
+        owner_id = storage.register_supervisor(
+            host="otherhost", process="9999", thread="8888"
+        )
+        ORMSupervisor.objects.filter(id=owner_id).update(
+            last_seen=local_now()
+            - datetime.timedelta(
+                seconds=OPTIONS["Tasks"]["SUPERVISOR_STALE_THRESHOLD"] + 1
+            )
+        )
+        job_id = storage.enqueue_in(
+            datetime.timedelta(hours=1), Job(id, args=(9,)), QUEUE
+        )
+        storage.mark_job_as_running(job_id, supervisor_id=owner_id)
+
+        w = WorkerSupervisor(regular_workers=1, high_workers=1)
+        try:
+            orm_job = ORMJob.objects.get(id=job_id)
+            assert orm_job.state == State.QUEUED
+            assert orm_job.supervisor_id is None
+            assert not ORMSupervisor.objects.filter(id=owner_id).exists()
+        finally:
+            w.storage.clear(force=True)
+            w.shutdown()
+            ORMSupervisor.objects.all().delete()

--- a/kolibri/core/tasks/test/taskrunner/test_supervisor.py
+++ b/kolibri/core/tasks/test/taskrunner/test_supervisor.py
@@ -521,6 +521,20 @@ class TestJobSupervisorId:
         assert orm_job.state == State.SELECTED
         assert orm_job.supervisor_id == supervisor_id
 
+    def test_claimed_job_inflates_with_selected_state(self, defaultbackend, simplejob):
+        # The claim updates only the state column, not saved_job; an inflated
+        # job must still report SELECTED, since the column is the source of
+        # truth for state.
+        supervisor_id = defaultbackend.register_supervisor(
+            host="testhost", process="1234", thread="5678"
+        )
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        claimed = defaultbackend.get_next_queued_job(supervisor_id=supervisor_id)
+
+        assert claimed.state == State.SELECTED
+        assert defaultbackend.get_job(job_id).state == State.SELECTED
+
     @pytest.mark.django_db(databases="__all__", transaction=True)
     def test_get_next_queued_job_claims_job_exactly_once_across_threads(
         self, defaultbackend

--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -6,8 +6,7 @@ from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.test.taskrunner.test_job_running import EventProxy
-from kolibri.core.tasks.worker import Worker
-from kolibri.utils import conf
+from kolibri.core.tasks.worker import WorkerSupervisor
 
 QUEUE = "pytest"
 
@@ -40,7 +39,7 @@ def toggle_flag(flag_id):
 
 @pytest.fixture
 def worker():
-    b = Worker(regular_workers=1, high_workers=1)
+    b = WorkerSupervisor(regular_workers=1, high_workers=1)
     b.storage.clear(force=True)
     yield b
     b.storage.clear(force=True)
@@ -103,20 +102,19 @@ class TestWorker:
         assert job.state == State.COMPLETED
 
     def test_enqueue_job_runs_job_once(self, worker, flag):
-        # Do conditional check in here, as it seems to not work properly
-        # inside a pytest.mark.skipIf
-        if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
-            b = Worker(regular_workers=1, high_workers=1)
-            job = Job(toggle_flag, args=(flag.event_id,))
-            worker.storage.enqueue_job(job, QUEUE)
+        # Two concurrent supervisors must not both pick up the same job -
+        # if the job runs twice, the flag toggles back off.
+        b = WorkerSupervisor(regular_workers=1, high_workers=1)
+        job = Job(toggle_flag, args=(flag.event_id,))
+        worker.storage.enqueue_job(job, QUEUE)
 
-            while job.state != State.COMPLETED:
-                job = worker.storage.get_job(job.job_id)
-                time.sleep(0.5)
+        while job.state != State.COMPLETED:
+            job = worker.storage.get_job(job.job_id)
+            time.sleep(0.5)
 
-            assert job.state == State.COMPLETED
-            assert flag.is_set()
-            b.shutdown()
+        assert job.state == State.COMPLETED
+        assert flag.is_set()
+        b.shutdown()
 
     def test_can_handle_unicode_exceptions(self, worker):
         # Make sure task exception info is not an object, but is either a string or None.
@@ -171,6 +169,13 @@ class TestWorker:
         assert job is None
 
     def test_high_tasks_dont_wait_when_regular_workers_busy(self, worker):
+        # Stop the supervisor thread first - with the fake busy mapping below
+        # it too becomes eligible to claim the HIGH job, and on postgres its
+        # skip_locked claim makes this test's own claim return None. We are
+        # testing get_next_job's priority logic directly, not the loop.
+        worker.supervisor_thread.stop()
+        worker.supervisor_thread.join()
+
         # We have one task running right now.
         worker.future_job_mapping = {"job_id": "future"}
 

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -5,6 +5,7 @@ import mock
 from django.test.testcases import TestCase
 from requests.exceptions import HTTPError
 
+from kolibri.core.tasks.constants import NO_VALUE
 from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.job import Job
@@ -32,7 +33,21 @@ class JobTest(TestCase):
 
         self.job.save_as_cancellable(cancellable=cancellable)
         self.job.storage.save_job_as_cancellable.assert_called_once_with(
-            self.job.job_id, cancellable=cancellable
+            self.job.job_id,
+            cancellable=cancellable,
+            expected_supervisor_id=NO_VALUE,
+        )
+
+    def test_job_update_worker_info_carries_fence_token(self):
+        self.job.update_worker_info(host="host", process="123", thread="456")
+
+        self.job.storage.save_worker_info.assert_called_once_with(
+            self.job.job_id,
+            host="host",
+            process="123",
+            thread="456",
+            extra=None,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_save_as_cancellable_sets_cancellable(self):
@@ -44,7 +59,11 @@ class JobTest(TestCase):
     def test_job_update_progress_saves_progress_to_storage(self):
         self.job.update_progress(0.5, 1.5)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.5, 1.5, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.5,
+            1.5,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_sets_progress(self):
@@ -192,7 +211,11 @@ class JobTest(TestCase):
         # Initial progress update
         self.job.update_progress(0.1, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.1, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.1,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
@@ -208,28 +231,44 @@ class JobTest(TestCase):
         # Initial progress update
         self.job.update_progress(0.1, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.1, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.1,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
         # Progress update with ≥1% change should be sent to storage
         self.job.update_progress(0.12, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.12, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.12,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_sends_on_completion(self):
         # Initial progress update
         self.job.update_progress(0.999, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.999, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.999,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
         # Small progress update that reaches 100% should be sent to storage
         self.job.update_progress(1.0, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 1.0, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            1.0,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_sends_on_first_total(self):
@@ -240,28 +279,44 @@ class JobTest(TestCase):
         # First update that sets a total should be sent
         job.update_progress(0.1, 100.0)
         job.storage.update_job_progress.assert_called_once_with(
-            job.job_id, 0.1, 100.0, extra_metadata=job.extra_metadata
+            job.job_id,
+            0.1,
+            100.0,
+            extra_metadata=job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_sends_on_changed_total(self):
         # First update that sets a total should be sent
         self.job.update_progress(0.1, 100.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.1, 100.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.1,
+            100.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_sends_on_progress_decrease(self):
         # Initial progress update
         self.job.update_progress(0.5, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.5, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.5,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
         # Progress update that decreases progress should be sent to storage
         self.job.update_progress(0.499, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.499, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.499,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_retains_last_saved_values(self):
@@ -311,14 +366,22 @@ class JobTest(TestCase):
 
         # Verify storage was called with the correct parameters
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.5, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.5,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_job_update_progress_throttles_with_metadata(self):
         # Initial progress update with metadata
         self.job.update_progress(0.1, 1.0, extra_metadata={"stage": "start"})
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.1, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.1,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
@@ -332,7 +395,11 @@ class JobTest(TestCase):
         # Significant progress update should update both progress and all metadata
         self.job.update_progress(0.2, 1.0, extra_metadata={"files": 10})
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.2, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.2,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
 
     def test_update_metadata_still_works_separately(self):
@@ -345,7 +412,11 @@ class JobTest(TestCase):
         # Initial progress update
         self.job.update_progress(0.1, 1.0)
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.1, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.1,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.job.storage.update_job_progress.reset_mock()
 
@@ -363,7 +434,11 @@ class JobTest(TestCase):
         # Significant update should send all accumulated metadata
         self.job.update_progress(0.2, 1.0, extra_metadata={"step": 4})
         self.job.storage.update_job_progress.assert_called_once_with(
-            self.job.job_id, 0.2, 1.0, extra_metadata=self.job.extra_metadata
+            self.job.job_id,
+            0.2,
+            1.0,
+            extra_metadata=self.job.extra_metadata,
+            expected_supervisor_id=NO_VALUE,
         )
         self.assertEqual(self.job.extra_metadata["step"], 4)
 

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -2,7 +2,6 @@ import concurrent.futures
 import logging
 import os
 import sqlite3
-import time
 import uuid
 from threading import Event
 from threading import local
@@ -126,7 +125,10 @@ class InfiniteLoopThread(Thread):
         wait = self.wait - (corrected_time if corrected_time is not None else 0)
 
         if wait > 0:
-            time.sleep(wait)
+            # Wait on the shutdown event rather than sleeping, so that a stop()
+            # request during the interval is acted on promptly instead of having
+            # to wait out the full interval (important for long intervals).
+            self.shutdown_event.wait(wait)
 
     def stop(self):
         self.shutdown_event.set()

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -1,4 +1,8 @@
 import logging
+import os
+import socket
+import threading
+import time
 from concurrent.futures import CancelledError
 from concurrent.futures import ThreadPoolExecutor
 
@@ -6,6 +10,7 @@ from django.db import connection as django_connection
 
 from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.utils import InfiniteLoopThread
+from kolibri.utils.conf import OPTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -16,41 +21,86 @@ def execute_job(
     worker_process=None,
     worker_thread=None,
     worker_extra=None,
+    supervisor_id=None,
 ):
     """
     Call the function stored in the job.func.
-    :return: None
+
+    supervisor_id is the dispatcher owning this execution (the WorkerSupervisor,
+    or an external dispatcher like Android's WorkManager) and doubles as the
+    execution's fence token (see Job.execute).
     """
     from kolibri.core.tasks.main import job_storage
 
     job = job_storage.get_job(job_id)
 
-    job.update_worker_info(worker_host, worker_process, worker_thread, worker_extra)
+    try:
+        if supervisor_id is not None:
+            # Claim only if unowned; a peer that reclaimed the job keeps it. On
+            # the python worker path the supervisor already stamped ownership,
+            # so this is an identical re-mark that no-ops.
+            applied = job_storage.mark_job_as_running(
+                job_id, supervisor_id=supervisor_id, expected_supervisor_id=None
+            )
+            if not applied:
+                # Owned by a peer - bail before running a duplicate whose writes
+                # the fence would discard anyway.
+                logger.info(
+                    f"Not executing job {job_id} - it is owned by another supervisor."
+                )
+                return
 
-    job.execute()
+        # Fenced so a peer's reclaimed execution is not misattributed to us.
+        job_storage.save_worker_info(
+            job_id,
+            host=worker_host,
+            process=worker_process,
+            thread=worker_thread,
+            extra=worker_extra,
+            expected_supervisor_id=supervisor_id,
+        )
 
-    # Close any django connections opened here
-    django_connection.close()
+        job.execute(supervisor_id=supervisor_id)
+    finally:
+        # Close any django connections opened here
+        django_connection.close()
 
 
-def execute_job_with_python_worker(job_id):
+def _python_worker_identity():
+    """
+    The host/process/thread identity of the current python worker context,
+    taken directly from python internals.
+    """
+    return {
+        "host": socket.gethostname(),
+        "process": str(os.getpid()),
+        "thread": str(threading.get_ident()),
+    }
+
+
+def execute_job_with_python_worker(job_id, supervisor_id=None):
     """
     Call execute_job but additionally with the current host, process and thread information taken
     directly from python internals.
     """
-    import os
-    import socket
-    import threading
-
+    identity = _python_worker_identity()
     execute_job(
         job_id,
-        worker_host=socket.gethostname(),
-        worker_process=str(os.getpid()),
-        worker_thread=str(threading.get_ident()),
+        worker_host=identity["host"],
+        worker_process=identity["process"],
+        worker_thread=identity["thread"],
+        supervisor_id=supervisor_id,
     )
 
 
-class Worker:
+class WorkerSupervisor:
+    """
+    Supervises a pool of worker executors. Each supervisor registers itself in
+    the supervisor registry and periodically updates a heartbeat so that, if it
+    dies, other supervisors can detect the stale heartbeat and requeue the jobs
+    it was responsible for.
+    """
+
     def __init__(self, regular_workers=2, high_workers=1):
         # Internally, we use concurrent.future.Future to run and track
         # job executions. We need to keep track of which future maps to which
@@ -67,31 +117,84 @@ class Worker:
 
         self.storage = job_storage
 
-        self.requeue_stalled_jobs()
+        # Register this supervisor in the registry, keeping the identity
+        # so that the heartbeat can re-register if a peer wrongly declares
+        # this supervisor dead and removes its record.
+        self._identity = _python_worker_identity()
+        self.supervisor_id = self.storage.register_supervisor(**self._identity)
+
+        self.supervisor_stale_threshold = OPTIONS["Tasks"]["SUPERVISOR_STALE_THRESHOLD"]
+
+        # Requeue jobs from any dead supervisors and clean up the registry.
+        self._reconcile_stalled_jobs()
 
         # Regular workers run both 'high' and 'regular' priority jobs.
         # High workers run only 'high' priority jobs.
         self.regular_workers = regular_workers
         self.max_workers = regular_workers + high_workers
 
-        self.workers = self.start_workers()
-        self.job_checker = self.start_job_checker()
+        # Heartbeat a third of the stale threshold, so three must be missed
+        # before a peer declares this supervisor dead.
+        self._heartbeat_interval = self.supervisor_stale_threshold / 3
+        self._last_heartbeat = time.monotonic()
+        # Set during shutdown to stop claiming new jobs while the loop keeps
+        # heartbeating until in-flight jobs drain.
+        self._draining = threading.Event()
 
-    def requeue_stalled_jobs(self):
-        logger.info("Requeuing stalled jobs.")
-        for job in self.storage.get_running_jobs():
-            logger.info("Requeuing job id {}.".format(job.job_id))
-            self.storage.mark_job_as_queued(job.job_id)
+        self.workers = self.start_workers()
+        self.supervisor_thread = self.start_supervisor_thread()
+
+    def start_supervisor_thread(self):
+        """
+        Start the single supervisor loop: claim and dispatch jobs, finalize
+        cancellations, and periodically heartbeat and reconcile.
+        Returns: the Thread object.
+        """
+        t = InfiniteLoopThread(
+            self._supervise, thread_name="SUPERVISOR", wait_between_runs=0.2
+        )
+        t.start()
+        return t
+
+    def _supervise(self):
+        # While draining (shutdown), stop claiming but keep heartbeating so a
+        # peer does not declare us dead and requeue our still-running jobs.
+        if not self._draining.is_set():
+            self.check_jobs()
+        self._maybe_heartbeat()
+
+    def _maybe_heartbeat(self):
+        now = time.monotonic()
+        if now - self._last_heartbeat >= self._heartbeat_interval:
+            self._last_heartbeat = now
+            self._do_supervisor_heartbeat()
+
+    def _do_supervisor_heartbeat(self):
+        """
+        Update this supervisor's last_seen timestamp, then requeue jobs from
+        any supervisors that have died since this one started. Heartbeating
+        first keeps our own record fresh when reconciliation runs.
+        """
+        self.storage.heartbeat_supervisor(self.supervisor_id, **self._identity)
+        self._reconcile_stalled_jobs()
+
+    def _reconcile_stalled_jobs(self):
+        self.storage.reconcile_stalled_jobs(
+            supervisor_stale_threshold=self.supervisor_stale_threshold
+        )
 
     def shutdown_workers(self, wait=True):
-        # First cancel all running jobs
-        # Coerce to a list, as otherwise the iterable can change size
-        # during iteration, as jobs are cancelled and removed from the mapping
-        for job in self.storage.get_running_jobs():
-            logger.info("Canceling job id {}.".format(job.job_id))
-            self.storage.mark_job_as_canceling(job.job_id)
+        # Cancel only our own running jobs (orphans are reconciliation's), each
+        # write fenced on our id so a peer that reclaimed one is not clobbered.
+        for job in self.storage.get_running_jobs(supervisor_id=self.supervisor_id):
+            logger.info(f"Canceling job id {job.job_id}.")
+            self.storage.mark_job_as_canceling(
+                job.job_id, expected_supervisor_id=self.supervisor_id
+            )
             if self.cancel(job.job_id):
-                self.storage.mark_job_as_canceled(job.job_id)
+                self.storage.mark_job_as_canceled(
+                    job.job_id, expected_supervisor_id=self.supervisor_id
+                )
         # Now shutdown the workers
         self.workers.shutdown(wait=wait)
 
@@ -110,30 +213,26 @@ class Worker:
             try:
                 future.result()
             except CancelledError:
-                self.storage.mark_job_as_canceled(job.job_id)
+                # Fenced on our id so a peer that reclaimed the job is not
+                # clobbered.
+                self.storage.mark_job_as_canceled(
+                    job.job_id, expected_supervisor_id=self.supervisor_id
+                )
         except KeyError:
             pass
 
     def shutdown(self, wait=True):
         logger.info("Asking job schedulers to shut down.")
-        self.job_checker.stop()
-        # Wait for the job checker to finish
-        # before attempting to pause any running jobs
-        if wait:
-            self.job_checker.join()
+        # Stop claiming new jobs but keep the loop heartbeating through the
+        # drain: a job outlasting the stale threshold would otherwise let a peer
+        # declare us dead and requeue our still-running jobs.
+        self._draining.set()
         self.shutdown_workers(wait=wait)
-
-    def start_job_checker(self):
-        """
-        Starts up the job checker thread, that starts scheduled jobs when there are workers free,
-        and checks for cancellation requests for jobs currently assigned to a worker.
-        Returns: the Thread object.
-        """
-        t = InfiniteLoopThread(
-            self.check_jobs, thread_name="JOBCHECKER", wait_between_runs=0.2
-        )
-        t.start()
-        return t
+        # Drained - stop the loop and deregister.
+        self.supervisor_thread.stop()
+        if wait:
+            self.supervisor_thread.join()
+        self.storage.unregister_supervisor(self.supervisor_id)
 
     def check_jobs(self):
         """
@@ -146,12 +245,18 @@ class Worker:
             self.start_next_job(job_to_start)
             job_to_start = self.get_next_job()
 
-        for job in self.storage.get_canceling_jobs():
+        # Finalize CANCELING jobs we own, plus unowned ones (canceled before
+        # pickup); a live peer's are its own to finalize.
+        for job in self.storage.get_canceling_jobs(
+            supervisor_id=self.supervisor_id, include_unowned=True
+        ):
             job_id = job.job_id
             if job_id in self.future_job_mapping:
                 self.cancel(job_id)
             else:
-                self.storage.mark_job_as_canceled(job_id)
+                # Only unowned jobs reach here (ours are in the mapping above);
+                # fence on "still unowned" so a reclaiming peer is not clobbered.
+                self.storage.mark_job_as_canceled(job_id, expected_supervisor_id=None)
 
     def get_next_job(self):
         """
@@ -172,9 +277,11 @@ class Worker:
         workers_currently_busy = len(self.future_job_mapping)
 
         if workers_currently_busy < self.regular_workers:
-            job = self.storage.get_next_queued_job()
+            job = self.storage.get_next_queued_job(supervisor_id=self.supervisor_id)
         elif workers_currently_busy < self.max_workers:
-            job = self.storage.get_next_queued_job(priority=Priority.HIGH)
+            job = self.storage.get_next_queued_job(
+                priority=Priority.HIGH, supervisor_id=self.supervisor_id
+            )
         else:
             logger.debug("All workers busy.")
             return None
@@ -187,9 +294,23 @@ class Worker:
 
         :return future:
         """
+        # Mark RUNNING before dispatching, fenced on our claim: if we lost the
+        # job between claim and here, don't dispatch a disowned execution.
+        applied = self.storage.mark_job_as_running(
+            job.job_id,
+            supervisor_id=self.supervisor_id,
+            expected_supervisor_id=self.supervisor_id,
+        )
+        if not applied:
+            logger.info(
+                f"Not dispatching job {job.job_id} - it is no longer owned by this supervisor."
+            )
+            return None
+
         future = self.workers.submit(
             execute_job_with_python_worker,
             job_id=job.job_id,
+            supervisor_id=self.supervisor_id,
         )
 
         # Check if the job ID already exists in the future_job_mapping dictionary

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -800,6 +800,24 @@ base_option_spec = {
                 The file to use for the job storage database. This is only used in the case that the database backend being used is SQLite.
             """,
         },
+        "SUPERVISOR_STALE_THRESHOLD": {
+            "type": "integer",
+            "default": 30,
+            # The floor guards against a misconfiguration hammering the job
+            # storage database - each supervisor heartbeats and reconciles at
+            # a third of this interval.
+            "validator_args": {"min": 15},
+            "description": """
+                The time in seconds without a heartbeat update before a supervisor is
+                considered dead and its jobs are requeued. Each supervisor heartbeats at a
+                third of this interval, so three consecutive heartbeats must be missed
+                before a supervisor is declared dead. Heartbeats are timestamped and
+                compared using database time, so clock differences between processes and
+                hosts do not eat into the margin. Deployments where a worker process can
+                pause for long periods (e.g. system sleep, or container freezes) should
+                increase this to avoid jobs being requeued while their worker is paused.
+            """,
+        },
     },
 }
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -873,13 +873,22 @@ def get_configspec():
             if isinstance(default, list) and not default:
                 raise RuntimeError("For an empty list don't specify a default")
             the_type = attrs["type"]
-            args = ["%r" % op for op in attrs.get("options", [])] + [
-                "default=list('{default_list}')".format(
-                    default_list="','".join(default)
-                )
-                if isinstance(default, list)
-                else "default='{default}'".format(default=default)
-            ]
+            args = (
+                ["%r" % op for op in attrs.get("options", [])]
+                + [
+                    # Pass any extra arguments through to the checker function,
+                    # e.g. min/max bounds for integer options.
+                    "{key}={value!r}".format(key=key, value=value)
+                    for key, value in attrs.get("validator_args", {}).items()
+                ]
+                + [
+                    "default=list('{default_list}')".format(
+                        default_list="','".join(default)
+                    )
+                    if isinstance(default, list)
+                    else "default='{default}'".format(default=default)
+                ]
+            )
             line = "{name} = {type}({args})".format(
                 name=name, type=the_type, args=", ".join(args)
             )

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -160,6 +160,16 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
                 options.read_options_file(ini_filename=tmp_ini_path)
             assert 'value "baba" is of the wrong type' in LOG_LOGGER[-2][1]
 
+        # out-of-bounds value for an option with validator_args bounds causes it to bail
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Tasks]", "SUPERVISOR_STALE_THRESHOLD = 14"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
+        ):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "14" is too small' in LOG_LOGGER[-2][1]
+
         # invalid choice for "option" type causes it to bail
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Database]", "DATABASE_ENGINE = penguin"]))

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -2,6 +2,7 @@
 Tests for `kolibri.utils.options` module.
 """
 
+import copy
 import logging
 import os
 import sys
@@ -178,6 +179,38 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
             with pytest.raises(SystemExit):
                 options.read_options_file(ini_filename=tmp_ini_path)
             assert 'value "maybe" is unacceptable' in LOG_LOGGER[-2][1]
+
+
+def test_validator_args_enforce_bounds(monkeypatch):
+    """
+    Checks that validator_args on an option spec are passed through to the
+    underlying configobj checker (e.g. min/max for integer options).
+    """
+    spec = copy.deepcopy(options.option_spec)
+    spec["Tasks"]["REGULAR_PRIORITY_WORKERS"]["validator_args"] = {"min": 1}
+    monkeypatch.setattr(options, "option_spec", spec)
+
+    with activate_log_logger(monkeypatch):
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+
+        # out-of-bounds values log errors and exit
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Tasks]", "REGULAR_PRIORITY_WORKERS = 0"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
+        ):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "0" is too small' in LOG_LOGGER[-2][1]
+
+        # values within bounds are read as normal
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Tasks]", "REGULAR_PRIORITY_WORKERS = 2"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
+        ):
+            OPTIONS = options.read_options_file(ini_filename=tmp_ini_path)
+            assert OPTIONS["Tasks"]["REGULAR_PRIORITY_WORKERS"] == 2
 
 
 def test_deprecated_values_ini_file(monkeypatch):

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -112,9 +112,11 @@ class TestServerServices:
         # Initialize and ready services plugin for testing
         services_plugin = server.ServicesPlugin(mock.MagicMock(name="bus"))
 
-        from kolibri.core.tasks.worker import Worker
+        from kolibri.core.tasks.worker import WorkerSupervisor
 
-        services_plugin.worker = mock.MagicMock(name="worker", spec_set=Worker)
+        services_plugin.worker = mock.MagicMock(
+            name="worker", spec_set=WorkerSupervisor
+        )
 
         # Now, let us stop services plugin
         services_plugin.STOP()


### PR DESCRIPTION
## Summary

Adds multi-supervisor support to the task runner so several worker supervisors — separate processes, or separate hosts sharing one job storage — can serve the same queue concurrently. Previously a single worker requeued all running jobs on startup, which can't distinguish a peer's live job from a dead one's.

- **Supervisor registry + heartbeats** replace `requeue_stalled_jobs`. Each supervisor heartbeats at a third of a configurable stale threshold and requeues jobs whose owner has no fresh heartbeat. Timestamps are written and compared in database time, so liveness doesn't depend on clock sync across processes or hosts.
- **Ownership fencing.** Because a supervisor wrongly declared dead keeps running while its job is requeued (and possibly reclaimed by a peer), execution is at-least-once; every storage write from an execution carries its supervisor id as a fence token, so a disowned write is discarded rather than corrupting the newer state.
- **External dispatchers** (e.g. Android WorkManager) use the same API: claim ownership via `execute_job`, reconcile against an explicit live set.

Smaller supporting changes: `validator_args` on option specs (min/max bounds for integer options), and making the job `state`/`func`/`id` columns authoritative instead of duplicating them in the `saved_job` JSON.

## References

- Downstream consumer: learningequality/kolibri#15014 — adopts this ownership/reconciliation API for WorkManager-dispatched jobs.

## Reviewer guidance

The task suite exercises the fencing and claim paths against both backends (`databases="__all__"`, including cross-thread claim/finalize race tests):

```
pytest kolibri/core/tasks/test/
```

The concurrency surface is what to scrutinise: the fence comparison must be atomic with the write under the row lock (`get_next_queued_job` and `_update_job` in `storage.py`), exercised on postgres (`FOR UPDATE SKIP LOCKED`) as well as SQLite. One back-compat note — `Job.from_orm` now reads `state`/`func`/`id` from the row, ignoring the stale copies still present in older `saved_job` blobs.

## AI usage

The initial prototype was built with Claude Code on the web, then taken through roughly ten rounds of iteration — during which the need for ownership fencing (gating disowned writes) surfaced — followed by further rounds and multiple passes of human review to reach the final implementation. Beyond the automated suite (run against both SQLite and Postgres), Claude Code exercised it live in containers, running several worker supervisors against a shared Postgres instance.
