### PR TITLE
Add learner-defined custom themes to the EPUB reader

### DIFF
--- a/kolibri/plugins/epub_viewer/frontend/composables/__tests__/useCustomThemes.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/composables/__tests__/useCustomThemes.spec.js
@@ -1,0 +1,78 @@
+import Lockr from 'lockr';
+import useCustomThemes from '../useCustomThemes';
+import { CUSTOM_THEMES_STORAGE_KEY } from '../../views/EpubConstants';
+
+describe('useCustomThemes', () => {
+  beforeEach(() => {
+    // The map lives at module scope, so reset the shared state between tests.
+    useCustomThemes().customThemes.value = {};
+    Lockr.rm(CUSTOM_THEMES_STORAGE_KEY);
+  });
+
+  it('shares one reactive map across all consumers', () => {
+    const a = useCustomThemes();
+    const b = useCustomThemes();
+
+    const created = a.createCustomTheme({ name: 'Shared' });
+
+    expect(b.customThemes.value[created.id]).toEqual(created);
+  });
+
+  it('creates a theme under a generated id and persists it', () => {
+    const { createCustomTheme, customThemes } = useCustomThemes();
+
+    const created = createCustomTheme({ name: 'Day', backgroundColor: '#ffffff' });
+
+    expect(created.id).toEqual(expect.any(String));
+    expect(created.name).toBe('Day');
+    expect(customThemes.value[created.id]).toEqual(created);
+    expect(Lockr.get(CUSTOM_THEMES_STORAGE_KEY)[created.id]).toEqual(created);
+  });
+
+  it('assigns a distinct id to each created theme', () => {
+    const { createCustomTheme } = useCustomThemes();
+
+    const first = createCustomTheme({ name: 'A' });
+    const second = createCustomTheme({ name: 'B' });
+
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it('updates an existing theme in place, keeping its id', () => {
+    const { createCustomTheme, updateCustomTheme, customThemes } = useCustomThemes();
+    const created = createCustomTheme({ name: 'A', backgroundColor: '#000000' });
+
+    const updated = updateCustomTheme(created.id, { name: 'Renamed', backgroundColor: '#ffffff' });
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.name).toBe('Renamed');
+    expect(Object.keys(customThemes.value)).toEqual([created.id]);
+    expect(Lockr.get(CUSTOM_THEMES_STORAGE_KEY)[created.id].name).toBe('Renamed');
+  });
+
+  it('removes a theme by id and persists the removal', () => {
+    const { createCustomTheme, removeCustomTheme, customThemes } = useCustomThemes();
+    const created = createCustomTheme({ name: 'A' });
+
+    removeCustomTheme(created.id);
+
+    expect(customThemes.value[created.id]).toBeUndefined();
+    expect(Lockr.get(CUSTOM_THEMES_STORAGE_KEY)).toEqual({});
+  });
+
+  it('detects a duplicate name', () => {
+    const { createCustomTheme, isDuplicateName } = useCustomThemes();
+    createCustomTheme({ name: 'Taken' });
+
+    expect(isDuplicateName('Taken')).toBe(true);
+    expect(isDuplicateName('Free')).toBe(false);
+  });
+
+  it('excludes a given id from the duplicate-name check', () => {
+    // Editing a theme without renaming it must not flag the theme against itself.
+    const { createCustomTheme, isDuplicateName } = useCustomThemes();
+    const created = createCustomTheme({ name: 'Taken' });
+
+    expect(isDuplicateName('Taken', created.id)).toBe(false);
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/composables/useCustomThemes.js
+++ b/kolibri/plugins/epub_viewer/frontend/composables/useCustomThemes.js
@@ -1,0 +1,57 @@
+import { ref } from 'vue';
+import Lockr from 'lockr';
+import { v4 as uuidv4 } from 'uuid';
+import { CUSTOM_THEMES_STORAGE_KEY } from '../views/EpubConstants';
+
+/**
+ * Persistence for learner-defined EPUB themes.
+ *
+ * Themes are stored in localStorage as a map keyed by a stable uuid `id`, so a
+ * theme's identity is independent of its (editable) `name`. The reactive map is
+ * created once at module scope and shared by every consumer, so a mutation made
+ * through one component is immediately reflected in all of them; localStorage is
+ * kept in sync as the persistent source of truth.
+ */
+const customThemes = ref(Lockr.get(CUSTOM_THEMES_STORAGE_KEY) || {});
+
+function persist() {
+  Lockr.set(CUSTOM_THEMES_STORAGE_KEY, customThemes.value);
+}
+
+export default function useCustomThemes() {
+  function save(id, theme) {
+    const stored = { ...theme, id };
+    customThemes.value = { ...customThemes.value, [id]: stored };
+    persist();
+    return stored;
+  }
+
+  function createCustomTheme(theme) {
+    return save(uuidv4(), theme);
+  }
+
+  function updateCustomTheme(id, theme) {
+    return save(id, theme);
+  }
+
+  function removeCustomTheme(id) {
+    const next = { ...customThemes.value };
+    delete next[id];
+    customThemes.value = next;
+    persist();
+  }
+
+  function isDuplicateName(name, excludeId = null) {
+    return Object.values(customThemes.value).some(
+      theme => theme.name === name && theme.id !== excludeId,
+    );
+  }
+
+  return {
+    customThemes,
+    createCustomTheme,
+    updateCustomTheme,
+    removeCustomTheme,
+    isDuplicateName,
+  };
+}

--- a/kolibri/plugins/epub_viewer/frontend/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/AddEditCustomThemeModal.vue
@@ -1,0 +1,385 @@
+<template>
+
+  <!-- A single KModal hosts both the theme form and the color picker, swapping its
+       content rather than mounting a second modal. Mounting a second KModal makes
+       its overlay fade in from transparent while the first is removed at full
+       opacity, which reads as a white flash between the two. -->
+  <KModal
+    :title="modalTitle"
+    :submitText="modalSubmitText"
+    :cancelText="coreString('cancelAction')"
+    :disabled="!showColorPicker && submitting"
+    @submit="handleModalSubmit"
+    @cancel="handleModalCancel"
+  >
+    <template v-if="!showColorPicker">
+      <KTextbox
+        ref="customThemeNameTextbox"
+        v-model.trim="customThemeName"
+        class="theme-name"
+        type="text"
+        :label="customThemeNameLabel$()"
+        :autofocus="false"
+        :disabled="submitting"
+        :invalid="customThemeNameIsInvalid"
+        :invalidText="customThemeNameIsInvalidText"
+        :maxlength="maxThemeNameLength"
+      />
+
+      <h2 class="theme-preview-heading">
+        {{ customThemePreview$() }}
+      </h2>
+
+      <div
+        class="theme-preview"
+        role="img"
+        :aria-label="customThemePreview$()"
+        :style="{
+          backgroundColor: tempTheme.backgroundColor,
+          color: tempTheme.textColor,
+          borderColor: $themeTokens.fineLine,
+        }"
+      >
+        <h3>{{ thisIsASampleText$() }}</h3>
+        <p>
+          {{ samplePreviewText$() }}
+          <a :style="{ color: tempTheme.linkColor }">{{ linkPreviewText$() }}</a>
+        </p>
+      </div>
+
+      <div
+        class="color-select-container"
+        :class="{ 'color-select-container-mobile': windowIsSmall }"
+      >
+        <div class="theme-option-container">
+          <KButton
+            ref="backgroundColorButton"
+            class="theme-color-button"
+            :aria-label="selectBackgroundColor$()"
+            :appearanceOverrides="
+              themeColorOptionStyles(tempTheme.backgroundColor, $themeTokens.fineLine)
+            "
+            @click="openColorPicker('backgroundColor')"
+          />
+          <p>{{ themeBackgroundColorButtonDescription$() }}</p>
+        </div>
+
+        <div class="theme-option-container">
+          <KButton
+            ref="textColorButton"
+            class="theme-color-button"
+            :aria-label="selectTextColor$()"
+            :appearanceOverrides="
+              themeColorOptionStyles(tempTheme.textColor, $themeTokens.fineLine)
+            "
+            @click="openColorPicker('textColor')"
+          />
+          <p>{{ themeTextColorButtonDescription$() }}</p>
+        </div>
+
+        <div class="theme-option-container">
+          <KButton
+            ref="linkColorButton"
+            class="theme-color-button"
+            :aria-label="selectLinkColor$()"
+            :appearanceOverrides="
+              themeColorOptionStyles(tempTheme.linkColor, $themeTokens.fineLine)
+            "
+            @click="openColorPicker('linkColor')"
+          />
+          <p>{{ themeLinkColorButtonDescription$() }}</p>
+        </div>
+      </div>
+    </template>
+
+    <ColorPicker
+      v-else
+      :color="tempTheme[showColorPicker]"
+      @change="pendingColor = $event"
+    />
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { computed, ref, onMounted, nextTick } from 'vue';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { coreString } from 'kolibri/uiText/commonCoreStrings';
+  import useCustomThemes from '../composables/useCustomThemes';
+  import { DEFAULT_LINK_COLOR, MAX_THEME_NAME_LENGTH, deriveHoverColor } from './EpubConstants';
+  import { customThemeStrings } from './customThemeStrings';
+  import ColorPicker from './ColorPicker';
+
+  export default {
+    name: 'AddEditCustomThemeModal',
+    components: {
+      ColorPicker,
+    },
+    setup(props, { emit }) {
+      const { windowIsSmall } = useKResponsiveWindow();
+      const { isDuplicateName } = useCustomThemes();
+      const {
+        addCustomThemeTitle$,
+        editCustomThemeTitle$,
+        addAction$,
+        customThemeNameLabel$,
+        duplicateCustomThemeName$,
+        customThemePreview$,
+        thisIsASampleText$,
+        samplePreviewText$,
+        linkPreviewText$,
+        themeBackgroundColorButtonDescription$,
+        themeTextColorButtonDescription$,
+        themeLinkColorButtonDescription$,
+        selectBackgroundColor$,
+        selectTextColor$,
+        selectLinkColor$,
+        titleSelectBackground$,
+        titleSelectText$,
+        titleSelectLink$,
+        titleSelectColor$,
+        selectAction$,
+      } = customThemeStrings;
+
+      const customThemeName = ref(props.themeName);
+      const submitting = ref(false);
+      const formSubmitted = ref(false);
+      const tempTheme = ref({
+        backgroundColor: props.theme.backgroundColor,
+        textColor: props.theme.textColor,
+        linkColor: props.theme.linkColor || DEFAULT_LINK_COLOR,
+      });
+      // The color field currently being picked (backgroundColor/textColor/linkColor),
+      // or null when the theme form is shown.
+      const showColorPicker = ref(null);
+      // Latest hex emitted by the color picker, applied to tempTheme on confirm.
+      const pendingColor = ref(null);
+      // In edit mode the theme's own name must not flag itself as a duplicate.
+      const excludeNameId = props.modalMode === 'edit' ? props.theme.id : null;
+
+      // Template refs
+      const customThemeNameTextbox = ref(null);
+      const backgroundColorButton = ref(null);
+      const textColorButton = ref(null);
+      const linkColorButton = ref(null);
+      const colorButtonRefs = {
+        backgroundColor: backgroundColorButton,
+        textColor: textColorButton,
+        linkColor: linkColorButton,
+      };
+
+      const generateTitle = computed(() => {
+        if (props.modalMode === 'add') {
+          return addCustomThemeTitle$();
+        } else if (props.modalMode === 'edit') {
+          return editCustomThemeTitle$();
+        }
+        return ''; // not supposed to happen
+      });
+      // A new theme is applied the moment it's added, so the add-mode button reads
+      // "Add" rather than "Save"; editing an existing theme keeps "Save".
+      const submitText = computed(() =>
+        props.modalMode === 'add' ? addAction$() : coreString('saveAction'),
+      );
+      const pickerTitle = computed(() => {
+        if (showColorPicker.value === 'backgroundColor') return titleSelectBackground$();
+        if (showColorPicker.value === 'textColor') return titleSelectText$();
+        if (showColorPicker.value === 'linkColor') return titleSelectLink$();
+        return titleSelectColor$();
+      });
+      // The single modal shows the picker's title/button while a color is being
+      // picked, and the theme form's otherwise.
+      const modalTitle = computed(() =>
+        showColorPicker.value ? pickerTitle.value : generateTitle.value,
+      );
+      const modalSubmitText = computed(() =>
+        showColorPicker.value ? selectAction$() : submitText.value,
+      );
+      const customThemeNameIsInvalidText = computed(() => {
+        if (!formSubmitted.value) {
+          if (customThemeName.value === '') {
+            return coreString('requiredFieldError');
+          }
+          if (isDuplicateName(customThemeName.value, excludeNameId)) {
+            return duplicateCustomThemeName$();
+          }
+        }
+        return '';
+      });
+      const customThemeNameIsInvalid = computed(() => Boolean(customThemeNameIsInvalidText.value));
+      const formIsValid = computed(() => !customThemeNameIsInvalid.value);
+
+      onMounted(() => {
+        customThemeNameTextbox.value.focus();
+      });
+
+      function openColorPicker(field) {
+        // Seed the pending color so confirming without touching the picker keeps
+        // the field's current value.
+        pendingColor.value = tempTheme.value[field];
+        showColorPicker.value = field;
+      }
+      function restoreColorButtonFocus() {
+        const buttonRef = colorButtonRefs[showColorPicker.value];
+        showColorPicker.value = null;
+        nextTick(() => {
+          buttonRef.value.$el.focus();
+        });
+      }
+      function confirmColor() {
+        // Rewrite the whole object rather than mutating a key, so a plain ref suffices.
+        tempTheme.value = { ...tempTheme.value, [showColorPicker.value]: pendingColor.value };
+        restoreColorButtonFocus();
+      }
+      // The modal's submit/cancel drive either the picker or the form depending on
+      // which content is showing.
+      function handleModalSubmit() {
+        if (showColorPicker.value) {
+          confirmColor();
+        } else {
+          handleSubmit();
+        }
+      }
+      function handleModalCancel() {
+        if (showColorPicker.value) {
+          restoreColorButtonFocus();
+        } else {
+          emit('cancel');
+        }
+      }
+      function handleSubmit() {
+        submitting.value = true;
+        if (formIsValid.value) {
+          formSubmitted.value = true;
+          emit('submit', {
+            ...tempTheme.value,
+            name: customThemeName.value,
+            hoverColor: deriveHoverColor(tempTheme.value.backgroundColor),
+          });
+        } else {
+          submitting.value = false;
+          customThemeNameTextbox.value.focus();
+        }
+      }
+      function themeColorOptionStyles(bgColor, borderColor) {
+        return {
+          backgroundColor: bgColor,
+          border: `1px solid ${borderColor}`,
+          ':hover': {
+            backgroundColor: bgColor,
+            opacity: 0.9,
+            boxShadow: '0 1px 4px',
+          },
+        };
+      }
+
+      return {
+        coreString,
+        windowIsSmall,
+        maxThemeNameLength: MAX_THEME_NAME_LENGTH,
+        customThemeName,
+        submitting,
+        tempTheme,
+        showColorPicker,
+        pendingColor,
+        customThemeNameTextbox,
+        backgroundColorButton,
+        textColorButton,
+        linkColorButton,
+        modalTitle,
+        modalSubmitText,
+        customThemeNameIsInvalid,
+        customThemeNameIsInvalidText,
+        openColorPicker,
+        handleModalSubmit,
+        handleModalCancel,
+        themeColorOptionStyles,
+        customThemeNameLabel$,
+        customThemePreview$,
+        thisIsASampleText$,
+        samplePreviewText$,
+        linkPreviewText$,
+        themeBackgroundColorButtonDescription$,
+        themeTextColorButtonDescription$,
+        themeLinkColorButtonDescription$,
+        selectBackgroundColor$,
+        selectTextColor$,
+        selectLinkColor$,
+      };
+    },
+    props: {
+      modalMode: {
+        type: String,
+        required: true,
+      },
+      theme: {
+        type: Object,
+        required: true,
+      },
+      themeName: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .theme-name {
+    margin: 24px;
+  }
+
+  .theme-preview {
+    padding: 24px;
+    margin: 12px 24px;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 4px;
+  }
+
+  .theme-preview-heading {
+    margin: 0 24px;
+  }
+
+  .color-select-container {
+    display: flex;
+  }
+
+  .theme-option-container {
+    flex: 1;
+    padding: 10px;
+    text-align: center;
+  }
+
+  .theme-color-button {
+    width: 75px;
+    height: 48px;
+    margin: 0 auto;
+    border-radius: 4px;
+    transition: box-shadow 0.3s ease-in-out;
+  }
+
+  .color-select-container-mobile {
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+    margin: auto;
+  }
+
+  .color-select-container-mobile .theme-option-container {
+    display: flex;
+    flex-direction: row-reverse;
+    width: 100%;
+    margin-left: 10px;
+  }
+
+  .color-select-container-mobile .theme-option-container .theme-color-button {
+    margin-right: 10px;
+  }
+
+</style>

--- a/kolibri/plugins/epub_viewer/frontend/views/ColorPicker.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/ColorPicker.vue
@@ -1,0 +1,99 @@
+<template>
+
+  <div ref="pickerRoot">
+    <div ref="colorPickerEl"></div>
+    <div
+      ref="pickerBox"
+      class="picker-box"
+    ></div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+  import Alwan from 'alwan';
+  import 'alwan/dist/css/alwan.min.css';
+
+  export default {
+    name: 'ColorPicker',
+    setup(props, { emit }) {
+      const pickerRoot = ref(null);
+      const colorPickerEl = ref(null);
+      const pickerBox = ref(null);
+      let alwanInstance;
+
+      onMounted(() => {
+        alwanInstance = new Alwan(colorPickerEl.value, {
+          theme: 'light',
+          toggle: false,
+          popover: false,
+          preset: false,
+          color: props.color,
+          default: props.color,
+          target: pickerBox.value,
+          opacity: false,
+        });
+        alwanInstance.on('change', color => {
+          // alwan reports the color as an object; emit only the hex string so the
+          // value stays consistent with the string we were initialized with.
+          emit('change', color.hex);
+        });
+        patchAlwanAccessibility(pickerRoot.value);
+      });
+
+      onUnmounted(() => {
+        if (alwanInstance) {
+          alwanInstance.destroy();
+        }
+      });
+
+      // alwan ships two a11y defects in its own markup that it does not expose
+      // through its API, and that axe flags. Patch them once the widget has
+      // rendered:
+      //  - its 2D spectrum is a focusable div carrying an aria-label but no role
+      //    (aria-prohibited-attr); give it a role that legitimately accepts a name.
+      //  - its control icons use the invalid attribute aria-role="none"
+      //    (aria-valid-attr); replace it with aria-hidden so AT skips the
+      //    decorative svgs.
+      function patchAlwanAccessibility(root) {
+        nextTick(() => {
+          const palette = root.querySelector('.alwan__palette');
+          if (palette && !palette.hasAttribute('role')) {
+            palette.setAttribute('role', 'application');
+          }
+          root.querySelectorAll('svg[aria-role]').forEach(svg => {
+            svg.removeAttribute('aria-role');
+            svg.setAttribute('aria-hidden', 'true');
+          });
+        });
+      }
+
+      return {
+        pickerRoot,
+        colorPickerEl,
+        pickerBox,
+      };
+    },
+    props: {
+      color: {
+        type: String,
+        default: '#000000',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .picker-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+</style>

--- a/kolibri/plugins/epub_viewer/frontend/views/CustomThemeItem.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/CustomThemeItem.vue
@@ -1,0 +1,148 @@
+<template>
+
+  <div class="theme-item">
+    <KButton
+      ref="colorButton"
+      class="theme-color-button"
+      :aria-label="setCustomTheme$({ themeName: theme.name })"
+      :appearanceOverrides="themeStyle($coreOutline)"
+      @click="$emit('setCustomTheme', theme)"
+    >
+      <div class="theme-color-button-content">
+        <KIcon
+          v-if="isApplied"
+          icon="check"
+          :style="{ fill: appliedIndicatorColor }"
+          class="applied-icon"
+        />
+        <div class="truncate">{{ theme.name }}</div>
+      </div>
+    </KButton>
+
+    <KButton
+      ref="editButton"
+      appearance="flat-button"
+      :aria-label="editCustomTheme$({ themeName: theme.name })"
+      :text="edit$()"
+      @click="$emit('editCustomTheme', theme)"
+    />
+
+    <KButton
+      ref="deleteButton"
+      appearance="flat-button"
+      :aria-label="deleteCustomTheme$({ themeName: theme.name })"
+      :text="delete$()"
+      @click="$emit('deleteCustomTheme', theme)"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed } from 'vue';
+  import { customThemeStrings } from './customThemeStrings';
+  import { isDarkColor } from './EpubConstants';
+
+  export default {
+    name: 'CustomThemeItem',
+    setup(props) {
+      const { setCustomTheme$, deleteCustomTheme$, editCustomTheme$, delete$, edit$ } =
+        customThemeStrings;
+
+      // The applied-state check and outline must contrast with the swatch
+      // background, not the theme's text color — otherwise a theme whose text
+      // color is close to its background (a valid choice) would hide them.
+      const appliedIndicatorColor = computed(() =>
+        isDarkColor(props.theme.backgroundColor) ? '#ffffff' : '#212121',
+      );
+
+      // coreOutline is passed from the template, where $coreOutline is available,
+      // so the component doesn't depend on Vue's getCurrentInstance escape hatch.
+      function themeStyle(coreOutline) {
+        return {
+          ':focus': {
+            ...coreOutline,
+            outlineOffset: '0px',
+            outlineWidth: '2px',
+          },
+          backgroundColor: props.theme.backgroundColor,
+          color: props.theme.textColor,
+          // Mark the applied theme with a bold inset ring that contrasts with the
+          // swatch, so selection reads at a glance alongside the checkmark. Inset
+          // (not a border) avoids shifting the swatch's fixed dimensions.
+          ...(props.isApplied
+            ? { boxShadow: `inset 0 0 0 3px ${appliedIndicatorColor.value}` }
+            : {}),
+          ':hover': {
+            backgroundColor: props.theme.hoverColor,
+          },
+        };
+      }
+
+      return {
+        themeStyle,
+        appliedIndicatorColor,
+        setCustomTheme$,
+        deleteCustomTheme$,
+        editCustomTheme$,
+        delete$,
+        edit$,
+      };
+    },
+    props: {
+      theme: {
+        type: Object,
+        required: true,
+      },
+      isApplied: {
+        type: Boolean,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import './EpubStyles';
+
+  .theme-item {
+    display: flex;
+    align-items: center;
+    margin-top: 16px;
+  }
+
+  .truncate {
+    max-width: 100%;
+    @include truncate-text;
+  }
+
+  .theme-color-button {
+    flex: 1;
+    min-width: 0;
+    height: 64px;
+    padding: 8px;
+    margin: 2px;
+    border-radius: 8px;
+  }
+
+  // Stack the applied check above the name, centered, so neither overflows the
+  // fixed-height swatch (mirrors the fixed-theme buttons in SettingsSideBar).
+  .theme-color-button-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .applied-icon {
+    top: 0;
+    width: 24px;
+    height: 24px;
+  }
+
+</style>

--- a/kolibri/plugins/epub_viewer/frontend/views/DeleteCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/DeleteCustomThemeModal.vue
@@ -1,0 +1,45 @@
+<template>
+
+  <KModal
+    :title="titleDeleteTheme$()"
+    :submitText="coreString('deleteAction')"
+    :cancelText="coreString('cancelAction')"
+    @submit="$emit('submit')"
+    @cancel="$emit('cancel')"
+  >
+    <p v-if="themeName">
+      {{ confirmationQuestion$({ themeName }) }}
+    </p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { coreString } from 'kolibri/uiText/commonCoreStrings';
+  import { customThemeStrings } from './customThemeStrings';
+
+  export default {
+    name: 'DeleteCustomThemeModal',
+    setup() {
+      const { confirmationQuestion$, titleDeleteTheme$ } = customThemeStrings;
+      return {
+        coreString,
+        confirmationQuestion$,
+        titleDeleteTheme$,
+      };
+    },
+    props: {
+      themeName: {
+        type: String,
+        default: null,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/epub_viewer/frontend/views/EpubConstants.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/EpubConstants.js
@@ -1,42 +1,123 @@
 // colors are hardcoded deliberately since Epub Reader
-// themes are meant to be independent of Kolibri themes
+// themes are meant to be independent of Kolibri themes.
+// Each fixed theme carries an `id` (equal to its key) that identifies it
+// independently of its colors, and a `linkColor` chosen to stay legible on the
+// theme's background (a dark blue on light themes, a light blue on dark ones).
 export const THEMES = {
   WHITE: {
+    id: 'WHITE',
     name: 'WHITE',
     backgroundColor: '#ffffff',
     hoverColor: '#eeeeee',
     textColor: '#212121',
+    linkColor: '#1565c0',
   },
   BEIGE: {
+    id: 'BEIGE',
     name: 'BEIGE',
     backgroundColor: '#efebe9',
     hoverColor: '#d7ccc8',
     textColor: '#4e342e',
+    linkColor: '#1565c0',
   },
   GREY: {
+    id: 'GREY',
     name: 'GREY',
     backgroundColor: '#424242',
     hoverColor: '#757575',
     textColor: '#ffffff',
+    linkColor: '#90caf9',
   },
   BLACK: {
+    id: 'BLACK',
     name: 'BLACK',
     backgroundColor: '#212121',
     hoverColor: '#616161',
     textColor: '#bdbdbd',
+    linkColor: '#90caf9',
   },
   YELLOW: {
+    id: 'YELLOW',
     name: 'YELLOW',
     backgroundColor: '#212121',
     hoverColor: '#616161',
     textColor: '#fff176',
+    linkColor: '#90caf9',
   },
   BLUE: {
+    id: 'BLUE',
     name: 'BLUE',
     backgroundColor: '#ffffff',
     hoverColor: '#eeeeee',
     textColor: '#1565c0',
+    linkColor: '#0d47a1',
   },
 };
 
-export const darkThemeNames = ['BLACK', 'GREY', 'YELLOW'];
+// Resolve a persisted theme snapshot to its live definition. Fixed themes are
+// re-resolved by id so saved selections pick up current colors (e.g. link
+// colors); a legacy snapshot saved before themes had ids is resolved by name.
+// Custom themes (uuid ids, absent from THEMES) are returned untouched.
+export function resolveTheme(theme) {
+  if (!theme) {
+    return THEMES.WHITE;
+  }
+  if (theme.id) {
+    return THEMES[theme.id] || theme;
+  }
+  return THEMES[theme.name] || theme;
+}
+
+// localStorage key under which learner-defined custom themes are persisted
+export const CUSTOM_THEMES_STORAGE_KEY = 'kolibriEpubRendererCustomThemes';
+
+// every theme defines its own link color; this only guards against a malformed
+// snapshot that somehow lacks one, falling back to the browser default link blue
+export const DEFAULT_LINK_COLOR = '#0000EE';
+
+// the most custom themes a learner can keep at once
+export const MAX_CUSTOM_THEMES = 8;
+
+// maximum length of a custom theme name the learner can enter
+export const MAX_THEME_NAME_LENGTH = 50;
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const full =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map(char => char + char)
+          .join('')
+      : normalized;
+  return [0, 2, 4].map(start => parseInt(full.slice(start, start + 2), 16));
+}
+
+function toHexPair(value) {
+  return Math.round(value).toString(16).padStart(2, '0');
+}
+
+// Perceived brightness (ITU-R BT.601) of a hex color, on a 0–255 scale.
+function perceivedLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+// Whether a background color is dark enough that overlaid controls need a light
+// (rather than dark) treatment to stay visible. Used for both fixed and custom
+// themes, so a dark custom theme gets legible navigation arrows.
+export function isDarkColor(hex) {
+  return perceivedLuminance(hex) <= 128;
+}
+
+// Custom themes only capture background/text/link colors, but theme buttons shift
+// their background on hover. Derive a subtle hover shade by blending the background
+// toward black (for light backgrounds) or white (for dark ones), mirroring how the
+// fixed themes pair a background with a contrasting hover color.
+export function deriveHoverColor(backgroundColor) {
+  const [r, g, b] = hexToRgb(backgroundColor);
+  const blendTarget = isDarkColor(backgroundColor) ? 255 : 0;
+  const blendRatio = 0.12;
+  const blend = channel => channel + (blendTarget - channel) * blendRatio;
+  return `#${toHexPair(blend(r))}${toHexPair(blend(g))}${toHexPair(blend(b))}`;
+}

--- a/kolibri/plugins/epub_viewer/frontend/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/EpubRendererIndex.vue
@@ -73,6 +73,7 @@
           @decreaseFontSize="handleChangeFontSize(-1)"
           @increaseFontSize="handleChangeFontSize(+1)"
           @setTheme="setTheme"
+          @closeSideBar="handleSettingToggle"
         />
       </FocusLock>
 
@@ -166,7 +167,6 @@
   import Epub from 'epubjs/src/epub';
   import { EVENTS } from 'epubjs/src/utils/constants';
   import Mark from 'mark.js';
-  import isEqual from 'lodash/isEqual';
   import get from 'lodash/get';
   import clamp from 'lodash/clamp';
   import Lockr from 'lockr';
@@ -189,7 +189,7 @@
   import SettingsButton from './SettingsButton';
   import SearchButton from './SearchButton';
 
-  import { THEMES, darkThemeNames } from './EpubConstants';
+  import { THEMES, isDarkColor, DEFAULT_LINK_COLOR, resolveTheme } from './EpubConstants';
 
   const FONT_SIZE_MIN = 8;
   const FONT_SIZE_MAX = 32;
@@ -312,6 +312,9 @@
       textColor() {
         return this.theme.textColor;
       },
+      linkColor() {
+        return this.theme.linkColor || DEFAULT_LINK_COLOR;
+      },
       themeStyle() {
         const colorStyle = {
           'background-color': `${this.backgroundColor}!important`,
@@ -350,6 +353,7 @@
           // help media not overflow their columns
           video: { 'max-width': '100%' },
           img: { 'max-width': '100%' },
+          a: { color: `${this.linkColor}!important` },
         };
       },
       tocSideBarIsOpen() {
@@ -367,9 +371,9 @@
         };
       },
       navigationButtonColor() {
-        return darkThemeNames.some(themeName => isEqual(this.theme.name, themeName))
-          ? 'white'
-          : 'black';
+        // Choose arrow color from the actual background luminance so custom themes
+        // (which aren't in the fixed set) get legible arrows on dark backgrounds too.
+        return isDarkColor(this.backgroundColor) ? 'white' : 'black';
       },
       bottomBarHeading() {
         if (this.currentSection) {
@@ -438,7 +442,9 @@
 
       const { theme = this.theme, fontSize = this.fontSize } =
         Lockr.get(EPUB_RENDERER_SETTINGS_KEY) || {};
-      this.theme = theme;
+      // resolveTheme re-resolves fixed themes to their live definition so a saved
+      // selection picks up an id (for matching) and current colors (e.g. link color).
+      this.theme = resolveTheme(theme);
       this.fontSize = fontSize;
     },
     mounted() {

--- a/kolibri/plugins/epub_viewer/frontend/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/SettingsSideBar.vue
@@ -1,8 +1,19 @@
 <template>
 
-  <SideBar>
+  <SideBar :class="['epub-sidebar', getClassByWindowSize]">
+    <div class="sidebar-titlebar">
+      <h2>{{ sideBarTitle$() }}</h2>
+      <KIconButton
+        :ariaLabel="closeSideBar$()"
+        icon="close"
+        @click="$emit('closeSideBar')"
+      />
+    </div>
+
+    <hr >
+
     <div class="o-f-h">
-      <h3>{{ $tr('textSize') }}</h3>
+      <h3>{{ textSize$() }}</h3>
       <KFixedGrid
         numCols="2"
         gutter="8"
@@ -17,11 +28,11 @@
             <template #icon>
               <KIcon
                 icon="minus"
-                style="top: 0; width: 24px; height: 24px"
+                class="font-size-icon"
               />
             </template>
             <div class="truncate">
-              {{ $tr('decrease') }}
+              {{ decrease$() }}
             </div>
           </KButton>
         </KFixedGridItem>
@@ -35,22 +46,24 @@
             <template #icon>
               <KIcon
                 icon="plus"
-                style="top: 0; width: 24px; height: 24px"
+                class="font-size-icon"
               />
             </template>
             <div class="truncate">
-              {{ $tr('increase') }}
+              {{ increase$() }}
             </div>
           </KButton>
         </KFixedGridItem>
       </KFixedGrid>
     </div>
 
+    <hr >
+
     <div class="o-f-h">
-      <h3>{{ $tr('theme') }}</h3>
+      <h3>{{ theme$() }}</h3>
       <KFixedGrid
-        numCols="4"
-        gutter="8"
+        numCols="3"
+        gutter="16"
       >
         <KFixedGridItem
           v-for="(value, key) in themes"
@@ -61,17 +74,77 @@
             class="settings-button theme-button"
             :aria-label="generateThemeAriaLabel(key)"
             :appearanceOverrides="generateStyle(value)"
+            :text="generateThemeName(key)"
             @click="$emit('setTheme', value)"
           >
-            <KIcon
-              v-if="isCurrentlySelectedTheme(value)"
-              icon="check"
-              :style="{ fill: value.textColor }"
-              style="top: 0; width: 24px; height: 24px"
-            />
+            <div class="default-theme-selected">
+              <KIcon
+                v-if="isCurrentlySelectedTheme(value)"
+                icon="check"
+                :style="{ fill: value.textColor }"
+                class="default-theme-selected-icon"
+              />
+            </div>
           </KButton>
         </KFixedGridItem>
       </KFixedGrid>
+    </div>
+
+    <hr >
+
+    <div class="o-f-h">
+      <h3>{{ customTheme$() }}</h3>
+
+      <div>
+        <CustomThemeItem
+          v-for="(value, key) in customThemes"
+          :ref="instance => setCustomThemeItemRef(key, instance)"
+          :key="key"
+          :theme="value"
+          :isApplied="isCurrentlySelectedTheme(value)"
+          @setCustomTheme="$emit('setTheme', value)"
+          @deleteCustomTheme="themeToDelete = value"
+          @editCustomTheme="startEditCustomTheme(value)"
+        />
+
+        <!-- Button to add a new custom theme -->
+        <KFixedGrid
+          numCols="3"
+          gutter="16"
+        >
+          <KFixedGridItem
+            v-if="canAddCustomTheme"
+            span="3"
+          >
+            <KButton
+              ref="addCustomThemeButton"
+              class="settings-button theme-button"
+              :aria-label="addNewTheme$()"
+              :text="addNewTheme$()"
+              :icon="'plus'"
+              @click="newThemeName = generateNewThemeName()"
+            />
+          </KFixedGridItem>
+        </KFixedGrid>
+      </div>
+
+      <!-- Modal to confirm deletion of a custom theme -->
+      <DeleteCustomThemeModal
+        v-if="themeToDelete"
+        :themeName="themeToDelete.name"
+        @submit="deleteTheme(themeToDelete)"
+        @cancel="themeToDelete = null"
+      />
+
+      <!-- Modal to configure a custom theme -->
+      <AddEditCustomThemeModal
+        v-if="newThemeName || editingTheme"
+        :modalMode="newThemeName ? 'add' : 'edit'"
+        :theme="newThemeName ? theme : editingTheme"
+        :themeName="newThemeName ? newThemeName : editingTheme.name"
+        @submit="newThemeName ? createTheme($event) : updateTheme($event)"
+        @cancel="newThemeName ? cancelAdd() : cancelEdit()"
+      />
     </div>
   </SideBar>
 
@@ -80,13 +153,191 @@
 
 <script>
 
-  import { THEMES } from './EpubConstants';
+  import { ref, computed, nextTick } from 'vue';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import useCustomThemes from '../composables/useCustomThemes';
+  import { THEMES, MAX_CUSTOM_THEMES } from './EpubConstants';
+  import { customThemeStrings } from './customThemeStrings';
+  import { settingsSideBarStrings } from './settingsSideBarStrings';
   import SideBar from './SideBar';
+  import DeleteCustomThemeModal from './DeleteCustomThemeModal.vue';
+  import AddEditCustomThemeModal from './AddEditCustomThemeModal.vue';
+  import CustomThemeItem from './CustomThemeItem.vue';
 
   export default {
     name: 'SettingsSideBar',
     components: {
       SideBar,
+      DeleteCustomThemeModal,
+      AddEditCustomThemeModal,
+      CustomThemeItem,
+    },
+    setup(props, { emit }) {
+      const { windowIsLarge, windowIsMedium, windowIsSmall } = useKResponsiveWindow();
+      const { customThemes, createCustomTheme, updateCustomTheme, removeCustomTheme } =
+        useCustomThemes();
+      const { defaultThemeName$ } = customThemeStrings;
+      const {
+        sideBarTitle$,
+        closeSideBar$,
+        textSize$,
+        decrease$,
+        increase$,
+        theme$,
+        customTheme$,
+        addNewTheme$,
+        whiteTheme$,
+        beigeTheme$,
+        greyTheme$,
+        blackTheme$,
+        yellowTheme$,
+        blueTheme$,
+        setWhiteTheme$,
+        setBeigeTheme$,
+        setGreyTheme$,
+        setBlackTheme$,
+        setYellowTheme$,
+        setBlueTheme$,
+      } = settingsSideBarStrings;
+      // THEMES keys are internal constants, so both the visible label and the
+      // aria label come from translated strings keyed off them.
+      const themeStrings = {
+        WHITE: { name$: whiteTheme$, ariaLabel$: setWhiteTheme$ },
+        BEIGE: { name$: beigeTheme$, ariaLabel$: setBeigeTheme$ },
+        GREY: { name$: greyTheme$, ariaLabel$: setGreyTheme$ },
+        BLACK: { name$: blackTheme$, ariaLabel$: setBlackTheme$ },
+        YELLOW: { name$: yellowTheme$, ariaLabel$: setYellowTheme$ },
+        BLUE: { name$: blueTheme$, ariaLabel$: setBlueTheme$ },
+      };
+
+      // theme object pending deletion (null when no confirmation is open)
+      const themeToDelete = ref(null);
+      // theme object currently being edited (null when not editing)
+      const editingTheme = ref(null);
+      // default name for a theme being added (null when not adding)
+      const newThemeName = ref(null);
+
+      // Add-theme button, focused after a theme is created/deleted or the add modal closes.
+      const addCustomThemeButton = ref(null);
+      // CustomThemeItem instances keyed by theme id, for restoring focus after edit.
+      const customThemeItemRefs = {};
+      function setCustomThemeItemRef(id, instance) {
+        if (instance) {
+          customThemeItemRefs[id] = instance;
+        } else {
+          delete customThemeItemRefs[id];
+        }
+      }
+
+      const canAddCustomTheme = computed(
+        () => Object.keys(customThemes.value).length < MAX_CUSTOM_THEMES,
+      );
+
+      const getClassByWindowSize = computed(() => {
+        if (windowIsLarge.value) return 'large';
+        if (windowIsMedium.value) return 'medium';
+        if (windowIsSmall.value) return 'small';
+        return null;
+      });
+
+      function startEditCustomTheme(theme) {
+        editingTheme.value = theme;
+      }
+
+      function generateNewThemeName() {
+        // Pick the lowest index that isn't already taken, so a name freed up by
+        // a deletion doesn't collide with a still-present theme.
+        const existingNames = Object.values(customThemes.value).map(theme => theme.name);
+        let index = 1;
+        while (existingNames.includes(defaultThemeName$({ index }))) {
+          index += 1;
+        }
+        return defaultThemeName$({ index });
+      }
+
+      function generateThemeName(themeKey) {
+        return themeStrings[themeKey] ? themeStrings[themeKey].name$() : '';
+      }
+
+      function generateThemeAriaLabel(themeKey) {
+        return themeStrings[themeKey] ? themeStrings[themeKey].ariaLabel$() : '';
+      }
+
+      // After each add/edit/delete the modal closes, so focus is restored to a
+      // sensible button. KButton gained a public focus() method in KDS 5.8.0; until
+      // we upgrade from 5.7.0 we focus its root element directly via $el (which is
+      // exactly what that method does internally).
+      function createTheme(tempTheme) {
+        const created = createCustomTheme(tempTheme);
+        emit('setTheme', created);
+        newThemeName.value = null;
+        nextTick(() => {
+          customThemeItemRefs[created.id].$refs.colorButton.$el.focus();
+        });
+      }
+
+      function updateTheme(tempTheme) {
+        const updated = updateCustomTheme(editingTheme.value.id, tempTheme);
+        emit('setTheme', updated);
+        editingTheme.value = null;
+        nextTick(() => {
+          customThemeItemRefs[updated.id].$refs.editButton.$el.focus();
+        });
+      }
+
+      function deleteTheme(theme) {
+        removeCustomTheme(theme.id);
+        themeToDelete.value = null;
+        if (theme.id === props.theme.id) {
+          emit('setTheme', THEMES.WHITE); // apply the default theme
+        }
+        nextTick(() => {
+          addCustomThemeButton.value.$el.focus();
+        });
+      }
+
+      function cancelAdd() {
+        newThemeName.value = null;
+        nextTick(() => {
+          addCustomThemeButton.value.$el.focus();
+        });
+      }
+
+      function cancelEdit() {
+        const { id } = editingTheme.value;
+        editingTheme.value = null;
+        nextTick(() => {
+          customThemeItemRefs[id].$refs.editButton.$el.focus();
+        });
+      }
+
+      return {
+        customThemes,
+        themeToDelete,
+        editingTheme,
+        newThemeName,
+        addCustomThemeButton,
+        setCustomThemeItemRef,
+        canAddCustomTheme,
+        getClassByWindowSize,
+        startEditCustomTheme,
+        generateNewThemeName,
+        generateThemeName,
+        generateThemeAriaLabel,
+        createTheme,
+        updateTheme,
+        deleteTheme,
+        cancelAdd,
+        cancelEdit,
+        sideBarTitle$,
+        closeSideBar$,
+        textSize$,
+        decrease$,
+        increase$,
+        theme$,
+        customTheme$,
+        addNewTheme$,
+      };
     },
     props: {
       theme: {
@@ -119,74 +370,18 @@
       },
     },
     methods: {
-      generateThemeAriaLabel(themeName) {
-        switch (themeName) {
-          case 'WHITE':
-            return this.$tr('setWhiteTheme');
-          case 'BEIGE':
-            return this.$tr('setBeigeTheme');
-          case 'GREY':
-            return this.$tr('setGreyTheme');
-          case 'BLACK':
-            return this.$tr('setBlackTheme');
-          default:
-            return '';
-        }
-      },
       isCurrentlySelectedTheme(theme) {
-        return (
-          theme.backgroundColor === this.theme.backgroundColor &&
-          theme.textColor === this.theme.textColor
-        );
+        return theme.id === this.theme.id;
       },
       generateStyle(theme) {
         return {
           ...this.settingsButtonFocus,
           backgroundColor: theme.backgroundColor,
+          color: theme.textColor,
           ':hover': {
             backgroundColor: theme.hoverColor,
           },
         };
-      },
-    },
-    $trs: {
-      textSize: {
-        message: 'Text size',
-        context:
-          'Indicate the size of the text in the EPUB reader. Learner can either decrease of increase the size of the text.',
-      },
-      decrease: {
-        message: 'Decrease',
-        context: 'Button used to make the EPUB reader text size smaller.',
-      },
-      increase: {
-        message: 'Increase',
-        context: 'Button used to make the EPUB reader text size larger.',
-      },
-      theme: {
-        message: 'Theme',
-        context:
-          "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option.",
-      },
-      setWhiteTheme: {
-        message: 'Set white theme',
-        context:
-          "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to white.",
-      },
-      setBeigeTheme: {
-        message: 'Set beige theme',
-        context:
-          "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to beige.",
-      },
-      setGreyTheme: {
-        message: 'Set grey theme',
-        context:
-          "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to grey.",
-      },
-      setBlackTheme: {
-        message: 'Set black theme',
-        context:
-          "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to black.",
       },
     },
   };
@@ -198,6 +393,32 @@
 
   @import './EpubStyles';
 
+  // Promote the theme modals' overlay onto its own compositing layer. On Safari a
+  // composited iframe (the rendered EPUB) can paint over a position:fixed overlay
+  // regardless of z-index; a null translateZ forces the overlay into its own layer
+  // so it stacks above the book. Mirrors the Safari layering fix in AuthBase
+  // (commit 04884db290).
+  /deep/ .modal-overlay {
+    transform: translateZ(1px);
+  }
+
+  hr {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+
+  .sidebar-titlebar {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .font-size-icon {
+    top: 0;
+    width: 24px;
+    height: 24px;
+  }
+
   .settings-button {
     width: calc(100% - 4px);
     min-width: unset;
@@ -208,9 +429,23 @@
   }
 
   .theme-button {
-    height: 44.5px;
+    height: 64px;
+    margin-top: 16px;
     border-style: solid;
     border-width: 2px;
+    border-radius: 8px;
+  }
+
+  .default-theme-selected {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .default-theme-selected-icon {
+    top: 0;
+    width: 24px;
+    height: 24px;
   }
 
   .o-f-h {
@@ -219,6 +454,18 @@
 
   .truncate {
     @include truncate-text;
+  }
+
+  .epub-sidebar.large {
+    width: 500px;
+  }
+
+  .epub-sidebar.medium {
+    width: 400px;
+  }
+
+  .epub-sidebar.small {
+    width: 100%;
   }
 
 </style>

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/AddEditCustomThemeModal.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/AddEditCustomThemeModal.spec.js
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/vue';
+import Lockr from 'lockr';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
+import AddEditCustomThemeModal from '../AddEditCustomThemeModal';
+import { THEMES, CUSTOM_THEMES_STORAGE_KEY, deriveHoverColor } from '../EpubConstants';
+import { customThemeStrings } from '../customThemeStrings';
+import useCustomThemes from '../../composables/useCustomThemes';
+
+// alwan (used by the nested ColorPicker) needs a canvas; stub it out, capturing
+// the 'change' callback so tests can simulate the user picking a color.
+let mockChangeCallback;
+jest.mock('alwan', () => ({
+  __esModule: true,
+  default: class Alwan {
+    on(event, callback) {
+      if (event === 'change') {
+        mockChangeCallback = callback;
+      }
+    }
+    destroy() {}
+  },
+}));
+
+const { customThemePreview$, selectBackgroundColor$, selectAction$, addAction$ } =
+  customThemeStrings;
+
+function renderModal(props = {}) {
+  return render(AddEditCustomThemeModal, {
+    props: {
+      modalMode: 'add',
+      theme: THEMES.WHITE,
+      themeName: 'myTheme1',
+      ...props,
+    },
+  });
+}
+
+// Add mode's submit button reads "Add"; edit mode keeps "Save".
+function clickSubmit(name = addAction$()) {
+  return fireEvent.click(screen.getByRole('button', { name }));
+}
+
+function seedCustomThemes(themes) {
+  useCustomThemes().customThemes.value = themes;
+}
+
+describe('AddEditCustomThemeModal', () => {
+  beforeEach(() => {
+    // The custom-themes map lives at module scope; reset it between tests.
+    useCustomThemes().customThemes.value = {};
+    Lockr.rm(CUSTOM_THEMES_STORAGE_KEY);
+  });
+
+  it('updates the preview when a new background color is picked', async () => {
+    renderModal();
+
+    // Open the color picker for the background, pick a color, and confirm it.
+    await fireEvent.click(screen.getByRole('button', { name: selectBackgroundColor$() }));
+    mockChangeCallback({ hex: '#abcdef' });
+    await fireEvent.click(screen.getByRole('button', { name: selectAction$() }));
+
+    expect(screen.getByRole('img', { name: customThemePreview$() })).toHaveStyle({
+      backgroundColor: '#abcdef',
+    });
+  });
+
+  it('saves a theme that carries a hoverColor derived from its background', async () => {
+    const { emitted } = renderModal();
+
+    await clickSubmit();
+
+    expect(emitted().submit).toBeTruthy();
+    const savedTheme = emitted().submit[0][0];
+    expect(savedTheme.hoverColor).toBe(deriveHoverColor(THEMES.WHITE.backgroundColor));
+  });
+
+  it('does not save when the name duplicates an existing theme', async () => {
+    seedCustomThemes({ 'id-1': { id: 'id-1', name: 'myTheme1' } });
+    const { emitted } = renderModal({ themeName: 'myTheme1' });
+
+    await clickSubmit();
+
+    // Name is non-empty, so a blocked save isolates the duplicate-name rule.
+    expect(emitted().submit).toBeFalsy();
+  });
+
+  it('saves an edited theme under its own existing name', async () => {
+    // In add mode this name would be rejected as a duplicate; edit mode must exclude
+    // the theme's own id from that check so the save goes through.
+    seedCustomThemes({ 'id-1': { id: 'id-1', name: 'myTheme1' } });
+    const { emitted } = renderModal({
+      modalMode: 'edit',
+      themeName: 'myTheme1',
+      theme: { ...THEMES.WHITE, id: 'id-1', name: 'myTheme1', linkColor: '#0000ee' },
+    });
+
+    await clickSubmit(coreString('saveAction'));
+
+    expect(emitted().submit).toBeTruthy();
+    expect(emitted().submit[0][0].name).toBe('myTheme1');
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/ColorPicker.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/ColorPicker.spec.js
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/vue';
+import ColorPicker from '../ColorPicker';
+
+// alwan instantiates a canvas-backed color picker on mount, which jsdom does not
+// implement. Replace it with a stub that captures the 'change' callback so tests
+// can simulate the user picking a color, and records the color it was initialized with.
+let mockChangeCallback;
+let mockInitColor;
+jest.mock('alwan', () => ({
+  __esModule: true,
+  default: class Alwan {
+    constructor(el, options) {
+      mockInitColor = options.color;
+    }
+    on(event, callback) {
+      if (event === 'change') {
+        mockChangeCallback = callback;
+      }
+    }
+    destroy() {}
+  },
+}));
+
+describe('ColorPicker', () => {
+  it('initializes alwan with the provided color', () => {
+    render(ColorPicker, { props: { color: '#abcdef' } });
+    expect(mockInitColor).toBe('#abcdef');
+  });
+
+  it('emits the picked color as a hex string', () => {
+    const { emitted } = render(ColorPicker, { props: { color: '#000000' } });
+
+    // alwan reports the chosen color as an object; the component should emit just
+    // the hex string.
+    mockChangeCallback({ hex: '#123456', rgb: 'rgb(18, 52, 86)' });
+
+    expect(emitted().change[0][0]).toBe('#123456');
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/CustomThemeItem.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/CustomThemeItem.spec.js
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/vue';
+import CustomThemeItem from '../CustomThemeItem';
+import { customThemeStrings } from '../customThemeStrings';
+
+const { setCustomTheme$, deleteCustomTheme$, editCustomTheme$ } = customThemeStrings;
+
+const theme = {
+  name: 'myTheme1',
+  backgroundColor: '#ffffff',
+  textColor: '#212121',
+  hoverColor: '#eeeeee',
+};
+
+function renderItem(props = {}) {
+  return render(CustomThemeItem, {
+    props: { theme, isApplied: false, ...props },
+  });
+}
+
+describe('CustomThemeItem', () => {
+  it('renders set, delete, and edit buttons labelled for the theme', () => {
+    renderItem();
+
+    expect(
+      screen.getByRole('button', { name: setCustomTheme$({ themeName: 'myTheme1' }) }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: deleteCustomTheme$({ themeName: 'myTheme1' }) }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: editCustomTheme$({ themeName: 'myTheme1' }) }),
+    ).toBeInTheDocument();
+  });
+
+  it('emits setCustomTheme with the theme when the color button is clicked', async () => {
+    const { emitted } = renderItem();
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: setCustomTheme$({ themeName: 'myTheme1' }) }),
+    );
+
+    expect(emitted().setCustomTheme[0][0]).toBe(theme);
+  });
+
+  it('keeps the full theme name in the DOM rather than truncating it in JS', () => {
+    // The name is truncated visually with CSS ellipsis, so the full string stays
+    // in the DOM (and in the button's accessible name) rather than being cut in JS.
+    renderItem({ theme: { ...theme, name: 'aReallyLongThemeName' } });
+
+    expect(
+      screen.getByRole('button', { name: setCustomTheme$({ themeName: 'aReallyLongThemeName' }) }),
+    ).toBeInTheDocument();
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/DeleteCustomThemeModal.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/DeleteCustomThemeModal.spec.js
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/vue';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
+import DeleteCustomThemeModal from '../DeleteCustomThemeModal';
+import { customThemeStrings } from '../customThemeStrings';
+
+const { titleDeleteTheme$, confirmationQuestion$ } = customThemeStrings;
+
+function renderModal(props = {}) {
+  return render(DeleteCustomThemeModal, {
+    props: { themeName: 'myTheme1', ...props },
+  });
+}
+
+describe('DeleteCustomThemeModal', () => {
+  it('titles the modal and asks to confirm deletion of the named theme', () => {
+    renderModal();
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(titleDeleteTheme$());
+    expect(screen.getByText(confirmationQuestion$({ themeName: 'myTheme1' }))).toBeInTheDocument();
+  });
+
+  it('emits submit when the delete button is clicked', async () => {
+    const { emitted } = renderModal();
+
+    await fireEvent.click(screen.getByRole('button', { name: coreString('deleteAction') }));
+
+    expect(emitted().submit).toBeTruthy();
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/EpubConstants.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/EpubConstants.spec.js
@@ -1,0 +1,65 @@
+import { deriveHoverColor, resolveTheme, THEMES } from '../EpubConstants';
+
+function channelSum(hex) {
+  const value = hex.replace('#', '');
+  return [0, 2, 4].reduce((sum, start) => sum + parseInt(value.slice(start, start + 2), 16), 0);
+}
+
+describe('deriveHoverColor', () => {
+  it('returns a valid 6-digit hex color', () => {
+    expect(deriveHoverColor('#3366cc')).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('darkens a light background', () => {
+    const hover = deriveHoverColor('#ffffff');
+    expect(hover).not.toBe('#ffffff');
+    expect(channelSum(hover)).toBeLessThan(channelSum('#ffffff'));
+  });
+
+  it('lightens a dark background', () => {
+    const hover = deriveHoverColor('#000000');
+    expect(hover).not.toBe('#000000');
+    expect(channelSum(hover)).toBeGreaterThan(channelSum('#000000'));
+  });
+
+  it('accepts shorthand hex notation', () => {
+    expect(deriveHoverColor('#fff')).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe('resolveTheme', () => {
+  it('resolves a fixed theme by id to the canonical theme', () => {
+    // A persisted snapshot may carry stale colors; resolving returns the live theme.
+    const stale = { id: 'WHITE', backgroundColor: '#ffffff', textColor: '#000000' };
+    expect(resolveTheme(stale)).toBe(THEMES.WHITE);
+  });
+
+  it('resolves a legacy fixed-theme snapshot (no id) by name', () => {
+    const legacy = { name: 'BLACK', backgroundColor: '#212121', textColor: '#bdbdbd' };
+    expect(resolveTheme(legacy)).toBe(THEMES.BLACK);
+  });
+
+  it('returns a custom theme unchanged', () => {
+    const custom = { id: 'a3f2-uuid', name: 'My theme', backgroundColor: '#abcdef' };
+    expect(resolveTheme(custom)).toBe(custom);
+  });
+
+  it('does not resolve a custom theme to a fixed theme that shares its name', () => {
+    // Identity is the uuid, so a custom theme named like a fixed one stays itself.
+    const custom = { id: 'b71c-uuid', name: 'WHITE', backgroundColor: '#abcdef' };
+    expect(resolveTheme(custom)).toBe(custom);
+  });
+
+  it('falls back to the default theme when given nothing', () => {
+    expect(resolveTheme(null)).toBe(THEMES.WHITE);
+  });
+});
+
+describe('fixed THEMES', () => {
+  it('every fixed theme carries a matching id and a link color', () => {
+    for (const [key, theme] of Object.entries(THEMES)) {
+      expect(theme.id).toBe(key);
+      expect(theme.linkColor).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/EpubRendererIndex.spec.js
@@ -1,5 +1,15 @@
 import EpubRendererIndex from '../EpubRendererIndex';
 
+// alwan (used by the settings sidebar's nested ColorPicker) needs a canvas,
+// which jsdom does not implement; stub it out so the module tree can load.
+jest.mock('alwan', () => ({
+  __esModule: true,
+  default: class Alwan {
+    on() {}
+    destroy() {}
+  },
+}));
+
 const { methods } = EpubRendererIndex;
 
 describe('updateProgress', () => {

--- a/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/__tests__/SettingsSideBar.spec.js
@@ -1,10 +1,44 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
-import { createTranslator } from 'kolibri/utils/i18n';
+import Lockr from 'lockr';
+import { coreString } from 'kolibri/uiText/commonCoreStrings';
 import SettingsSideBar from '../SettingsSideBar';
-import { THEMES } from '../EpubConstants';
+import { THEMES, CUSTOM_THEMES_STORAGE_KEY } from '../EpubConstants';
+import { customThemeStrings } from '../customThemeStrings';
+import { settingsSideBarStrings } from '../settingsSideBarStrings';
+import useCustomThemes from '../../composables/useCustomThemes';
 
-const { decrease$, increase$, setWhiteTheme$, setBeigeTheme$, setGreyTheme$, setBlackTheme$ } =
-  createTranslator(SettingsSideBar.name, SettingsSideBar.$trs);
+// alwan (used by the nested ColorPicker) needs a canvas, which jsdom does
+// not implement; stub it out so the module tree can load.
+jest.mock('alwan', () => ({
+  __esModule: true,
+  default: class Alwan {
+    on() {}
+    destroy() {}
+  },
+}));
+
+const {
+  decrease$,
+  increase$,
+  setWhiteTheme$,
+  setBeigeTheme$,
+  setGreyTheme$,
+  setBlackTheme$,
+  setYellowTheme$,
+  setBlueTheme$,
+  addNewTheme$,
+} = settingsSideBarStrings;
+
+const { setCustomTheme$, editCustomTheme$, deleteCustomTheme$, addAction$ } = customThemeStrings;
+
+const customTheme = {
+  id: 'abc',
+  name: 'Night',
+  backgroundColor: '#000000',
+  textColor: '#ffffff',
+  hoverColor: '#222222',
+  linkColor: '#90caf9',
+};
 
 function renderSettingsSideBar(props = {}) {
   return render(SettingsSideBar, {
@@ -15,23 +49,28 @@ function renderSettingsSideBar(props = {}) {
   });
 }
 
+function seedCustomThemes(themes) {
+  useCustomThemes().customThemes.value = themes;
+}
+
 describe('Settings side bar', () => {
-  it('renders font size controls and theme options', () => {
+  beforeEach(() => {
+    // The custom-themes map lives at module scope; reset it between tests.
+    useCustomThemes().customThemes.value = {};
+    Lockr.rm(CUSTOM_THEMES_STORAGE_KEY);
+  });
+
+  it('renders font size controls', () => {
     renderSettingsSideBar();
 
-    // Font buttons
-    expect(screen.getByText(decrease$())).toBeInTheDocument();
-    expect(screen.getByText(increase$())).toBeInTheDocument();
-
-    // Theme buttons (check a few representative ones)
-    expect(screen.getByLabelText(setWhiteTheme$())).toBeInTheDocument();
-    expect(screen.getByLabelText(setBeigeTheme$())).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: decrease$() })).toBeEnabled();
+    expect(screen.getByRole('button', { name: increase$() })).toBeEnabled();
   });
 
   it('emits event when decrease font size button is clicked', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByText(decrease$()));
+    await fireEvent.click(screen.getByRole('button', { name: decrease$() }));
 
     expect(emitted().decreaseFontSize).toBeTruthy();
   });
@@ -39,27 +78,103 @@ describe('Settings side bar', () => {
   it('emits event when increase font size button is clicked', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByText(increase$()));
+    await fireEvent.click(screen.getByRole('button', { name: increase$() }));
 
     expect(emitted().increaseFontSize).toBeTruthy();
   });
 
-  it('renders expected theme options', () => {
+  it('renders a button for every fixed theme', () => {
     renderSettingsSideBar();
 
-    const themeLabels = [setWhiteTheme$(), setBeigeTheme$(), setGreyTheme$(), setBlackTheme$()];
+    const themeLabels = [
+      setWhiteTheme$(),
+      setBeigeTheme$(),
+      setGreyTheme$(),
+      setBlackTheme$(),
+      setYellowTheme$(),
+      setBlueTheme$(),
+    ];
 
-    const renderedThemes = themeLabels.filter(label => screen.queryByLabelText(label));
+    const themeButtonNames = screen
+      .getAllByRole('button')
+      .map(button => button.getAttribute('aria-label'))
+      .filter(label => themeLabels.includes(label));
 
-    expect([2, 3, 4, 6]).toContain(renderedThemes.length);
+    expect(themeButtonNames).toEqual(themeLabels);
   });
 
-  it('emits event when a theme is selected', async () => {
+  it('emits setTheme with the selected theme when a theme is clicked', async () => {
     const { emitted } = renderSettingsSideBar();
 
-    await fireEvent.click(screen.getByLabelText(setWhiteTheme$()));
+    await fireEvent.click(screen.getByRole('button', { name: setWhiteTheme$() }));
 
     expect(emitted().setTheme).toBeTruthy();
     expect(emitted().setTheme[0][0]).toBe(THEMES.WHITE);
+  });
+
+  it('renders custom themes from storage and emits setTheme when one is clicked', async () => {
+    seedCustomThemes({ abc: customTheme });
+
+    const { emitted } = renderSettingsSideBar();
+    await fireEvent.click(
+      screen.getByRole('button', { name: setCustomTheme$({ themeName: 'Night' }) }),
+    );
+
+    expect(emitted().setTheme[0][0]).toEqual(customTheme);
+  });
+
+  it('opens the add-theme modal when "Add new theme" is clicked', async () => {
+    renderSettingsSideBar();
+
+    await fireEvent.click(screen.getByRole('button', { name: addNewTheme$() }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('creates a theme and emits setTheme when the add modal is submitted', async () => {
+    const { emitted } = renderSettingsSideBar();
+
+    await fireEvent.click(screen.getByRole('button', { name: addNewTheme$() }));
+    await fireEvent.click(screen.getByRole('button', { name: addAction$() }));
+
+    // The new theme is applied and now appears in the list under its default name.
+    const applied = emitted().setTheme[emitted().setTheme.length - 1][0];
+    expect(
+      screen.getByRole('button', { name: setCustomTheme$({ themeName: applied.name }) }),
+    ).toHaveFocus();
+  });
+
+  it('opens the edit modal and emits setTheme for the same theme when saved', async () => {
+    seedCustomThemes({ abc: customTheme });
+    const { emitted } = renderSettingsSideBar();
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: editCustomTheme$({ themeName: 'Night' }) }),
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: coreString('saveAction') }));
+
+    const updated = emitted().setTheme[emitted().setTheme.length - 1][0];
+    expect(updated.id).toBe('abc');
+    // Focus returns to the edited theme's edit button.
+    expect(
+      screen.getByRole('button', { name: editCustomTheme$({ themeName: 'Night' }) }),
+    ).toHaveFocus();
+  });
+
+  it('removes a custom theme when its deletion is confirmed', async () => {
+    seedCustomThemes({ abc: customTheme });
+    renderSettingsSideBar();
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: deleteCustomTheme$({ themeName: 'Night' }) }),
+    );
+    await fireEvent.click(screen.getByRole('button', { name: coreString('deleteAction') }));
+
+    expect(
+      screen.queryByRole('button', { name: setCustomTheme$({ themeName: 'Night' }) }),
+    ).not.toBeInTheDocument();
+    // Focus returns to the add-theme button after the row is removed.
+    expect(screen.getByRole('button', { name: addNewTheme$() })).toHaveFocus();
   });
 });

--- a/kolibri/plugins/epub_viewer/frontend/views/customThemeStrings.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/customThemeStrings.js
@@ -1,0 +1,132 @@
+import { createTranslator } from 'kolibri/utils/i18n';
+
+// Shared strings for the EPUB viewer custom-theme components: the add/edit modal,
+// the color picker, the theme list item, and the delete confirmation.
+export const customThemeStrings = createTranslator('CustomThemeStrings', {
+  // Add/edit modal
+  addCustomThemeTitle: {
+    message: 'Add new theme',
+    context: 'Title of the modal to add a new custom theme',
+  },
+  editCustomThemeTitle: {
+    message: 'Edit theme',
+    context: 'Title of the modal to edit an existing custom theme',
+  },
+  addAction: {
+    message: 'Add',
+    context:
+      'Button that adds and applies the new custom theme. The theme takes effect immediately, so this is labeled "Add" rather than "Save".',
+  },
+  customThemeNameLabel: {
+    message: 'Theme name',
+    context: 'Label for the textbox to enter the name of the custom theme',
+  },
+  duplicateCustomThemeName: {
+    message: 'A theme with this name already exists',
+    context: 'Error message when trying to add a custom theme with a name that already exists',
+  },
+  defaultThemeName: {
+    message: 'My theme {index, number}',
+    context:
+      'Default name pre-filled when a learner adds a new custom theme, where {index} is a number that keeps the name unique.',
+  },
+  customThemePreview: {
+    message: 'Theme preview',
+    context: 'Heading for the preview of the custom theme that is being created or edited',
+  },
+  thisIsASampleText: {
+    message: 'This is a sample text.',
+    context: 'Language specific sample text in the preview of the custom theme',
+  },
+  samplePreviewText: {
+    message: 'The quick brown fox jumps over the lazy dog.',
+    context: 'Language specific sample sentence shown in the preview of the custom theme',
+  },
+  linkPreviewText: {
+    message: 'This is a link',
+    context: 'Text that is a link in the preview of the custom theme',
+  },
+  themeBackgroundColorButtonDescription: {
+    message: 'Background',
+    context: 'Description of the button to change the background color of the custom theme',
+  },
+  themeTextColorButtonDescription: {
+    message: 'Text',
+    context: 'Description of the button to change the text color of the custom theme',
+  },
+  themeLinkColorButtonDescription: {
+    message: 'Links',
+    context: 'Description of the button to change the link color of the custom theme',
+  },
+  selectBackgroundColor: {
+    message: 'Select background color',
+    context: 'Aria label for the button to select the background color of the custom theme',
+  },
+  selectTextColor: {
+    message: 'Select text color',
+    context: 'Aria label for the button to select the text color of the custom theme',
+  },
+  selectLinkColor: {
+    message: 'Select link color',
+    context: 'Aria label for the button to select the link color of the custom theme',
+  },
+
+  // Color picker modal
+  titleSelectBackground: {
+    message: 'Select background color',
+    context: 'Title of window that displays when a user tries to select a new background color.',
+  },
+  titleSelectText: {
+    message: 'Select text color',
+    context: 'Title of window that displays when a user tries to select a new text color.',
+  },
+  titleSelectLink: {
+    message: 'Select link color',
+    context: 'Title of window that displays when a user tries to select a new link color.',
+  },
+  titleSelectColor: {
+    message: 'Select theme color',
+    context: 'Title of window that displays when a user tries to select a new theme color.',
+  },
+  selectAction: {
+    message: 'Select',
+    context: 'Button that selects a color.',
+  },
+
+  // Theme list item
+  edit: {
+    message: 'Edit',
+    context:
+      "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to edit a theme.",
+  },
+  delete: {
+    message: 'Delete',
+    context:
+      "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to delete a theme.",
+  },
+  setCustomTheme: {
+    message: "Set custom theme '{themeName}'",
+    context:
+      "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be set to {themeName}.",
+  },
+  editCustomTheme: {
+    message: "Edit custom theme '{themeName}'",
+    context:
+      "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be edited.",
+  },
+  deleteCustomTheme: {
+    message: "Delete custom theme '{themeName}'",
+    context:
+      "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be deleted.",
+  },
+
+  // Delete confirmation modal
+  titleDeleteTheme: {
+    message: 'Delete theme',
+    context: 'Title of window that displays when a user tries to delete a custom theme.',
+  },
+  confirmationQuestion: {
+    message: `Are you sure you want to delete '{themeName}' from your device?`,
+    context: 'Confirmation of delete message.',
+  },
+});

--- a/kolibri/plugins/epub_viewer/frontend/views/settingsSideBarStrings.js
+++ b/kolibri/plugins/epub_viewer/frontend/views/settingsSideBarStrings.js
@@ -1,0 +1,84 @@
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export const settingsSideBarStrings = createTranslator('SettingsSideBar', {
+  textSize: {
+    message: 'Text size',
+    context: 'Heading for the EPUB reader text-size controls.',
+  },
+  decrease: {
+    message: 'Decrease',
+    context: 'Button that makes the EPUB reader text smaller.',
+  },
+  increase: {
+    message: 'Increase',
+    context: 'Button that makes the EPUB reader text larger.',
+  },
+  theme: {
+    message: 'Themes',
+    context: 'Heading for the fixed background themes.',
+  },
+  customTheme: {
+    message: 'My themes',
+    context: 'Heading for the learner-created custom themes.',
+  },
+  addNewTheme: {
+    message: 'Add new theme',
+    context: 'Button that opens the modal to create a custom theme.',
+  },
+  whiteTheme: {
+    message: 'White',
+    context: 'Label on the white background theme button.',
+  },
+  beigeTheme: {
+    message: 'Beige',
+    context: 'Label on the beige background theme button.',
+  },
+  greyTheme: {
+    message: 'Grey',
+    context: 'Label on the grey background theme button.',
+  },
+  blackTheme: {
+    message: 'Black',
+    context: 'Label on the black background theme button.',
+  },
+  yellowTheme: {
+    message: 'Yellow',
+    context: 'Label on the yellow background theme button.',
+  },
+  blueTheme: {
+    message: 'Blue',
+    context: 'Label on the blue background theme button.',
+  },
+  setWhiteTheme: {
+    message: 'Set white theme',
+    context: 'Aria label for the white background theme button.',
+  },
+  setBeigeTheme: {
+    message: 'Set beige theme',
+    context: 'Aria label for the beige background theme button.',
+  },
+  setGreyTheme: {
+    message: 'Set grey theme',
+    context: 'Aria label for the grey background theme button.',
+  },
+  setBlackTheme: {
+    message: 'Set black theme',
+    context: 'Aria label for the black background theme button.',
+  },
+  setYellowTheme: {
+    message: 'Set yellow theme',
+    context: 'Aria label for the yellow background theme button.',
+  },
+  setBlueTheme: {
+    message: 'Set blue theme',
+    context: 'Aria label for the blue background theme button.',
+  },
+  closeSideBar: {
+    message: 'Close settings',
+    context: 'Aria label for the button that closes the settings sidebar.',
+  },
+  sideBarTitle: {
+    message: 'Settings',
+    context: 'Title of the EPUB reader settings sidebar.',
+  },
+});

--- a/kolibri/plugins/epub_viewer/package.json
+++ b/kolibri/plugins/epub_viewer/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
+    "alwan": "^1.3.0",
     "browserify-zlib": "^0.2.0",
     "epubjs": "0.3.84",
     "event-emitter": "^0.3.5",
@@ -17,6 +18,7 @@
     "marks-pane": "^1.0.9",
     "path-webpack": "^0.0.3",
     "url-polyfill": "^1.1.12",
+    "uuid": "^11.1.0",
     "vue": "catalog:",
     "vue-focus-lock": "^1.4.1",
     "web-streams-polyfill": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
 
   kolibri/plugins/epub_viewer:
     dependencies:
+      alwan:
+        specifier: ^1.3.0
+        version: 1.4.0
       browserify-zlib:
         specifier: ^0.2.0
         version: 0.2.0
@@ -353,6 +356,9 @@ importers:
       url-polyfill:
         specifier: ^1.1.12
         version: 1.1.14
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.1
       vue:
         specifier: 'catalog:'
         version: 2.7.16
@@ -4252,6 +4258,9 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  alwan@1.4.0:
+    resolution: {integrity: sha512-6eEECPJ5tKObAhPt5hTc6eYduEJbo8tH85WVwoAtEqn6qMBnu71CJ+0Nk23FQtyU1PLsTGBAYLNTc5e9D67DbQ==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -9607,6 +9616,10 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
@@ -13240,6 +13253,8 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alwan@1.4.0: {}
 
   ansi-colors@4.1.3: {}
 
@@ -19354,6 +19369,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.1: {}
 
   uuid@14.0.1: {}
 


### PR DESCRIPTION
## Summary

Brings the EPUB reader's **custom themes** feature — originally a GSoC contribution — to merge-readiness on the current codebase. Alongside the six fixed themes, learners can create, edit, and delete their own themes (background, text, and link colors), picked via a color picker and persisted per-device in `localStorage`.

The feature was functional in the GSoC branch; this branch modernises and hardens it.

| State | Screenshot |
|-------|------------|
| Add / edit theme modal | ![modal](https://i.imgur.com/JJHNeFM.png) |
| Color picker | ![picker](https://i.imgur.com/maHjGC7.png) |
| Custom theme applied (My themes list) | ![applied](https://i.imgur.com/G72UIhb.png) |
| Dark fixed theme — accessible link color | ![dark](https://i.imgur.com/LvccMKC.png) |

## References

Continues the custom-themes work from the GSoC-era [`epub-custom-themes`](https://github.com/learningequality/kolibri/tree/epub-custom-themes) branch (merge base ~July 2023). No tracking issue was filed for the original work.

## Reviewer guidance

**How to test:** Open any EPUB and open the reader settings (sliders icon). Under **Themes**, switch the six fixed themes — check link contrast on the dark ones (Black / Grey / Yellow). Under **My themes** (signed in), add a theme: name it, pick background/text/link colors, save; confirm it applies, appears in the list, and that rename/edit and delete work.

**Deliberate convention departure:** the six fixed themes are hardcoded hex in `EpubConstants.js` rather than `$themeTokens`/`$themePalette`, so EPUB reading palettes don't shift with Kolibri's app theme. Intentional, but it diverges from the "use theme tokens" guideline and is worth a deliberate decision.

Two maintenance notes:
- The `alwan` accessibility patch in `ColorPickerModal.vue` keys off the library's internal class/attribute names, so an `alwan` upgrade could silently turn it into a no-op.
- The focus-restore calls in `SettingsSideBar.vue` use `$refs.<button>.$el.focus()`. KButton gained a public `focus()` method in KDS 5.8.0, which internally just calls `this.$el.focus()`; we're pinned to 5.7.0, so we focus `$el` directly for now. Switch these to the public `focus()` when KDS is upgraded.

## AI usage

Used Claude Code throughout. It reviewed the GSoC-derived branch and, under my direction, modernised and hardened it — converting the components from Options (and mixed) API to Composition API, extracting persistence into the `useCustomThemes` composable, and adding stable theme ids, accessible link colors, CSS-ellipsis names, an `alwan` accessibility patch, and the test suite — then drove a headless browser to verify rendering and run axe audits on the new UI. I made the design decisions (theme identity, hardcoded vs token colors, auditing color-picker alternatives before keeping `alwan`) and critically reviewed and revised its output.
