### PR TITLE
Update kolibri-installer-android to v0.2.0

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -39,10 +39,10 @@ jobs:
   apk:
     name: Build APK file
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.10
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.2.0
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
-      ref: v0.1.10
+      ref: v0.2.0
   zip:
     name: Build Raspberry Pi Image
     needs: deb

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -119,11 +119,11 @@ jobs:
   apk:
     name: Build Android APK
     needs: whl
-    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.1.10
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@v0.2.0
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
       release: true
-      ref: v0.1.10
+      ref: v0.2.0
     secrets:
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE }}
       KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD }}
@@ -239,10 +239,10 @@ jobs:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}
     needs: [apk, block_release_step]
-    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.1.10
+    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@v0.2.0
     with:
       version-code: ${{ needs.apk.outputs.version-code }}
-      ref: v0.1.10
+      ref: v0.2.0
     secrets:
       KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON: ${{ secrets.KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON }}
   container_image_publish:


### PR DESCRIPTION
## Summary
Bump the `kolibri-installer-android` reusable workflow reference from `v0.1.10` to `v0.2.0` across the release and PR build workflows (`build_apk.yml`, `release_apk.yml`). This pulls in the chaquopy migration of the Android app.

## References
- [kolibri-installer-android v0.2.0](https://github.com/learningequality/kolibri-installer-android/releases/tag/v0.2.0)

## Reviewer guidance
- CI-config change only; the actual build logic lives in the bumped `kolibri-installer-android` reusable workflows.
- Manually test the built Android APK from this PR, since it pulls in the chaquopy migration.

## AI usage
Used Claude Code to locate the three workflow references and bump the version. Reviewed the diff and confirmed the version is consistent across both workflow files.