### PR TITLE
Enable ruff isort import rules

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ e59c54a53fe4305700d4ced05134ab95b7436b1e
 
 # Ruff and yamlfmt reformatting
 301b08fd04c464ca3b11b5b12a001db83c364b03
+
+# Reformatted imports after enabling ruff isort rules
+51b7e61d74714aed5d82555114066fb5cc4b814e

--- a/.pre-commit-hooks/check_lfs_pointers.py
+++ b/.pre-commit-hooks/check_lfs_pointers.py
@@ -14,7 +14,6 @@ import logging
 import subprocess
 import sys
 
-
 LFS_POINTER_HEADER = b"version https://git-lfs.github.com/spec/v1"
 
 

--- a/build_tools/i18n/nutritionfacts_i18n.py
+++ b/build_tools/i18n/nutritionfacts_i18n.py
@@ -12,7 +12,6 @@ import sys
 import click
 import utils
 
-
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
 

--- a/integration_testing/load_testing/kolibri_client.py
+++ b/integration_testing/load_testing/kolibri_client.py
@@ -16,7 +16,6 @@ from requests.exceptions import RequestException
 from utils import generate_users_csv
 from utils import get_or_generate_lesson_resources
 
-
 TASKS_API_PATH = "/api/tasks/tasks/"
 LESSON_TITLE = "Load Test Lesson"
 LESSON_DESCRIPTION = "Load test lesson with comprehensive content types"

--- a/integration_testing/load_testing/loadtest.py
+++ b/integration_testing/load_testing/loadtest.py
@@ -34,7 +34,6 @@ from logger import section
 from logger import step
 from logger import success
 
-
 # Constants
 HAR_FILES_DIR = os.path.join(os.path.dirname(__file__), "har_files")
 QA_CHANNEL_ID = "95a52b386f2c485cb97dd60901674a98"

--- a/integration_testing/load_testing/locustfile.py
+++ b/integration_testing/load_testing/locustfile.py
@@ -29,7 +29,6 @@ from locust import between
 from locust import HttpUser
 from locust import task
 
-
 # Load configuration from environment variables
 HAR_FILE = os.environ["KOLIBRI_HAR_FILE"]
 SERVER_URL = os.environ["KOLIBRI_SERVER_URL"]

--- a/integration_testing/load_testing/utils.py
+++ b/integration_testing/load_testing/utils.py
@@ -12,7 +12,6 @@ from logger import info
 from logger import plain
 from logger import warning
 
-
 # Path to saved lesson resources
 LESSON_RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "lesson_resources.json")
 

--- a/integration_testing/scripts/viewset_serialization_benchmark.py
+++ b/integration_testing/scripts/viewset_serialization_benchmark.py
@@ -35,7 +35,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 # Must import kolibri before Django to apply compat patches (e.g. cgi module on Python 3.13+)
-from kolibri.utils.main import initialize
+from kolibri.utils.main import initialize  # isort: skip
 
 from django.conf import settings
 from django.db import connection

--- a/kolibri/core/analytics/local_notifications.py
+++ b/kolibri/core/analytics/local_notifications.py
@@ -5,7 +5,6 @@ from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.utils.time_utils import local_now
 
-
 IMPACT_STORIES_KEY = "impact-stories"
 
 ROLLING_WINDOW_DAYS = 90

--- a/kolibri/core/analytics/models.py
+++ b/kolibri/core/analytics/models.py
@@ -1,9 +1,10 @@
 from django.db import models
 
-from .constants import nutrition_endpoints
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.general import IsOwn
 from kolibri.core.fields import JSONField
+
+from .constants import nutrition_endpoints
 
 
 class PingbackNotification(models.Model):

--- a/kolibri/core/analytics/test/test_api.py
+++ b/kolibri/core/analytics/test/test_api.py
@@ -3,14 +3,15 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ..constants.nutrition_endpoints import PINGBACK
-from ..models import PingbackNotification
-from ..models import PingbackNotificationDismissed
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.auth.test.test_api import FacilityUserFactory
+
+from ..constants.nutrition_endpoints import PINGBACK
+from ..models import PingbackNotification
+from ..models import PingbackNotificationDismissed
 
 
 class PingbackNotificationTestCase(APITestCase):

--- a/kolibri/core/analytics/test/test_local_notification.py
+++ b/kolibri/core/analytics/test/test_local_notification.py
@@ -6,13 +6,6 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ..local_notifications import create_impact_stories_notification_if_needed
-from ..local_notifications import IMPACT_STORIES_KEY
-from ..models import LocalNotification
-from ..tasks import _run_local_notification_generation
-from ..tasks import COOLDOWN_DAYS
-from ..tasks import DEFAULT_CADENCE_DAYS
-from ..tasks import schedule_local_notification_generation
 from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
@@ -20,6 +13,14 @@ from kolibri.core.auth.test.test_api import FacilityUserFactory
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.utils.time_utils import local_now
+
+from ..local_notifications import create_impact_stories_notification_if_needed
+from ..local_notifications import IMPACT_STORIES_KEY
+from ..models import LocalNotification
+from ..tasks import _run_local_notification_generation
+from ..tasks import COOLDOWN_DAYS
+from ..tasks import DEFAULT_CADENCE_DAYS
+from ..tasks import schedule_local_notification_generation
 
 
 class LocalNotificationAPITestCase(APITestCase):

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -38,7 +38,6 @@ from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.logger.utils import user_data
 
-
 USER_CSV_PATH = "kolibri/core/logger/management/commands/user_data.csv"
 
 

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -19,8 +19,6 @@ from le_utils.constants import content_kinds
 from morango.models import InstanceIDModel
 
 import kolibri
-from .constants import nutrition_endpoints
-from .models import PingbackNotification
 from kolibri.core.auth.constants import demographics
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import Classroom
@@ -43,6 +41,9 @@ from kolibri.core.utils.lock import db_lock
 from kolibri.utils import conf
 from kolibri.utils.server import installation_type
 from kolibri.utils.time_utils import local_now
+
+from .constants import nutrition_endpoints
+from .models import PingbackNotification
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/analytics/viewsets/analytics.py
+++ b/kolibri/core/analytics/viewsets/analytics.py
@@ -3,14 +3,15 @@ from rest_framework import serializers
 from rest_framework import viewsets
 
 import kolibri
-from ..models import LocalNotification
-from ..models import PingbackNotification
-from ..models import PingbackNotificationDismissed
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.utils.picture_passwords import get_learner_count
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.utils.version import version_matches_range
+
+from ..models import LocalNotification
+from ..models import PingbackNotification
+from ..models import PingbackNotificationDismissed
 
 
 class PingbackNotificationSerializer(serializers.ModelSerializer):

--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -39,7 +39,6 @@ from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_201_CREATED
 from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
 
-from .utils.portal import registerfacility
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.tasks import enqueue_automatic_kdp_sync
 from kolibri.core.discovery.utils.network.client import NetworkClient
@@ -49,6 +48,8 @@ from kolibri.core.utils.serializer_introspection import derive_values_from_seria
 from kolibri.core.utils.serializer_introspection import normalize_field_map
 from kolibri.core.utils.serializer_introspection import ValuesMethodField  # noqa: F401
 from kolibri.utils import conf
+
+from .utils.portal import registerfacility
 
 
 class KolibriDataPortalViewSet(viewsets.ViewSet):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -49,23 +49,6 @@ from rest_framework.mixins import CreateModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from .constants import collection_kinds
-from .constants import role_kinds
-from .models import Classroom
-from .models import Facility
-from .models import FacilityDataset
-from .models import FacilityUser
-from .models import LearnerGroup
-from .models import Membership
-from .models import Role
-from .serializers import ClassroomSerializer
-from .serializers import CreateFacilitySerializer
-from .serializers import ExtraFieldsSerializer
-from .serializers import FacilitySerializer
-from .serializers import LearnerGroupSerializer
-from .serializers import MembershipSerializer
-from .serializers import PublicFacilitySerializer
-from .serializers import RoleSerializer
 from kolibri.core import error_constants
 from kolibri.core.api import ValuesViewset
 from kolibri.core.auth.constants import user_kinds
@@ -92,6 +75,24 @@ from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.core.utils.token_generator import TokenGenerator
 from kolibri.core.utils.urls import reverse_path
+
+from .constants import collection_kinds
+from .constants import role_kinds
+from .models import Classroom
+from .models import Facility
+from .models import FacilityDataset
+from .models import FacilityUser
+from .models import LearnerGroup
+from .models import Membership
+from .models import Role
+from .serializers import ClassroomSerializer
+from .serializers import CreateFacilitySerializer
+from .serializers import ExtraFieldsSerializer
+from .serializers import FacilitySerializer
+from .serializers import LearnerGroupSerializer
+from .serializers import MembershipSerializer
+from .serializers import PublicFacilitySerializer
+from .serializers import RoleSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -1,11 +1,11 @@
 from django.urls import re_path
 from rest_framework import routers
 
+from kolibri.core.api import KolibriDataPortalViewSet
+from kolibri.core.routers import BulkDeleteRouter
+
 from .api import ClassroomViewSet
 from .api import DeleteImportedUserView
-from .viewsets.facility_dataset import FacilityDatasetViewSet
-from .viewsets.facility_user import DeletedFacilityUserViewSet
-from .viewsets.facility_user import FacilityUserViewSet
 from .api import FacilityViewSet
 from .api import IsPINValidView
 from .api import LearnerGroupViewSet
@@ -17,8 +17,9 @@ from .api import SessionViewSet
 from .api import SetNonSpecifiedPasswordView
 from .api import SignUpViewSet
 from .api import UsernameAvailableView
-from kolibri.core.api import KolibriDataPortalViewSet
-from kolibri.core.routers import BulkDeleteRouter
+from .viewsets.facility_dataset import FacilityDatasetViewSet
+from .viewsets.facility_user import DeletedFacilityUserViewSet
+from .viewsets.facility_user import FacilityUserViewSet
 
 router = routers.SimpleRouter()
 

--- a/kolibri/core/auth/apps.py
+++ b/kolibri/core/auth/apps.py
@@ -7,14 +7,17 @@ class KolibriAuthConfig(AppConfig):
     verbose_name = "Kolibri Auth"
 
     def ready(self):
-        from .signals import cascade_delete_membership  # noqa: F401
-        from .signals import cascade_delete_user  # noqa: F401
+        from morango.api.viewsets import session_controller  # noqa: F401
 
         from kolibri.core.auth.sync_event_hook_utils import (
-            pre_sync_transfer_handler,
             post_sync_transfer_handler,
         )  # noqa: F401
-        from morango.api.viewsets import session_controller  # noqa: F401
+        from kolibri.core.auth.sync_event_hook_utils import (
+            pre_sync_transfer_handler,
+        )  # noqa: F401
+
+        from .signals import cascade_delete_membership  # noqa: F401
+        from .signals import cascade_delete_user  # noqa: F401
 
         # attach to `initializing.completed` signal so that the context has all information needed
         # for the handler and any hooks invoked by it

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -19,7 +19,6 @@ from kolibri.core.auth.models import Role
 from kolibri.core.auth.models import Session
 from kolibri.core.device.utils import is_full_facility_import
 
-
 FACILITY_CREDENTIAL_KEY = "facility"
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/constants/demographics.py
+++ b/kolibri/core/auth/constants/demographics.py
@@ -5,7 +5,6 @@ from kolibri.core.utils.validators import JSON_Schema_Validator
 from kolibri.core.utils.validators import NoRepeatedValueJSONArrayValidator
 from kolibri.utils.i18n import KOLIBRI_SUPPORTED_LANGUAGES
 
-
 MALE = "MALE"
 FEMALE = "FEMALE"
 NOT_SPECIFIED = "NOT_SPECIFIED"

--- a/kolibri/core/auth/constants/morango_sync.py
+++ b/kolibri/core/auth/constants/morango_sync.py
@@ -1,7 +1,6 @@
 from kolibri import __version__
 from kolibri.utils import conf
 
-
 PROFILE_FACILITY_DATA = "facilitydata"
 DATA_PORTAL_SYNCING_BASE_URL = conf.OPTIONS["Urls"]["DATA_PORTAL_SYNCING_BASE_URL"]
 CUSTOM_INSTANCE_INFO = {

--- a/kolibri/core/auth/constants/picture_passwords.py
+++ b/kolibri/core/auth/constants/picture_passwords.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 # Upper bound on auto-assignment: reserve a small buffer below the total
 # number of unique 3-pick permutations (12P3 = 1320) so assignment never
 # exhausts the pool entirely.

--- a/kolibri/core/auth/csv_utils.py
+++ b/kolibri/core/auth/csv_utils.py
@@ -18,7 +18,6 @@ from kolibri.core.utils.csv import open_csv_for_writing
 from kolibri.core.utils.csv import output_mapper
 from kolibri.core.utils.csv import validate_open_csv_params
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -12,9 +12,6 @@ from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
-from .bulkimportusers import FILE_WRITE_ERROR
-from .bulkimportusers import MESSAGES
-from .bulkimportusers import NO_FACILITY
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.constants.demographics import DEFERRED
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
@@ -28,6 +25,10 @@ from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.csv import open_csv_for_writing
 from kolibri.core.utils.csv import output_mapper
 from kolibri.core.utils.csv import validate_open_csv_params
+
+from .bulkimportusers import FILE_WRITE_ERROR
+from .bulkimportusers import MESSAGES
+from .bulkimportusers import NO_FACILITY
 
 try:
     FileNotFoundError

--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -12,7 +12,6 @@ from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.auth.utils.delete import get_delete_group_for_facility
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/management/commands/flushsyncsessions.py
+++ b/kolibri/core/auth/management/commands/flushsyncsessions.py
@@ -13,7 +13,6 @@ from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.utils.delete import GroupDeletion
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/management/commands/recreatefacility.py
+++ b/kolibri/core/auth/management/commands/recreatefacility.py
@@ -7,7 +7,6 @@ from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.utils.migrate import migrate_facility
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -5,14 +5,15 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from morango.models import ScopeDefinition
 
-from ..utils import get_client_and_server_certs
-from ..utils import get_facility_dataset_id
 from kolibri.core.auth.constants.morango_sync import DATA_PORTAL_SYNCING_BASE_URL
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.management.utils import get_network_connection
 from kolibri.core.auth.management.utils import is_portal_sync
 from kolibri.core.auth.management.utils import MorangoSyncCommand
+
+from ..utils import get_client_and_server_certs
+from ..utils import get_facility_dataset_id
 
 
 class Command(MorangoSyncCommand):

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -40,7 +40,6 @@ from kolibri.core.utils.lock import db_lock_sqlite_only
 from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.data import bytes_for_humans
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -41,6 +41,30 @@ from morango.models import SyncableModelQuerySet
 from morango.models import UUIDField
 from mptt.models import TreeForeignKey
 
+from kolibri.core import error_constants
+from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
+from kolibri.core.auth.constants.demographics import custom_demographics_schema
+from kolibri.core.auth.constants.demographics import DEFERRED
+from kolibri.core.auth.constants.demographics import DescriptionTranslationValidator
+from kolibri.core.auth.constants.demographics import EnumValuesValidator
+from kolibri.core.auth.constants.demographics import FacilityUserDemographicValidator
+from kolibri.core.auth.constants.demographics import LabelTranslationValidator
+from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
+from kolibri.core.auth.constants.demographics import UniqueIdsValidator
+from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
+from kolibri.core.device.hooks import GetOSUserHook
+from kolibri.core.device.utils import device_provisioned
+from kolibri.core.device.utils import get_device_setting
+from kolibri.core.device.utils import is_full_facility_import
+from kolibri.core.device.utils import set_device_settings
+from kolibri.core.errors import KolibriValidationError
+from kolibri.core.fields import DateTimeTzField
+from kolibri.core.fields import JSONField
+from kolibri.core.utils.model_router import KolibriModelRouter
+from kolibri.core.utils.validators import JSON_Schema_Validator
+from kolibri.deployment.default.sqlite_db_names import SESSIONS
+from kolibri.utils.time_utils import local_now
+
 from .constants import collection_kinds
 from .constants import facility_presets
 from .constants import morango_sync
@@ -65,29 +89,6 @@ from .permissions.base import RoleBasedPermissions
 from .permissions.general import IsAdminForOwnFacility
 from .permissions.general import IsOwn
 from .permissions.general import IsSelf
-from kolibri.core import error_constants
-from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
-from kolibri.core.auth.constants.demographics import custom_demographics_schema
-from kolibri.core.auth.constants.demographics import DEFERRED
-from kolibri.core.auth.constants.demographics import DescriptionTranslationValidator
-from kolibri.core.auth.constants.demographics import EnumValuesValidator
-from kolibri.core.auth.constants.demographics import FacilityUserDemographicValidator
-from kolibri.core.auth.constants.demographics import LabelTranslationValidator
-from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
-from kolibri.core.auth.constants.demographics import UniqueIdsValidator
-from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
-from kolibri.core.device.hooks import GetOSUserHook
-from kolibri.core.device.utils import device_provisioned
-from kolibri.core.device.utils import get_device_setting
-from kolibri.core.device.utils import is_full_facility_import
-from kolibri.core.device.utils import set_device_settings
-from kolibri.core.errors import KolibriValidationError
-from kolibri.core.fields import DateTimeTzField
-from kolibri.core.fields import JSONField
-from kolibri.core.utils.model_router import KolibriModelRouter
-from kolibri.core.utils.validators import JSON_Schema_Validator
-from kolibri.deployment.default.sqlite_db_names import SESSIONS
-from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/permissions/base.py
+++ b/kolibri/core/auth/permissions/base.py
@@ -6,7 +6,6 @@ from django.db.models import Q
 
 from kolibri.core.auth.constants import role_kinds
 
-
 ####################################################################################################################
 # This section contains base classes that can be inherited and extended to define more complex permissions behavior.
 ####################################################################################################################

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -8,6 +8,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.validators import UniqueTogetherValidator
 
+from kolibri.core import error_constants
+
 from .constants import collection_kinds
 from .constants import facility_presets
 from .constants import role_kinds
@@ -20,7 +22,6 @@ from .models import FacilityDataset
 from .models import LearnerGroup
 from .models import Membership
 from .models import Role
-from kolibri.core import error_constants
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/signals.py
+++ b/kolibri/core/auth/signals.py
@@ -2,11 +2,12 @@ from django.db.models.signals import post_save
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
+from kolibri.core.notifications.models import LearnerProgressNotification
+
 from .models import FacilityUser
 from .models import Membership
 from .models import Role
 from .utils.picture_passwords import get_learner_count
-from kolibri.core.notifications.models import LearnerProgressNotification
 
 
 @receiver(pre_delete, sender=Membership)

--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -8,7 +8,6 @@ from morango.sync.context import LocalSessionContext
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -14,11 +14,6 @@ from morango.sync.operations import LocalOperation
 from morango.sync.operations import NetworkInitializeOperation
 from morango.sync.operations import ReceiverDeserializeOperation
 
-from .sync_event_hook_utils import get_dataset_id
-from .sync_event_hook_utils import get_other_side_kolibri_version
-from .sync_event_hook_utils import get_user_id_for_single_user_sync
-from .sync_event_hook_utils import other_side_using_single_user_cert
-from .sync_event_hook_utils import this_side_using_single_user_cert
 from kolibri.core.auth.constants.picture_passwords import PICTURE_PASSWORD_SET
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.models import Facility
@@ -29,6 +24,12 @@ from kolibri.core.auth.utils.picture_passwords import get_assigned_sequences
 from kolibri.core.auth.utils.sync import ClassroomPartitionFilterFactory
 from kolibri.core.upgrade import matches_version
 from kolibri.utils.version import truncate_version
+
+from .sync_event_hook_utils import get_dataset_id
+from .sync_event_hook_utils import get_other_side_kolibri_version
+from .sync_event_hook_utils import get_user_id_for_single_user_sync
+from .sync_event_hook_utils import other_side_using_single_user_cert
+from .sync_event_hook_utils import this_side_using_single_user_cert
 
 logger = logging.getLogger(__name__)
 SORTED_STAGES = sorted(transfer_stages.ALL, key=lambda s: transfer_stages.precedence(s))

--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -8,14 +8,15 @@ from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 from rest_framework.test import APITransactionTestCase
 
+from kolibri.core.auth.constants import role_kinds
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.utils import provision_device as _provision_device  # noqa
+
 from ..models import Classroom
 from ..models import Facility
 from ..models import FacilityDataset
 from ..models import FacilityUser
 from ..models import LearnerGroup
-from kolibri.core.auth.constants import role_kinds
-from kolibri.core.device.models import DevicePermissions
-from kolibri.core.device.utils import provision_device as _provision_device  # noqa
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/auth/test/migrationtestcase.py
+++ b/kolibri/core/auth/test/migrationtestcase.py
@@ -3,7 +3,6 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TransactionTestCase
 
-
 # Modified from https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 
 

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -27,6 +27,19 @@ from morango.sync.controller import MorangoProfileController
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from kolibri.core import error_constants
+from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
+from kolibri.core.auth.constants import demographics
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
+from kolibri.core.auth.errors import NoAvailableSequences
+from kolibri.core.auth.models import FacilityDataset
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.signals import cascade_delete_user
+from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
+from kolibri.core.device.models import OSUser
+from kolibri.core.device.utils import set_device_settings
+from kolibri.core.tasks.job import Job
+
 from .. import models
 from ..constants import role_kinds
 from ..constants.facility_presets import mappings
@@ -40,18 +53,6 @@ from .helpers import KolibriAPITestCase as APITestCase
 from .helpers import KolibriAPITransactionTestCase as APITransactionTestCase
 from .helpers import provision_device
 from .helpers import setup_device
-from kolibri.core import error_constants
-from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
-from kolibri.core.auth.constants import demographics
-from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
-from kolibri.core.auth.errors import NoAvailableSequences
-from kolibri.core.auth.models import FacilityDataset
-from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.signals import cascade_delete_user
-from kolibri.core.auth.tasks import assign_picture_passwords_to_facility
-from kolibri.core.device.models import OSUser
-from kolibri.core.device.utils import set_device_settings
-from kolibri.core.tasks.job import Job
 
 
 class FacilityFactory(factory.DjangoModelFactory):

--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -14,8 +14,6 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APITestCase
 
-from .helpers import clear_process_cache
-from .helpers import provision_device
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import State as FacilitySyncState
 from kolibri.core.auth.models import Facility
@@ -38,6 +36,8 @@ from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 
+from .helpers import clear_process_cache
+from .helpers import provision_device
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/auth/test/test_bulk_export.py
+++ b/kolibri/core/auth/test/test_bulk_export.py
@@ -4,10 +4,11 @@ import tempfile
 from django.test import override_settings
 from django.test import TestCase
 
-from .helpers import create_dummy_facility_data
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.utils.csv import open_csv_for_reading
+
+from .helpers import create_dummy_facility_data
 
 CLASSROOMS = 2
 

--- a/kolibri/core/auth/test/test_bulk_import.py
+++ b/kolibri/core/auth/test/test_bulk_import.py
@@ -10,9 +10,6 @@ from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
 
-from ..management.commands import bulkimportusers as b
-from ..management.commands.bulkexportusers import labels
-from .helpers import create_dummy_facility_data
 from kolibri.core.auth.constants import demographics
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import Classroom
@@ -20,6 +17,9 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.utils.csv import open_csv_for_reading
 from kolibri.core.utils.csv import open_csv_for_writing
 
+from ..management.commands import bulkimportusers as b
+from ..management.commands.bulkexportusers import labels
+from .helpers import create_dummy_facility_data
 
 CLASSROOMS = 2
 

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -7,17 +7,18 @@ import uuid
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
+from kolibri.core.auth.constants import role_kinds
+from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
+
 from ..errors import IncompatibleDeviceSettingError
 from ..models import Classroom
 from ..models import Facility
 from ..models import FacilityDataset
 from ..models import FacilityUser
 from ..models import LearnerGroup
-from kolibri.core.auth.constants import role_kinds
-from kolibri.core.exams.models import Exam
-from kolibri.core.exams.models import ExamAssignment
-from kolibri.core.lessons.models import Lesson
-from kolibri.core.lessons.models import LessonAssignment
 
 
 def _create_classroom_data():

--- a/kolibri/core/auth/test/test_deprovisioning.py
+++ b/kolibri/core/auth/test/test_deprovisioning.py
@@ -12,10 +12,6 @@ from morango.models import HardDeletedModels
 from morango.models import Store
 from morango.sync.controller import MorangoProfileController
 
-from .. import models as auth_models
-from .helpers import setup_device
-from .test_api import ClassroomFactory
-from .test_api import LearnerGroupFactory
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.content import models as content_models
 from kolibri.core.device.models import DevicePermissions
@@ -27,6 +23,11 @@ from kolibri.core.logger.test.factory_logger import ContentSessionLogFactory
 from kolibri.core.logger.test.factory_logger import ContentSummaryLogFactory
 from kolibri.core.logger.test.factory_logger import FacilityUserFactory
 from kolibri.core.logger.test.factory_logger import UserSessionLogFactory
+
+from .. import models as auth_models
+from .helpers import setup_device
+from .test_api import ClassroomFactory
+from .test_api import LearnerGroupFactory
 
 MODELS_DELETED_BY_DEPROVISION = [
     AttemptLog,

--- a/kolibri/core/auth/test/test_hooks.py
+++ b/kolibri/core/auth/test/test_hooks.py
@@ -5,11 +5,12 @@ from django.test import TestCase
 from django.utils.timezone import now
 from morango.sync.context import LocalSessionContext
 
-from .helpers import provision_device
 from kolibri.core.auth.kolibri_plugin import AuthSyncHook
 from kolibri.core.auth.kolibri_plugin import CleanUpTaskOperation
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+
+from .helpers import provision_device
 
 
 @mock.patch("kolibri.core.auth.kolibri_plugin.cleanupsync")

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -7,6 +7,11 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 
+from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.models import DeviceSettings
+from kolibri.utils.time_utils import local_now
+
 from ..constants import collection_kinds
 from ..constants import role_kinds
 from ..errors import InvalidCollectionHierarchy
@@ -24,10 +29,6 @@ from ..models import Membership
 from ..models import Role
 from ..models import Session
 from .helpers import create_superuser
-from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
-from kolibri.core.device.models import DevicePermissions
-from kolibri.core.device.models import DeviceSettings
-from kolibri.utils.time_utils import local_now
 
 
 class CollectionRoleMembershipDeletionTestCase(TestCase):

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -25,17 +25,6 @@ from morango.models import Store
 from morango.models import syncable_models
 from morango.sync.controller import MorangoProfileController
 
-from ..constants.morango_sync import PROFILE_FACILITY_DATA
-from ..models import AdHocGroup
-from ..models import Classroom
-from ..models import Facility
-from ..models import FacilityDataset
-from ..models import FacilityUser
-from ..models import LearnerGroup
-from ..models import Membership
-from ..models import Role
-from .helpers import DUMMY_PASSWORD
-from .sync_utils import multiple_kolibri_servers
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.management.utils import get_client_and_server_certs
 from kolibri.core.auth.utils.sync import find_soud_sync_session_for_resume
@@ -53,6 +42,18 @@ from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
 from kolibri.core.logger.models import MasteryLog
+
+from ..constants.morango_sync import PROFILE_FACILITY_DATA
+from ..models import AdHocGroup
+from ..models import Classroom
+from ..models import Facility
+from ..models import FacilityDataset
+from ..models import FacilityUser
+from ..models import LearnerGroup
+from ..models import Membership
+from ..models import Role
+from .helpers import DUMMY_PASSWORD
+from .sync_utils import multiple_kolibri_servers
 
 
 class FacilityDatasetCertificateTestCase(TestCase):

--- a/kolibri/core/auth/test/test_permissions.py
+++ b/kolibri/core/auth/test/test_permissions.py
@@ -4,6 +4,8 @@ Tests of the permissions on specific models in the auth app. For tests of the pe
 
 from django.test import TestCase
 
+from kolibri.core.device.models import DevicePermissions
+
 from ..constants import role_kinds
 from ..models import Classroom
 from ..models import Facility
@@ -15,7 +17,6 @@ from ..models import Membership
 from ..models import Role
 from .helpers import create_dummy_facility_data
 from .helpers import create_superuser
-from kolibri.core.device.models import DevicePermissions
 
 
 class ImproperUsageIsProperlyHandledTestCase(TestCase):

--- a/kolibri/core/auth/test/test_picture_passwords.py
+++ b/kolibri/core/auth/test/test_picture_passwords.py
@@ -5,10 +5,6 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from mock import patch
 
-from ..models import Facility
-from ..models import FacilityUser
-from .helpers import create_superuser
-from .helpers import DUMMY_PASSWORD
 from kolibri.core.auth.constants.picture_passwords import PICTURE_PASSWORD_SET
 from kolibri.core.auth.constants.picture_passwords import SEQUENCE_LENGTH
 from kolibri.core.auth.constants.role_kinds import ADMIN
@@ -19,6 +15,11 @@ from kolibri.core.auth.utils.picture_passwords import assign_picture_password
 from kolibri.core.auth.utils.picture_passwords import get_all_valid_sequences
 from kolibri.core.auth.utils.picture_passwords import get_assigned_sequences
 from kolibri.core.auth.utils.picture_passwords import get_learner_count
+
+from ..models import Facility
+from ..models import FacilityUser
+from .helpers import create_superuser
+from .helpers import DUMMY_PASSWORD
 
 
 class GetAllValidSequencesTestCase(TestCase):

--- a/kolibri/core/auth/test/test_sync_event_hook_utils.py
+++ b/kolibri/core/auth/test/test_sync_event_hook_utils.py
@@ -6,7 +6,6 @@ from morango.sync.context import LocalSessionContext
 from kolibri.core.auth.sync_event_hook_utils import post_sync_transfer_handler
 from kolibri.core.auth.sync_event_hook_utils import pre_sync_transfer_handler
 
-
 MODULE_NAME = "kolibri.core.auth.sync_event_hook_utils"
 
 

--- a/kolibri/core/auth/test/test_sync_utils.py
+++ b/kolibri/core/auth/test/test_sync_utils.py
@@ -5,8 +5,6 @@ from mock import Mock
 from morango.models import Filter
 from morango.sync.utils import SyncSignalGroup
 
-from .helpers import create_dummy_facility_data
-from .helpers import provision_device
 from kolibri.core.auth.constants.morango_sync import PARTITION_CLASSROOM
 from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_COACH_RW
 from kolibri.core.auth.constants.morango_sync import PARTITION_SUFFIX_LEARNER_RW
@@ -24,6 +22,9 @@ from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
+
+from .helpers import create_dummy_facility_data
+from .helpers import provision_device
 
 
 class TestProgressTracking(TestCase):

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -11,7 +11,6 @@ from morango.sync.context import CompositeSessionContext
 from morango.sync.context import LocalSessionContext
 from morango.sync.context import NetworkSessionContext
 
-from ..models import Facility
 from kolibri.core.auth.management import utils
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
@@ -26,6 +25,8 @@ from kolibri.core.auth.utils.delete import get_delete_group_for_facility
 from kolibri.core.auth.utils.migrate import fork_facility
 from kolibri.core.auth.utils.migrate import merge_users
 from kolibri.core.logger import models as log_models
+
+from ..models import Facility
 
 
 class GetFacilityTestCase(TestCase):

--- a/kolibri/core/auth/utils/delete.py
+++ b/kolibri/core/auth/utils/delete.py
@@ -50,7 +50,6 @@ from kolibri.core.logger.models import GenerateCSVLogRequest
 from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.models import UserSessionLog
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/utils/migrate.py
+++ b/kolibri/core/auth/utils/migrate.py
@@ -21,7 +21,6 @@ from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.models import UserSessionLog
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/utils/picture_passwords.py
+++ b/kolibri/core/auth/utils/picture_passwords.py
@@ -14,7 +14,6 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.utils.cache import process_cache as cache
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/auth/viewsets/facility_dataset.py
+++ b/kolibri/core/auth/viewsets/facility_dataset.py
@@ -11,13 +11,6 @@ from rest_framework import serializers
 from rest_framework import status
 from rest_framework.response import Response
 
-from ..api import KolibriAuthPermissions
-from ..api import KolibriAuthPermissionsFilter
-from ..constants import collection_kinds
-from ..errors import IncompatibleDeviceSettingError
-from ..models import Facility
-from ..models import FacilityDataset
-from ..serializers import ExtraFieldsSerializer
 from kolibri.core import error_constants
 from kolibri.core.api import ValuesMethodField
 from kolibri.core.api import ValuesViewset
@@ -28,6 +21,14 @@ from kolibri.core.device.utils import (
     is_full_facility_import as _is_full_facility_import,
 )
 from kolibri.core.tasks.main import job_storage
+
+from ..api import KolibriAuthPermissions
+from ..api import KolibriAuthPermissionsFilter
+from ..constants import collection_kinds
+from ..errors import IncompatibleDeviceSettingError
+from ..models import Facility
+from ..models import FacilityDataset
+from ..serializers import ExtraFieldsSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/auth/viewsets/facility_user.py
+++ b/kolibri/core/auth/viewsets/facility_user.py
@@ -25,6 +25,15 @@ from rest_framework.mixins import DestroyModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from kolibri.core import error_constants
+from kolibri.core.api import ReadOnlyValuesViewset
+from kolibri.core.api import ValuesViewset
+from kolibri.core.api import ValuesViewsetOrderingFilter
+from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
+from kolibri.core.auth.tasks import cleanup_expired_deleted_users
+from kolibri.core.mixins import BulkDeleteMixin
+from kolibri.core.tasks.exceptions import JobRunning
+
 from ..api import KolibriAuthPermissions
 from ..api import KolibriAuthPermissionsFilter
 from ..api import OptionalPageNumberPagination
@@ -40,14 +49,6 @@ from ..models import validate_username_allowed_chars
 from ..models import validate_username_max_length
 from ..utils.picture_passwords import are_picture_passwords_exhausted
 from ..utils.picture_passwords import assign_picture_password
-from kolibri.core import error_constants
-from kolibri.core.api import ReadOnlyValuesViewset
-from kolibri.core.api import ValuesViewset
-from kolibri.core.api import ValuesViewsetOrderingFilter
-from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
-from kolibri.core.auth.tasks import cleanup_expired_deleted_users
-from kolibri.core.mixins import BulkDeleteMixin
-from kolibri.core.tasks.exceptions import JobRunning
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/__init__.py
+++ b/kolibri/core/content/__init__.py
@@ -1,7 +1,6 @@
 import mimetypes
 import os
 
-
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
 # https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
 mimetypes.init(

--- a/kolibri/core/content/apps.py
+++ b/kolibri/core/content/apps.py
@@ -7,11 +7,11 @@ class KolibriContentConfig(AppConfig):
     verbose_name = "Kolibri Content"
 
     def ready(self):
-        from .utils.assignment import ContentAssignmentManager  # noqa: F401
         from .signals import add_download_requests  # noqa: F401
         from .signals import add_removal_requests  # noqa: F401
-        from .signals import reorder_channels_upon_deletion  # noqa: F401
         from .signals import cascade_delete_node  # noqa: F401
+        from .signals import reorder_channels_upon_deletion  # noqa: F401
+        from .utils.assignment import ContentAssignmentManager  # noqa: F401
 
         ContentAssignmentManager.on_any_downloadable_assignment(add_download_requests)
         ContentAssignmentManager.on_any_removable_assignment(add_removal_requests)

--- a/kolibri/core/content/constants/kind_to_learningactivity.py
+++ b/kolibri/core/content/constants/kind_to_learningactivity.py
@@ -1,7 +1,6 @@
 from le_utils.constants import content_kinds
 from le_utils.constants.labels import learning_activities
 
-
 kind_activity_map = {
     content_kinds.EXERCISE: learning_activities.PRACTICE,
     content_kinds.VIDEO: learning_activities.WATCH,

--- a/kolibri/core/content/contentschema/models.py
+++ b/kolibri/core/content/contentschema/models.py
@@ -2,7 +2,6 @@ from django.db.models import Model
 
 from kolibri.core.content import base_models
 
-
 for model in base_models.__dict__.values():
     if (
         isinstance(model, type)

--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -16,7 +16,6 @@ from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.hooks import NetworkLocationDiscoveryHook
 from kolibri.plugins.hooks import register_hook
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/legacy_models.py
+++ b/kolibri/core/content/legacy_models.py
@@ -1,7 +1,6 @@
 from django.db import models
 from le_utils.constants import file_formats
 
-
 """
 All models in here must have Meta property abstract = True so that they are available for inspection
 but otherwise have no impact on the content app models

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -3,7 +3,6 @@ import logging
 from kolibri.core.content.utils.content_delete import delete_content
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -2,9 +2,10 @@ import logging
 
 from django.core.management.base import CommandError
 
-from ...utils import paths
 from kolibri.core.content.utils.resource_export import DiskChannelResourceExportManager
 from kolibri.core.tasks.management.commands.base import AsyncCommand
+
+from ...utils import paths
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -2,7 +2,6 @@ import logging
 
 from django.core.management.base import CommandError
 
-from ...utils import paths
 from kolibri.core.content.constants.transfer_types import COPY_METHOD
 from kolibri.core.content.constants.transfer_types import DOWNLOAD_METHOD
 from kolibri.core.content.utils.annotation import set_channel_metadata_fields
@@ -16,6 +15,8 @@ from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseT
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.utils import conf
 from kolibri.utils.uuids import is_valid_uuid
+
+from ...utils import paths
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -3,7 +3,6 @@ import argparse
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 
-from ...utils import paths
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.utils.resource_import import DiskChannelResourceImportManager
 from kolibri.core.content.utils.resource_import import DiskChannelUpdateManager
@@ -13,6 +12,8 @@ from kolibri.core.content.utils.resource_import import (
 from kolibri.core.content.utils.resource_import import RemoteChannelUpdateManager
 from kolibri.utils import conf
 from kolibri.utils import file_transfer as transfer
+
+from ...utils import paths
 
 # constants to specify the transfer method to be used
 DOWNLOAD_METHOD = "download"

--- a/kolibri/core/content/management/commands/scanforcontent.py
+++ b/kolibri/core/content/management/commands/scanforcontent.py
@@ -4,6 +4,9 @@ from argparse import SUPPRESS
 from django.core.management.base import BaseCommand
 from sqlalchemy.exc import DatabaseError
 
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.utils.paths import get_all_content_dir_paths
+
 from ...utils.annotation import set_content_visibility_from_disk
 from ...utils.channel_import import FutureSchemaError
 from ...utils.channel_import import import_channel_from_local_db
@@ -11,8 +14,6 @@ from ...utils.channel_import import InvalidSchemaVersionError
 from ...utils.channels import get_channel_ids_for_content_dirs
 from ...utils.channels import read_channel_metadata_from_db_file
 from ...utils.paths import get_content_database_file_path
-from kolibri.core.content.models import ChannelMetadata
-from kolibri.core.content.utils.paths import get_all_content_dir_paths
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -40,7 +40,6 @@ from mptt.managers import TreeManager
 from mptt.querysets import TreeQuerySet
 from sortedm2m.fields import SortedManyToManyField
 
-from .utils import paths
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content import base_models
@@ -54,6 +53,7 @@ from kolibri.core.mixins import FilterByUUIDQuerysetMixin
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
 
+from .utils import paths
 
 PRESET_LOOKUP = dict(format_presets.choices)
 

--- a/kolibri/core/content/signals.py
+++ b/kolibri/core/content/signals.py
@@ -2,13 +2,14 @@ from django.db.models import F
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
-from .models import ChannelMetadata
-from .models import ContentNode
 from kolibri.core.auth.models import Facility
 from kolibri.core.content.utils.content_request import create_content_download_requests
 from kolibri.core.content.utils.content_request import create_content_removal_requests
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.notifications.models import LearnerProgressNotification
+
+from .models import ChannelMetadata
+from .models import ContentNode
 
 
 @receiver(pre_delete, sender=ContentNode)

--- a/kolibri/core/content/test/helpers.py
+++ b/kolibri/core/content/test/helpers.py
@@ -21,7 +21,6 @@ from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.content_types_tools import renderable_files_presets
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -9,7 +9,6 @@ from django.test import TransactionTestCase
 from le_utils.constants import content_kinds
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
@@ -31,6 +30,8 @@ from kolibri.core.content.utils.annotation import (
 )
 from kolibri.core.content.utils.annotation import set_leaf_nodes_invisible
 from kolibri.core.content.utils.annotation import set_local_file_availability_from_disk
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -16,8 +16,6 @@ from mock import Mock
 from mock import patch
 from sqlalchemy import create_engine
 
-from .sqlalchemytesting import django_connection_engine
-from .test_content_app import ContentNodeTestBase
 from kolibri.core.content import models as content
 from kolibri.core.content.constants.kind_to_learningactivity import kind_activity_map
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
@@ -47,6 +45,9 @@ from kolibri.core.content.utils.channel_import import import_channel_from_local_
 from kolibri.core.content.utils.channel_import import topological_sort
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import load_metadata
+
+from .sqlalchemytesting import django_connection_engine
+from .test_content_app import ContentNodeTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/test/test_content_request.py
+++ b/kolibri/core/content/test/test_content_request.py
@@ -5,11 +5,12 @@ from rest_framework import exceptions
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ..serializers import ContentDownloadRequestSerializer
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentRequestStatus
+
+from ..serializers import ContentDownloadRequestSerializer
 
 
 class ContentDownloadRequestSerializerTestCase(TestCase):

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -10,11 +10,12 @@ from le_utils.constants import file_formats
 from le_utils.constants import format_presets
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.paths import get_content_storage_file_path
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_deletechannel.py
+++ b/kolibri/core/content/test/test_deletechannel.py
@@ -5,9 +5,10 @@ from django.test import TransactionTestCase
 from mock import call
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content import models as content
 from kolibri.core.content.utils.content_delete import delete_content
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 from django.test import TransactionTestCase
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.file_availability import (
     get_available_checksums_from_disk,
@@ -17,6 +16,8 @@ from kolibri.core.content.utils.file_availability import (
 )
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.utils.cache import process_cache
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_importability.py
+++ b/kolibri/core/content/test/test_importability.py
@@ -2,12 +2,13 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.importability_annotation import (
     get_channel_annotation_stats,
 )
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_upgrade.py
+++ b/kolibri/core/content/test/test_upgrade.py
@@ -8,13 +8,14 @@ from le_utils.constants import content_kinds
 from mock import call
 from mock import patch
 
-from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.upgrade import fix_multiple_trees_with_tree_id1
 from kolibri.core.content.upgrade import update_num_coach_contents
 from kolibri.core.content.utils.upgrade import diff_stats
+
+from .sqlalchemytesting import django_connection_engine
 
 
 def get_engine(connection_string):

--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -13,7 +13,6 @@ from kolibri.core.content.zip_wsgi import generate_zip_content_response
 from kolibri.core.content.zip_wsgi import INITIALIZE_SANDBOX_FROM_IFRAME
 from kolibri.utils.tests.helpers import override_option
 
-
 sandbox_injection = '<script type="text/javascript">{}</script>'.format(
     INITIALIZE_SANDBOX_FROM_IFRAME
 )

--- a/kolibri/core/content/test/utils/test_assignment.py
+++ b/kolibri/core/content/test/utils/test_assignment.py
@@ -15,7 +15,6 @@ from kolibri.core.exams.models import IndividualSyncableExam
 from kolibri.core.lessons.models import IndividualSyncableLesson
 from kolibri.core.lessons.models import Lesson
 
-
 _module = "kolibri.core.content.utils.assignment."
 
 

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -22,11 +22,6 @@ from sqlalchemy import String
 from sqlalchemy.sql.expression import literal
 from sqlalchemy.sql.functions import coalesce
 
-from .paths import get_content_file_name
-from .paths import get_content_storage_file_path
-from .paths import using_remote_storage
-from .sqlalchemybridge import Bridge
-from .sqlalchemybridge import filter_by_uuids
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import ChannelMetadata
@@ -39,6 +34,12 @@ from kolibri.core.content.utils.tree import get_channel_node_depth
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.utils.lock import db_lock
+
+from .paths import get_content_file_name
+from .paths import get_content_storage_file_path
+from .paths import using_remote_storage
+from .sqlalchemybridge import Bridge
+from .sqlalchemybridge import filter_by_uuids
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -10,7 +10,6 @@ from kolibri.core.auth.models import AbstractFacilityDataModel
 from kolibri.core.content.models import ContentRequestPriority
 from kolibri.core.utils.cache import process_cache
 
-
 _CONTENT_ASSIGNMENT_INSTANCE_CACHE_TIMEOUT = 300
 
 _ContentAssignment = namedtuple(

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -16,10 +16,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import select
 from sqlalchemy.sql import text
 
-from .channels import read_channel_metadata_from_db_file
-from .paths import get_content_database_file_path
-from .sqlalchemybridge import Bridge
-from .sqlalchemybridge import ClassNotFoundError
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.constants.kind_to_learningactivity import kind_activity_map
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
@@ -44,6 +40,11 @@ from kolibri.core.content.utils.search import annotate_label_bitmasks
 from kolibri.core.content.utils.search import annotate_modality
 from kolibri.core.errors import KolibriUpgradeError
 from kolibri.utils.time_utils import local_now
+
+from .channels import read_channel_metadata_from_db_file
+from .paths import get_content_database_file_path
+from .sqlalchemybridge import Bridge
+from .sqlalchemybridge import ClassNotFoundError
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -6,10 +6,11 @@ from django.core.cache import cache
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql import select
 
-from .paths import get_content_database_dir_path
-from .sqlalchemybridge import Bridge
 from kolibri.core.discovery.utils.filesystem import enumerate_mounted_disk_partitions
 from kolibri.utils.uuids import is_valid_uuid
+
+from .paths import get_content_database_dir_path
+from .sqlalchemybridge import Bridge
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/utils/content_delete.py
+++ b/kolibri/core/content/utils/content_delete.py
@@ -16,7 +16,6 @@ from kolibri.core.content.utils.importability_annotation import clear_channel_st
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.utils.lock import db_lock
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -9,7 +9,6 @@ from json import JSONDecodeError
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -18,7 +18,6 @@ from kolibri.core.content.utils.importability_annotation import (
 )
 from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 
-
 CHUNKSIZE = 10000
 
 

--- a/kolibri/core/content/utils/resource_export.py
+++ b/kolibri/core/content/utils/resource_export.py
@@ -11,7 +11,6 @@ from kolibri.core.content.utils.paths import get_content_file_name
 from kolibri.core.tasks.utils import JobProgressMixin
 from kolibri.utils import file_transfer as transfer
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -25,8 +25,8 @@ from le_utils.constants.labels.learning_activities import LEARNINGACTIVITIESLIST
 from le_utils.constants.labels.levels import LEVELSLIST
 from le_utils.constants.labels.needs import NEEDSLIST
 from le_utils.constants.labels.subjects import SUBJECTSLIST
-from kolibri.core.utils.cache import process_cache as cache
 
+from kolibri.core.utils.cache import process_cache as cache
 
 metadata_lookup = {
     "learning_activities": LEARNINGACTIVITIESLIST,

--- a/kolibri/core/content/views.py
+++ b/kolibri/core/content/views.py
@@ -4,8 +4,9 @@ from django.http import Http404
 from django.http import HttpResponseRedirect
 from django.views.generic.base import View
 
-from .models import ContentNode
 from kolibri.core.content.hooks import ContentNodeDisplayHook
+
+from .models import ContentNode
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -34,7 +34,6 @@ from kolibri.core.content.utils.paths import get_zip_content_base_path
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.utils.file_transfer import RemoteFile
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/courses/test/test_api.py
+++ b/kolibri/core/courses/test/test_api.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from le_utils.constants import modalities
 from rest_framework import status
 
-from .. import models
 from kolibri.core.auth.constants import collection_kinds
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
@@ -15,6 +14,8 @@ from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
+
+from .. import models
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/courses/test/test_unit_test_assignment.py
+++ b/kolibri/core/courses/test/test_unit_test_assignment.py
@@ -8,14 +8,15 @@ from mock import MagicMock
 from mock import patch
 from morango.models import Filter
 
-from .. import models
-from ..models import TestType
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ContentNode
+
+from .. import models
+from ..models import TestType
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/courses/viewsets.py
+++ b/kolibri/core/courses/viewsets.py
@@ -19,11 +19,6 @@ from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_200_OK
 from rest_framework.status import HTTP_404_NOT_FOUND
 
-from .models import CourseSession
-from .models import CourseSessionAssignment
-from .models import TestType
-from .models import UnitPhase
-from .models import UnitTestAssignment
 from kolibri.core import error_constants
 from kolibri.core.api import ValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
@@ -36,6 +31,12 @@ from kolibri.core.auth.utils.users import create_adhoc_group_for_learners
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.query import annotate_array_aggregate
+
+from .models import CourseSession
+from .models import CourseSessionAssignment
+from .models import TestType
+from .models import UnitPhase
+from .models import UnitTestAssignment
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/device/api_urls.py
+++ b/kolibri/core/device/api_urls.py
@@ -3,11 +3,11 @@ from django.urls import path
 from django.urls import re_path
 from rest_framework import routers
 
-from .viewsets.device_permissions import DevicePermissionsViewSet
 from .viewsets.device_info import DeviceInfoView
+from .viewsets.device_permissions import DevicePermissionsViewSet
+from .viewsets.device_restart import DeviceRestartView
 from .viewsets.device_settings import DeviceNameView
 from .viewsets.device_settings import DeviceSettingsView
-from .viewsets.device_restart import DeviceRestartView
 from .viewsets.drive_info import DriveInfoViewSet
 from .viewsets.free_space import FreeSpaceView
 from .viewsets.initialize_app import InitializeAppView

--- a/kolibri/core/device/kolibri_plugin.py
+++ b/kolibri/core/device/kolibri_plugin.py
@@ -24,8 +24,8 @@ class SyncQueueStatusHook(FacilityDataSyncHook):
     ):
         # if we're about to do a single user sync, update SyncQueue status accordingly
         if context.sync_session and single_user_id is not None:
-            from kolibri.core.device.models import SyncQueueStatus
             from kolibri.core.device.models import SyncQueue
+            from kolibri.core.device.models import SyncQueueStatus
 
             instance_id = (
                 context.sync_session.client_instance_id
@@ -54,8 +54,8 @@ class SyncQueueStatusHook(FacilityDataSyncHook):
         # if we're concluding a single user sync, update SyncQueue status accordingly
         if context.sync_session and single_user_id is not None:
             from kolibri.core.auth.models import FacilityUser
-            from kolibri.core.device.models import SyncQueueStatus
             from kolibri.core.device.models import SyncQueue
+            from kolibri.core.device.models import SyncQueueStatus
 
             instance_id = (
                 context.sync_session.client_instance_id

--- a/kolibri/core/device/management/commands/loadingpage.py
+++ b/kolibri/core/device/management/commands/loadingpage.py
@@ -7,7 +7,6 @@ from django.utils.translation import override
 
 from kolibri.utils.i18n import KOLIBRI_SUPPORTED_LANGUAGES
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -9,10 +9,11 @@ from django.urls import Resolver404
 from django.utils import translation
 from django.views.generic.base import RedirectView
 
-from .translation import get_language_from_request_and_is_from_path
 from kolibri.core.device.hooks import SetupHook
 from kolibri.core.device.utils import device_provisioned
 from kolibri.utils.conf import OPTIONS
+
+from .translation import get_language_from_request_and_is_from_path
 
 
 class KolibriLocaleMiddleware:

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -11,8 +11,6 @@ from morango.models import UUIDField
 from morango.models.core import InstanceIDModel
 from morango.models.core import SyncSession
 
-from .utils import LANDING_PAGE_LEARN
-from .utils import LANDING_PAGE_SIGN_IN
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.constants.demographics import custom_demographics_schema
 from kolibri.core.auth.constants.demographics import DescriptionTranslationValidator
@@ -37,6 +35,9 @@ from kolibri.deployment.default.sqlite_db_names import SYNC_QUEUE
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.options import update_options_file
+
+from .utils import LANDING_PAGE_LEARN
+from .utils import LANDING_PAGE_SIGN_IN
 
 device_permissions_fields = ["is_superuser", "can_manage_content"]
 

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -32,7 +32,6 @@ from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.conf import OPTIONS
 
-
 logger = logging.getLogger(__name__)
 WINDOW_SEC = 3
 MAX_ATTEMPTS = 5

--- a/kolibri/core/device/tasks.py
+++ b/kolibri/core/device/tasks.py
@@ -14,12 +14,12 @@ from kolibri.core.auth.utils.deprovision import deprovision
 from kolibri.core.device.hooks import GetOSUserHook
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import OSUser
-from kolibri.core.device.viewsets.device_settings import DeviceSerializerMixin
-from kolibri.core.device.viewsets.initialize_app import NoFacilityFacilityUserSerializer
 from kolibri.core.device.utils import APP_AUTH_TOKEN_COOKIE_NAME
 from kolibri.core.device.utils import provision_device
 from kolibri.core.device.utils import provision_single_user_device
 from kolibri.core.device.utils import valid_app_key_on_request
+from kolibri.core.device.viewsets.device_settings import DeviceSerializerMixin
+from kolibri.core.device.viewsets.initialize_app import NoFacilityFacilityUserSerializer
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.permissions import FirstProvisioning
 from kolibri.core.tasks.permissions import IsDeviceUnusable

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -39,9 +39,9 @@ from kolibri.core.device.models import StatusSentiment
 from kolibri.core.device.models import SyncQueueStatus
 from kolibri.core.device.models import UserSyncStatus
 from kolibri.core.device.utils import app_initialize_url
+from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.public.constants import user_sync_statuses
 from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
-from kolibri.core.discovery.models import NetworkLocation
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.tests.helpers import override_option
 

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -6,7 +6,6 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.test import TestCase
 
-from ..models import DeviceSettings
 from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.auth.constants.facility_presets import presets
 from kolibri.core.auth.models import Facility
@@ -18,6 +17,8 @@ from kolibri.core.device.utils import LANDING_PAGE_LEARN
 from kolibri.core.device.utils import provision_device
 from kolibri.core.device.utils import provision_from_file
 from kolibri.core.device.utils import setup_device_and_facility
+
+from ..models import DeviceSettings
 
 
 class DeviceProvisionTestCase(TestCase):

--- a/kolibri/core/device/test/test_locale_middleware.py
+++ b/kolibri/core/device/test/test_locale_middleware.py
@@ -12,7 +12,6 @@ from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.tests.helpers import override_option
 
-
 settings_override_dict = {
     "USE_I18N": True,
     "LANGUAGE_CODE": "en",

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -12,11 +12,6 @@ from django.test import TestCase
 from morango.errors import MorangoResumeSyncError
 from morango.sync.utils import mute_signals
 
-from ..soud import Context
-from ..soud import execute_sync
-from ..soud import execute_syncs
-from ..soud import request_sync_hook
-from ..soud import WINDOW_SEC
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import SyncQueue
@@ -24,6 +19,12 @@ from kolibri.core.device.models import SyncQueueStatus
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import DynamicNetworkLocation
 from kolibri.core.discovery.models import StaticNetworkLocation
+
+from ..soud import Context
+from ..soud import execute_sync
+from ..soud import execute_syncs
+from ..soud import request_sync_hook
+from ..soud import WINDOW_SEC
 
 
 class SoudContextTestCase(TestCase):

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -51,8 +51,9 @@ def get_device_setting(setting):
     :param setting: a string key to the model attribute or property
     :return: the value of the setting
     """
-    from .models import DeviceSettings
     from kolibri.core.auth.models import Facility
+
+    from .models import DeviceSettings
 
     try:
         device_settings = DeviceSettings.objects.get()
@@ -488,6 +489,7 @@ def is_full_facility_import(dataset_id):
     Returns True if this the dataset_id holds a facility that has been fully imported.
     """
     from morango.models.certificates import Certificate
+
     from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 
     return (

--- a/kolibri/core/device/viewsets/device_info.py
+++ b/kolibri/core/device/viewsets/device_info.py
@@ -1,10 +1,9 @@
 from sys import version_info
 
 from django.conf import settings
+from morango.models import InstanceIDModel
 from rest_framework import views
 from rest_framework.response import Response
-
-from morango.models import InstanceIDModel
 
 import kolibri
 from kolibri.core.device.permissions import UserHasAnyDevicePermissions

--- a/kolibri/core/deviceadmin/management/commands/dbbackup.py
+++ b/kolibri/core/deviceadmin/management/commands/dbbackup.py
@@ -3,8 +3,9 @@ import logging
 from django.core.management.base import BaseCommand
 
 import kolibri
-from ...utils import dbbackup
 from kolibri.utils import server
+
+from ...utils import dbbackup
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/deviceadmin/management/commands/dbrestore.py
+++ b/kolibri/core/deviceadmin/management/commands/dbrestore.py
@@ -6,11 +6,12 @@ from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 
 import kolibri
+from kolibri.utils import server
+
 from ...utils import dbrestore
 from ...utils import default_backup_folder
 from ...utils import get_dtm_from_backup_name
 from ...utils import search_latest
-from kolibri.utils import server
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/deviceadmin/tasks.py
+++ b/kolibri/core/deviceadmin/tasks.py
@@ -11,7 +11,6 @@ from kolibri.utils.conf import OPTIONS
 from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
 from kolibri.utils.time_utils import local_now
 
-
 logger = logging.getLogger(__name__)
 
 # Constant job_id for vacuum task

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -10,10 +10,6 @@ from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.status import HTTP_404_NOT_FOUND
 from rest_framework.test import APITestCase
 
-from .. import models
-from ..utils.network import connections
-from .helpers import mock_happy_no_os_request
-from .helpers import mock_request
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
 from kolibri.core.auth.test.helpers import provision_device
@@ -23,6 +19,11 @@ from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
 from kolibri.core.discovery.well_known import DATA_PORTAL_BASE_INSTANCE_ID
 from kolibri.core.discovery.well_known import DATA_PORTAL_SYNCING_BASE_URL
+
+from .. import models
+from ..utils.network import connections
+from .helpers import mock_happy_no_os_request
+from .helpers import mock_request
 
 
 @mock.patch.object(requests.Session, "request", mock_request)

--- a/kolibri/core/discovery/test/test_connections.py
+++ b/kolibri/core/discovery/test/test_connections.py
@@ -1,6 +1,8 @@
 import mock
 from django.test import TestCase
 
+from kolibri.core.auth.models import Facility
+
 from ..models import ConnectionStatus
 from ..models import LocationTypes
 from ..models import NetworkLocation
@@ -10,7 +12,6 @@ from ..utils.network.connections import capture_connection_state
 from ..utils.network.connections import update_network_location
 from .helpers import info as mock_device_info
 from .helpers import mock_response
-from kolibri.core.auth.models import Facility
 
 
 class BaseTestCase(TestCase):

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,10 +1,11 @@
 import mock
 from django.test import TestCase
 
+from kolibri.core.tasks.job import Priority
+
 from ..utils.network.broadcast import KolibriBroadcast
 from ..utils.network.broadcast import KolibriInstance
 from ..utils.network.search import NetworkLocationListener
-from kolibri.core.tasks.job import Priority
 
 MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -3,6 +3,7 @@ import requests
 from django.test import TestCase
 
 import kolibri
+
 from ..models import ConnectionStatus
 from ..models import LocationTypes
 from ..models import NetworkLocation

--- a/kolibri/core/discovery/test/test_tasks.py
+++ b/kolibri/core/discovery/test/test_tasks.py
@@ -5,6 +5,9 @@ import uuid
 import mock
 from django.test import TestCase
 
+from kolibri.core.tasks.job import Priority
+from kolibri.core.tasks.registry import RegisteredTask
+
 from ..models import ConnectionStatus
 from ..models import DynamicNetworkLocation
 from ..models import LocationTypes
@@ -23,8 +26,6 @@ from ..tasks import remove_dynamic_network_location
 from ..tasks import reset_connection_states
 from ..utils.network.broadcast import KolibriInstance
 from .helpers import info as mock_device_info
-from kolibri.core.tasks.job import Priority
-from kolibri.core.tasks.registry import RegisteredTask
 
 MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555

--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -5,8 +5,9 @@ import shutil
 import subprocess
 import sys
 
-from .constants import drivetypes
 from kolibri.utils.android import on_android
+
+from .constants import drivetypes
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -18,7 +18,6 @@ from zeroconf import Zeroconf
 from kolibri.core.device.utils import get_device_info
 from kolibri.utils.conf import OPTIONS
 
-
 SERVICE_TYPE = "Kolibri._sub._http._tcp.local."
 LOCAL_DOMAIN = "kolibri.local"
 TRUE = "TRUE"

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -6,10 +6,6 @@ import requests
 from django.utils import timezone
 
 import kolibri
-from . import errors
-from .urls import get_normalized_url_variations
-from .urls import HTTP_PORTS
-from .urls import HTTPS_PORTS
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import LocationTypes
 from kolibri.core.discovery.models import NetworkLocation
@@ -17,6 +13,11 @@ from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.urls import join_url
 from kolibri.utils.http_session import SameHostSession
 from kolibri.utils.server import get_urls
+
+from . import errors
+from .urls import get_normalized_url_variations
+from .urls import HTTP_PORTS
+from .urls import HTTPS_PORTS
 
 logger = logging.getLogger(__name__)
 
@@ -238,8 +239,8 @@ class NetworkClient(SameHostSession):
         :return: A boolean determining success, never False if `raise_if_unavailable=True`
         """
 
-        from kolibri.core.device.utils import DEVICE_INFO_VERSION
         from kolibri.core.device.utils import device_info_keys
+        from kolibri.core.device.utils import DEVICE_INFO_VERSION
 
         # don't reconnect if client has already done so
         if self.device_info is not None:

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -3,12 +3,13 @@ from contextlib import closing
 from contextlib import contextmanager
 from ipaddress import ip_address
 
-from . import errors
-from .client import NetworkClient
-from .urls import parse_address_into_components
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import LocationTypes
 from kolibri.core.discovery.models import NetworkLocation
+
+from . import errors
+from .client import NetworkClient
+from .urls import parse_address_into_components
 
 
 def check_if_port_open(base_url, timeout=1):
@@ -42,8 +43,8 @@ def capture_network_state(network_location, client):
     :param client: The NetworkClient which successfully connected to the location
     :type client: NetworkClient
     """
-    from kolibri.core.device.utils import DEVICE_INFO_VERSION
     from kolibri.core.device.utils import device_info_keys
+    from kolibri.core.device.utils import DEVICE_INFO_VERSION
 
     # having validated the base URL, we can save that
     network_location.base_url = client.base_url

--- a/kolibri/core/discovery/utils/network/urls.py
+++ b/kolibri/core/discovery/utils/network/urls.py
@@ -3,7 +3,6 @@ from urllib.parse import urlparse
 
 from . import errors
 
-
 # android is served on port 5000
 HTTP_PORTS = (8080, 80, 8008, 8000, 5000)
 HTTPS_PORTS = (443,)

--- a/kolibri/core/exams/kolibri_plugin.py
+++ b/kolibri/core/exams/kolibri_plugin.py
@@ -1,12 +1,13 @@
+from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
+from kolibri.plugins.hooks import register_hook
+
 from .single_user_assignment_utils import (
     update_assignments_from_individual_syncable_exams,
 )
 from .single_user_assignment_utils import (
     update_individual_syncable_exams_from_assignments,
 )
-from kolibri.core.auth.hooks import FacilityDataSyncHook
-from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
-from kolibri.plugins.hooks import register_hook
 
 
 class SingleUserExamSerializeOperation(KolibriSingleUserSyncOperation):

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -4,8 +4,6 @@ from django.db import models
 from django.db.utils import IntegrityError
 from django.utils import timezone
 
-from .permissions import UserCanReadExamAssignmentData
-from .permissions import UserCanReadExamData
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import AbstractFacilityDataModel
 from kolibri.core.auth.models import Collection
@@ -14,6 +12,9 @@ from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.fields import JSONField
 from kolibri.core.notifications.models import LearnerProgressNotification
+
+from .permissions import UserCanReadExamAssignmentData
+from .permissions import UserCanReadExamData
 
 
 def exam_assignment_lookup(question_sources):

--- a/kolibri/core/exams/single_user_assignment_utils.py
+++ b/kolibri/core/exams/single_user_assignment_utils.py
@@ -1,8 +1,9 @@
-from .models import ExamAssignment
-from .models import IndividualSyncableExam
 from kolibri.core.auth.constants import collection_kinds
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
+
+from .models import ExamAssignment
+from .models import IndividualSyncableExam
 
 
 def update_individual_syncable_exams_from_assignments(user_id):

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -5,7 +5,6 @@ from django.utils.timezone import now
 from le_utils.constants import content_kinds
 from rest_framework import status
 
-from .. import models
 from kolibri.core import error_constants
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
@@ -17,6 +16,8 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.exams.constants import MAX_QUESTIONS_PER_QUIZ_SECTION
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
+
+from .. import models
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -8,7 +8,6 @@ from django.db.models.fields import Field
 from django.utils import timezone
 from jsonfield import JSONField as JSONFieldBase
 
-
 date_time_format = "%Y-%m-%d %H:%M:%S.%f"
 tz_format = "({tz})"
 tz_regex = re.compile(r"\(([^\)]+)\)")

--- a/kolibri/core/lessons/kolibri_plugin.py
+++ b/kolibri/core/lessons/kolibri_plugin.py
@@ -1,12 +1,13 @@
+from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
+from kolibri.plugins.hooks import register_hook
+
 from .single_user_assignment_utils import (
     update_assignments_from_individual_syncable_lessons,
 )
 from .single_user_assignment_utils import (
     update_individual_syncable_lessons_from_assignments,
 )
-from kolibri.core.auth.hooks import FacilityDataSyncHook
-from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
-from kolibri.plugins.hooks import register_hook
 
 
 class SingleUserLessonSerializeOperation(KolibriSingleUserSyncOperation):

--- a/kolibri/core/lessons/single_user_assignment_utils.py
+++ b/kolibri/core/lessons/single_user_assignment_utils.py
@@ -1,7 +1,8 @@
-from .models import IndividualSyncableLesson
-from .models import LessonAssignment
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
+
+from .models import IndividualSyncableLesson
+from .models import LessonAssignment
 
 
 def update_individual_syncable_lessons_from_assignments(user_id):

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -1,7 +1,6 @@
 from django.urls import reverse
 from rest_framework import status
 
-from .. import models
 from kolibri.core import error_constants
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
@@ -15,6 +14,7 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 
+from .. import models
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/core/lessons/viewsets/lesson.py
+++ b/kolibri/core/lessons/viewsets/lesson.py
@@ -13,9 +13,9 @@ from kolibri.core import error_constants
 from kolibri.core.api import HexUUIDField
 from kolibri.core.api import ValuesMethodField
 from kolibri.core.api import ValuesViewset
+from kolibri.core.auth.api import _ensure_raw_dict
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
-from kolibri.core.auth.api import _ensure_raw_dict
 from kolibri.core.auth.constants.collection_kinds import ADHOCLEARNERSGROUP
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -19,8 +19,6 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from le_utils.constants import content_kinds
 
-from .models import ContentSessionLog
-from .models import ContentSummaryLog
 from kolibri.core.auth.constants import user_kinds
 from kolibri.core.auth.models import Role
 from kolibri.core.content.models import ChannelMetadata
@@ -29,6 +27,8 @@ from kolibri.core.utils.csv import open_csv_for_writing
 from kolibri.core.utils.csv import output_mapper
 from kolibri.core.utils.csv import validate_open_csv_params
 
+from .models import ContentSessionLog
+from .models import ContentSummaryLog
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/logger/evaluation.py
+++ b/kolibri/core/logger/evaluation.py
@@ -4,7 +4,6 @@ from django.db.models.expressions import F
 from django.db.models.expressions import OuterRef
 from django.db.models.expressions import Subquery
 
-
 LOG_ORDER_BY = F("end_timestamp").desc(nulls_last=True)
 
 

--- a/kolibri/core/logger/kolibri_plugin.py
+++ b/kolibri/core/logger/kolibri_plugin.py
@@ -11,7 +11,6 @@ from kolibri.core.logger.utils.attempt_log_consolidation import (
 from kolibri.core.logger.utils.exam_log_migration import migrate_from_exam_logs
 from kolibri.plugins.hooks import register_hook
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/logger/management/commands/generateuserdata.py
+++ b/kolibri/core/logger/management/commands/generateuserdata.py
@@ -11,7 +11,6 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.logger.utils import user_data as utils
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -25,7 +25,6 @@ from django.utils import timezone
 from morango.models import SyncableModelQuerySet
 from morango.models import UUIDField
 
-from .permissions import AnyoneCanWriteAnonymousLogs
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import AbstractFacilityDataModel
 from kolibri.core.auth.models import Facility
@@ -37,6 +36,7 @@ from kolibri.core.fields import DateTimeTzField
 from kolibri.core.fields import JSONField
 from kolibri.utils.time_utils import local_now
 
+from .permissions import AnyoneCanWriteAnonymousLogs
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/logger/test/factory_logger.py
+++ b/kolibri/core/logger/test/factory_logger.py
@@ -1,8 +1,9 @@
 import factory
 
-from .. import models
 from kolibri.core.auth.test.test_api import FacilityUserFactory
 from kolibri.utils.time_utils import local_now
+
+from .. import models
 
 
 class ContentSessionLogFactory(factory.DjangoModelFactory):

--- a/kolibri/core/logger/test/helpers.py
+++ b/kolibri/core/logger/test/helpers.py
@@ -7,16 +7,17 @@ from le_utils.constants import content_kinds
 from le_utils.constants import exercises
 from le_utils.constants import modalities
 
-from .factory_logger import ContentSessionLogFactory
-from .factory_logger import ContentSummaryLogFactory
-from .factory_logger import FacilityUserFactory
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ContentNode
-from kolibri.core.logger.viewsets.progress_tracking import MIN_INTEGER
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.viewsets.progress_tracking import MIN_INTEGER
+
+from .factory_logger import ContentSessionLogFactory
+from .factory_logger import ContentSummaryLogFactory
+from .factory_logger import FacilityUserFactory
 
 
 class EvaluationMixin:

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -16,15 +16,6 @@ from django.core.management import call_command
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
-from ..models import ContentSessionLog
-from ..models import ContentSummaryLog
-from ..models import GenerateCSVLogRequest
-from ..models import MasteryLog
-from ..viewsets.mastery_log import MasteryLogSerializer
-from .factory_logger import ContentSessionLogFactory
-from .factory_logger import ContentSummaryLogFactory
-from .factory_logger import FacilityUserFactory
-from .helpers import EvaluationMixin
 from kolibri.core.auth.management.commands.bulkexportusers import (
     CSV_EXPORT_FILENAMES as USER_CSV_EXPORT_FILENAMES,
 )
@@ -37,6 +28,16 @@ from kolibri.core.logger.tasks import get_filepath
 from kolibri.core.logger.tasks import log_exports_cleanup
 from kolibri.core.utils.csv import open_csv_for_reading
 from kolibri.utils.time_utils import local_now
+
+from ..models import ContentSessionLog
+from ..models import ContentSummaryLog
+from ..models import GenerateCSVLogRequest
+from ..models import MasteryLog
+from ..viewsets.mastery_log import MasteryLogSerializer
+from .factory_logger import ContentSessionLogFactory
+from .factory_logger import ContentSummaryLogFactory
+from .factory_logger import FacilityUserFactory
+from .helpers import EvaluationMixin
 
 
 class ContentSummaryLogCSVExportTestCase(APITestCase):

--- a/kolibri/core/logger/test/test_evaluation.py
+++ b/kolibri/core/logger/test/test_evaluation.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
 
-from .helpers import EvaluationMixin
 from kolibri.core.logger.evaluation import attempts_diff
 from kolibri.core.logger.models import AttemptLog
+
+from .helpers import EvaluationMixin
 
 
 class EvaluationTestCase(EvaluationMixin, TestCase):

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -16,11 +16,6 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
-from ..models import AttemptLog
-from ..models import ContentSessionLog
-from ..models import ContentSummaryLog
-from ..models import MasteryLog
-from .factory_logger import FacilityUserFactory
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
@@ -41,6 +36,12 @@ from kolibri.core.notifications.api import quiz_answered_notification
 from kolibri.core.notifications.api import quiz_completed_notification
 from kolibri.core.notifications.api import quiz_started_notification
 from kolibri.utils.time_utils import local_now
+
+from ..models import AttemptLog
+from ..models import ContentSessionLog
+from ..models import ContentSummaryLog
+from ..models import MasteryLog
+from .factory_logger import FacilityUserFactory
 
 
 def create_assigned_quiz_for_user(user):

--- a/kolibri/core/logger/test/test_permissions.py
+++ b/kolibri/core/logger/test/test_permissions.py
@@ -6,11 +6,12 @@ import uuid
 
 from django.test import TestCase
 
+from kolibri.core.auth.test.helpers import create_dummy_facility_data
+
 from .factory_logger import ContentSessionLogFactory
 from .factory_logger import ContentSummaryLogFactory
 from .factory_logger import GenerateCSVLogRequestFactory
 from .factory_logger import UserSessionLogFactory
-from kolibri.core.auth.test.helpers import create_dummy_facility_data
 
 
 class ContentSessionLogPermissionsTestCase(TestCase):

--- a/kolibri/core/logger/viewsets/attempt_log.py
+++ b/kolibri/core/logger/viewsets/attempt_log.py
@@ -3,12 +3,13 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import NumberFilter
 from rest_framework import serializers
 
-from ..models import AttemptLog
-from .filters import BaseLogFilter
 from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.content.api import OptionalPageNumberPagination
+
+from ..models import AttemptLog
+from .filters import BaseLogFilter
 
 
 class AttemptLogSerializer(serializers.ModelSerializer):

--- a/kolibri/core/logger/viewsets/csv_log_request.py
+++ b/kolibri/core/logger/viewsets/csv_log_request.py
@@ -5,10 +5,11 @@ from django_filters.rest_framework import ModelChoiceFilter
 from rest_framework import serializers
 from rest_framework import viewsets
 
-from ..models import GenerateCSVLogRequest
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.models import Facility
+
+from ..models import GenerateCSVLogRequest
 
 
 class GenerateCSVLogRequestSerializer(serializers.ModelSerializer):

--- a/kolibri/core/logger/viewsets/mastery_log.py
+++ b/kolibri/core/logger/viewsets/mastery_log.py
@@ -9,18 +9,19 @@ from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from .attempt_log import AttemptLogDiffSerializer
-from .attempt_log import AttemptLogViewSet
-from .filters import BaseLogFilter
-from ..evaluation import attempts_diff
-from ..evaluation import LOG_ORDER_BY
-from ..models import AttemptLog
-from ..models import MasteryLog
 from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.content.api import OptionalPageNumberPagination
 from kolibri.core.decorators import query_params_required
+
+from ..evaluation import attempts_diff
+from ..evaluation import LOG_ORDER_BY
+from ..models import AttemptLog
+from ..models import MasteryLog
+from .attempt_log import AttemptLogDiffSerializer
+from .attempt_log import AttemptLogViewSet
+from .filters import BaseLogFilter
 
 
 class _AttemptLogDiffViewSet(AttemptLogViewSet):

--- a/kolibri/core/logger/viewsets/progress_tracking.py
+++ b/kolibri/core/logger/viewsets/progress_tracking.py
@@ -25,10 +25,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 
-from ..models import AttemptLog
-from ..models import ContentSessionLog
-from ..models import ContentSummaryLog
-from ..models import MasteryLog
 from kolibri.core.auth.models import dataset_cache
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.exams.models import Exam
@@ -46,6 +42,11 @@ from kolibri.core.notifications.api import quiz_started_notification
 from kolibri.core.notifications.api import start_lesson_resource
 from kolibri.core.notifications.tasks import wrap_to_save_queue
 from kolibri.utils.time_utils import local_now
+
+from ..models import AttemptLog
+from ..models import ContentSessionLog
+from ..models import ContentSummaryLog
+from ..models import MasteryLog
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -7,11 +7,6 @@ from django.db.models import Sum
 from django.db.models import When
 from le_utils.constants import content_kinds
 
-from .models import HelpReason
-from .models import LearnerProgressNotification
-from .models import NotificationEventType
-from .models import NotificationObjectType
-from .utils import memoize
 from kolibri.core.content.models import ContentNode
 from kolibri.core.courses.models import CourseSession
 from kolibri.core.courses.models import CourseSessionAssignment
@@ -25,6 +20,12 @@ from kolibri.core.logger.models import ExamLog
 from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.utils.quiz import annotate_response_summary
 from kolibri.core.query import annotate_array_aggregate
+
+from .models import HelpReason
+from .models import LearnerProgressNotification
+from .models import NotificationEventType
+from .models import NotificationObjectType
+from .utils import memoize
 
 NEEDS_HELP_NOTIFICATION_THRESHOLD = 4
 

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -27,7 +27,6 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .. import error_constants
 from kolibri.core.api import BaseValuesViewset
 from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.middleware import session_exempt
@@ -54,6 +53,8 @@ from kolibri.core.public.constants.user_sync_options import HANDSHAKING_TIME
 from kolibri.core.public.constants.user_sync_options import MAX_CONCURRENT_SYNCS
 from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.utils.conf import OPTIONS
+
+from .. import error_constants
 
 
 class InfoViewSet(viewsets.ViewSet):

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -19,9 +19,11 @@ from django.urls import include
 from django.urls import re_path
 from rest_framework import routers
 
+from kolibri.core.content.public_api import ImportMetadataViewset
+
 from ..auth.api import PublicFacilityViewSet
-from ..auth.viewsets.facility_user import PublicFacilityUserViewSet
 from ..auth.api import PublicSignUpViewSet
+from ..auth.viewsets.facility_user import PublicFacilityUserViewSet
 from .api import FacilitySearchUsernameViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
@@ -31,8 +33,6 @@ from .api import PublicChannelMetadataViewSet
 from .api import PublicContentNodeTreeViewSet
 from .api import PublicContentNodeViewSet
 from .api import SyncQueueAPIView
-from kolibri.core.content.public_api import ImportMetadataViewset
-
 
 router = routers.SimpleRouter()
 

--- a/kolibri/core/sqlite/utils.py
+++ b/kolibri/core/sqlite/utils.py
@@ -72,8 +72,8 @@ def check_sqlite_integrity(connection):
 
 
 def repair_sqlite_db(connection):
-    from kolibri.core.deviceadmin.utils import KWARGS_IO_WRITE
     from kolibri.core.deviceadmin.utils import default_backup_folder
+    from kolibri.core.deviceadmin.utils import KWARGS_IO_WRITE
 
     if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
         return

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -6,7 +6,6 @@ from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.worker import Worker
 from kolibri.utils import conf
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -14,7 +14,6 @@ from kolibri.core.tasks.permissions import BasePermission
 from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.validation import JobValidator
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -17,7 +17,6 @@ from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.utils.time_utils import local_now
 
-
 QUEUE = "pytest"
 
 

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -26,7 +26,6 @@ from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.registry import TaskRegistry
 from kolibri.core.tasks.validation import JobValidator
 
-
 DUMMY_PASSWORD = "password"
 
 fake_job_defaults = dict(

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -23,7 +23,6 @@ from kolibri.utils import conf
 from kolibri.utils.options import FD_PER_THREAD
 from kolibri.utils.system import get_fd_limit
 
-
 logger = logging.getLogger(__name__)
 
 # An object on which to store data about the current job

--- a/kolibri/core/tasks/viewsets/tasks.py
+++ b/kolibri/core/tasks/viewsets/tasks.py
@@ -18,7 +18,6 @@ from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.registry import TaskRegistry
 from kolibri.core.tasks.validation import EnqueueArgsSerializer
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -8,7 +8,6 @@ from kolibri.utils.version import get_version_and_operator_from_range
 from kolibri.utils.version import normalize_version_to_semver
 from kolibri.utils.version import version_matches_range
 
-
 CURRENT_VERSION = VersionInfo.parse(normalize_version_to_semver(kolibri.__version__))
 
 

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -35,15 +35,16 @@ from django.urls import include
 from django.urls import re_path
 from rest_framework import routers
 
+from kolibri.core.device.translation import i18n_patterns
+from kolibri.core.device.viewsets.plugins import PluginsViewSet
+from kolibri.plugins.utils.urls import get_urls as plugin_urls
+
 from .views import GuestRedirectView
 from .views import logout_view
 from .views import RootURLRedirectView
 from .views import set_language
 from .views import StatusCheckView
 from .views import UnsupportedBrowserView
-from kolibri.core.device.viewsets.plugins import PluginsViewSet
-from kolibri.core.device.translation import i18n_patterns
-from kolibri.plugins.utils.urls import get_urls as plugin_urls
 
 app_name = "kolibri"
 

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -4,7 +4,6 @@ from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
 from django.utils.functional import SimpleLazyObject
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -28,7 +28,6 @@ from importlib_resources import files
 
 from kolibri.plugins import hooks
 
-
 IGNORE_PATTERNS = (re.compile(I) for I in [r".+\.hot-update.js", r".+\.map"])
 
 

--- a/kolibri/core/webpack/middleware.py
+++ b/kolibri/core/webpack/middleware.py
@@ -4,7 +4,6 @@ from django.shortcuts import render
 
 from .hooks import WebpackError
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/core/webpack/test/base.py
+++ b/kolibri/core/webpack/test/base.py
@@ -2,7 +2,6 @@ import copy
 
 from ..hooks import WebpackBundleHook
 
-
 TEST_STATS_FILE_DATA = {
     "status": "done",
     "chunks": {

--- a/kolibri/core/webpack/test/test_webpack_tags.py
+++ b/kolibri/core/webpack/test/test_webpack_tags.py
@@ -1,7 +1,8 @@
 from django.test.testcases import TestCase
 
-from .base import Hook
 from kolibri.plugins.hooks import register_hook
+
+from .base import Hook
 
 
 class KolibriTagNavigationTestCase(TestCase):

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -28,7 +28,6 @@ from kolibri.utils import conf
 from kolibri.utils import i18n
 from kolibri.utils.logger import get_logging_config
 
-
 try:
     isolation_level = None
     import psycopg2  # noqa

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -8,7 +8,6 @@ from rest_framework import permissions
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from .serializers import LessonReportSerializer
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
@@ -17,6 +16,8 @@ from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import MasteryLog
+
+from .serializers import LessonReportSerializer
 
 
 class LessonReportPermissions(permissions.BasePermission):

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -11,7 +11,6 @@ from kolibri.plugins.hooks import register_hook
 from kolibri.utils import translation
 from kolibri.utils.translation import gettext as _
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from django.utils import timezone
 from le_utils.constants import content_kinds
 
-from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
@@ -27,6 +26,8 @@ from kolibri.plugins.coach.class_summary_api import HELP_NEEDED
 from kolibri.plugins.coach.class_summary_api import NOT_STARTED
 from kolibri.plugins.coach.class_summary_api import STARTED
 from kolibri.utils.time_utils import local_now
+
+from . import helpers
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/plugins/coach/test/test_classroom_notifications.py
+++ b/kolibri/plugins/coach/test/test_classroom_notifications.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from django.db.utils import DatabaseError
 from django.urls import reverse
 
-from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
@@ -12,6 +11,7 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.notifications.models import LearnerProgressNotification
 from kolibri.utils.time_utils import local_now
 
+from . import helpers
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from django.utils.timezone import now
 from le_utils.constants import content_kinds
 
-from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -20,6 +19,8 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
+
+from . import helpers
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/plugins/coach/test/test_lesson_report.py
+++ b/kolibri/plugins/coach/test/test_lesson_report.py
@@ -2,7 +2,6 @@ import datetime
 
 from django.urls import reverse
 
-from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
@@ -11,6 +10,8 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
 from kolibri.core.logger.models import ContentSummaryLog
+
+from . import helpers
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/plugins/coach/test/test_unit_report.py
+++ b/kolibri/plugins/coach/test/test_unit_report.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from le_utils.constants import content_kinds
 from le_utils.constants import modalities
 
-from . import helpers
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
@@ -28,6 +27,8 @@ from kolibri.plugins.coach.unit_report_api import get_test_status
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_CLOSED
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_NOT_ACTIVATED
 from kolibri.plugins.coach.unit_report_api import TEST_STATUS_OPEN
+
+from . import helpers
 
 DUMMY_PASSWORD = "password"
 

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -60,9 +60,9 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 
     @property
     def plugin_data(self):
-        from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
-        from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
         from kolibri.core.content.models import ContentNode
+        from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
+        from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_URL
 
         courses_exist = ContentNode.objects.filter(
             available=True, modality=modalities.COURSE

--- a/kolibri/plugins/learn/test/test_learner_course.py
+++ b/kolibri/plugins/learn/test/test_learner_course.py
@@ -19,7 +19,6 @@ from kolibri.core.courses.models import TestType
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import ContentSummaryLog
 
-
 DUMMY_PASSWORD = "password"
 
 

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -27,7 +27,6 @@ from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
 
-
 contentnode_progress_viewset = ContentNodeProgressViewset()
 contentnode_viewset = ContentNodeViewset()
 user_contentnode_viewset = UserContentNodeViewset()

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -105,8 +105,8 @@ def status_fn(job):
 
 
 def start_soud_sync(user_id):
-    from kolibri.core.device import soud
     from kolibri.core.auth.tasks import enqueue_soud_sync_processing
+    from kolibri.core.device import soud
 
     # This user would not previously have been included in any syncs
     # triggered by a device appearing on the network, so request syncs for them now

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -13,12 +13,12 @@ from django.urls import reverse
 from semver import VersionInfo
 
 if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
     from importlib_metadata import distribution
+    from importlib_metadata import entry_points
     from importlib_metadata import PackageNotFoundError
 else:
-    from importlib.metadata import entry_points
     from importlib.metadata import distribution
+    from importlib.metadata import entry_points
     from importlib.metadata import PackageNotFoundError
 
 import kolibri
@@ -30,8 +30,8 @@ from kolibri.plugins import ConfigDict
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import KolibriHook
-from kolibri.utils.modules import module_exists
 from kolibri.utils.conf import KOLIBRI_HOME
+from kolibri.utils.modules import module_exists
 from kolibri.utils.version import normalize_version_to_semver
 
 logger = logging.getLogger(__name__)

--- a/kolibri/utils/android.py
+++ b/kolibri/utils/android.py
@@ -1,6 +1,5 @@
 import sys
 
-
 # A constant to be used in place of Python's platform.system()
 # when we know we are on an Android system.
 ANDROID_PLATFORM_SYSTEM_VALUE = "Android"

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -21,14 +21,13 @@ from kolibri.plugins.utils import enable_default_plugins
 from kolibri.plugins.utils import enable_plugins
 from kolibri.plugins.utils import iterate_plugins
 from kolibri.utils import server
-from kolibri.utils.modules import module_exists
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.constants import installation_types
 from kolibri.utils.debian_check import check_debian_user
 from kolibri.utils.main import initialize
 from kolibri.utils.main import set_django_settings_and_python_path
 from kolibri.utils.main import setup_logging
-
+from kolibri.utils.modules import module_exists
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/utils/data.py
+++ b/kolibri/utils/data.py
@@ -1,6 +1,5 @@
 import re
 
-
 BYTES_PREFIXES = ("", "K", "M", "G", "T", "P")
 PREFIX_FACTOR_BYTES = 1000.0
 

--- a/kolibri/utils/database.py
+++ b/kolibri/utils/database.py
@@ -4,7 +4,6 @@ import os
 import sqlite3
 from datetime import datetime
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -21,7 +21,6 @@ from requests.exceptions import Timeout
 
 from kolibri.utils.http_session import SameHostSession
 
-
 try:
     # Pre-empt the PanicException that importing cryptography can cause
     # when we are using a non-compatible version of cffi on Python 3.13

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -24,7 +24,6 @@ from whitenoise.string_utils import decode_path_info
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.utils.file_transfer import RemoteFile
 
-
 compressed_file_extensions = ("gz",)
 
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -8,7 +8,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-
 GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -30,15 +30,12 @@ except NotImplementedError:
     psutil = None
 
 
+from kolibri.deployment.default.sqlite_db_names import ADDITIONAL_SQLITE_DATABASES
+from kolibri.plugins.utils.options import extend_config_spec
 from kolibri.utils.data import bytes_from_humans
 from kolibri.utils.i18n import KOLIBRI_LANGUAGE_INFO
 from kolibri.utils.i18n import KOLIBRI_SUPPORTED_LANGUAGES
-from kolibri.plugins.utils.options import extend_config_spec
-from kolibri.deployment.default.sqlite_db_names import (
-    ADDITIONAL_SQLITE_DATABASES,
-)
 from kolibri.utils.system import get_fd_limit
-
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/utils/pskolibri/__init__.py
+++ b/kolibri/utils/pskolibri/__init__.py
@@ -52,7 +52,6 @@ from kolibri.utils.pskolibri.common import memoize_when_activated
 from kolibri.utils.pskolibri.common import NoSuchProcess
 from kolibri.utils.pskolibri.common import WINDOWS
 
-
 _TOTAL_PHYMEM = None
 _timer = getattr(time, "monotonic", time.time)
 

--- a/kolibri/utils/pskolibri/common.py
+++ b/kolibri/utils/pskolibri/common.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 from kolibri.utils.android import on_android
 
-
 POSIX = os.name == "posix"
 WINDOWS = os.name == "nt"
 LINUX = sys.platform.startswith("linux") and not on_android()

--- a/kolibri/utils/server/__init__.py
+++ b/kolibri/utils/server/__init__.py
@@ -45,7 +45,6 @@ from kolibri.utils.server.hooks import KolibriProcessHook
 from kolibri.utils.system import become_daemon
 from kolibri.utils.system import pid_exists
 
-
 logger = logging.getLogger(__name__)
 
 # Status codes for kolibri
@@ -261,8 +260,8 @@ class DefaultScheduledTasksPlugin(SimplePlugin):
     def START(self):
         from kolibri.core.analytics.tasks import schedule_local_notification_generation
         from kolibri.core.analytics.tasks import schedule_ping
-        from kolibri.core.deviceadmin.tasks import schedule_vacuum
         from kolibri.core.deviceadmin.tasks import schedule_streamed_cache_cleanup
+        from kolibri.core.deviceadmin.tasks import schedule_vacuum
 
         # schedule the pingback job if not already scheduled
         schedule_ping()
@@ -335,8 +334,8 @@ class ZeroConfPlugin(Monitor):
         # Register the Kolibri zeroconf service so it will be discoverable on the network
         from kolibri.core.discovery.utils.network.broadcast import (
             build_broadcast_instance,
-            KolibriBroadcast,
         )
+        from kolibri.core.discovery.utils.network.broadcast import KolibriBroadcast
         from kolibri.core.discovery.utils.network.search import NetworkLocationListener
 
         instance = build_broadcast_instance(self.port)

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -105,7 +105,8 @@ def test_conditional_backup():
         pass
     os.mkdir(default_path)
 
-    from kolibri.core.deviceadmin.utils import dbbackup, get_backup_files
+    from kolibri.core.deviceadmin.utils import dbbackup
+    from kolibri.core.deviceadmin.utils import get_backup_files
 
     # Making few backups
     dbbackup("0.11.0")

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -136,8 +136,9 @@ class TestServerDefaultScheduledTasks:
     ):
         with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
             # Schedule two userdefined jobs
-            from kolibri.utils.time_utils import local_now
             from datetime import timedelta
+
+            from kolibri.utils.time_utils import local_now
 
             schedule_time = local_now() + timedelta(hours=1)
             test1 = job_storage.schedule(schedule_time, Job(id))

--- a/kolibri/utils/translation.py
+++ b/kolibri/utils/translation.py
@@ -21,7 +21,6 @@ from django.utils.translation.trans_real import DjangoTranslation
 
 import kolibri
 
-
 # Translations are cached in a dictionary for every language.
 # The active translations are stored by threadid to make them thread local.
 _translations = {}

--- a/packages/kolibri-build/src/webpack_json.py
+++ b/packages/kolibri-build/src/webpack_json.py
@@ -10,10 +10,12 @@ import tempfile
 # Use modern APIs exclusively, with backports for older Python versions
 try:
     # Python 3.8+ has importlib.metadata
-    from importlib.metadata import distribution, PackageNotFoundError
+    from importlib.metadata import distribution
+    from importlib.metadata import PackageNotFoundError
 except ImportError:
     # Python 3.6-3.7 need the backport
-    from importlib_metadata import distribution, PackageNotFoundError
+    from importlib_metadata import distribution
+    from importlib_metadata import PackageNotFoundError
 
 try:
     # Python 3.9+ has full importlib.resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "C90", "T20"]
+select = ["E", "F", "W", "C90", "T20", "I"]
 ignore = ["E203", "E721", "E741"]
 # Exclude migrations from linting (auto-generated code) but still format them
 exclude = ["kolibri/*/migrations/*"]
@@ -185,6 +185,10 @@ max-complexity = 10
 
 [tool.ruff.lint.isort]
 known-first-party = ["kolibri"]
+# Match the prior reorder-python-imports style: one import per line,
+# sorted case-insensitively rather than grouped by type.
+force-single-line = true
+order-by-type = false
 
 [tool.coverage.run]
 branch = true

--- a/test/test_cext.py
+++ b/test/test_cext.py
@@ -29,8 +29,8 @@ def test_cryptography_runs():
     """
     if os.environ.get("GITHUB_JOB") == "cext":
         try:
-            from cryptography.hazmat.primitives.asymmetric import rsa
             from cryptography.hazmat.backends import default_backend
+            from cryptography.hazmat.primitives.asymmetric import rsa
 
             crypto_backend = default_backend()
             rsa.generate_private_key(


### PR DESCRIPTION
## Summary

Import-ordering enforcement was silently lost when Kolibri migrated from `reorder_python_imports` to ruff — the `I` rule category was never added to ruff's `select`, so nothing reordered or split imports. This adds `I` and configures isort to reproduce the old one-per-line style (`force-single-line`, `order-by-type = false`, i.e. case-insensitive rather than CapWords-first).

Three commits: the config change, a mechanical one-time reformat (188 files, `ruff check --fix`), and a `.git-blame-ignore-revs` entry for the reformat.

`from kolibri.utils.main import initialize` in `integration_testing/scripts/viewset_serialization_benchmark.py` is marked `# isort: skip` to preserve its load-bearing kolibri-before-Django order (compat patches must apply before Django is imported).

## References

None — no tracking issue. Part of a cross-repo pass restoring import-ordering enforcement after the uv migrations.

## Reviewer guidance

The reformat commit is purely mechanical — review the config commit for intent. The reformat is excluded from `git blame` via `.git-blame-ignore-revs`. Verify with `ruff check --select I .` (clean on the branch).

Each reformat diff was scanned for semantic import-order changes; the only one found was the benchmark import above, now protected with `# isort: skip`.

## AI usage

Used Claude Code to investigate why import style was no longer enforced after the uv migration, derive the ruff isort config that reproduces the old `reorder_python_imports` behaviour, and apply it. The reformat diff was reviewed for load-bearing import-order changes before committing.