### PR TITLE
Speed up the Python test suite

### DIFF
--- a/kolibri/conftest.py
+++ b/kolibri/conftest.py
@@ -72,9 +72,37 @@ def _guarded_socket_connect(sock, address):
     return _real_socket_connect(sock, address)
 
 
+def _use_small_test_keys():
+    # Morango generates a 2048-bit RSA keypair for every Key() (certificates,
+    # instance IDs, sync setup). With the pure-Python ``rsa`` backend that
+    # Kolibri ships, each keygen costs ~1-2s and dominates test setup. Key
+    # *size* is irrelevant to test correctness (sign/verify still round-trips
+    # and keys stay distinct), so force a small size in tests - the crypto
+    # analogue of using a fast password hasher.
+    #
+    # Only the pure-Python backend supports arbitrary key sizes: the
+    # ``cryptography`` backend stores public keys against a hardcoded 2048-bit
+    # DER header (PKCS8_HEADER), so a smaller key fails to deserialize. That
+    # backend (and M2Crypto) generates keys in milliseconds anyway, so there
+    # is nothing to gain - only patch the slow pure-Python path.
+    from morango.models.fields.crypto import Key
+    from morango.models.fields.crypto import PythonRSAKey
+
+    if Key is not PythonRSAKey:
+        return
+
+    _orig_generate = Key.generate_new_key
+
+    def _generate_small_key(self, keysize=2048):
+        return _orig_generate(self, keysize=512)
+
+    Key.generate_new_key = _generate_small_key
+
+
 def pytest_configure(config):
     socket.getaddrinfo = _guarded_getaddrinfo
     socket.socket.connect = _guarded_socket_connect
+    _use_small_test_keys()
 
 
 @pytest.fixture(autouse=True)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -28,6 +28,7 @@ from kolibri.core.auth.models import LearnerGroup
 from kolibri.core.auth.test.helpers import KolibriAPITestCase as APITestCase
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content import models as content
+from kolibri.core.content.api import NUM_CHILDREN
 from kolibri.core.content.test.helpers import ChannelBuilder
 from kolibri.core.content.utils.paths import get_v2_channel_lookup_url
 from kolibri.core.device.models import ContentCacheKey
@@ -473,23 +474,6 @@ class ContentNodeAPIBase:
         self.assertEqual(response.content, b"")
         self.assertEqual(response.headers["ETag"], '"{}"'.format(cache_key))
 
-    @unittest.skipIf(
-        getattr(settings, "DATABASES")["default"]["ENGINE"]
-        == "django.db.backends.postgresql",
-        "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
-    )
-    def test_contentnode_list_long(self):
-        # This will make > 1000 nodes which should test our ancestor batching behaviour
-        builder = ChannelBuilder(num_children=10)
-        builder.insert_into_default_db()
-        content.ContentNode.objects.update(available=True)
-        nodes = content.ContentNode.objects.filter(available=True)
-        expected_output = len(nodes)
-        self.assertGreater(expected_output, 1000)
-        response = self._get(reverse("kolibri:core:contentnode-list"))
-        self.assertEqual(len(response.data), expected_output)
-        self._assert_nodes(response.data, nodes)
-
     def _recurse_and_assert(self, data, nodes, recursion_depth=0):
         recursion_depths = []
         nodes_by_id = {n.id: n for n in nodes}
@@ -560,7 +544,8 @@ class ContentNodeAPIBase:
         "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
     )
     def test_contentnode_tree_long(self):
-        builder = ChannelBuilder(levels=2, num_children=30)
+        # One past a page triggers the "more" marker at both root and child levels.
+        builder = ChannelBuilder(levels=2, num_children=NUM_CHILDREN + 1)
         builder.insert_into_default_db()
         content.ContentNode.objects.all().update(available=True)
         root = content.ContentNode.objects.get(id=builder.root_node["id"])
@@ -583,18 +568,23 @@ class ContentNodeAPIBase:
         "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
     )
     def test_contentnode_tree_next__gt(self):
-        builder = ChannelBuilder(levels=2, num_children=17)
+        # A page plus a partial second page, so paging past the first returns
+        # the remainder with no further "more" marker.
+        remainder = 5
+        builder = ChannelBuilder(levels=2, num_children=NUM_CHILDREN + remainder)
         builder.insert_into_default_db()
         content.ContentNode.objects.all().update(available=True)
         root = content.ContentNode.objects.get(id=builder.root_node["id"])
-        next__gt = content.ContentNode.objects.filter(parent=root)[11].rght
+        next__gt = content.ContentNode.objects.filter(parent=root)[
+            NUM_CHILDREN - 1
+        ].rght
         response = self._get(
             reverse("kolibri:core:contentnode_tree-detail", kwargs={"pk": root.id}),
             data={"next__gt": next__gt},
         )
-        self.assertEqual(len(response.data["children"]["results"]), 5)
+        self.assertEqual(len(response.data["children"]["results"]), remainder)
         self.assertIsNone(response.data["children"]["more"])
-        first_node = content.ContentNode.objects.filter(parent=root)[12]
+        first_node = content.ContentNode.objects.filter(parent=root)[NUM_CHILDREN]
         self._recurse_and_assert(
             [response.data["children"]["results"][0]], [first_node], recursion_depth=1
         )
@@ -605,7 +595,10 @@ class ContentNodeAPIBase:
         "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
     )
     def test_contentnode_tree_more(self):
-        builder = ChannelBuilder(levels=2, num_children=17)
+        # A page plus a partial second page, so following the "more" marker
+        # returns the remainder with no further marker.
+        remainder = 5
+        builder = ChannelBuilder(levels=2, num_children=NUM_CHILDREN + remainder)
         builder.insert_into_default_db()
         content.ContentNode.objects.all().update(available=True)
         root = content.ContentNode.objects.get(id=builder.root_node["id"])
@@ -621,7 +614,9 @@ class ContentNodeAPIBase:
             ),
             data=first_child["children"]["more"]["params"],
         )
-        self.assertEqual(len(nested_page_response.data["children"]["results"]), 5)
+        self.assertEqual(
+            len(nested_page_response.data["children"]["results"]), remainder
+        )
         self.assertIsNone(nested_page_response.data["children"]["more"])
 
     def test_contentnode_tree_singleton_path(self):

--- a/kolibri/deployment/default/settings/test.py
+++ b/kolibri/deployment/default/settings/test.py
@@ -31,3 +31,22 @@ TESTING = True
 # hash there fails to verify - leave the default hashers in that case.
 if not os.environ.get("INTEGRATION_TEST"):
     PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+# Kolibri's default logging writes to rotating files on disk; in tests that
+# I/O happens on every log record across thousands of tests for no benefit.
+# Keep console output at WARNING (so errors still surface) but drop the file
+# handlers. Tests that specifically exercise logging reinstate the real
+# config locally (see test_handler.py, test_cli.py).
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {"simple": {"format": "%(levelname)s %(name)s: %(message)s"}},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+            "level": "WARNING",
+        }
+    },
+    "root": {"handlers": ["console"], "level": "WARNING"},
+}

--- a/kolibri/deployment/default/settings/test.py
+++ b/kolibri/deployment/default/settings/test.py
@@ -24,3 +24,10 @@ if process_cache:
     CACHES["process_cache"] = process_cache
 
 TESTING = True
+
+# MD5 over the default PBKDF2: its many rounds dominate user creation and login
+# in tests for no benefit. The integration tests set passwords in-process but
+# verify them in a spawned server running base settings (PBKDF2), so an md5$
+# hash there fails to verify - leave the default hashers in that case.
+if not os.environ.get("INTEGRATION_TEST"):
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -34,6 +34,10 @@ def activate_log_logger(monkeypatch):
     Activates logging everything to ``LOG_LOGGER`` with the monkeypatch pattern
     of py.test (test accepts a ``monkeypatch`` argument)
     """
+    # Capture every record regardless of configured level - the test suite
+    # raises the log level for speed (see settings/test.py), which would
+    # otherwise filter messages out before they reach _log.
+    monkeypatch.setattr(logging.Logger, "isEnabledFor", lambda self, level: True)
     monkeypatch.setattr(logging.Logger, "__log", logging.Logger._log, raising=False)
     monkeypatch.setattr(logging.Logger, "_log", log_logger)
 

--- a/kolibri/utils/tests/test_handler.py
+++ b/kolibri/utils/tests/test_handler.py
@@ -4,10 +4,12 @@ import tempfile
 from time import sleep
 
 from django.conf import settings
+from django.test import override_settings
 from django.test import TestCase
 from mock import patch
 
 from kolibri.utils import cli
+from kolibri.utils.logger import get_logging_config
 from kolibri.utils.logger import KolibriTimedRotatingFileHandler
 
 
@@ -15,25 +17,30 @@ class KolibriTimedRotatingFileHandlerTestCase(TestCase):
     # Mock this function to avoid calling the logger in a way that prevents the archive
     @patch("kolibri.utils.main._upgrades_before_django_setup")
     def test_do_rollover(self, upgrades_mock):
-        archive_dir = os.path.join(os.environ["KOLIBRI_HOME"], "logs", "archive")
-        orig_value = settings.LOGGING["handlers"]["file"]["when"]
+        log_root = os.path.join(os.environ["KOLIBRI_HOME"], "logs")
+        archive_dir = os.path.join(log_root, "archive")
 
-        # Temporarily set the rotation time of the log file to be every second
-        settings.LOGGING["handlers"]["file"]["when"] = "s"
-        # make sure that kolibri will be running for more than one second
-        try:
-            cli.main(["manage", "--skip-update", "help"])
-        except SystemExit:
-            pass
-        sleep(1)
-        try:
-            cli.main(["manage", "--skip-update", "help"])
-        except SystemExit:
-            pass
-        # change back to the original rotation time
-        settings.LOGGING["handlers"]["file"]["when"] = orig_value
+        # The test suite disables file logging for speed (see settings/test.py);
+        # reinstate the real file-based config to exercise log rotation.
+        with override_settings(LOGGING=get_logging_config(log_root)):
+            orig_value = settings.LOGGING["handlers"]["file"]["when"]
 
-        self.assertNotEqual(os.listdir(archive_dir), [])
+            # Temporarily set the rotation time of the log file to be every second
+            settings.LOGGING["handlers"]["file"]["when"] = "s"
+            # make sure that kolibri will be running for more than one second
+            try:
+                cli.main(["manage", "--skip-update", "help"])
+            except SystemExit:
+                pass
+            sleep(1)
+            try:
+                cli.main(["manage", "--skip-update", "help"])
+            except SystemExit:
+                pass
+            # change back to the original rotation time
+            settings.LOGGING["handlers"]["file"]["when"] = orig_value
+
+            self.assertNotEqual(os.listdir(archive_dir), [])
 
     def test_getFilesToDelete(self):
         temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary

Three independent changes to speed up the Python test suite (~38m → ~5.5m locally):

- **Cheap crypto in tests** — MD5 password hasher + 512-bit morango keys instead of PBKDF2 + pure-Python 2048-bit RSA. ~4× on crypto-heavy modules.
- **Dropped `test_contentnode_list_long`** — it guarded ancestor-batching that no longer exists; shrank `test_contentnode_tree_long` to the pagination boundary.
- **Console-only logging in tests** — drop the per-record rotating-file writes.

## References

None — no tracking issue.

## Reviewer guidance

The headline check is wall-clock: compare the **Python tests** run on this PR against a recent `develop` run — every matrix job should finish noticeably faster.

Two judgment calls to sanity-check:
- **512-bit test keys** — correctness is unchanged (morango sign/verify round-trips, keys stay distinct); only key strength drops, which is irrelevant in tests.
- **Deleting `test_contentnode_list_long`** — the ancestor-batching it guarded no longer exists (ancestors are pre-annotated); `test_contentnode_list` still covers list correctness.

## AI usage

Used Claude Code to profile the suite (`pytest --durations`), pinpoint the costs (PBKDF2 hashing, pure-Python RSA keygen, file logging) and the obsolete scale test, and make the changes. I drove the investigation, vetted each finding against the code and git history before accepting it, and validated every change with full-suite runs before committing.