### PR TITLE
Speed up the WHL build: parallelize C extensions, cache webpack and cext

### DIFF
--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -42,6 +42,26 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Install Python dependencies
         run: uv sync --group dev
+      # Restore the webpack filesystem cache so PR builds only recompile their
+      # own diff. The unique key always misses (forcing a fresh save at job end),
+      # while restore-keys pulls the most recent cache for the same lockfile —
+      # primed on `develop` by warm_build_cache.yml so fork PRs get a hit too.
+      - name: Cache webpack build
+        uses: actions/cache@v6.0.0
+        with:
+          path: node_modules/.cache/webpack
+          key: webpack-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            webpack-${{ hashFiles('pnpm-lock.yaml') }}-
+      # The bundled C extensions are pinned wheels that change only when the
+      # cext requirements change, so an exact-match key is enough — no re-download
+      # once `develop` has primed it. `.cext_cache` is the pip cache dir that the
+      # `staticdeps-cext` Makefile target writes to (via --cache-path).
+      - name: Cache C extension downloads
+        uses: actions/cache@v6.0.0
+        with:
+          path: .cext_cache
+          key: cext-${{ hashFiles('requirements/cext.txt', 'requirements/cext_noarch.txt') }}
       - name: Build Kolibri
         run: make dist
       - name: Get WHL filename

--- a/.github/workflows/warm_build_cache.yml
+++ b/.github/workflows/warm_build_cache.yml
@@ -1,0 +1,18 @@
+name: Warm build caches
+# Run the WHL build on every push to develop so its caches (webpack, C
+# extensions, uv, pnpm) are saved in the default-branch scope. Pull requests —
+# including those from forks, which cannot write caches themselves — restore
+# from that scope, so they only recompile their own diff.
+on:
+  push:
+    branches:
+      - develop
+concurrency:
+  group: warm-build-cache
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  warm:
+    name: Warm WHL build caches
+    uses: ./.github/workflows/build_whl.yml

--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ SQLITE_MAX_VARIABLE_NUMBER.cache
 !h5p-core-18.ttf
 
 # static c extensions cache folder
-cext_cache
+.cext_cache
 
 # ignore gzipped files
 *.gz

--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -7,7 +7,7 @@ This module defines functions to install c extensions for all the platforms into
 Kolibri.
 
 Usage:
-> python build_tools/install_cexts.py --file "requirements/cext.txt" --cache-path "/cext_cache"
+> python build_tools/install_cexts.py --file "requirements/cext.txt" --cache-path ".cext_cache"
 
 It reads the package name and version from requirements/cext.txt file and
 installs the package and its dependencies using `pip install` with cache_path as
@@ -27,6 +27,7 @@ created under the directory where the script runs to store the cache data.
 """
 
 import argparse
+import concurrent.futures
 import logging
 import os
 import shutil
@@ -120,52 +121,104 @@ def run_pip_install(
     return return_code
 
 
-def install_package(package_name, package_version, index_url, info, cache_path):
+DEFAULT_MAX_WORKERS = 8
+
+
+def build_install_tasks(package_name, package_version, index_url, info, cache_path):
     """
-    Install packages based on the information we gather from the index_url page
+    Turn the parsed wheel infos for a package into install task descriptors.
+    Pure data transformation — does no I/O — so the tasks can be collected
+    across packages and indexes and then installed concurrently.
     """
+    tasks = []
     for item in info:
-        platform = item["platform"]
-        implementation = item["implementation"]
-        python_version = item["version"]
-        abi = item["abi"]
-        filename = "-".join([package_name, package_version, abi, platform])
-
-        # Calculate the path that the package will be installed into
-        # Cryptography builds for Linux target Python 3.6+ but the only existing
-        # build is labeled 3.6 (the lowest version supported).
-        # So install abi3 packages into a separate folder to be used across all Python 3 versions.
-        # https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-my-python3-x-version
-        version_path = os.path.join(
-            DIST_CEXT, abi if abi == "abi3" else implementation + python_version
+        tasks.append(
+            {
+                "package_name": package_name,
+                "package_version": package_version,
+                "index_url": index_url,
+                "platform": item["platform"],
+                "implementation": item["implementation"],
+                "python_version": item["version"],
+                "abi": item["abi"],
+                "cache_path": cache_path,
+            }
         )
-        package_path = get_path_with_arch(
-            platform, version_path, abi, implementation, python_version
-        )
+    return tasks
 
-        logger.info("Installing package {}...".format(filename))
-        # Install the package using pip with cache_path as the cache directory
-        install_return = run_pip_install(
-            package_path,
-            platform,
-            python_version,
-            implementation,
-            abi,
-            package_name,
-            package_version,
-            index_url,
-            cache_path,
-        )
 
-        # Ignore Piwheels installation failure because the website is not always stable
-        if install_return == 1 and index_url == PYPI_DOWNLOAD:
-            sys.exit("\nInstallation failed for package {}.\n".format(filename))
-        else:
-            # Clean up .dist-info folders
-            dist_info_folders = os.listdir(package_path)
-            for folder in dist_info_folders:
-                if folder.endswith(".dist-info"):
-                    shutil.rmtree(os.path.join(package_path, folder))
+def install_one(task):
+    """
+    Install a single wheel target. Raises RuntimeError on a fatal (PyPI)
+    failure; a tolerated (Piwheels) failure is ignored.
+    """
+    abi = task["abi"]
+    implementation = task["implementation"]
+    python_version = task["python_version"]
+    platform = task["platform"]
+    package_name = task["package_name"]
+    package_version = task["package_version"]
+    index_url = task["index_url"]
+    cache_path = task["cache_path"]
+
+    filename = "-".join([package_name, package_version, abi, platform])
+
+    # Calculate the path that the package will be installed into
+    # Cryptography builds for Linux target Python 3.6+ but the only existing
+    # build is labeled 3.6 (the lowest version supported).
+    # So install abi3 packages into a separate folder to be used across all Python 3 versions.
+    # https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-my-python3-x-version
+    version_path = os.path.join(
+        DIST_CEXT, abi if abi == "abi3" else implementation + python_version
+    )
+    package_path = get_path_with_arch(
+        platform, version_path, abi, implementation, python_version
+    )
+
+    logger.info("Installing package {}...".format(filename))
+    # Install the package using pip with cache_path as the cache directory
+    install_return = run_pip_install(
+        package_path,
+        platform,
+        python_version,
+        implementation,
+        abi,
+        package_name,
+        package_version,
+        index_url,
+        cache_path,
+    )
+
+    if install_return == 1:
+        if index_url == PYPI_DOWNLOAD:
+            raise RuntimeError("Installation failed for package {}.".format(filename))
+        # Ignore Piwheels installation failure because the website is not always
+        # stable. Nothing was installed, so there is no dist-info to clean up.
+        return
+
+    # Clean up .dist-info folders
+    if os.path.isdir(package_path):
+        for folder in os.listdir(package_path):
+            if folder.endswith(".dist-info"):
+                shutil.rmtree(os.path.join(package_path, folder))
+
+
+def run_installs(tasks, max_workers=DEFAULT_MAX_WORKERS):
+    """
+    Install all collected wheel tasks concurrently. Each task is an independent,
+    network-bound `pip install` into its own target directory, so a thread pool
+    overlaps the downloads. A fatal (PyPI) failure aborts the build.
+    """
+    errors = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(install_one, task) for task in tasks]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except RuntimeError as e:
+                errors.append(str(e))
+    if errors:
+        sys.exit("\n" + "\n".join(errors) + "\n")
 
 
 supported_python3_versions = ["36", "37", "38", "39", "310", "311"]
@@ -182,6 +235,7 @@ def parse_package_page(files, pk_version, index_url, cache_path):
     """
 
     result = []
+    package_name = None
     for file in files.find_all("a"):
         # Skip if not a whl file
         if not file.string.endswith("whl"):
@@ -211,13 +265,17 @@ def parse_package_page(files, pk_version, index_url, cache_path):
         }
         result.append(info)
 
-    install_package(package_name, pk_version, index_url, result, cache_path)
+    if package_name is None:
+        return []
+
+    return build_install_tasks(package_name, pk_version, index_url, result, cache_path)
 
 
 def parse_pypi_and_piwheels(name, pk_version, cache_path, session):
     """
-    Start installing from the pypi and piwheels pages of the package.
+    Collect the install tasks from the pypi and piwheels pages of the package.
     """
+    tasks = []
     links = [PYPI_DOWNLOAD, PIWHEEL_DOWNLOAD]
     for link in links:
         url = link + name
@@ -243,33 +301,31 @@ def parse_pypi_and_piwheels(name, pk_version, cache_path, session):
 
         if r:
             files = BeautifulSoup(r.content, "html.parser")
-            parse_package_page(files, pk_version, link, cache_path)
+            tasks.extend(parse_package_page(files, pk_version, link, cache_path))
         else:
             sys.exit("\nUnable to find package {} on {}.\n".format(name, link))
+    return tasks
 
 
 def check_cache_path_writable(cache_path):
     """
     If the defined cache path is not writable, change it to a folder named
-    cext_cache under the current directory where the script runs.
+    .cext_cache under the current directory where the script runs.
     """
     try:
+        os.makedirs(cache_path, exist_ok=True)
         check_file = os.path.join(cache_path, "check.txt")
         with open(check_file, "w") as f:
             f.write("check")
         os.remove(check_file)
         return cache_path
     except OSError:
-        new_path = os.path.realpath("cext_cache")
-        logger.info(
-            "The cache directory {old_path} is not writable. Changing to directory {new_path}.".format(
-                old_path=cache_path, new_path=new_path
-            )
+        sys.exit(
+            f"Cache path {cache_path} is not writeable, please ensure that you choose a writable location."
         )
-        return new_path
 
 
-def parse_requirements(args):
+def parse_requirements(requirements_file, cache_path):
     """
     Parse the requirements.txt to get packages' names and versions,
     then install them.
@@ -288,22 +344,27 @@ def parse_requirements(args):
     # Start a requests session to reuse HTTP connections
     session = requests.Session()
 
-    with open(args.file) as f:
-        cache_path = os.path.realpath(args.cache_path)
-        cache_path = check_cache_path_writable(cache_path)
+    tasks = []
+    with open(requirements_file) as f:
         for line in f:
             char_list = line.split("==")
             if len(char_list) == 2:
-                # Parse PyPi and Piwheels pages to install package according to
-                # its name and version
-                parse_pypi_and_piwheels(
-                    char_list[0].strip(), char_list[1].strip(), cache_path, session
+                # Parse PyPi and Piwheels pages to collect the install tasks for
+                # the package according to its name and version
+                tasks.extend(
+                    parse_pypi_and_piwheels(
+                        char_list[0].strip(),
+                        char_list[1].strip(),
+                        cache_path,
+                        session,
+                    )
                 )
             # Ignore comments
             elif not line.startswith("#"):
                 sys.exit(
                     "\nName format in cext.txt is incorrect. Should be 'packageName==packageVersion'.\n"
                 )
+    return tasks
 
 
 if __name__ == "__main__":
@@ -316,8 +377,14 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--cache-path",
-        default="/cext_cache",
+        default=".cext_cache",
         help="The path in which pip cache data is stored",
     )
     args = parser.parse_args()
-    parse_requirements(args)
+    requirements_file = args.file
+    if not os.path.exists(requirements_file):
+        sys.exit("Must specify a readable requirements file")
+    cache_path = os.path.realpath(args.cache_path)
+    check_cache_path_writable(cache_path)
+    install_tasks = parse_requirements(requirements_file, cache_path)
+    run_installs(install_tasks)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test-jest": "jest --config ./jest.conf.js",
     "test-jest-cov": "pnpm run test-jest --coverage",
     "coverage": "pnpm run test-jest-cov",
-    "build": "pnpm run sandbox-build && kolibri-build prod --file ./build_tools/build_plugins.txt --transpile",
+    "build": "pnpm run sandbox-build && kolibri-build prod --file ./build_tools/build_plugins.txt --transpile --cache",
     "makemessages": "kolibri-i18n extract-messages --pluginFile ./build_tools/build_plugins.txt --namespace kolibri-common --searchPath ./packages/kolibri-common --namespace kolibri-core --searchPath ./packages/kolibri",
     "createprofiles": "kolibri-i18n profile --pluginFile ./build_tools/build_plugins.txt --output-file ./kolibri/locale/en/LC_MESSAGES/profiles/strings.csv --namespace kolibri-common --searchPath ./packages/kolibri-common --namespace kolibri-core --searchPath ./packages/kolibri",
     "auditdittostrings": "kolibri-i18n audit --pluginFile ./build_tools/build_plugins.txt --output-file ./kolibri/locale/en/LC_MESSAGES/profiles/ditto.csv --namespace kolibri-common --searchPath ./packages/kolibri-common --namespace kolibri-core --searchPath ./packages/kolibri",

--- a/test/test_install_cexts.py
+++ b/test/test_install_cexts.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for build_tools/install_cexts.py.
+
+The C-extension install step downloads a dozen-plus independent wheels with one
+`pip install` subprocess each. These tests pin the behaviour of the concurrent
+executor: every collected task is installed, a PyPI failure is fatal, and a
+Piwheels failure is tolerated (the site is flaky by design).
+"""
+
+import importlib.util
+import os
+import threading
+
+import pytest
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    "build_tools",
+    "install_cexts.py",
+)
+_spec = importlib.util.spec_from_file_location("install_cexts", _MODULE_PATH)
+install_cexts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(install_cexts)
+
+
+def _task(
+    name="cffi",
+    index_url=install_cexts.PYPI_DOWNLOAD,
+    platform="manylinux1_x86_64",
+    version="38",
+):
+    return {
+        "package_name": name,
+        "package_version": "1.0.0",
+        "index_url": index_url,
+        "platform": platform,
+        "implementation": "cp",
+        "python_version": version,
+        "abi": "cp38",
+        "cache_path": "/tmp/cext_cache",
+    }
+
+
+def test_run_installs_attempts_every_task(monkeypatch):
+    tasks = [
+        _task(platform="manylinux1_x86_64", version="38"),
+        _task(platform="manylinux1_x86_64", version="39"),
+        _task(platform="win_amd64", version="310"),
+    ]
+    called = []
+    lock = threading.Lock()
+
+    def fake_run_pip_install(
+        path,
+        platform,
+        version,
+        implementation,
+        abi,
+        name,
+        pk_version,
+        index_url,
+        cache_path,
+    ):
+        with lock:
+            called.append((platform, version))
+        return 0
+
+    monkeypatch.setattr(install_cexts, "run_pip_install", fake_run_pip_install)
+
+    install_cexts.run_installs(tasks)
+
+    assert sorted(called) == sorted(
+        [(t["platform"], t["python_version"]) for t in tasks]
+    )
+
+
+def test_run_installs_fatal_on_pypi_failure(monkeypatch):
+    monkeypatch.setattr(install_cexts, "run_pip_install", lambda *a, **k: 1)
+
+    with pytest.raises(SystemExit):
+        install_cexts.run_installs([_task(index_url=install_cexts.PYPI_DOWNLOAD)])
+
+
+def test_run_installs_tolerates_piwheels_failure(monkeypatch):
+    monkeypatch.setattr(install_cexts, "run_pip_install", lambda *a, **k: 1)
+
+    # Must not raise: Piwheels is flaky and its failures are non-fatal.
+    install_cexts.run_installs([_task(index_url=install_cexts.PIWHEEL_DOWNLOAD)])


### PR DESCRIPTION
## Summary

Speeds up the `Build WHL` job, which gates every downstream installer and smoke-test job in the PR build. Two independent changes:

- **Parallelize the C extension install** — it ran one sequential `pip install` subprocess per wheel (cffi/cryptography across py3.6–3.11 and platforms). The downloads are independent and network-bound, so they now run through a thread pool. ~73s → ~24s on a cold cache.
- **Cache webpack + cext in CI** — the build recompiled the whole frontend and re-downloaded the C extensions every run. Adds `actions/cache` for both and enables `kolibri-build`'s existing `--cache` flag. Since the PR build only runs on `pull_request`, a new workflow warms these caches on every push to `develop` — that's what lets pull requests from forks (which can't write caches) restore them.

## References

No linked issue — opportunistic build-speed work.

## Reviewer guidance

- `pytest test/test_install_cexts.py` covers the executor (all tasks installed, PyPI failure fatal, Piwheels tolerated). `make staticdeps-cext` confirms a real run still populates `kolibri/dist/cext`.
- `.cext_cache` is duplicated between `Makefile` and `build_whl.yml` — they must stay in sync.
- Cache hits only show on fork PRs after this merges and `warm_build_cache.yml` runs once on `develop`.

## AI usage

Written with Claude Code. I investigated the CI timings, identified the parallelization and caching opportunities, and wrote the cext refactor test-first. Reviewed all output, corrected course where the analysis was wrong (dropped a proposed `uv build` split after confirming it would regress), and verified the speedup by timing sequential vs. parallel runs locally.