### PR TITLE
Speed up frontend linting and trim the Linting CI job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,11 +38,6 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-          cache-python: true
-      - name: Install Python
-        run: uv python install 3.11
-      - name: Install dev dependencies
-        run: uv sync --group dev --python 3.11
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9
       - name: Use Node.js

--- a/packages/kolibri-format/eslint.config.mjs
+++ b/packages/kolibri-format/eslint.config.mjs
@@ -341,6 +341,13 @@ export default [
           pathGroupsExcludedImportTypes: [],
         },
       ],
+      // import-x/namespace is the single most expensive rule in the lint
+      // (~47% of all ESLint rule time): it deep-walks each imported module's
+      // export graph to validate `import * as ns` member access. That pattern
+      // is rare in our code, and the webpack build plus tests already catch
+      // bad namespace access — so the cost far outweighs the value. `named`
+      // (validating named imports) is kept; it is far cheaper and higher value.
+      'import-x/namespace': OFF,
       // Disable rules not present in eslint-plugin-import or with resolver issues
       'import-x/no-rename-default': OFF,
       // import-x/default doesn't handle CJS module.exports as default exports

--- a/packages/kolibri-format/index.js
+++ b/packages/kolibri-format/index.js
@@ -72,7 +72,7 @@ async function prettierFormat(code, file, messages) {
     prettierConfig,
   );
   try {
-    return prettier.format(code, options);
+    return await prettier.format(code, options);
   } catch (e) {
     messages.push(
       `${chalk.underline(file)}\n${chalk.red('Parsing error during prettier formatting:')}\n${

--- a/packages/kolibri-format/package.json
+++ b/packages/kolibri-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-format",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A module for formatting frontend code to Kolibri standards",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Speeds up frontend linting, locally and in CI, with three changes:

- **Disable `import-x/namespace`** — it deep-walks every imported module's export graph to validate `import * as ns` member access, costing ~47% of all ESLint rule time for little value (the webpack build and tests already catch bad namespace access). `import-x/named` is kept — far cheaper, higher value.
- **Drop the explicit Python/dev-deps install steps in the Linting CI job** — `uv run prek` syncs the dev group and fetches Python on demand, so the separate `uv python install` and `uv sync --group dev` (~58s, present only to obtain prek) steps were redundant. The Node toolchain is kept for the hooks that need it.
- **Fix a latent bug in `prettierFormat`** — it returned the `prettier.format()` promise from inside its `try` without `await`, so parse-error rejections escaped the catch.

## References

No tracking issue — performance follow-up from profiling the Linting CI job.

## Reviewer guidance

- The workflow change is the risk — check this PR's Linting run passes every hook (especially `uv-lock` and the `python`-based hooks, now that the explicit `uv sync` is gone and `uv run prek` syncs on demand).
- Dropping `import-x/namespace` only removes `import * as ns` member checks; `import-x/named` still catches missing named imports.

## AI usage

I used Claude Code to profile the linting, identify that `import-x/namespace` dominated ESLint rule time, and draft these changes. I directed the investigation and the decisions (which rule to drop, dropping the redundant Python/dev-deps install steps), reviewed each diff, and confirmed the lint hook still passes locally.
