### PR TITLE
Upgrade pi image version for faster builds

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -46,10 +46,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.0
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.1
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v1.1.0
+      ref: v1.1.1
   browser_smoke_test:
     name: Browser smoke test
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -107,10 +107,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.0
+    uses: learningequality/kolibri-image-pi/.github/workflows/build_img.yml@v1.1.1
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v1.1.0
+      ref: v1.1.1
   upload_zip:
     uses: ./.github/workflows/upload_github_release_asset.yml
     needs: zip


### PR DESCRIPTION
## Summary
Upgrade pi image build  to version that uses arm64 runners for faster execution

## References
https://github.com/learningequality/kolibri-image-pi/releases/tag/v1.1.1

## Reviewer guidance
Does the Raspberry Pi image build in ~4 minutes instead of ~12 minutes?

## AI usage
@rtibblesbot implemented the changes on the image repo, this PR was hand crafted