### PR TITLE
Avoid loading the entirety of commonCoreStrings in SideNav unnecessarily

### DIFF
--- a/kolibri/plugins/coach/frontend/views/CoachSideNavEntry.js
+++ b/kolibri/plugins/coach/frontend/views/CoachSideNavEntry.js
@@ -1,11 +1,45 @@
+import { createTranslator } from 'kolibri/utils/i18n';
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import { UserKinds } from 'kolibri/constants';
 import plugin_data from 'kolibri-plugin-data';
-import { coursesStrings } from 'kolibri-common/strings/coursesStrings';
 import baseRoutes from '../routes/baseRoutes';
-import { coachStrings } from './common/commonCoachStrings';
+
+const navStrings = createTranslator('CoachSideNavEntryStrings', {
+  classHome: {
+    message: 'Class home',
+    context:
+      'The main section where the coach can see all the information relating to a specific class.',
+  },
+  coachLabel: {
+    message: 'Coach',
+    context:
+      'A coach is a specific type of user in Kolibri who can manage classes and learners. A coach can be either a class coach or a facility coach.',
+  },
+  coursesLabel: {
+    message: 'Courses',
+    context: 'Label for courses that contain units and lessons.',
+  },
+  groupsLabel: {
+    message: 'Groups',
+    context:
+      'A group is a collection of learners created by a coach inside a class to help with differentiated learning. Quizzes and lessons can be assigned to individual groups as well as to the whole class.',
+  },
+  learnersLabel: {
+    message: 'Learners',
+    context:
+      'Learner is an account type that has limited permissions. Learners can be enrolled in classes, get assigned resources through lessons and quizzes, and navigate channels directly. We intentionally did not use the term "student" to be more inclusive of non-formal educational contexts.',
+  },
+  lessonsLabel: {
+    message: 'Lessons',
+    context:
+      'A lesson is a linear learning pathway defined by a coach. The coach can select resources from any channel, add them to the lesson, define the ordering, and assign the lesson to learners in their class.',
+  },
+  quizzesLabel: {
+    message: 'Quizzes',
+    context: 'Plural of quiz.',
+  },
+});
 
 registerNavItem({
   get url() {
@@ -14,31 +48,31 @@ registerNavItem({
   get routes() {
     const _routes = [
       {
-        label: coreStrings.$tr('classHome'),
+        label: navStrings.$tr('classHome'),
         route: baseRoutes.classHome.path,
         icon: 'dashboard',
         name: baseRoutes.classHome.name,
       },
       {
-        label: coachStrings.$tr('lessonsLabel'),
+        label: navStrings.$tr('lessonsLabel'),
         route: baseRoutes.lessons.path,
         icon: 'lesson',
         name: baseRoutes.lessons.name,
       },
       {
-        label: coachStrings.$tr('quizzesLabel'),
+        label: navStrings.$tr('quizzesLabel'),
         route: baseRoutes.quizzes.path,
         icon: 'quiz',
         name: baseRoutes.quizzes.name,
       },
       {
-        label: coachStrings.$tr('learnersLabel'),
+        label: navStrings.$tr('learnersLabel'),
         route: baseRoutes.learners.path,
         icon: 'person',
         name: baseRoutes.learners.name,
       },
       {
-        label: coachStrings.$tr('groupsLabel'),
+        label: navStrings.$tr('groupsLabel'),
         route: baseRoutes.groups.path,
         icon: 'group',
         name: baseRoutes.groups.name,
@@ -48,7 +82,7 @@ registerNavItem({
     if (plugin_data.courses_exist) {
       // Insert 'Courses' nav item just after 'Class Home'
       _routes.splice(1, 0, {
-        label: coursesStrings.$tr('coursesLabel'),
+        label: navStrings.$tr('coursesLabel'),
         route: baseRoutes.courses.path,
         icon: 'lesson',
         name: baseRoutes.courses.name,
@@ -58,7 +92,7 @@ registerNavItem({
     return _routes;
   },
   get label() {
-    return coreStrings.$tr('coachLabel');
+    return navStrings.$tr('coachLabel');
   },
   icon: 'coach',
   role: UserKinds.COACH,

--- a/kolibri/plugins/device/frontend/views/DeviceManagementSideNavEntry.js
+++ b/kolibri/plugins/device/frontend/views/DeviceManagementSideNavEntry.js
@@ -3,9 +3,43 @@ import { UserKinds } from 'kolibri/constants';
 import useUser from 'kolibri/composables/useUser';
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
 import baseRoutes from '../routes/baseRoutes';
-import { deviceString } from './commonDeviceStrings';
+
+const navStrings = createTranslator('DeviceManagementSideNavEntryStrings', {
+  channelsLabel: {
+    message: 'Channels',
+    context:
+      'Channels are collections of educational resources (video, audio, document files or interactive apps) prepared and organized by the channel curator for their use in Kolibri.\n\nA learner will see a set of channels available to them when they first open Kolibri.',
+  },
+  facilitiesLabel: {
+    message: 'Facilities',
+    context:
+      'Facilities are the centers of education which are managed in Kolibri, such as a school. To manage facilities on a given device, a user must have super admin permissions.',
+  },
+  usersLabel: {
+    message: 'Users',
+    context:
+      'A user is any person who has access to a facility in Kolibri. There are four main types of users in Kolibri: Learners, Coaches, Admins and Super admins.',
+  },
+  infoLabel: {
+    message: 'Info',
+    context: "Title of tab in 'Device' section.",
+  },
+  settingsLabel: {
+    message: 'Settings',
+    context: "Title of tab used in 'Facility' and 'Device' sections.",
+  },
+  deviceManagementTitle: {
+    message: 'Device',
+    context:
+      'The device is the physical or virtual machine that has the Kolibri server installed on it.',
+  },
+  permissionsLabel: {
+    message: 'Permissions',
+    context: "Title of tab in 'Device' section.",
+  },
+});
 
 registerNavItem({
   get url() {
@@ -16,42 +50,42 @@ registerNavItem({
     const routes = [];
     const routeDefs = [
       {
-        label: coreStrings.$tr('channelsLabel'),
+        label: navStrings.$tr('channelsLabel'),
         route: baseRoutes.content.path,
         icon: 'channel',
         name: baseRoutes.content.name,
         condition: get(canManageContent) || get(isSuperuser),
       },
       {
-        label: coreStrings.$tr('facilitiesLabel'),
+        label: navStrings.$tr('facilitiesLabel'),
         route: baseRoutes.facilities.path,
         icon: 'facility',
         name: baseRoutes.facilities.name,
         condition: get(isSuperuser) && !get(isLearnerOnlyImport),
       },
       {
-        label: coreStrings.$tr('usersLabel'),
+        label: navStrings.$tr('usersLabel'),
         route: baseRoutes.users.path,
         icon: 'audience',
         name: baseRoutes.users.name,
         condition: get(isSuperuser) && get(isLearnerOnlyImport),
       },
       {
-        label: deviceString('permissionsLabel'),
+        label: navStrings.$tr('permissionsLabel'),
         route: baseRoutes.permissions.path,
         icon: 'permissions',
         name: baseRoutes.permissions.name,
         condition: get(isSuperuser),
       },
       {
-        label: coreStrings.$tr('infoLabel'),
+        label: navStrings.$tr('infoLabel'),
         route: baseRoutes.info.path,
         icon: 'deviceInfo',
         name: baseRoutes.info.name,
         condition: get(isSuperuser),
       },
       {
-        label: coreStrings.$tr('settingsLabel'),
+        label: navStrings.$tr('settingsLabel'),
         route: baseRoutes.settings.path,
         icon: 'settings',
         name: baseRoutes.settings.name,
@@ -66,7 +100,7 @@ registerNavItem({
     return routes;
   },
   get label() {
-    return deviceString('deviceManagementTitle');
+    return navStrings.$tr('deviceManagementTitle');
   },
   icon: 'device',
   role: UserKinds.CAN_MANAGE_CONTENT,

--- a/kolibri/plugins/facility/frontend/views/FacilityManagementSideNavEntry.js
+++ b/kolibri/plugins/facility/frontend/views/FacilityManagementSideNavEntry.js
@@ -1,8 +1,33 @@
 import { UserKinds } from 'kolibri/constants';
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
 import baseRoutes from '../baseRoutes';
+
+const navStrings = createTranslator('FacilityManagementSideNavEntryStrings', {
+  classesLabel: {
+    message: 'Classes',
+    context:
+      'In the classes section of Kolibri users can view the list of all the classes in their facility, with the number of enrolled users for each class, and the coaches assigned.',
+  },
+  usersLabel: {
+    message: 'Users',
+    context:
+      'A user is any person who has access to a facility in Kolibri. There are four main types of users in Kolibri: Learners, Coaches, Admins and Super admins.',
+  },
+  settingsLabel: {
+    message: 'Settings',
+    context: "Title of tab used in 'Facility' and 'Device' sections.",
+  },
+  dataLabel: {
+    message: 'Data',
+    context: "Title of tab in 'Facility' section.",
+  },
+  facilityLabel: {
+    message: 'Facility',
+    context: 'A facility is a center of education, such as a school.',
+  },
+});
 
 registerNavItem({
   get url() {
@@ -11,25 +36,25 @@ registerNavItem({
   get routes() {
     return [
       {
-        label: coreStrings.$tr('classesLabel'),
+        label: navStrings.$tr('classesLabel'),
         route: baseRoutes.classes.path,
         icon: 'classes',
         name: baseRoutes.classes.name,
       },
       {
-        label: coreStrings.$tr('usersLabel'),
+        label: navStrings.$tr('usersLabel'),
         route: baseRoutes.users.path,
         icon: 'people',
         name: baseRoutes.users.name,
       },
       {
-        label: coreStrings.$tr('settingsLabel'),
+        label: navStrings.$tr('settingsLabel'),
         route: baseRoutes.settings.path,
         icon: 'settings',
         name: baseRoutes.settings.name,
       },
       {
-        label: coreStrings.$tr('dataLabel'),
+        label: navStrings.$tr('dataLabel'),
         route: baseRoutes.data.path,
         icon: 'save',
         name: baseRoutes.data.name,
@@ -37,7 +62,7 @@ registerNavItem({
     ];
   },
   get label() {
-    return coreStrings.$tr('facilityLabel');
+    return navStrings.$tr('facilityLabel');
   },
   icon: 'facility',
   role: UserKinds.ADMIN,

--- a/kolibri/plugins/learn/frontend/my_downloads/views/MyDownloadsSideNavEntry.js
+++ b/kolibri/plugins/learn/frontend/my_downloads/views/MyDownloadsSideNavEntry.js
@@ -1,8 +1,15 @@
+import { createTranslator } from 'kolibri/utils/i18n';
 import { UserKinds, NavComponentSections } from 'kolibri/constants';
 import { registerNavItem } from 'kolibri/composables/useNav';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import urls from 'kolibri/urls';
 import plugin_data from 'kolibri-plugin-data';
+
+const navStrings = createTranslator('MyDownloadsSideNavEntryStrings', {
+  myDownloadsLabel: {
+    message: 'My downloads',
+    context: "Users can access and see their content downloads via 'my downloads' option.",
+  },
+});
 
 if (plugin_data.allowLearnerDownloads) {
   registerNavItem({
@@ -10,7 +17,7 @@ if (plugin_data.allowLearnerDownloads) {
       return urls['kolibri:kolibri.plugins.learn:my_downloads']();
     },
     get label() {
-      return coreStrings.$tr('myDownloadsLabel');
+      return navStrings.$tr('myDownloadsLabel');
     },
     icon: 'download',
     role: UserKinds.LEARNER,

--- a/kolibri/plugins/learn/frontend/views/LearnSideNavEntry.js
+++ b/kolibri/plugins/learn/frontend/views/LearnSideNavEntry.js
@@ -1,9 +1,31 @@
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
 import useUser from 'kolibri/composables/useUser';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { createTranslator } from 'kolibri/utils/i18n';
 import baseRoutes from '../routes/baseRoutes';
-import { learnStrings } from './commonLearnStrings';
+
+const navStrings = createTranslator('LearnSideNavEntryStrings', {
+  homeLabel: {
+    message: 'Home',
+    context:
+      "Home page is a place for learners containing summary of their activities and suggestions for what to do next. For example, they can see a list of classes they're enrolled in, their recent lessons and quizzes, and they can directly navigate to resources to continue learning from.",
+  },
+  libraryLabel: {
+    message: 'Library',
+    context:
+      "The 'Library' section displays channels available on Kolibri server, and allows learners to browse, explore and filter topics and resources on their own.",
+  },
+  bookmarksLabel: {
+    message: 'Bookmarks',
+    context:
+      'Bookmarks are used to give all users a way of saving a reference for a specific resource or topic to come back to later.',
+  },
+  learnLabel: {
+    message: 'Learn',
+    context:
+      "Each time a learner signs in to Kolibri, the first thing they see is the  'Learn' page with the list of all the classes they are enrolled to.",
+  },
+});
 
 registerNavItem({
   get url() {
@@ -16,19 +38,19 @@ registerNavItem({
     }
     return [
       {
-        label: coreStrings.$tr('homeLabel'),
+        label: navStrings.$tr('homeLabel'),
         icon: 'dashboard',
         route: baseRoutes.home.path,
         name: baseRoutes.home.name,
       },
       {
-        label: coreStrings.$tr('libraryLabel'),
+        label: navStrings.$tr('libraryLabel'),
         icon: 'library',
         route: baseRoutes.library.path,
         name: baseRoutes.library.name,
       },
       {
-        label: coreStrings.$tr('bookmarksLabel'),
+        label: navStrings.$tr('bookmarksLabel'),
         icon: 'bookmark',
         route: baseRoutes.bookmarks.path,
         name: baseRoutes.bookmarks.name,
@@ -36,7 +58,7 @@ registerNavItem({
     ];
   },
   get label() {
-    return learnStrings.$tr('learnLabel');
+    return navStrings.$tr('learnLabel');
   },
   icon: 'learn',
   bottomBar: true,

--- a/kolibri/plugins/user_auth/frontend/views/LoginSideNavEntry.js
+++ b/kolibri/plugins/user_auth/frontend/views/LoginSideNavEntry.js
@@ -1,14 +1,22 @@
+import { createTranslator } from 'kolibri/utils/i18n';
 import { UserKinds, NavComponentSections } from 'kolibri/constants';
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+
+const navStrings = createTranslator('LoginSideNavEntryStrings', {
+  signInLabel: {
+    message: 'Sign in',
+    context:
+      "Users select the 'SIGN IN' button if they already have an account and a username in Kolibri to get access to the platform.",
+  },
+});
 
 registerNavItem({
   get url() {
     return urls['kolibri:kolibri.plugins.user_auth:user_auth']();
   },
   get label() {
-    return coreStrings.$tr('signInLabel');
+    return navStrings.$tr('signInLabel');
   },
   icon: 'login',
   role: UserKinds.ANONYMOUS,

--- a/kolibri/plugins/user_profile/frontend/views/UserProfileSideNavEntry.js
+++ b/kolibri/plugins/user_profile/frontend/views/UserProfileSideNavEntry.js
@@ -1,14 +1,21 @@
+import { createTranslator } from 'kolibri/utils/i18n';
 import { UserKinds, NavComponentSections } from 'kolibri/constants';
 import { registerNavItem } from 'kolibri/composables/useNav';
 import urls from 'kolibri/urls';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+
+const navStrings = createTranslator('UserProfileSideNavEntryStrings', {
+  profileLabel: {
+    message: 'Profile',
+    context: "Users can access and edit their personal details via the 'profile' option.",
+  },
+});
 
 registerNavItem({
   get url() {
     return urls['kolibri:kolibri.plugins.user_profile:user_profile']();
   },
   get label() {
-    return coreStrings.$tr('profileLabel');
+    return navStrings.$tr('profileLabel');
   },
   icon: 'person',
   role: UserKinds.LEARNER,


### PR DESCRIPTION

## Summary
Per [suggestion from Richard](https://github.com/learningequality/kolibri/issues/10499#issuecomment-1513658140), this PR updates to create a SideNav translator object that references the common string namespace, but only includes a subset of specific required strings, thus avoiding loading the entire large object

## References
Fixes #10499


## Reviewer guidance
Do the side nav strings still work in non-English UI? (should not require re-translation or using TM for string "moving")

## AI usage
Done with Claude for efficiency/not missing things. Claude + self-review