### PR TITLE
Filter related content data by id list instead of the live queryset

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -750,10 +750,15 @@ class BaseContentNodeMixin:
         return models.ContentNode.objects.filter(available=True)
 
     def get_related_data_maps(self, items, queryset):
+        # items is already the materialized page from this queryset, so filter
+        # the related tables by its content-node ids directly. Passing the live
+        # annotated queryset here would re-execute it (including its correlated
+        # subqueries) once per related-data query.
+        content_node_ids = [item["id"] for item in items]
         assessmentmetadata_map = {
             a["contentnode"]: a
             for a in models.AssessmentMetaData.objects.filter(
-                contentnode__in=queryset
+                contentnode__in=content_node_ids
             ).values(
                 "assessment_item_ids",
                 "number_of_assessments",
@@ -767,7 +772,7 @@ class BaseContentNodeMixin:
         files_map = {}
 
         files = list(
-            models.File.objects.filter(contentnode__in=queryset).values(
+            models.File.objects.filter(contentnode__in=content_node_ids).values(
                 "id",
                 "contentnode",
                 "local_file__id",
@@ -802,7 +807,7 @@ class BaseContentNodeMixin:
         tags_map = {}
 
         for t in (
-            models.ContentTag.objects.filter(tagged_content__in=queryset)
+            models.ContentTag.objects.filter(tagged_content__in=content_node_ids)
             .values(
                 "tag_name",
                 "tagged_content",


### PR DESCRIPTION
## Summary
`get_related_data_maps` filtered its related-table lookups with `contentnode__in=queryset`, where `queryset` is the annotated `ContentNode` queryset — re-running its correlated subqueries on each lookup. The page is already materialized in `items`, so filtering by its ids returns the same rows without re-executing the annotation.

## References
None — standalone query-cost improvement, no related issue.

## Reviewer guidance
- `items` is the materialized page that `consolidate` iterates by `item["id"]`, so the related maps are keyed on exactly those ids either way — same rows returned, only the related-table SQL changes.
- Covered by the existing content node API tests (`kolibri/core/content/test/test_content_app.py`); related metadata, files and tags on list/detail responses are the surface to check.

## AI usage
I used Claude Code to spot the repeated annotated-subquery cost in `get_related_data_maps` during a load-test investigation and to write the change. I reviewed it for query equivalence and rely on the existing content node API tests to confirm behaviour is unchanged.

Noting that this is an independent rediscovery of the same optimization that I implemented here https://github.com/learningequality/kolibri/pull/12892/changes#r1920517694