### PR TITLE
Refactor content viewer to a composable API

### DIFF
--- a/docs/frontend_architecture/single_page_apps.rst
+++ b/docs/frontend_architecture/single_page_apps.rst
@@ -92,13 +92,13 @@ A special kind of Kolibri Module is dedicated to rendering particular content ty
     :members:
     :noindex:
 
-The ``ContentViewer`` class has one required property ``viewerComponent`` which should return a Vue component that wraps the content rendering code. This component will be passed ``files``, ``file``, ``itemData``, ``preset``, ``itemId``, ``answerState``, ``allowHints``, ``extraFields``, ``interactive``, ``lang``, ``showCorrectAnswer``, ``defaultItemPreset``, ``availableFiles``, ``defaultFile``, ``supplementaryFiles``, ``thumbnailFiles``, ``contentDirection``, and ``contentIsRtl`` props, defining the files associated with the piece of content, and other required data for rendering.
+The ``ContentViewer`` class has one required property ``viewerComponent`` which should return a Vue component that wraps the content rendering code. The ``ContentViewer`` wrapper accepts a ``contentNode`` prop containing the content metadata (including ``files``, ``lang``, ``options``, and ``duration``), and provides all necessary data to descendant viewer components via the ``useContentViewer`` composable.
 
-The component should use the `useContentViewer` composable and the `contentViewerProps`, importable as follows:
+The component should use the `useContentViewer` composable, importable as follows:
 
 .. code-block:: javascript
 
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
 
 In order to log data about users viewing content, the component should emit ``startTracking``, ``updateProgress``, and ``stopTracking`` events, using the Vue ``$emit`` method. ``startTracking`` and ``stopTracking`` are emitted without any arguments, whereas ``updateProgress`` should be emitted with a single value between 0 and 1 representing the current proportion of progress on the content.
 

--- a/kolibri/core/content/hooks.py
+++ b/kolibri/core/content/hooks.py
@@ -10,6 +10,8 @@ from abc import abstractmethod
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.safestring import mark_safe
+from le_utils.constants import file_formats
+from le_utils.constants import format_presets
 
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.core.webpack.hooks import WebpackInclusionMixin
@@ -29,6 +31,30 @@ class ContentRendererHook(WebpackBundleHook, WebpackInclusionMixin):
     @abstractmethod
     def presets(self):
         pass
+
+    #: Optional tuple of CSS selectors that this content renderer can handle
+    css_selectors = ()
+
+    #: Whether to allow object tag handling (defaults to False for sandboxing compatibility)
+    allow_object_tag = False
+
+    @classmethod
+    def all_css_selectors(cls):
+        """Get all CSS selectors (auto-generated from presets + custom), cached."""
+        if not hasattr(cls, "_cached_css_selectors"):
+            selectors = list(cls.css_selectors)
+
+            if cls.allow_object_tag:
+                for preset in cls.presets:
+                    preset_obj = next(
+                        x for x in format_presets.PRESETLIST if x.id == preset
+                    )
+                    for fmt in preset_obj.allowed_formats:
+                        fmt_obj = file_formats.getformat(fmt)
+                        selectors.append(f'object[type="{fmt_obj.mimetype}"]')
+
+            cls._cached_css_selectors = tuple(sorted(set(selectors)))
+        return cls._cached_css_selectors
 
     @classmethod
     def html(cls):
@@ -54,7 +80,11 @@ class ContentRendererHook(WebpackBundleHook, WebpackInclusionMixin):
                 '<template data-viewer="{bundle}">{data}</template>'.format(
                     bundle=self.unique_id,
                     data=json.dumps(
-                        {"urls": urls, "presets": self.presets},
+                        {
+                            "urls": urls,
+                            "presets": self.presets,
+                            "css_selectors": self.all_css_selectors(),
+                        },
                         separators=(",", ":"),
                         ensure_ascii=False,
                         cls=DjangoJSONEncoder,

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -24,6 +24,7 @@ from le_utils.constants.file_formats import BLOOMD
 from le_utils.constants.file_formats import BLOOMPUB
 from le_utils.constants.file_formats import H5P
 from le_utils.constants.file_formats import HTML5
+from le_utils.constants.file_formats import HTML5_ARTICLE
 from le_utils.constants.file_formats import PERSEUS
 from whitenoise.responders import StaticFile
 
@@ -269,7 +270,7 @@ def get_embedded_file(
         return response
 
 
-archive_file_types = (HTML5, H5P, BLOOMPUB, BLOOMD, PERSEUS)
+archive_file_types = (HTML5, H5P, BLOOMPUB, BLOOMD, PERSEUS, HTML5_ARTICLE)
 archive_file_extension_match = "|".join(archive_file_types)
 
 # Allows a base url to be passed in the main

--- a/kolibri/plugins/bloompub_viewer/frontend/views/BloomPubRendererIndex.vue
+++ b/kolibri/plugins/bloompub_viewer/frontend/views/BloomPubRendererIndex.vue
@@ -60,7 +60,7 @@
   import { now } from 'kolibri/utils/serverClock';
   import CoreFullscreen from 'kolibri-common/components/CoreFullscreen';
   import Sandbox from 'kolibri-sandbox';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
 
   const defaultContentHeight = '500px';
   const frameTopbarHeight = '37px';
@@ -70,18 +70,31 @@
       CoreFullscreen,
     },
     setup(props, context) {
-      const { defaultFile, forceDurationBasedProgress, reportError } = useContentViewer(
-        props,
-        context,
-        { defaultDuration: 300 },
-      );
-      return {
+      const {
         defaultFile,
+        options,
         forceDurationBasedProgress,
         reportError,
+        userId,
+        userFullName,
+        progress,
+        lang,
+        timeSpent,
+        extraFields,
+      } = useContentViewer(context, { defaultDuration: 300 });
+      return {
+        defaultFile,
+        options,
+        forceDurationBasedProgress,
+        reportError,
+        userId,
+        userFullName,
+        progress,
+        lang,
+        timeSpent,
+        extraFields,
       };
     },
-    props: contentViewerProps,
     data() {
       return {
         iframeHeight: (this.options && this.options.height) || defaultContentHeight,

--- a/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
@@ -104,10 +104,8 @@
                 <ContentViewer
                   v-if="questionContentExists(question)"
                   :ref="`contentRenderer-${question.item}`"
-                  :lang="getQuestionContent(question).lang"
-                  :files="getQuestionContent(question).files"
+                  :contentNode="getQuestionContent(question)"
                   :itemId="question.question_id"
-                  :assessment="true"
                   :allowHints="false"
                   :interactive="false"
                   :showCorrectAnswer="true"

--- a/kolibri/plugins/coach/frontend/views/common/reports/QuestionLearnersPage.vue
+++ b/kolibri/plugins/coach/frontend/views/common/reports/QuestionLearnersPage.vue
@@ -59,14 +59,12 @@
             />
             <ContentViewer
               v-if="currentInteraction"
+              :contentNode="exercise"
               :itemId="currentLearner.item"
-              :assessment="true"
               :allowHints="false"
-              :files="exercise.files"
               :answerState="answerState"
               :showCorrectAnswer="showCorrectAnswer"
               :interactive="false"
-              :extraFields="exercise.extra_fields"
             />
           </div>
         </template>

--- a/kolibri/plugins/coach/frontend/views/common/resourceSelection/UpdatedResourceSelection.vue
+++ b/kolibri/plugins/coach/frontend/views/common/resourceSelection/UpdatedResourceSelection.vue
@@ -120,6 +120,7 @@
                 type: Array,
                 spec: {
                   type: Function,
+                  required: true,
                 },
                 default: () => [],
               },
@@ -142,6 +143,7 @@
                 type: Array,
                 spec: {
                   type: Function,
+                  required: true,
                 },
                 default: () => [],
               },

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonSelectionContentPreviewPage/LessonContentPreview/ContentArea.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonSelectionContentPreviewPage/LessonContentPreview/ContentArea.vue
@@ -10,11 +10,10 @@
     <ContentViewer
       v-if="content.available"
       class="content-viewer"
+      :contentNode="content"
       :showCorrectAnswer="true"
       :itemId="selectedQuestion"
       :allowHints="false"
-      :files="content.files"
-      :extraFields="content.extra_fields"
       :interactive="false"
     />
     <MissingResourceAlert

--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/QuestionListPreview.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/QuestionListPreview.vue
@@ -122,10 +122,8 @@
       <ContentViewer
         v-if="content && content.available && currentQuestion.question_id"
         ref="contentViewer"
-        :files="content.files"
-        :extraFields="content.extra_fields"
+        :contentNode="content"
         :itemId="currentQuestion.question_id"
-        :assessment="true"
         :allowHints="false"
         :showCorrectAnswer="true"
         :interactive="false"

--- a/kolibri/plugins/epub_viewer/frontend/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/frontend/views/EpubRendererIndex.vue
@@ -173,7 +173,7 @@
   import FocusLock from 'vue-focus-lock';
   import CoreFullscreen from 'kolibri-common/components/CoreFullscreen';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import { ref, computed } from 'vue';
   import iFrameView from './SandboxIFrameView';
   import LoadingScreen from './LoadingScreen';
@@ -239,16 +239,18 @@
       });
       const {
         defaultFile,
+        extraFields,
         forceDurationBasedProgress,
         durationBasedProgress,
         contentDirection,
         contentIsRtl,
         reportLoadingError,
-      } = useContentViewer(props, context, { defaultDuration });
+      } = useContentViewer(context, { defaultDuration });
       return {
         windowIsSmall,
         locations,
         defaultFile,
+        extraFields,
         forceDurationBasedProgress,
         durationBasedProgress,
         contentDirection,
@@ -256,7 +258,6 @@
         reportLoadingError,
       };
     },
-    props: contentViewerProps,
     data() {
       return {
         book: null,

--- a/kolibri/plugins/epub_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/epub_viewer/kolibri_plugin.py
@@ -13,3 +13,4 @@ class DocumentEPUBRenderPlugin(KolibriPluginBase):
 class DocumentEPUBRenderAsset(content_hooks.ContentRendererHook):
     bundle_id = "main"
     presets = (format_presets.EPUB,)
+    allow_object_tag = True

--- a/kolibri/plugins/html5_viewer/frontend/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/frontend/views/Html5AppRendererIndex.vue
@@ -60,7 +60,7 @@
   import { now } from 'kolibri/utils/serverClock';
   import CoreFullscreen from 'kolibri-common/components/CoreFullscreen';
   import Sandbox from 'kolibri-sandbox';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
 
   const defaultContentHeight = '500px';
   const frameTopbarHeight = '37px';
@@ -70,16 +70,33 @@
       CoreFullscreen,
     },
     setup(props, context) {
-      const { defaultFile, forceDurationBasedProgress, durationBasedProgress, reportError } =
-        useContentViewer(props, context, { defaultDuration: 300 });
-      return {
-        defaultFile,
+      const {
+        options,
+        lang,
         forceDurationBasedProgress,
         durationBasedProgress,
+        defaultFile,
         reportError,
+        extraFields,
+        timeSpent,
+        userId,
+        userFullName,
+        progress,
+      } = useContentViewer(context, { defaultDuration: 300 });
+      return {
+        options,
+        lang,
+        forceDurationBasedProgress,
+        durationBasedProgress,
+        defaultFile,
+        reportError,
+        extraFields,
+        timeSpent,
+        userId,
+        userFullName,
+        progress,
       };
     },
-    props: contentViewerProps,
     data() {
       return {
         iframeHeight: (this.options && this.options.height) || defaultContentHeight,

--- a/kolibri/plugins/learn/frontend/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/AssessmentWrapper/index.vue
@@ -52,10 +52,8 @@
       >
         <ContentViewer
           ref="contentViewer"
-          :lang="lang"
-          :files="files"
+          :contentNode="contentNode"
           :extraFields="extraFields"
-          :assessment="true"
           :itemId="currentItemId"
           :progress="progress"
           :userId="userId"
@@ -144,10 +142,10 @@
 
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { MasteryModelGenerators } from 'kolibri/constants';
-  import { contentViewerProps } from 'kolibri/composables/useContentViewer';
   import shuffled from 'kolibri-common/utils/shuffled';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { computed } from 'vue';
   import BottomAppBar from 'kolibri/components/BottomAppBar';
   import CoreInfoIcon from 'kolibri-common/components/labels/CoreInfoIcon';
   import { createTranslator } from 'kolibri/utils/i18n';
@@ -181,27 +179,46 @@
       CoreInfoIcon,
     },
     mixins: [commonCoreStrings],
-    setup() {
+    setup(props) {
       const { windowIsSmall } = useKResponsiveWindow();
       const { currentUserId } = useUser();
+      const assessmentIds = computed(
+        () => props.contentNode.assessmentmetadata.assessment_item_ids,
+      );
+      const randomize = computed(() => props.contentNode.assessmentmetadata.randomize);
+      const masteryModel = computed(() => props.contentNode.assessmentmetadata.mastery_model);
       return {
         windowIsSmall,
         currentUserId,
+        assessmentIds,
+        randomize,
+        masteryModel,
       };
     },
     props: {
-      ...contentViewerProps,
-      assessmentIds: {
-        type: Array,
-        required: true,
-      },
-      randomize: {
-        type: Boolean,
-        required: true,
-      },
-      masteryModel: {
+      contentNode: {
         type: Object,
         required: true,
+      },
+      extraFields: {
+        type: Object,
+        default: () => ({}),
+      },
+      progress: {
+        type: Number,
+        default: 0,
+      },
+      userId: {
+        type: String,
+        default: '',
+      },
+      userFullName: {
+        type: String,
+        default: '',
+      },
+      timeSpent: {
+        type: Number,
+        default: 0,
       },
       pastattempts: {
         type: Array,

--- a/kolibri/plugins/learn/frontend/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/frontend/views/ChannelRenderer/ContentItem.vue
@@ -95,11 +95,7 @@
           return {};
         }
         return {
-          kind: this.contentNode.kind,
-          lang: this.contentNode.lang,
-          files: this.contentNode.files,
-          options: this.contentNode.options,
-          available: this.contentNode.available,
+          contentNode: this.contentNode,
           extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,
@@ -111,15 +107,8 @@
         if (!this.contentIsExercise) {
           return {};
         }
-        const assessment = this.contentNode.assessmentmetadata || {};
         return {
-          kind: this.contentNode.kind,
-          files: this.contentNode.files,
-          lang: this.contentNode.lang,
-          randomize: this.contentNode.randomize,
-          masteryModel: assessment.mastery_model,
-          assessmentIds: assessment.assessment_item_ids,
-          available: this.contentNode.available,
+          contentNode: this.contentNode,
           extraFields: this.extra_fields,
           progress: this.progress,
           userId: this.currentUserId,

--- a/kolibri/plugins/learn/frontend/views/ContentPage.vue
+++ b/kolibri/plugins/learn/frontend/views/ContentPage.vue
@@ -5,10 +5,7 @@
       <ContentViewer
         v-if="!content.assessmentmetadata"
         class="content-viewer"
-        :lang="content.lang"
-        :files="content.files"
-        :options="content.options"
-        :duration="content.duration"
+        :contentNode="content"
         :extraFields="extra_fields"
         :progress="progress"
         :userId="currentUserId"
@@ -50,11 +47,7 @@
       <AssessmentWrapper
         v-else
         class="content-viewer"
-        :files="content.files"
-        :lang="content.lang"
-        :randomize="content.assessmentmetadata.randomize"
-        :masteryModel="content.assessmentmetadata.mastery_model"
-        :assessmentIds="content.assessmentmetadata.assessment_item_ids"
+        :contentNode="content"
         :extraFields="extra_fields"
         :progress="progress"
         :userId="currentUserId"

--- a/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseUnitView/CourseContentViewer.vue
@@ -87,11 +87,7 @@
       <AssessmentWrapper
         v-else
         class="content-viewer"
-        :files="contentNode.files"
-        :lang="contentNode.lang"
-        :randomize="contentNode.assessmentmetadata.randomize"
-        :masteryModel="contentNode.assessmentmetadata.mastery_model"
-        :assessmentIds="contentNode.assessmentmetadata.assessment_item_ids"
+        :contentNode="contentNode"
         :extraFields="extra_fields"
         :progress="progress"
         :userId="currentUserId"

--- a/kolibri/plugins/learn/frontend/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/ExamPage/index.vue
@@ -185,10 +185,8 @@
               <ContentViewer
                 v-if="content && itemId"
                 ref="contentViewer"
-                :files="content.files"
-                :extraFields="content.extra_fields"
+                :contentNode="content"
                 :itemId="itemId"
-                :assessment="true"
                 :allowHints="false"
                 :answerState="currentAttempt.answer"
                 @interaction="interactionHandler"

--- a/kolibri/plugins/learn/frontend/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/frontend/views/QuizRenderer/index.vue
@@ -45,11 +45,9 @@
             <ContentViewer
               v-if="itemId"
               ref="contentViewer"
-              :lang="content.lang"
-              :files="content.files"
+              :contentNode="content"
               :extraFields="extraFields"
               :itemId="itemId"
-              :assessment="true"
               :allowHints="false"
               :answerState="currentAttempt.answer"
               :progress="progress"

--- a/kolibri/plugins/learn/frontend/views/__tests__/AssessmentWrapper.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/AssessmentWrapper.spec.js
@@ -15,9 +15,13 @@ const createComponent = (totalattempts, pastattempts, masteryModel) => {
   const propsData = {
     id: 'test',
     kind: 'test',
-    assessmentIds: [],
-    masteryModel: masteryModel || {},
-    randomize: false,
+    contentNode: {
+      assessmentmetadata: {
+        assessment_item_ids: [],
+        mastery_model: masteryModel || {},
+        randomize: false,
+      },
+    },
     totalattempts,
     pastattempts,
   };

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/__tests__/AssessmentWrapper.spec.js
@@ -1,39 +1,55 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
-
 import { createTranslator } from 'kolibri/utils/i18n';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-import AssessmentWrapper, { hintTranslator } from '../index.vue';
 
-const { completedLabel$ } = coreStrings;
+import AssessmentWrapper from '../index.vue';
 
 jest.mock('kolibri/composables/useUser');
 
 const {
-  goal$,
   check$,
   next$,
-  inputAnswer$,
-  correct$,
   tryAgain$,
+  correct$,
   greatKeepGoing$,
-  itemError$,
+  hintUsed$,
+  inputAnswer$,
+  itemError$: itemErrorMessage$,
   tryDifferentQuestion$,
+  tryNextQuestion$,
+  goal$,
 } = createTranslator(AssessmentWrapper.name, AssessmentWrapper.$trs);
+
+const { hint$, noMoreHint$ } = createTranslator('PerseusRendererIndex', {
+  hint: { message: 'Use a hint ({hintsLeft, number} left)' },
+  noMoreHint: { message: 'No more hints' },
+});
+
+const { completedLabel$ } = coreStrings;
 
 const ASSESSMENT_IDS = ['item-1', 'item-2', 'item-3', 'item-4', 'item-5'];
 const DEFAULT_MASTERY_MODEL = { type: 'm_of_n', m: 3, n: 5 };
 
 function buildProps(overrides = {}) {
+  const {
+    assessmentIds = ASSESSMENT_IDS,
+    randomize = false,
+    masteryModel = DEFAULT_MASTERY_MODEL,
+    ...rest
+  } = overrides;
   return {
-    files: [],
-    assessmentIds: ASSESSMENT_IDS,
-    randomize: false,
-    masteryModel: DEFAULT_MASTERY_MODEL,
+    contentNode: {
+      assessmentmetadata: {
+        assessment_item_ids: assessmentIds,
+        randomize,
+        mastery_model: masteryModel,
+      },
+    },
     pastattempts: [],
     mastered: false,
     totalattempts: 0,
     hasNextResource: false,
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -57,8 +73,7 @@ function makeContentViewerStub({ checkAnswerFn, availableHints = 0, totalHints =
   return {
     name: 'ContentViewer',
     props: [
-      'lang',
-      'files',
+      'contentNode',
       'extraFields',
       'assessment',
       'itemId',
@@ -111,9 +126,11 @@ function renderComponent(props = {}, { stubs, ...restOptions } = {}) {
   const mergedProps = buildProps(props);
   return render(AssessmentWrapper, {
     props: mergedProps,
-    // ContentViewer is a complex renderer intentionally implemented as a stub
-    // to allow for testing AssessmentWrapper behavior in response to events
-    // emitted by ContentViewer
+    // The jest setup ships a minimal global ContentViewer stub, but AssessmentWrapper
+    // calls `this.$refs.contentViewer.checkAnswer()` and reads `availableHints`/`totalHints`
+    // from the viewer, which the global stub doesn't expose. Override it here.
+    // ContentViewer is globally registered, not imported, so jest.mock can't substitute
+    // it — a stub is the appropriate seam.
     // eslint-disable-next-line kolibri/tests-no-stubs
     stubs: {
       ContentViewer: DefaultStub,
@@ -406,7 +423,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-item-error'));
 
       await waitFor(() => {
-        expect(screen.getByText(itemError$())).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveTextContent(itemErrorMessage$());
         expect(screen.getByText(tryDifferentQuestion$())).toBeInTheDocument();
       });
     });
@@ -416,7 +433,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-item-error'));
 
       await waitFor(() => {
-        expect(getStatusText()).toBe('Try next question');
+        expect(getStatusText()).toBe(tryNextQuestion$());
       });
     });
 
@@ -450,7 +467,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByText(tryDifferentQuestion$()));
 
       await waitFor(() => {
-        expect(screen.queryByText(itemError$())).not.toBeInTheDocument();
+        expect(screen.queryByText(itemErrorMessage$())).not.toBeInTheDocument();
         expect(screen.getByText(check$())).toBeInTheDocument();
       });
     });
@@ -474,7 +491,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-hint-taken'));
 
       await waitFor(() => {
-        expect(getStatusText()).toBe('Hint used');
+        expect(getStatusText()).toBe(hintUsed$());
       });
     });
   });
@@ -540,10 +557,8 @@ describe('AssessmentWrapper', () => {
   describe('hints UI', () => {
     it('does not show hint buttons when totalHints is 0', () => {
       renderComponent();
-      expect(
-        screen.queryByText(hintTranslator.hint$({ hintsLeft: 1 }), { exact: false }),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText(hintTranslator.noMoreHint$())).not.toBeInTheDocument();
+      expect(screen.queryByText(hint$({ hintsLeft: 0 }))).not.toBeInTheDocument();
+      expect(screen.queryByText(noMoreHint$())).not.toBeInTheDocument();
     });
 
     it('shows hint button with count after startTracking', async () => {
@@ -553,7 +568,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 }))).toBeInTheDocument();
+        screen.getByText(hint$({ hintsLeft: 3 }));
       });
     });
 
@@ -564,7 +579,7 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText(hintTranslator.noMoreHint$())).toBeInTheDocument();
+        screen.getByText(noMoreHint$());
       });
     });
 
@@ -575,10 +590,10 @@ describe('AssessmentWrapper', () => {
       await fireEvent.click(screen.getByTestId('trigger-start-tracking'));
 
       await waitFor(() => {
-        expect(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 }))).toBeInTheDocument();
+        screen.getByText(hint$({ hintsLeft: 3 }));
       });
 
-      await fireEvent.click(screen.getByText(hintTranslator.hint$({ hintsLeft: 3 })));
+      await fireEvent.click(screen.getByText(hint$({ hintsLeft: 3 })));
 
       await waitFor(() => {
         expect(emitted().updateInteraction).toBeTruthy();
@@ -594,22 +609,26 @@ describe('AssessmentWrapper', () => {
         assessmentIds: ['a', 'b'],
         masteryModel: { type: 'do_all' },
       });
-      expect(screen.getAllByText(goal$({ count: 2 })).length).toBeGreaterThanOrEqual(1);
+      const elements = screen.getAllByText(goal$({ count: 2 }));
+      expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_2', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_2' } });
-      expect(screen.getAllByText(goal$({ count: 2 })).length).toBeGreaterThanOrEqual(1);
+      const elements = screen.getAllByText(goal$({ count: 2 }));
+      expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_3', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_3' } });
-      expect(screen.getAllByText(goal$({ count: 3 })).length).toBeGreaterThanOrEqual(1);
+      const elements = screen.getAllByText(goal$({ count: 3 }));
+      expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows correct goal for num_correct_in_a_row_10', () => {
       renderComponent({ masteryModel: { type: 'num_correct_in_a_row_10' } });
-      expect(screen.getAllByText(goal$({ count: 10 })).length).toBeGreaterThanOrEqual(1);
+      const elements = screen.getAllByText(goal$({ count: 10 }));
+      expect(elements.length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders the correct number of attempt placeholder slots for do_all', () => {

--- a/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/frontend/views/courses/AssessmentWrapper/index.vue
@@ -54,8 +54,7 @@
           >
             <ContentViewer
               ref="contentViewer"
-              :lang="lang"
-              :files="files"
+              :contentNode="contentNode"
               :extraFields="extraFields"
               :assessment="true"
               :itemId="currentItemId"
@@ -166,13 +165,13 @@
 
 <script>
 
+  import { computed } from 'vue';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import { MasteryModelGenerators } from 'kolibri/constants';
-  import { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import { createTranslator } from 'kolibri/utils/i18n';
   import shuffled from 'kolibri-common/utils/shuffled';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import CoreInfoIcon from 'kolibri-common/components/labels/CoreInfoIcon';
-  import { createTranslator } from 'kolibri/utils/i18n';
   import useUser from 'kolibri/composables/useUser';
   import { coursesStrings } from 'kolibri-common/strings/coursesStrings.js';
   import ResourceLayout from '../../ResourceLayout/index.vue';
@@ -205,28 +204,31 @@
       ResourceLayout,
     },
     mixins: [commonCoreStrings],
-    setup() {
+    setup(props) {
       const { currentUserId } = useUser();
       const { practiceAction$, nextLabel$ } = coursesStrings;
+      const assessmentIds = computed(
+        () => props.contentNode.assessmentmetadata.assessment_item_ids,
+      );
+      const randomize = computed(() => props.contentNode.assessmentmetadata.randomize);
+      const masteryModel = computed(() => props.contentNode.assessmentmetadata.mastery_model);
       return {
         currentUserId,
         practiceAction$,
         nextLabel$,
+        assessmentIds,
+        randomize,
+        masteryModel,
       };
     },
     props: {
-      ...contentViewerProps,
-      assessmentIds: {
-        type: Array,
-        required: true,
-      },
-      randomize: {
-        type: Boolean,
-        required: true,
-      },
-      masteryModel: {
+      contentNode: {
         type: Object,
         required: true,
+      },
+      extraFields: {
+        type: Object,
+        default: () => ({}),
       },
       pastattempts: {
         type: Array,

--- a/kolibri/plugins/media_player/frontend/utils/fileExtractors.js
+++ b/kolibri/plugins/media_player/frontend/utils/fileExtractors.js
@@ -1,0 +1,67 @@
+/**
+ * File extractor functions for media elements (video/audio)
+ */
+
+/**
+ * Generate file data object for media files
+ * @param {string} url - The file's storage URL
+ * @param {string} preset - Content preset
+ * @param {object} options - Additional file options
+ * @returns {object} File data object
+ */
+function _generateFileData(url, preset, options = {}) {
+  return {
+    storage_url: url,
+    preset,
+    available: true,
+    supplementary: false,
+    thumbnail: false,
+    priority: 1,
+    ...options,
+  };
+}
+
+/**
+ * Extract files from media elements (video/audio)
+ * @param {HTMLMediaElement} element - Source for file extraction
+ * @returns {Array} Array of file objects
+ */
+function extractMediaFiles(element) {
+  const files = [];
+  const preset = element.tagName.toLowerCase() === 'video' ? 'high_res_video' : 'audio';
+  let sourceCount = 0;
+
+  // Direct src attribute
+  if (element.src) {
+    files.push(_generateFileData(element.src, preset, { priority: 1 }));
+    sourceCount++;
+  }
+
+  // <source> and <track> children
+  for (const child of element.children) {
+    const childTag = child.tagName.toLowerCase();
+    const childSrc = child.getAttribute('src');
+
+    if (childTag === 'source' && child.src) {
+      files.push(_generateFileData(child.src, preset, { priority: sourceCount + 1 }));
+      sourceCount++;
+    } else if (childTag === 'track' && childSrc && !['metadata', 'chapters'].includes(child.kind)) {
+      files.push(
+        _generateFileData(childSrc, 'video_subtitle', {
+          supplementary: true,
+          lang: child.srclang,
+        }),
+      );
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Media extractors for use with useContentViewer
+ */
+export default {
+  video: extractMediaFiles,
+  audio: extractMediaFiles,
+};

--- a/kolibri/plugins/media_player/frontend/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/frontend/views/MediaPlayerIndex.vue
@@ -92,11 +92,12 @@
   import { mapActions, mapState, mapGetters } from 'vuex';
   import videojs from 'video.js';
   import throttle from 'lodash/throttle';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import { languageIdToCode } from 'kolibri/utils/i18n';
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import useKResponsiveElement from 'kolibri-design-system/lib/composables/useKResponsiveElement';
+  import customExtractors from '../utils/fileExtractors';
   import Settings from '../utils/settings';
   import { ReplayButton, ForwardButton } from './customButtons';
   import MediaPlayerFullscreen from './MediaPlayerFullscreen';
@@ -125,24 +126,32 @@
       const player = ref(null);
       const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
       const { elementWidth } = useKResponsiveElement();
-      const { thumbnailFiles, supplementaryFiles, reportLoadingError } = useContentViewer(
-        props,
-        context,
-        {
-          defaultDuration: computed(() => player?.value?.duration()),
-        },
-      );
+      const {
+        files,
+        thumbnailFiles,
+        supplementaryFiles,
+        extraFields,
+        forceDurationBasedProgress,
+        durationBasedProgress,
+        reportLoadingError,
+      } = useContentViewer(context, {
+        defaultDuration: computed(() => player?.value?.duration()),
+        customExtractors,
+      });
       return {
         windowIsSmall,
         windowIsPortrait,
         elementWidth,
+        files,
         thumbnailFiles,
         supplementaryFiles,
+        extraFields,
+        forceDurationBasedProgress,
+        durationBasedProgress,
         reportLoadingError,
         player,
       };
     },
-    props: contentViewerProps,
     data: () => ({
       dummyTime: 0,
       progressStartingPoint: 0,

--- a/kolibri/plugins/media_player/kolibri_plugin.py
+++ b/kolibri/plugins/media_player/kolibri_plugin.py
@@ -17,3 +17,5 @@ class MediaPlayerAsset(content_hooks.ContentRendererHook):
         format_presets.VIDEO_HIGH_RES,
         format_presets.VIDEO_LOW_RES,
     )
+    css_selectors = ("video", "audio")
+    allow_object_tag = True  # Media player can handle object tags for audio/video

--- a/kolibri/plugins/pdf_viewer/frontend/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/frontend/views/PdfRendererIndex.vue
@@ -6,6 +6,8 @@
     :class="{
       'pdf-controls-open': showControls,
       'pdf-full-screen': isInFullscreen,
+      'pdf-embedded': embedded,
+      'pdf-mobile-embedded': mobileEmbedded,
     }"
     :style="{ backgroundColor: $themeTokens.text }"
     @changeFullscreen="isInFullscreen = $event"
@@ -131,7 +133,7 @@
   import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import CoreFullscreen from 'kolibri-common/components/CoreFullscreen';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import { ref, computed } from 'vue';
   import '../utils/domPolyfills';
   import { EventBus } from '../utils/event_utils';
@@ -160,7 +162,14 @@
       const defaultDuration = computed(() => {
         return totalPages.value ? totalPages.value * 30 : null;
       });
-      const { defaultFile, reportLoadingError } = useContentViewer(props, context, {
+      const {
+        defaultFile,
+        reportLoadingError,
+        embedded,
+        extraFields,
+        forceDurationBasedProgress,
+        durationBasedProgress,
+      } = useContentViewer(context, {
         defaultDuration,
       });
       return {
@@ -169,9 +178,12 @@
         totalPages,
         defaultFile,
         reportLoadingError,
+        embedded,
+        extraFields,
+        forceDurationBasedProgress,
+        durationBasedProgress,
       };
     },
-    props: contentViewerProps,
     data: () => ({
       loadingProgress: null,
       scale: null,
@@ -210,10 +222,7 @@
         return this.firstPageHeight * this.scale + MARGIN;
       },
       savedLocation() {
-        if (this.extraFields && this.extraFields.contentState) {
-          return this.extraFields.contentState.savedLocation;
-        }
-        return 0;
+        return this.extraFields?.contentState?.savedLocation ?? 0;
       },
       savedVisitedPages: {
         get() {

--- a/kolibri/plugins/pdf_viewer/frontend/views/__tests__/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/frontend/views/__tests__/PdfRendererIndex.spec.js
@@ -1,14 +1,18 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
-import * as mockPDFJS from '../__mocks__/pdfjsMock';
+// eslint-disable-next-line import-x/named
+import useContentViewer, { useContentViewerMock } from 'kolibri/composables/useContentViewer';
 import PdfRendererIndex from '../PdfRendererIndex';
+import * as mockPDFJS from '../__mocks__/pdfjsMock';
 
-const { zoomIn$, zoomOut$ } = coreStrings;
+jest.mock('kolibri/composables/useContentViewer');
 
 jest.mock('kolibri/urls');
-jest.mock('pdfjs-dist/legacy/build/pdf', () => mockPDFJS);
+jest.mock('pdfjs-dist/legacy/build/pdf', () => require('../__mocks__/pdfjsMock'));
 jest.mock('lodash/debounce', () => fn => fn);
 jest.mock('lodash/throttle', () => fn => fn);
+
+const { zoomIn$, zoomOut$ } = coreStrings;
 
 const DUMMY_PDF_URL = 'http://localhost:8000/test.pdf';
 
@@ -19,8 +23,7 @@ function makeWrapper(options = {}) {
     ...options,
     data: () => ({
       defaultFile: { storage_url: DUMMY_PDF_URL },
-      forceDurationBasedProgress: null,
-      ...(options.data ? options.data() : {}),
+      ...options.data,
     }),
     mixins: [
       {
@@ -123,11 +126,12 @@ describe('PdfRendererIndex', () => {
       it('should load the proper page when there is a saved location', async () => {
         const savedLocation = 0.2;
         mockPDFJS.PdfDocument.numPages = 10;
-        await loadPdfContainer({
-          props: {
-            extraFields: { contentState: { savedLocation } },
-          },
-        });
+        useContentViewer.mockImplementationOnce(() =>
+          useContentViewerMock({
+            extraFields: { contentState: { savedLocation, savedVisitedPages: {} } },
+          }),
+        );
+        await loadPdfContainer();
         expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledWith(3);
       });
     });

--- a/kolibri/plugins/pdf_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/pdf_viewer/kolibri_plugin.py
@@ -13,3 +13,4 @@ class DocumentPDFRenderPlugin(KolibriPluginBase):
 class DocumentPDFRenderAsset(content_hooks.ContentRendererHook):
     bundle_id = "main"
     presets = (format_presets.DOCUMENT,)
+    allow_object_tag = True

--- a/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/frontend/views/PerseusRendererIndex.vue
@@ -45,7 +45,7 @@
   import logger from 'kolibri-logging';
   import { Mapper, defaultFilePathMappers } from 'kolibri-zip/src/fileUtils';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import urls from 'kolibri/urls';
   import { createElement as e } from 'react';
   import { createRoot } from 'react-dom/client';
@@ -281,18 +281,32 @@
     },
     setup(props, context) {
       const { windowBreakpoint } = useKResponsiveWindow();
-      const { defaultFile, contentDirection } = useContentViewer(props, context);
-      const { keypadAPI, keypadContextValue } = useKeypad();
+      const {
+        defaultFile,
+        contentDirection,
+        itemData,
+        itemId,
+        answerState,
+        showCorrectAnswer,
+        interactive,
+        lang,
+      } = useContentViewer(context);
 
+      const { keypadAPI, keypadContextValue } = useKeypad();
       return {
         windowBreakpoint,
         defaultFile,
         contentDirection,
         keypadAPI,
         keypadContextValue,
+        itemData,
+        itemId,
+        answerState,
+        showCorrectAnswer,
+        interactive,
+        lang,
       };
     },
-    props: contentViewerProps,
     data: () => ({
       // Is the perseus item loading?
       loading: true,

--- a/kolibri/plugins/perseus_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/perseus_viewer/kolibri_plugin.py
@@ -13,3 +13,4 @@ class ExercisePerseusRenderPlugin(KolibriPluginBase):
 class ExercisePerseusRenderAsset(content_hooks.ContentRendererHook):
     bundle_id = "main"
     presets = (format_presets.EXERCISE,)
+    allow_object_tag = True

--- a/kolibri/plugins/qti_viewer/frontend/components/QTIViewer.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/QTIViewer.vue
@@ -15,7 +15,7 @@
 
   import { computed, provide, ref, watch } from 'vue';
   import logger from 'kolibri-logging';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import useQTIResource from '../composables/useQTIResource';
   import { loadQTIPackage, parseXML } from '../utils/xml';
   import AssessmentItem from './AssessmentItem.vue';
@@ -29,20 +29,28 @@
     },
     inheritAttrs: false,
     setup(props, context) {
-      const { defaultFile, reportLoadingError } = useContentViewer(props, context);
+      const {
+        defaultFile,
+        itemData,
+        itemId,
+        answerState,
+        userId,
+        interactive,
+        reportLoadingError,
+      } = useContentViewer(context);
       const packageLoading = ref(true);
       // Store resources by identifier
       const resourcesMap = ref({});
 
       // Reactively get current resource based on itemId
       const currentResource = computed(() => {
-        return resourcesMap.value[props.itemId] || null;
+        return resourcesMap.value[itemId.value] || null;
       });
 
       const resourceUrl = computed(() => currentResource.value?.href);
       // If itemData is provided, we only support injecting AssessmentItem XML
       const resourceType = computed(() =>
-        props.itemData ? 'imsqti_item_xmlv3p0' : currentResource.value?.type,
+        itemData.value ? 'imsqti_item_xmlv3p0' : currentResource.value?.type,
       );
 
       const {
@@ -53,15 +61,15 @@
 
       const xmlDoc = computed(() => {
         // If itemData is provided, use it directly
-        if (props.itemData) {
-          return parseXML(props.itemData);
+        if (itemData.value) {
+          return parseXML(itemData.value);
         }
         // Otherwise, use the resource XML document
         return resourceXmlDoc.value;
       });
 
       const loading = computed(() => {
-        if (props.itemData) {
+        if (itemData.value) {
           return false;
         }
         return packageLoading.value || resourceLoading.value;
@@ -127,9 +135,9 @@
         'QTI_CONTEXT',
         computed(
           () =>
-            props.answerState?.QTI_CONTEXT ?? {
-              candidateIdentifier: props.userId,
-              testIdentifier: defaultFile?.checksum,
+            answerState.value?.QTI_CONTEXT ?? {
+              candidateIdentifier: userId.value,
+              testIdentifier: defaultFile.value?.checksum,
               environmentIdentifier: __version,
             },
         ),
@@ -137,11 +145,11 @@
 
       provide(
         'answerState',
-        computed(() => props.answerState || {}),
+        computed(() => answerState.value || {}),
       );
       provide(
         'interactive',
-        computed(() => props.interactive),
+        computed(() => interactive.value),
       );
 
       return {
@@ -154,7 +162,6 @@
         checkAnswer,
       };
     },
-    props: contentViewerProps,
   };
 
 </script>

--- a/kolibri/plugins/qti_viewer/kolibri_plugin.py
+++ b/kolibri/plugins/qti_viewer/kolibri_plugin.py
@@ -13,3 +13,4 @@ class QTIViewerPlugin(KolibriPluginBase):
 class QTIViewerAsset(content_hooks.ContentRendererHook):
     bundle_id = "main"
     presets = (format_presets.QTI_ZIP,)
+    allow_object_tag = True

--- a/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/SafeHtml5RendererIndex.vue
@@ -24,10 +24,12 @@
 <script>
 
   import ZipFile from 'kolibri-zip';
-  import SafeHTML from 'kolibri-common/components/SafeHTML';
+  import { createSafeHTML } from 'kolibri-common/components/SafeHTML';
   import debounce from 'lodash/debounce';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import urls from 'kolibri/urls';
+
+  const SafeHTML = createSafeHTML({}, { allowedOrigins: [urls.zipContentOrigin()] });
 
   export default {
     name: 'SafeHtml5RendererIndex',
@@ -35,18 +37,15 @@
       SafeHTML,
     },
     setup(props, context) {
-      const { defaultFile, forceDurationBasedProgress, durationBasedProgress } = useContentViewer(
-        props,
-        context,
-        { defaultDuration: 300 },
-      );
+      const { defaultFile, options, forceDurationBasedProgress, durationBasedProgress } =
+        useContentViewer(context, { defaultDuration: 300 });
       return {
         defaultFile,
+        options,
         forceDurationBasedProgress,
         durationBasedProgress,
       };
     },
-    props: contentViewerProps,
     data() {
       return {
         loading: true,

--- a/kolibri/plugins/safe_html5_viewer/frontend/views/__tests__/SafeHtml5RendererIndex.spec.js
+++ b/kolibri/plugins/safe_html5_viewer/frontend/views/__tests__/SafeHtml5RendererIndex.spec.js
@@ -1,6 +1,15 @@
 import { render, screen, waitFor } from '@testing-library/vue';
 import { createTranslator } from 'kolibri/utils/i18n';
+// eslint-disable-next-line import-x/named
+import useContentViewer, { useContentViewerMock } from 'kolibri/composables/useContentViewer';
 import SafeHtml5RendererIndex from '../SafeHtml5RendererIndex.vue';
+
+// Mock kolibri to prevent initialization side effects
+jest.mock('kolibri', () => ({
+  canHandleElement: jest.fn(() => false),
+}));
+
+jest.mock('kolibri/composables/useContentViewer');
 
 const { articleContent$ } = createTranslator(
   SafeHtml5RendererIndex.name,
@@ -31,13 +40,9 @@ jest.mock('kolibri-zip', () => {
   }));
 });
 
-const DUMMY_HTML5_URL = 'mock://test.html';
 const renderComponent = (dataOverrides = {}) => {
   return render(SafeHtml5RendererIndex, {
-    data: () => ({
-      defaultFile: { storage_url: DUMMY_HTML5_URL },
-      ...dataOverrides,
-    }),
+    data: () => dataOverrides,
   });
 };
 
@@ -57,6 +62,12 @@ async function setupTableContainer(scrollWidth, clientWidth) {
 }
 
 describe('SafeHtml5RendererIndex', () => {
+  beforeEach(() => {
+    useContentViewer.mockImplementation(() =>
+      useContentViewerMock({ defaultFile: { storage_url: 'mock://test.html' } }),
+    );
+  });
+
   describe('first render', () => {
     it('smoke test', async () => {
       renderComponent();
@@ -79,9 +90,9 @@ describe('SafeHtml5RendererIndex', () => {
       renderComponent();
       await waitFor(() => {
         expect(screen.getByLabelText(articleContent$())).toBeInTheDocument();
-        expect(screen.getByText(HEADING)).toBeInTheDocument();
-        expect(screen.getByText(TABLE_CAPTION)).toBeInTheDocument();
-        CELLS.forEach(cell => expect(screen.getByText(cell)).toBeInTheDocument());
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(HEADING);
+        expect(screen.getByText(TABLE_CAPTION).tagName).toBe('CAPTION');
+        CELLS.forEach(cell => screen.getByRole('cell', { name: cell }));
       });
     });
   });

--- a/kolibri/plugins/slideshow_viewer/frontend/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/frontend/views/SlideshowRendererComponent.vue
@@ -89,7 +89,7 @@
     Navigation as HooperNavigation,
     Pagination as HooperPagination,
   } from 'hooper';
-  import useContentViewer, { contentViewerProps } from 'kolibri/composables/useContentViewer';
+  import useContentViewer from 'kolibri/composables/useContentViewer';
   import { handleError } from 'kolibri/utils/appError';
 
   export default {
@@ -103,13 +103,26 @@
       HooperNavigation,
     },
     setup(props, context) {
-      const { files } = useContentViewer(props, context, { defaultDuration: 300 });
+      const {
+        files,
+        defaultFile,
+        extraFields,
+        itemData,
+        durationBasedProgress,
+        forceDurationBasedProgress,
+      } = useContentViewer(context, {
+        defaultDuration: 300,
+      });
       return {
         files,
+        defaultFile,
         handleError,
+        extraFields,
+        itemData,
+        durationBasedProgress,
+        forceDurationBasedProgress,
       };
     },
-    props: contentViewerProps,
     data: () => ({
       isInFullscreen: false,
       slides: [],

--- a/packages/kolibri-common/components/SafeHTML/__tests__/SafeHTML.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/SafeHTML.spec.js
@@ -1,0 +1,357 @@
+import Vue from 'vue';
+import { render, screen } from '@testing-library/vue';
+
+import kolibri from 'kolibri';
+import { createSafeHTML } from '../index';
+
+jest.mock('kolibri', () => ({
+  canHandleElement: jest.fn(),
+  objectViewerMimetypes: jest.fn(() => []),
+}));
+
+// Stub the ContentViewer so a handled object surfaces the file it received via
+// its `element` prop as `data-src`, letting tests assert what reaches the viewer.
+Vue.component('ContentViewer', {
+  props: { element: { type: null, default: null } },
+  render(h) {
+    return h('div', {
+      attrs: {
+        'data-testid': 'content-viewer',
+        'data-src': this.element && this.element.getAttribute('data'),
+      },
+    });
+  },
+});
+
+const SafeHTML = createSafeHTML();
+
+const HELLO_WORLD_TEXT = 'Hello World';
+const CONTENT_TEXT = 'Content';
+
+// MIME types a viewer hook registers an object[type="..."] selector for.
+const HANDLED_OBJECT_TYPES = ['application/pdf', 'video/mp4'];
+
+// Mirror the real mediator: an object MIME type is handled only if a viewer
+// registered a selector for it. canHandleElement routes the element;
+// objectViewerMimetypes gates its data attribute. They must agree.
+function handleObjectTypes(types = HANDLED_OBJECT_TYPES) {
+  kolibri.canHandleElement = jest.fn(
+    el => el && el.tagName === 'OBJECT' && types.includes(el.getAttribute('type')),
+  );
+  kolibri.objectViewerMimetypes = jest.fn(() => types);
+}
+
+describe('SafeHTML', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock: no element can be handled
+    kolibri.canHandleElement = jest.fn().mockReturnValue(false);
+    kolibri.objectViewerMimetypes = jest.fn(() => []);
+  });
+
+  describe('basic HTML sanitization', () => {
+    it('renders basic HTML content', () => {
+      render(SafeHTML, {
+        props: {
+          html: `<p>${HELLO_WORLD_TEXT}</p>`,
+        },
+      });
+      expect(screen.getByText(HELLO_WORLD_TEXT).tagName).toBe('P');
+    });
+
+    it('adds safe-html class to elements', () => {
+      render(SafeHTML, {
+        props: {
+          html: `<div id="test-div">${CONTENT_TEXT}</div>`,
+        },
+      });
+      const div = screen.getByText(CONTENT_TEXT);
+      expect(div).toHaveClass('safe-html');
+    });
+
+    it('strips forbidden tags like style', () => {
+      const { container } = render(SafeHTML, {
+        props: {
+          html: '<div>Content<style>.foo { color: red; }</style></div>',
+        },
+      });
+      expect(container.querySelector('style')).not.toBeInTheDocument();
+    });
+
+    it('strips forbidden attributes like style', () => {
+      render(SafeHTML, {
+        props: {
+          html: `<div style="color: red;">${CONTENT_TEXT}</div>`,
+        },
+      });
+      const div = screen.getByText(CONTENT_TEXT);
+      expect(div).not.toHaveAttribute('style');
+    });
+  });
+
+  describe('object tag handling', () => {
+    beforeEach(() => handleObjectTypes());
+
+    it('routes a handled object through the ContentViewer with its file', () => {
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: '<object data="test.pdf" type="application/pdf">PDF</object>',
+        },
+      });
+      // A renderable object is replaced by the ContentViewer, which receives the file.
+      expect(container.querySelector('object')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        'test.pdf',
+      );
+    });
+
+    it('renders an unhandled object inertly without its data', () => {
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: '<object data="thing.bin" type="application/x-unknown">x</object>',
+        },
+      });
+      const objectEl = container.querySelector('object');
+      expect(objectEl).toBeInTheDocument();
+      expect(objectEl).not.toHaveAttribute('data');
+    });
+  });
+
+  describe('data attribute sanitization', () => {
+    beforeEach(() => handleObjectTypes());
+
+    it('passes a valid file URL to the ContentViewer', () => {
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: '<object data="/path/to/file.pdf" type="application/pdf">PDF</object>',
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        '/path/to/file.pdf',
+      );
+    });
+
+    it('passes a blob URL to the ContentViewer', () => {
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: '<object data="blob:https://example.com/12345" type="application/pdf">PDF</object>',
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        'blob:https://example.com/12345',
+      );
+    });
+
+    it('drops javascript: URLs before they reach the ContentViewer', () => {
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: '<object data="javascript:alert(1)" type="application/pdf">PDF</object>',
+        },
+      });
+      // DOMPurify removes the dangerous URL, so nothing reaches the viewer.
+      expect(container.querySelector('[data-testid="content-viewer"]')).not.toHaveAttribute(
+        'data-src',
+      );
+    });
+
+    it('strips a base64 data: HTML payload on an unhandled object type', () => {
+      // Decodes to: <script>alert('Hello from Object!');</script>
+      const payload =
+        'data:text/html;base64,PHNjcmlwdD5hbGVydCgnSGVsbG8gZnJvbSBPYmplY3QhJyk7PC9zY3JpcHQ+';
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: `<object data="${payload}" type="text/html">payload</object>`,
+        },
+      });
+      // text/html is not a handled type, so the object renders inertly with no data.
+      expect(container.querySelector('object')).not.toHaveAttribute('data');
+    });
+
+    it('strips a data: HTML payload even when the type attribute claims a handled mimetype', () => {
+      // The type attribute lies (application/pdf), but the data: URI carries its own
+      // text/html media type, which the browser would honour and execute.
+      const payload =
+        'data:text/html;base64,PHNjcmlwdD5hbGVydCgnSGVsbG8gZnJvbSBPYmplY3QhJyk7PC9zY3JpcHQ+';
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: `<object data="${payload}" type="application/pdf">payload</object>`,
+        },
+      });
+      // Routed to the ContentViewer by the lying type, but the payload is stripped first.
+      expect(container.querySelector('[data-testid="content-viewer"]')).not.toHaveAttribute(
+        'data-src',
+      );
+    });
+
+    it('keeps a data: URI whose own mimetype is handled', () => {
+      const payload = 'data:application/pdf;base64,JVBERi0xLjQ=';
+      const { container } = render(createSafeHTML(), {
+        props: {
+          html: `<object data="${payload}" type="application/pdf">PDF</object>`,
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        payload,
+      );
+    });
+  });
+
+  describe('ContentViewer integration', () => {
+    it('calls canHandleElement for object tags', () => {
+      render(SafeHTML, {
+        props: {
+          html: '<object data="video.mp4" type="video/mp4">Video</object>',
+        },
+      });
+      expect(kolibri.canHandleElement).toHaveBeenCalled();
+    });
+
+    it('renders ContentViewer when element can be handled', () => {
+      kolibri.canHandleElement = jest.fn().mockReturnValue(true);
+
+      const { container } = render(SafeHTML, {
+        props: {
+          html: '<video src="video.mp4"></video>',
+        },
+      });
+
+      // Original <video> should be replaced by the ContentViewer stub.
+      expect(container.querySelector('video')).not.toBeInTheDocument();
+    });
+
+    it('renders original element when canHandleElement returns false', () => {
+      kolibri.canHandleElement = jest.fn().mockReturnValue(false);
+
+      const { container } = render(SafeHTML, {
+        props: {
+          html: '<video src="video.mp4"></video>',
+        },
+      });
+
+      expect(container.querySelector('video')).toBeInTheDocument();
+    });
+
+    it('checks video elements for ContentViewer handling', () => {
+      render(SafeHTML, {
+        props: {
+          html: '<video src="video.mp4"><source src="video.webm" type="video/webm"></video>',
+        },
+      });
+
+      expect(kolibri.canHandleElement).toHaveBeenCalled();
+      // Verify it was called with a video element
+      const call = kolibri.canHandleElement.mock.calls.find(
+        call => call[0].tagName?.toLowerCase() === 'video',
+      );
+      expect(call).toBeTruthy();
+    });
+
+    it('checks audio elements for ContentViewer handling', () => {
+      render(SafeHTML, {
+        props: {
+          html: '<audio src="audio.mp3"></audio>',
+        },
+      });
+
+      expect(kolibri.canHandleElement).toHaveBeenCalled();
+      const call = kolibri.canHandleElement.mock.calls.find(
+        call => call[0].tagName?.toLowerCase() === 'audio',
+      );
+      expect(call).toBeTruthy();
+    });
+  });
+
+  describe('allowed origins', () => {
+    it('strips src attributes with absolute URLs by default', () => {
+      const { container } = render(SafeHTML, {
+        props: {
+          html: '<audio src="http://localhost:8000/zipcontent/abc123.mp3" controls></audio>',
+        },
+      });
+      const audio = container.querySelector('audio');
+      expect(audio).toBeInTheDocument();
+      expect(audio).not.toHaveAttribute('src');
+    });
+
+    it('allows src attributes matching an allowed origin', () => {
+      const SafeHTMLWithOrigins = createSafeHTML({}, { allowedOrigins: ['http://localhost:8000'] });
+      const { container } = render(SafeHTMLWithOrigins, {
+        props: {
+          html: '<audio src="http://localhost:8000/zipcontent/abc123.mp3" controls></audio>',
+        },
+      });
+      const audio = container.querySelector('audio');
+      expect(audio).toHaveAttribute('src', 'http://localhost:8000/zipcontent/abc123.mp3');
+    });
+
+    it('strips src attributes not matching any allowed origin', () => {
+      const SafeHTMLWithOrigins = createSafeHTML({}, { allowedOrigins: ['http://localhost:8000'] });
+      const { container } = render(SafeHTMLWithOrigins, {
+        props: {
+          html: '<audio src="http://evil.com/malicious.mp3" controls></audio>',
+        },
+      });
+      const audio = container.querySelector('audio');
+      expect(audio).not.toHaveAttribute('src');
+    });
+
+    it('passes object data matching an allowed origin to the ContentViewer', () => {
+      handleObjectTypes();
+      const SafeHTMLWithOrigins = createSafeHTML({}, { allowedOrigins: ['http://localhost:8000'] });
+      const { container } = render(SafeHTMLWithOrigins, {
+        props: {
+          html: '<object data="http://localhost:8000/zipcontent/doc.pdf" type="application/pdf"></object>',
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        'http://localhost:8000/zipcontent/doc.pdf',
+      );
+    });
+
+    it('still passes blob URIs to the ContentViewer when origins are specified', () => {
+      handleObjectTypes();
+      const SafeHTMLWithOrigins = createSafeHTML({}, { allowedOrigins: ['http://localhost:8000'] });
+      const { container } = render(SafeHTMLWithOrigins, {
+        props: {
+          html: '<object data="blob:https://example.com/12345" type="application/pdf"></object>',
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        'blob:https://example.com/12345',
+      );
+    });
+
+    it('still passes relative URIs to the ContentViewer when origins are specified', () => {
+      handleObjectTypes();
+      const SafeHTMLWithOrigins = createSafeHTML({}, { allowedOrigins: ['http://localhost:8000'] });
+      const { container } = render(SafeHTMLWithOrigins, {
+        props: {
+          html: '<object data="./file.pdf" type="application/pdf"></object>',
+        },
+      });
+      expect(container.querySelector('[data-testid="content-viewer"]')).toHaveAttribute(
+        'data-src',
+        './file.pdf',
+      );
+    });
+  });
+
+  describe('semantics tag handling', () => {
+    it('allows semantics tag for MathML content', () => {
+      const { container } = render(SafeHTML, {
+        props: {
+          html: '<math><semantics><mi>x</mi></semantics></math>',
+        },
+      });
+      // Check that semantics tag is in the rendered output
+      expect(container.innerHTML).toContain('semantics');
+      expect(container.innerHTML).toContain('<mi');
+    });
+  });
+});

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -1,22 +1,68 @@
 import DOMPurify from 'dompurify';
 import kebabCase from 'lodash/kebabCase';
+import kolibri from 'kolibri';
 import './style.scss';
 import SafeHtmlTable from './SafeHtmlTable.vue';
 import SafeHtmlImage from './SafeHtmlImage.vue';
 
-const ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
+const DEFAULT_ALLOWED_URI_REGEXP = /^(?:(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 const FORBID_TAGS = ['style', 'link'];
 const FORBID_ATTR = ['style', 'width', 'height'];
-const ADD_TAGS = ['semantics'];
+const ADD_TAGS = ['object', 'semantics'];
+const ADD_ATTR = ['data'];
+const HTMLComponents = {
+  img: SafeHtmlImage,
+  table: SafeHtmlTable,
+};
+
+// The MIME type an <object> uses to render its data resource: a data: URI
+// carries its own media type, otherwise the type attribute applies. Using the
+// data: URI's own type stops a spoofed type attribute from smuggling one MIME
+// type past the filter while the browser renders another.
+function objectDataMimetype(node) {
+  const data = node.getAttribute('data') || '';
+  const dataUriMatch = data.match(/^data:([^;,]+)/i);
+  return dataUriMatch ? dataUriMatch[1].toLowerCase() : node.getAttribute('type');
+}
+
+function buildAllowedUriRegexp(allowedOrigins) {
+  if (!allowedOrigins || allowedOrigins.length === 0) {
+    return DEFAULT_ALLOWED_URI_REGEXP;
+  }
+  const escaped = allowedOrigins.map(o => o.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  // Allow the specified origins (with trailing slash/path) in addition to the defaults
+  const origins = escaped.join('|');
+  return new RegExp(
+    `^(?:(?:${origins})/|(?:blob:https?|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\\-:]|$))`,
+    'i',
+  );
+}
 
 // Factory function to create SafeHTML with custom component support
-export function createSafeHTML(customComponents = {}) {
+export function createSafeHTML(customComponents = {}, { allowedOrigins } = {}) {
   const validProps = Object.keys(customComponents).reduce((acc, tagName) => {
     for (const prop of Object.keys(customComponents[tagName].props || {})) {
       acc[kebabCase(prop)] = true;
     }
     return acc;
   }, {});
+  const ALLOWED_URI_REGEXP = buildAllowedUriRegexp(allowedOrigins);
+
+  // MIME types a registered viewer handles via its object[type="..."] selectors.
+  // Built lazily on first use so viewer registration has completed, then cached.
+  // This is the same allowlist that drives object rendering, so the data-attribute
+  // filter and the rendering decision never diverge.
+  let renderableObjectMimetypes = null;
+  function isRenderableObjectMimetype(mimetype) {
+    if (!mimetype) {
+      return false;
+    }
+    if (renderableObjectMimetypes === null) {
+      renderableObjectMimetypes = new Set(kolibri.objectViewerMimetypes());
+    }
+    return renderableObjectMimetypes.has(mimetype);
+  }
+
   return {
     name: 'SafeHTML',
     functional: true,
@@ -27,6 +73,7 @@ export function createSafeHTML(customComponents = {}) {
     },
     render(h, context) {
       const docFragment = DOMPurify.sanitize(context.props.html, {
+        ADD_ATTR,
         ADD_TAGS,
         FORBID_TAGS,
         ALLOWED_URI_REGEXP,
@@ -44,56 +91,51 @@ export function createSafeHTML(customComponents = {}) {
         if (node.nodeType === Node.ELEMENT_NODE) {
           const tagName = node.tagName.toLowerCase();
 
+          // Only allow <object data> when a registered viewer handles its
+          // effective MIME type. Blocks data:text/html (and other active-content)
+          // payloads from being embedded and executed in the object's context.
+          if (tagName === 'object' && !isRenderableObjectMimetype(objectDataMimetype(node))) {
+            node.removeAttribute('data');
+          }
+
+          // Extract attributes and convert to props
+          const attrs = {};
+          const props = {
+            node,
+          };
+
+          for (const attr of node.attributes) {
+            attrs[attr.name] = attr.value;
+            const propName = attr.name.replace(/-[a-z]/g, g => g[1].toUpperCase());
+            props[propName] = attr.value;
+          }
+
+          attrs.class = attrs.class ? `${attrs.class} safe-html` : 'safe-html';
+
           // Check if this is a custom element
-          const CustomComponent = customComponents[tagName];
+          const component =
+            customComponents[tagName] ||
+            HTMLComponents[tagName] ||
+            (kolibri.canHandleElement(node) ? 'ContentViewer' : null);
 
-          if (CustomComponent) {
-            // Extract attributes and convert to props
-            const attrs = {};
-            const props = {};
-
-            for (const attr of node.attributes) {
-              attrs[attr.name] = attr.value;
-              const propName = attr.name.replace(/-([a-z])/g, g => g[1].toUpperCase());
-              props[propName] = attr.value;
+          if (component) {
+            const childProps = { ...props };
+            // ContentViewer expects the DOM element as `element`, not `node`
+            if (component === 'ContentViewer') {
+              delete childProps.node;
+              childProps.element = node;
+              childProps.embedded = true;
             }
-
-            return h(
-              CustomComponent,
+            const childVNode = h(
+              component,
               {
-                props,
+                props: childProps,
                 attrs,
                 on: context.listeners,
               },
               mapChildren(node.childNodes),
             );
-          }
-          // Handle regular HTML elements
-          const attrs = {};
-          for (const attr of node.attributes) {
-            attrs[attr.name] = attr.value;
-          }
-
-          attrs.class = attrs.class ? `${attrs.class} safe-html` : 'safe-html';
-          if (tagName === 'table') {
-            return h(
-              SafeHtmlTable,
-              {
-                props: { node },
-                attrs,
-              },
-              mapChildren(node.childNodes),
-            );
-          }
-
-          if (tagName === 'img') {
-            return h(SafeHtmlImage, {
-              attrs,
-              props: {
-                src: attrs.src,
-                alt: attrs.alt,
-              },
-            });
+            return childVNode;
           }
 
           return h(tagName, { attrs }, mapChildren(node.childNodes));

--- a/packages/kolibri-common/components/quizzes/QuizReport/index.vue
+++ b/packages/kolibri-common/components/quizzes/QuizReport/index.vue
@@ -164,12 +164,10 @@
             />
           </div>
           <ContentViewer
+            :contentNode="exercise"
             :itemId="renderableItemId"
             :allowHints="false"
-            :files="exercise.files"
-            :extraFields="exercise.extra_fields"
             :interactive="false"
-            :assessment="true"
             :answerState="answerState"
             :showCorrectAnswer="showCorrectAnswer"
           />

--- a/packages/kolibri-zip/src/fileUtils.js
+++ b/packages/kolibri-zip/src/fileUtils.js
@@ -211,7 +211,7 @@ const domParser = new DOMParser();
 
 const domSerializer = new XMLSerializer();
 
-const urlAttributes = ['src', 'href'];
+const urlAttributes = ['src', 'href', 'data', 'poster'];
 
 const queryParamRegex = /([^?)]+)?(\?.*)/g;
 

--- a/packages/kolibri/components/__tests__/DownloadButton.spec.js
+++ b/packages/kolibri/components/__tests__/DownloadButton.spec.js
@@ -1,16 +1,19 @@
 import Vue from 'vue';
 import { render, screen } from '@testing-library/vue';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
-import { VIEWER_SUFFIX } from 'kolibri/constants';
+import kolibri from 'kolibri';
 import DownloadButton from '../DownloadButton';
 
 jest.mock('kolibri/composables/useUser');
+jest.mock('kolibri');
 
 const getDownloadableFile = (isExercise = false) => {
   const PRESET = isExercise ? 'exercise' : 'thumbnail';
 
-  // Register a component with the preset name so that the file is considered renderable
-  Vue.component(PRESET + VIEWER_SUFFIX, { template: '<div></div>' });
+  // Mock the preset viewer component so that the file is considered renderable
+  kolibri.presetViewerComponent = jest
+    .fn()
+    .mockImplementation(preset => (preset === PRESET ? { template: '<div></div>' } : null));
 
   return {
     preset: PRESET,

--- a/packages/kolibri/components/internal/ContentViewer/ContentViewerError.vue
+++ b/packages/kolibri/components/internal/ContentViewer/ContentViewerError.vue
@@ -45,7 +45,7 @@
     },
     props: {
       error: {
-        type: Object,
+        type: [Object, Error],
         default: null,
       },
       files: {

--- a/packages/kolibri/components/internal/ContentViewer/__tests__/contentViewer.spec.js
+++ b/packages/kolibri/components/internal/ContentViewer/__tests__/contentViewer.spec.js
@@ -1,28 +1,24 @@
-import Vue from 'vue';
-import { VIEWER_SUFFIX } from 'kolibri/constants';
-import { canRenderContent, getRenderableFiles, getDefaultFile, getFilePreset } from '../utils';
+// Mock kolibri before importing utils that depend on it
+import kolibri from 'kolibri';
+import { getRenderableFiles, getDefaultFile, getFilePreset } from '../utils';
 
-// Add a component to the Vue instance that can be used to test the utility functions
+jest.mock('kolibri', () => ({
+  default: { presetViewerComponent: jest.fn() },
+  __esModule: true,
+}));
+
+// Mock the preset viewer components so they can be used to test the utility functions
 const addRegisterableComponents = (...presets) => {
-  presets.forEach(preset => {
-    Vue.component(preset + VIEWER_SUFFIX, { template: '<div></div>' });
-  });
+  kolibri.presetViewerComponent.mockImplementation(preset =>
+    presets.includes(preset) ? { template: '<div></div>' } : null,
+  );
 };
 
 describe('Utility Functions', () => {
   beforeEach(() => {
-    Vue.options.components = {};
-  });
-
-  describe('canRenderContent', () => {
-    it('returns true if preset viewer component is registered', () => {
-      addRegisterableComponents('preset1');
-      expect(canRenderContent('preset1')).toBe(true);
-    });
-
-    it('returns false if preset viewer component is not registered', () => {
-      expect(canRenderContent('preset2')).toBe(false);
-    });
+    jest.clearAllMocks();
+    // Reset mock to return null by default (no viewer registered)
+    kolibri.presetViewerComponent.mockReturnValue(null);
   });
 
   describe('getRenderableFiles', () => {

--- a/packages/kolibri/components/internal/ContentViewer/index.js
+++ b/packages/kolibri/components/internal/ContentViewer/index.js
@@ -1,7 +1,100 @@
-import { VIEWER_SUFFIX } from 'kolibri/constants';
+import { h, ref, onErrorCaptured, provide, computed } from 'vue';
 import heartbeat from 'kolibri/heartbeat';
-import { canRenderContent, getRenderableFiles, getDefaultFile, getFilePreset } from './utils';
+import kolibri from 'kolibri';
+import { defaultLanguage } from 'kolibri/utils/i18n';
+import { MasteryModelTypes } from 'kolibri/constants';
+import { inferPresetFromMimetype } from 'kolibri/utils/mimetypes';
+import { validateObject } from 'kolibri/utils/objectSpecs';
+import { getRenderableFiles, getDefaultFile, getFilePreset } from './utils';
 import ContentViewerError from './ContentViewerError';
+
+export const CONTENT_VIEWER_CONTEXT_KEY = Symbol('contentViewerContext');
+
+// Module-level counter for unique viewer IDs
+let viewerIdCounter = 0;
+
+const langSpec = {
+  id: { type: String, required: true },
+  lang_name: { type: String, required: true },
+  lang_direction: { type: String, required: true },
+};
+
+const fileSpec = {
+  id: { type: String, required: true },
+  storage_url: { type: String, required: true },
+  extension: { type: String, required: true },
+  available: { type: Boolean, required: true },
+  file_size: { type: Number, required: true },
+  checksum: { type: String, required: true },
+  preset: { type: String, required: true },
+  lang: {
+    type: Object,
+    default: null,
+    spec: langSpec,
+  },
+  supplementary: { type: Boolean, required: true },
+  thumbnail: { type: Boolean, required: true },
+};
+
+const masteryModelTypes = Object.values(MasteryModelTypes);
+
+const masteryModelSpec = {
+  type: {
+    type: String,
+    required: true,
+    validator: value => masteryModelTypes.includes(value),
+  },
+  // Carried only for the 'm_of_n' type: m correct of the last n
+  m: { type: Number, default: null },
+  n: { type: Number, default: null },
+};
+
+const assessmentMetadataSpec = {
+  // Question ids the assessment can present
+  assessment_item_ids: {
+    type: Array,
+    required: true,
+    spec: { type: String, required: true },
+  },
+  number_of_assessments: { type: Number, required: true },
+  mastery_model: {
+    type: Object,
+    required: true,
+    spec: masteryModelSpec,
+  },
+  randomize: { type: Boolean, required: true },
+  is_manipulable: { type: Boolean, required: true },
+};
+
+const contentNodeSpec = {
+  files: {
+    type: Array,
+    required: true,
+    spec: {
+      type: Object,
+      required: true,
+      spec: fileSpec,
+    },
+  },
+  lang: {
+    type: Object,
+    default: null,
+    spec: langSpec,
+  },
+  options: {
+    type: Object,
+    default: () => ({}),
+  },
+  duration: {
+    type: Number,
+    default: null,
+  },
+  assessmentmetadata: {
+    type: Object,
+    default: null,
+    spec: assessmentMetadataSpec,
+  },
+};
 
 const interactionEvents = [
   'answerGiven',
@@ -16,55 +109,245 @@ const interactionEvents = [
   'finished',
 ];
 
-function combineEventListeners(existing, newListener) {
-  if (!existing) {
-    return newListener;
+/**
+ * Combines event listeners and appends a viewerId to all event arguments.
+ * This allows parent components to track which ContentViewer emitted the event.
+ * @param {Function|Array|undefined} existing - Existing listener(s) from context
+ * @param {Function} heartbeatListener - The heartbeat.setUserActive listener
+ * @param {string} viewerId - Unique identifier for this ContentViewer instance
+ * @returns {Function} Combined listener that calls heartbeat and existing listeners with viewerId
+ */
+function combineEventListenersWithViewerId(existing, heartbeatListener, viewerId) {
+  return (...args) => {
+    // Always call heartbeat
+    heartbeatListener();
+
+    // Call existing listeners with viewerId appended to args
+    if (existing) {
+      if (Array.isArray(existing)) {
+        existing.forEach(fn => fn(...args, viewerId));
+      } else {
+        existing(...args, viewerId);
+      }
+    }
+  };
+}
+
+function getComponent(element, defaultItemPreset) {
+  const domComponent = kolibri.elementViewerComponent(element);
+  if (domComponent) {
+    return domComponent;
   }
 
-  if (Array.isArray(existing)) {
-    return [...existing, newListener];
+  if (defaultItemPreset) {
+    return kolibri.presetViewerComponent(defaultItemPreset);
   }
 
-  return [existing, newListener];
+  return null;
 }
 
 export default {
-  functional: true,
-  render: function (createElement, context) {
-    const defaultItemPreset = getFilePreset(
-      getDefaultFile(getRenderableFiles(context.props.files || [])),
-      context.props.preset,
-    );
-    if (canRenderContent(defaultItemPreset)) {
-      const combinedListeners = {
-        ...context.listeners,
-        ...context.data.on,
-      };
-      for (const event of interactionEvents) {
-        combinedListeners[event] = combineEventListeners(
-          combinedListeners[event],
-          heartbeat.setUserActive,
-        );
-      }
+  name: 'ContentViewer',
+  props: {
+    // -- Content structure --
+    // What content to render and how to resolve the viewer component.
+    contentNode: {
+      type: Object,
+      default: null,
+      validator: contentNode => validateObject(contentNode, contentNodeSpec),
+    },
+    element: {
+      type: HTMLElement,
+      default: null,
+    },
+    itemData: {
+      default: null,
+    },
+    preset: {
+      default: null,
+      type: String,
+    },
 
-      const safeAttrs = {};
-      for (const [key, value] of Object.entries(context.data.attrs || {})) {
-        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-          safeAttrs[key] = value;
+    // -- Session state --
+    // Progress tracking state, relayed from the caller's useProgressTracking composable.
+    progress: {
+      type: Number,
+      default: 0,
+    },
+    timeSpent: {
+      type: Number,
+      default: 0,
+    },
+    extraFields: {
+      type: Object,
+      default: () => ({}),
+    },
+    answerState: {
+      type: Object,
+      default: () => ({}),
+    },
+
+    // -- User data --
+    // Identifies the user interacting with or being reviewed for this content.
+    // Not necessarily the logged-in user (e.g. coach reviewing a learner's work).
+    userId: {
+      type: String,
+      default: '',
+    },
+    userFullName: {
+      type: String,
+      default: '',
+    },
+
+    // -- Rendering context --
+    // Per-call-site configuration that controls how the viewer behaves.
+    itemId: {
+      type: String,
+    },
+    interactive: {
+      type: Boolean,
+      default: true,
+    },
+    showCorrectAnswer: {
+      type: Boolean,
+      default: false,
+    },
+    allowHints: {
+      type: Boolean,
+      default: true,
+    },
+    embedded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props, context) {
+    const error = ref(null);
+
+    // Generate unique viewer ID for this instance
+    const viewerId = `content-viewer-${++viewerIdCounter}`;
+
+    const _customExtractors = ref(null);
+
+    // Computed values that combine multiple prop sources
+    const files = computed(() => {
+      if (props.element && kolibri.canHandleElement(props.element)) {
+        // Check for custom extractors first (keyed by CSS selector)
+        for (const [selector, extractor] of Object.entries(_customExtractors.value || {})) {
+          if (props.element.matches(selector)) {
+            const extractedFiles = extractor(props.element);
+            if (extractedFiles && extractedFiles.length > 0) {
+              return extractedFiles;
+            }
+          }
+        }
+
+        // Default handling for <object> elements
+        if (props.element.matches('object[data][type]')) {
+          const mimeType = props.element.getAttribute('type');
+          return [
+            {
+              storage_url: props.element.getAttribute('data'),
+              preset: inferPresetFromMimetype(mimeType),
+              available: true,
+              supplementary: false,
+              thumbnail: false,
+              priority: 1,
+            },
+          ];
         }
       }
+      // Otherwise use the content node files
+      return props.contentNode?.files || [];
+    });
 
-      return createElement(
-        defaultItemPreset + VIEWER_SUFFIX,
+    const defaultFile = computed(() => {
+      return getDefaultFile(getRenderableFiles(files.value));
+    });
+
+    const defaultItemPreset = computed(() =>
+      getFilePreset(getDefaultFile(getRenderableFiles(files.value)), props.preset),
+    );
+
+    const options = computed(() => {
+      return props.contentNode?.options || {};
+    });
+
+    const lang = computed(() => {
+      return props.contentNode?.lang || defaultLanguage;
+    });
+
+    const duration = computed(() => {
+      return props.contentNode?.duration || null;
+    });
+
+    function setCustomExtractors(extractors) {
+      _customExtractors.value = extractors;
+    }
+
+    // Provide props context to descendant components via useContentViewer
+    const contentViewerContext = {
+      contentNode: computed(() => props.contentNode),
+      element: computed(() => props.element),
+      files,
+      defaultFile,
+      itemData: computed(() => props.itemData),
+      itemId: computed(() => props.itemId),
+      answerState: computed(() => props.answerState),
+      showCorrectAnswer: computed(() => props.showCorrectAnswer),
+      interactive: computed(() => props.interactive),
+      lang,
+      options,
+      extraFields: computed(() => props.extraFields),
+      userId: computed(() => props.userId),
+      allowHints: computed(() => props.allowHints),
+      timeSpent: computed(() => props.timeSpent),
+      duration,
+      userFullName: computed(() => props.userFullName),
+      progress: computed(() => props.progress),
+      embedded: computed(() => props.embedded),
+      setCustomExtractors,
+    };
+
+    provide(CONTENT_VIEWER_CONTEXT_KEY, contentViewerContext);
+
+    onErrorCaptured(err => {
+      // Error boundary - catches uncaught errors from child renderer components
+      error.value = err;
+      context.emit('error', err);
+    });
+
+    return () => {
+      const component = getComponent(props.element, defaultItemPreset.value);
+      // If we caught an error, show error component
+      if (error.value || !component) {
+        return h(ContentViewerError, {
+          props: {
+            error: error.value
+              ? error.value
+              : new Error('No compatible viewer found for this content.'),
+            files: files.value,
+          },
+        });
+      }
+
+      const combinedListeners = {
+        ...context.listeners,
+      };
+      for (const event of interactionEvents) {
+        combinedListeners[event] = combineEventListenersWithViewerId(
+          combinedListeners[event],
+          heartbeat.setUserActive,
+          viewerId,
+        );
+      }
+      return h(
+        component,
         {
-          ...context.data,
-          attrs: safeAttrs,
-          props: context.props,
           on: combinedListeners,
         },
-        context.children,
+        context.slots.default,
       );
-    }
-    return createElement(ContentViewerError);
+    };
   },
 };

--- a/packages/kolibri/components/internal/ContentViewer/utils.js
+++ b/packages/kolibri/components/internal/ContentViewer/utils.js
@@ -1,15 +1,18 @@
-import Vue from 'vue';
-import { VIEWER_SUFFIX } from 'kolibri/constants';
-
-export const canRenderContent = preset => Boolean(Vue.options.components[preset + VIEWER_SUFFIX]);
+// Deferred import to avoid circular dependency during module loading:
+// ContentViewer/utils → kolibri → pluginMediator → ContentViewerError
+// → DownloadButton → ContentViewer/utils
+const getKolibri = () => require('kolibri').default;
 
 export const getRenderableFiles = files =>
   files.filter(
     file =>
-      !file.thumbnail && !file.supplementary && file.available && canRenderContent(file.preset),
+      !file.thumbnail &&
+      !file.supplementary &&
+      file.available &&
+      getKolibri().presetViewerComponent(file.preset),
   );
 
 export const getDefaultFile = files => (files && files.length ? files[0] : undefined);
 
 export const getFilePreset = (file, preset) =>
-  file ? file.preset : canRenderContent(preset) ? preset : null;
+  file ? file.preset : getKolibri().presetViewerComponent(preset) ? preset : null;

--- a/packages/kolibri/composables/__mocks__/useContentViewer.js
+++ b/packages/kolibri/composables/__mocks__/useContentViewer.js
@@ -1,0 +1,85 @@
+/**
+ * `useContentViewer` composable function mock.
+ *
+ * If default values are sufficient for tests,
+ * you only need call `jest.mock('<useContentViewer file path>')`
+ * at the top of a test file.
+ *
+ * If you need to override some default values from some tests,
+ * you can import a helper function `useContentViewerMock` that accepts
+ * an object with values to be overriden and use it together
+ * with  `mockImplementation` as follows:
+ *
+ * ```
+ * // eslint-disable-next-line import-x/named
+ * import useContentViewer, { useContentViewerMock } from '<useContentViewer file path>';
+ *
+ * jest.mock('<useContentViewer file path>')
+ *
+ * it('test', () => {
+ *   useContentViewer.mockImplementation(
+ *     () => useContentViewerMock({ defaultFile: { storage_url: 'foo' } })
+ *   );
+ * })
+ * ```
+ *
+ * You can reset your mock implementation back to default values
+ * for other tests by calling the following in `beforeEach`:
+ *
+ * ```
+ * useContentViewer.mockImplementation(() => useContentViewerMock())
+ * ```
+ */
+import { ref } from 'vue';
+
+const MOCK_DEFAULTS = {
+  files: [],
+  options: {},
+  lang: null,
+  duration: null,
+  forceDurationBasedProgress: false,
+  durationBasedProgress: null,
+  defaultFile: null,
+  supplementaryFiles: [],
+  thumbnailFiles: [],
+  contentDirection: 'ltr',
+  contentIsRtl: false,
+  availableHints: 0,
+  totalHints: 0,
+  itemData: null,
+  itemId: null,
+  answerState: null,
+  allowHints: false,
+  extraFields: { contentState: {} },
+  interactive: false,
+  showCorrectAnswer: false,
+  timeSpent: 0,
+  userId: null,
+  userFullName: '',
+  progress: 0,
+  embedded: false,
+};
+
+const MOCK_METHODS = {
+  checkAnswer: jest.fn(() => null),
+  takeHint: jest.fn(() => null),
+  reportError: jest.fn(),
+  reportLoadingError: jest.fn(),
+};
+
+export function useContentViewerMock(overrides = {}) {
+  const mocks = {
+    ...MOCK_DEFAULTS,
+    ...overrides,
+  };
+  const refs = {};
+  for (const key in mocks) {
+    refs[key] = ref(mocks[key]);
+  }
+  return {
+    ...refs,
+    ...MOCK_METHODS,
+  };
+}
+
+export default jest.fn(() => useContentViewerMock());

--- a/packages/kolibri/composables/useContentViewer.js
+++ b/packages/kolibri/composables/useContentViewer.js
@@ -1,184 +1,190 @@
-import Vue, { ref, computed, getCurrentInstance } from 'vue';
+import { computed, inject } from 'vue';
 import { get } from '@vueuse/core';
 import logger from 'kolibri-logging';
 import { ContentErrorConstants } from 'kolibri/constants';
-import {
-  defaultLanguage,
-  languageValidator,
-  getContentLangDir,
-  languageDirections,
-} from 'kolibri/utils/i18n';
+import { getContentLangDir, languageDirections } from 'kolibri/utils/i18n';
 import { getRenderableFiles, getDefaultFile } from '../components/internal/ContentViewer/utils';
-import ContentViewerError from '../components/internal/ContentViewer/ContentViewerError';
+import { CONTENT_VIEWER_CONTEXT_KEY } from '../components/internal/ContentViewer';
 
 const logging = logger.getLogger(__filename);
 
-const ContentViewerErrorComponent = Vue.extend(ContentViewerError);
+/**
+ * @typedef {import('vue').ComputedRef} Ref
+ */
 
-const fileFieldMap = {
-  storage_url: {
-    type: String,
-  },
-  id: {
-    type: String,
-  },
-  priority: {
-    type: Number,
-  },
-  available: {
-    type: Boolean,
-  },
-  file_size: {
-    type: Number,
-  },
-  checksum: {
-    type: String,
-  },
-  extension: {
-    type: String,
-  },
-  preset: {
-    type: String,
-  },
-  lang: {
-    type: Object,
-    validator: lang => lang === null || languageValidator(lang),
-  },
-  supplementary: {
-    type: Boolean,
-  },
-  thumbnail: {
-    type: Boolean,
-  },
-};
+/**
+ * @typedef {object} ContentViewerApi
+ * @property {Ref<Array>} files - All available files for this content
+ * @property {Ref<object|null>} defaultFile - Primary file selected for viewing
+ * @property {Ref<Array>} supplementaryFiles - Subtitle and transcript files
+ * @property {Ref<Array>} thumbnailFiles - Thumbnail and poster image files
+ * @property {Ref<object>} options - Content-specific rendering configuration
+ * @property {Ref<object>} lang - Language metadata for the content
+ * @property {Ref<number|null>} duration - Content duration in seconds
+ * @property {Ref<boolean>} forceDurationBasedProgress - Forces progress to track elapsed time
+ * @property {Ref<number|null>} durationBasedProgress - Progress from time spent over duration
+ * @property {Ref<string>} contentDirection - Text direction, 'ltr' or 'rtl'
+ * @property {Ref<boolean>} contentIsRtl - True when content reads right-to-left
+ * @property {Function} reportError - Emit an error to the parent ContentViewer
+ * @property {Function} reportLoadingError - Emit a content-loading error
+ * @property {Ref} itemData - Raw assessment item payload
+ * @property {Ref<string>} itemId - Identifier of the current assessment item
+ * @property {Ref<object>} answerState - Saved learner responses
+ * @property {Ref<boolean>} interactive - Allows learner interaction when true
+ * @property {Ref<boolean>} showCorrectAnswer - Reveals correct answers when true
+ * @property {Ref<boolean>} allowHints - Permits taking hints when true
+ * @property {Ref<object>} extraFields - Additional persisted metadata fields
+ * @property {Ref<string>} userId - Id of the interacting or reviewed user
+ * @property {Ref<string>} userFullName - Full name of the interacting or reviewed user
+ * @property {Ref<number>} timeSpent - Seconds spent on this content
+ * @property {Ref<number>} progress - Completion fraction from 0 to 1
+ */
 
-function fileValidator(file) {
-  let result = true;
-  for (const key in fileFieldMap) {
-    const val =
-      typeof file[key] !== 'undefined' &&
-      typeof file[key] === typeof fileFieldMap[key].type() &&
-      (fileFieldMap[key].validator ? fileFieldMap[key].validator(file[key]) : true);
-    if (!val) {
-      logging.error(`Validation failed for '${key}' in `, file);
-      result = false;
-    }
+/**
+ * Composable for content viewer components.
+ *
+ * This composable provides access to content viewer state and utilities for
+ * viewer components that are rendered within a ContentViewer wrapper.
+ *
+ * The ContentViewer wrapper component is responsible for:
+ * - Resolving the appropriate viewer component based on content type
+ * - Extracting files from either contentNode props or DOM elements
+ * - Providing a unified context to all descendant viewer components
+ * @param {object} context - The Vue component context object
+ * @param {Function} context.emit - The component's emit function for emitting events
+ * @param {object} [options={}] - Configuration options
+ * @param {Ref|number|null} [options.defaultDuration=null] - Default duration for
+ * duration-based progress calculation. Can be a Vue ref or a static number. Used when the
+ * content doesn't have an explicit duration set.
+ * @param {{[key: string]: Function}} [options.customExtractors={}] - Custom file extractors
+ * for DOM-based viewing. These extractors are called when the ContentViewer receives
+ * a DOM node prop instead of files.
+ * The object keys are CSS selectors, and the values are extractor functions.
+ * When the ContentViewer has a node prop that matches a selector, the
+ * corresponding extractor function is called to extract file objects from the element.
+ * @returns {ContentViewerApi} Content viewer state and utilities
+ * @throws {Error} If called outside of a ContentViewer component hierarchy
+ * @example
+ * // Custom extractors for video and audio elements
+ * const customExtractors = {
+ *   'video': (element) => {
+ *     const files = [];
+ *     if (element.src) {
+ *       files.push({
+ *         storage_url: element.src,
+ *         preset: 'high_res_video',
+ *         available: true,
+ *         supplementary: false,
+ *         thumbnail: false,
+ *       });
+ *     }
+ *     // Extract from <source> children
+ *     for (const source of element.querySelectorAll('source')) {
+ *       files.push({
+ *         storage_url: source.src,
+ *         preset: 'high_res_video',
+ *         available: true,
+ *       });
+ *     }
+ *     return files;
+ *   },
+ *   'audio': (element) => {
+ *     // Similar extraction for audio elements
+ *     return [{ storage_url: element.src, preset: 'audio', available: true }];
+ *   },
+ * };
+ * // Usage in a viewer component's setup function
+ * setup(props, context) {
+ *   const { files, defaultFile } = useContentViewer(context, {
+ *     customExtractors,
+ *     defaultDuration: 300, // 5 minutes
+ *   });
+ *   // ...
+ * }
+ * @example
+ * // Basic usage in a viewer component
+ * import useContentViewer from 'kolibri/composables/useContentViewer';
+ *
+ * export default {
+ *   name: 'MyViewer',
+ *   setup(props, context) {
+ *     const {
+ *       defaultFile,
+ *       files,
+ *       reportLoadingError,
+ *       contentDirection,
+ *     } = useContentViewer(context);
+ *
+ *     return {
+ *       defaultFile,
+ *       files,
+ *       reportLoadingError,
+ *       contentDirection,
+ *     };
+ *   },
+ * };
+ */
+export default function useContentViewer(
+  { emit },
+  { defaultDuration = null, customExtractors = {} } = {},
+) {
+  // Inject props from ContentViewer
+  const injectedContext = inject(CONTENT_VIEWER_CONTEXT_KEY);
+
+  if (!injectedContext) {
+    throw new Error(
+      'useContentViewer must be called within a component that is a descendant of ContentViewer',
+    );
   }
-  return result;
-}
 
-function multipleFileValidator(files) {
-  return files.reduce((acc, file) => acc && fileValidator(file), true);
-}
+  const {
+    files,
+    itemData,
+    itemId,
+    answerState,
+    showCorrectAnswer,
+    interactive,
+    lang,
+    options,
+    extraFields,
+    userId,
+    allowHints,
+    timeSpent,
+    duration,
+    userFullName,
+    progress,
+    embedded,
+    setCustomExtractors,
+  } = injectedContext;
 
-export const contentViewerProps = {
-  files: {
-    type: Array,
-    default: () => [],
-    validator: multipleFileValidator,
-  },
-  // As an alternative to passing a file object to set the state of the
-  // content viewer, can also pass raw itemData (which will be parsed by
-  // the viewer if there are no files or file object).
-  // The type could depend on the viewer, so we enforce nothing here
-  // except a null default.
-  itemData: {
-    default: null,
-  },
-  // If just itemData is passed, we have no mechanism for knowing the preset
-  // of the data, and hence which viewer to choose. If itemData is utilized
-  // the preset must be explicitly set.
-  preset: {
-    default: null,
-    type: String,
-  },
-  itemId: {
-    type: String,
-  },
-  answerState: {
-    type: Object,
-    default: () => ({}),
-  },
-  allowHints: {
-    type: Boolean,
-    default: true,
-  },
-  extraFields: {
-    type: Object,
-    default: () => ({}),
-  },
-  options: {
-    type: Object,
-    default: () => ({}),
-  },
-  // Allow content viewers to display in a static mode
-  // where user interaction is not allowed
-  interactive: {
-    type: Boolean,
-    default: true,
-  },
-  lang: {
-    type: Object,
-    default: () => defaultLanguage,
-    validator: languageValidator,
-  },
-  showCorrectAnswer: {
-    type: Boolean,
-    default: false,
-  },
-  timeSpent: {
-    type: Number,
-    default: 0,
-  },
-  duration: {
-    type: Number,
-    default: null,
-  },
-  userId: {
-    type: String,
-    default: '',
-  },
-  userFullName: {
-    type: String,
-    default: '',
-  },
-  progress: {
-    type: Number,
-    default: 0,
-  },
-};
+  setCustomExtractors(customExtractors);
 
-export default function useContentViewer(props, { emit }, { defaultDuration = null } = {}) {
-  const instance = getCurrentInstance();
-  const _resourceError = ref(null);
-
-  // Computed properties
   const forceDurationBasedProgress = computed(() => {
-    return props.options.force_duration_based_progress || false;
+    return options.value.force_duration_based_progress || false;
   });
 
   const durationBasedProgress = computed(() => {
-    const duration = props.duration || get(defaultDuration);
-    if (!duration) {
+    const dur = duration.value || get(defaultDuration);
+    if (!dur) {
       return null;
     }
-    return props.timeSpent / duration;
+    return timeSpent.value / dur;
   });
 
   const defaultFile = computed(() => {
-    return getDefaultFile(getRenderableFiles(props.files));
+    return getDefaultFile(getRenderableFiles(files.value));
   });
 
   const supplementaryFiles = computed(() => {
-    return props.files.filter(file => file.supplementary && file.available);
+    return files.value.filter(file => file.supplementary && file.available);
   });
 
   const thumbnailFiles = computed(() => {
-    return props.files.filter(file => file.thumbnail && file.available);
+    return files.value.filter(file => file.thumbnail && file.available);
   });
 
   const contentDirection = computed(() => {
-    return getContentLangDir(props.lang);
+    return getContentLangDir(lang.value);
   });
 
   const contentIsRtl = computed(() => {
@@ -204,20 +210,8 @@ export default function useContentViewer(props, { emit }, { defaultDuration = nu
     return null;
   };
 
-  let _errorComponent;
-
   const reportError = error => {
     emit('error', error);
-    _resourceError.value = error;
-    if (!_errorComponent) {
-      const domNode = document.createElement('div');
-      instance.$el.prepend(domNode);
-      _errorComponent = new ContentViewerErrorComponent({
-        el: domNode,
-        parent: instance,
-        propsData: { error: _resourceError, files: props.files },
-      });
-    }
   };
 
   const reportLoadingError = error => {
@@ -228,7 +222,10 @@ export default function useContentViewer(props, { emit }, { defaultDuration = nu
   };
 
   return {
-    _resourceError,
+    files,
+    options,
+    lang,
+    duration,
     forceDurationBasedProgress,
     durationBasedProgress,
     defaultFile,
@@ -242,5 +239,17 @@ export default function useContentViewer(props, { emit }, { defaultDuration = nu
     takeHint,
     reportLoadingError,
     reportError,
+    itemData,
+    itemId,
+    answerState,
+    allowHints,
+    extraFields,
+    interactive,
+    showCorrectAnswer,
+    timeSpent,
+    userId,
+    userFullName,
+    progress,
+    embedded,
   };
 }

--- a/packages/kolibri/constants.js
+++ b/packages/kolibri/constants.js
@@ -216,8 +216,6 @@ export const MAX_QUESTIONS_PER_QUIZ_SECTION = 25;
 
 export const DisconnectionErrorCodes = [0, 502, 504, 511];
 
-export const VIEWER_SUFFIX = '_viewer';
-
 // enum identifying the types of setup for Lod devices
 export const LodTypePresets = Object.freeze({
   JOIN: 'JOIN',

--- a/packages/kolibri/internal/__tests__/pluginMediator.spec.js
+++ b/packages/kolibri/internal/__tests__/pluginMediator.spec.js
@@ -142,4 +142,24 @@ describe('Mediator', function () {
       });
     });
   });
+  describe('objectViewerMimetypes method', function () {
+    it('should return an empty array when no DOM viewers are registered', function () {
+      expect(mediator.objectViewerMimetypes()).toEqual([]);
+    });
+    it('should extract the MIME types from object[type="..."] selectors', function () {
+      mediator._contentViewerRegistry._dom_viewer = {
+        'object[type="application/pdf"]': () => {},
+        'object[type="video/mp4"]': () => {},
+      };
+      expect(mediator.objectViewerMimetypes().sort()).toEqual(['application/pdf', 'video/mp4']);
+    });
+    it('should ignore non-object selectors like bare tag names', function () {
+      mediator._contentViewerRegistry._dom_viewer = {
+        video: () => {},
+        audio: () => {},
+        'object[type="application/pdf"]': () => {},
+      };
+      expect(mediator.objectViewerMimetypes()).toEqual(['application/pdf']);
+    });
+  });
 });

--- a/packages/kolibri/internal/apiSpec.js
+++ b/packages/kolibri/internal/apiSpec.js
@@ -59,6 +59,7 @@ export default {
   'kolibri/utils/baseClient': require('kolibri/utils/baseClient'),
   'kolibri/utils/browserInfo': require('kolibri/utils/browserInfo'),
   'kolibri/utils/i18n': require('kolibri/utils/i18n'),
+  'kolibri/utils/mimetypes': require('kolibri/utils/mimetypes'),
   'kolibri/utils/objectSpecs': require('kolibri/utils/objectSpecs'),
   'kolibri/utils/onboardingSteps': require('kolibri/utils/onboardingSteps'),
   'kolibri/utils/redirectBrowser': require('kolibri/utils/redirectBrowser'),

--- a/packages/kolibri/internal/pluginMediator.js
+++ b/packages/kolibri/internal/pluginMediator.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import logging from 'kolibri-logging';
 import scriptLoader from 'kolibri/utils/scriptLoader';
-import { VIEWER_SUFFIX } from 'kolibri/constants';
 import { languageDirections, currentLanguage } from 'kolibri/utils/i18n';
 import { rtlManager } from 'kolibri/rtlcss';
 import ContentViewerLoading from '../components/internal/ContentViewer/ContentViewerLoading';
@@ -10,6 +9,9 @@ import ContentViewerError from '../components/internal/ContentViewer/ContentView
 /**
  * @typedef {import('kolibri-module').default} KolibriModule
  */
+
+const VIEWER_SUFFIX = '_viewer';
+const DOM_VIEWER_SUFFIX = '_dom_viewer';
 
 const logger = logging.getLogger(__filename);
 
@@ -24,6 +26,10 @@ const publicMethods = [
   'registerContentViewer',
   'loadDirectionalCSS',
   'ready',
+  'presetViewerComponent',
+  'elementViewerComponent',
+  'canHandleElement',
+  'objectViewerMimetypes',
 ];
 
 const domParser = new DOMParser();
@@ -163,6 +169,27 @@ export default function pluginMediatorFactory(facade) {
       }
       delete this._languageAssetRegistry;
     },
+    _registerViewerType(kolibriModuleName, items, suffix) {
+      for (const item of items) {
+        const registryKey = item + suffix;
+        if (!this._contentViewerRegistry[suffix]) {
+          this._contentViewerRegistry[suffix] = {};
+        }
+        const registry = this._contentViewerRegistry[suffix];
+        if (registry[item]) {
+          logger.warn(`Kolibri Modules: Two content viewers are registering for ${registryKey}`);
+          continue;
+        }
+        registry[item] = () => ({
+          component: this.retrieveContentViewer(kolibriModuleName),
+          loading: ContentViewerLoading,
+          error: ContentViewerError,
+          delay: 0,
+          timeout: 30000,
+        });
+      }
+    },
+
     /**
      * A method for registering content viewers for asynchronous loading and track
      * which file types we have registered viewers for.
@@ -170,31 +197,13 @@ export default function pluginMediatorFactory(facade) {
      * @param {string[]} kolibriModuleUrls - the URLs of the Javascript
      * files that constitute the kolibriModule
      * @param {string[]} contentPresets - the names of presets this content viewer can render
+     * @param {string[]} domTags - DOM tags handled
      */
-    registerContentViewer(kolibriModuleName, kolibriModuleUrls, contentPresets) {
+    registerContentViewer(kolibriModuleName, kolibriModuleUrls, contentPresets = [], domTags = []) {
       this._contentViewerUrls[kolibriModuleName] = kolibriModuleUrls;
-      contentPresets.forEach(preset => {
-        if (this._contentViewerRegistry[preset]) {
-          logger.warn(`Kolibri Modules: Two content viewers are registering for ${preset}`);
-        } else {
-          this._contentViewerRegistry[preset] = kolibriModuleName;
-          Vue.component(preset + VIEWER_SUFFIX, () => ({
-            /* Check the Kolibri core app for a content viewer module that is able to
-             * handle the rendering of the current content node.
-             */
-            component: this.retrieveContentViewer(preset),
-            // A component to use while the async component is loading
-            loading: ContentViewerLoading,
-            // A component to use if the load fails
-            error: ContentViewerError,
-            // Delay before showing the loading component.
-            delay: 0,
-            // The error component will be displayed if a timeout is
-            // provided and exceeded.
-            timeout: 30000,
-          }));
-        }
-      });
+
+      this._registerViewerType(kolibriModuleName, contentPresets, VIEWER_SUFFIX);
+      this._registerViewerType(kolibriModuleName, domTags, DOM_VIEWER_SUFFIX);
     },
 
     /**
@@ -209,9 +218,7 @@ export default function pluginMediatorFactory(facade) {
         const moduleName = element.getAttribute('data-viewer');
         try {
           const data = JSON.parse(decodeMarkedSafeText(element.innerHTML.trim()));
-          const presets = data.presets;
-          const urls = data.urls;
-          this.registerContentViewer(moduleName, urls, presets);
+          this.registerContentViewer(moduleName, data.urls, data.presets, data.css_selectors);
         } catch (e) {
           logger.error(`Error parsing content viewer for ${moduleName}`);
         }
@@ -220,24 +227,22 @@ export default function pluginMediatorFactory(facade) {
 
     /**
      * A method to retrieve a content viewer component.
-     * @param {string} preset - Content preset whose viewer component should be resolved
+     * @param {string} kolibriModuleName - module providing the viewer
      * @returns {Promise} Promise that resolves with loaded content viewer Vue component
      */
-    retrieveContentViewer(preset) {
+    retrieveContentViewer(kolibriModuleName) {
       return new Promise((resolve, reject) => {
-        const kolibriModuleName = this._contentViewerRegistry[preset];
         function resolveComponent(module) {
           if (module.viewerComponent) {
             resolve(module.viewerComponent);
           } else {
             reject(
-              `Content viewer registered for ${preset} but no viewerComponent found in module ${kolibriModuleName}`,
+              `Content viewer registered but no viewerComponent found in module ${kolibriModuleName}`,
             );
           }
         }
         if (!kolibriModuleName) {
-          // Our content viewer registry does not have a viewer for this content preset.
-          reject(`No registered content viewer available for preset: ${preset}`);
+          reject(`No registered content viewer available for: kolibriModuleName`);
         } else if (this._kolibriModuleRegistry[kolibriModuleName]) {
           // There is a named viewer for this preset, and it is already loaded.
           resolveComponent(this._kolibriModuleRegistry[kolibriModuleName]);
@@ -272,6 +277,78 @@ export default function pluginMediatorFactory(facade) {
         }
       });
     },
+    /**
+     * Get a viewer component for a preset
+     * @param {string} preset - Content preset name
+     * @returns {Function|null} Component resolver function or null
+     */
+    presetViewerComponent(preset) {
+      const viewerRegistry = this._contentViewerRegistry[VIEWER_SUFFIX];
+      return viewerRegistry?.[preset] || null;
+    },
+
+    /**
+     * Get a viewer component for a DOM element
+     * @param {?HTMLElement} element - DOM element, or null on the contentNode path
+     * @returns {Function|null} Component resolver function or null
+     */
+    elementViewerComponent(element) {
+      if (!element) {
+        return null;
+      }
+      const domViewerRegistry = this._contentViewerRegistry[DOM_VIEWER_SUFFIX];
+      if (!domViewerRegistry) {
+        return null;
+      }
+
+      // Check each registered selector to find a match
+      for (const [selector, component] of Object.entries(domViewerRegistry)) {
+        if (element.matches(selector)) {
+          return component;
+        }
+      }
+
+      return null;
+    },
+
+    /**
+     * Check if an element can be handled by any registered content viewer
+     * @param {?HTMLElement} element - DOM element to check, or null
+     * @returns {boolean} True if element can be handled
+     */
+    canHandleElement(element) {
+      if (!element) {
+        return false;
+      }
+      const domViewerRegistry = this._contentViewerRegistry[DOM_VIEWER_SUFFIX];
+      if (!domViewerRegistry) {
+        return false;
+      }
+
+      const allSelectors = Object.keys(domViewerRegistry).join(',');
+      return allSelectors && element.matches(allSelectors);
+    },
+
+    /**
+     * Get the MIME types handled by registered content viewers via their
+     * object[type="..."] selectors.
+     * @returns {string[]} Handled object MIME types
+     */
+    objectViewerMimetypes() {
+      const domViewerRegistry = this._contentViewerRegistry[DOM_VIEWER_SUFFIX];
+      if (!domViewerRegistry) {
+        return [];
+      }
+      const mimetypes = [];
+      for (const selector of Object.keys(domViewerRegistry)) {
+        const match = selector.match(/^object\[type=["']?([^"'\]]+)["']?\]$/);
+        if (match) {
+          mimetypes.push(match[1]);
+        }
+      }
+      return mimetypes;
+    },
+
     /*
      * Method to load the direction specific CSS for a particular content viewer
      * @param {ContentViewerModule} contentViewerModule The content viewer module to load the

--- a/packages/kolibri/package.json
+++ b/packages/kolibri/package.json
@@ -65,6 +65,7 @@
     "./utils/baseClient": "./utils/baseClient",
     "./utils/browserInfo": "./utils/browserInfo",
     "./utils/i18n": "./utils/i18n",
+    "./utils/mimetypes": "./utils/mimetypes",
     "./utils/objectSpecs": "./utils/objectSpecs",
     "./utils/onboardingSteps": "./utils/onboardingSteps",
     "./utils/redirectBrowser": "./utils/redirectBrowser",

--- a/packages/kolibri/styles/internal/initializeTheme.js
+++ b/packages/kolibri/styles/internal/initializeTheme.js
@@ -15,9 +15,13 @@ export function setThemeConfig(theme) {
   });
 }
 
+// Default matching ThemeHook.get_theme() in kolibri/core/theme_hook.py
+const DEFAULT_THEME = { signIn: {}, tokenMapping: {}, sideNav: {}, appBar: {} };
+
 export default function initializeTheme() {
-  validateObject(plugin_data.kolibriTheme, themeSpec);
-  const theme = objectWithDefaults(plugin_data.kolibriTheme, themeSpec);
+  const themeData = plugin_data.kolibriTheme || DEFAULT_THEME;
+  validateObject(themeData, themeSpec);
+  const theme = objectWithDefaults(themeData, themeSpec);
   if (theme.brandColors) {
     setBrandColors(theme.brandColors);
   }

--- a/packages/kolibri/urls.js
+++ b/packages/kolibri/urls.js
@@ -170,6 +170,14 @@ class UrlResolver {
       port: this.__zipContentPort,
     });
   }
+  zipContentOrigin() {
+    return new URL(
+      generateUrl(this.__zipContentUrl || '', {
+        origin: this.__zipContentOrigin,
+        port: this.__zipContentPort,
+      }),
+    ).origin;
+  }
   static(url) {
     if (!this.__staticUrl) {
       throw new ReferenceError('Static Url is not defined');
@@ -216,7 +224,11 @@ export const createUrlResolver = () => {
         if (prop in target) {
           return target[prop];
         }
-        return target._getUrlFunction(prop);
+        // Guard against Symbol props (e.g. Symbol.toPrimitive) which are
+        // passed by the JS runtime during type coercion and by Jest during mocking.
+        if (typeof prop === 'string') {
+          return target._getUrlFunction(prop);
+        }
       },
     });
   }

--- a/packages/kolibri/utils/__tests__/mimetypes.spec.js
+++ b/packages/kolibri/utils/__tests__/mimetypes.spec.js
@@ -1,0 +1,96 @@
+import {
+  inferPresetFromMimetype,
+  hasPresetForMimetype,
+  getRegisteredMimetypes,
+} from '../mimetypes';
+
+describe('mimetypes utility', () => {
+  describe('inferPresetFromMimetype', () => {
+    it('returns correct preset for video/mp4', () => {
+      expect(inferPresetFromMimetype('video/mp4')).toBe('high_res_video');
+    });
+
+    it('returns correct preset for video/webm', () => {
+      expect(inferPresetFromMimetype('video/webm')).toBe('high_res_video');
+    });
+
+    it('returns correct preset for audio/mp3', () => {
+      expect(inferPresetFromMimetype('audio/mp3')).toBe('audio');
+    });
+
+    it('returns correct preset for audio/mpeg', () => {
+      expect(inferPresetFromMimetype('audio/mpeg')).toBe('audio');
+    });
+
+    it('returns correct preset for application/pdf', () => {
+      expect(inferPresetFromMimetype('application/pdf')).toBe('document');
+    });
+
+    it('returns correct preset for application/epub+zip', () => {
+      expect(inferPresetFromMimetype('application/epub+zip')).toBe('epub');
+    });
+
+    it('returns correct preset for application/h5p+zip', () => {
+      expect(inferPresetFromMimetype('application/h5p+zip')).toBe('h5p');
+    });
+
+    it('returns correct preset for application/zip', () => {
+      expect(inferPresetFromMimetype('application/zip')).toBe('html5_zip');
+    });
+
+    it('returns "document" as default for unknown mimetypes', () => {
+      expect(inferPresetFromMimetype('application/unknown')).toBe('document');
+    });
+
+    it('returns "document" for null mimetype', () => {
+      expect(inferPresetFromMimetype(null)).toBe('document');
+    });
+
+    it('returns "document" for undefined mimetype', () => {
+      expect(inferPresetFromMimetype(undefined)).toBe('document');
+    });
+  });
+
+  describe('hasPresetForMimetype', () => {
+    it('returns true for known mimetypes', () => {
+      expect(hasPresetForMimetype('video/mp4')).toBe(true);
+      expect(hasPresetForMimetype('audio/mpeg')).toBe(true);
+      expect(hasPresetForMimetype('application/pdf')).toBe(true);
+    });
+
+    it('returns false for unknown mimetypes', () => {
+      expect(hasPresetForMimetype('application/unknown')).toBe(false);
+      expect(hasPresetForMimetype('text/html')).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(hasPresetForMimetype(null)).toBe(false);
+      expect(hasPresetForMimetype(undefined)).toBe(false);
+    });
+  });
+
+  describe('getRegisteredMimetypes', () => {
+    it('returns an array of mimetypes', () => {
+      const mimetypes = getRegisteredMimetypes();
+      expect(Array.isArray(mimetypes)).toBe(true);
+      expect(mimetypes.length).toBeGreaterThan(0);
+    });
+
+    it('includes expected video mimetypes', () => {
+      const mimetypes = getRegisteredMimetypes();
+      expect(mimetypes).toContain('video/mp4');
+      expect(mimetypes).toContain('video/webm');
+    });
+
+    it('includes expected audio mimetypes', () => {
+      const mimetypes = getRegisteredMimetypes();
+      expect(mimetypes).toContain('audio/mp3');
+      expect(mimetypes).toContain('audio/mpeg');
+    });
+
+    it('includes expected document mimetypes', () => {
+      const mimetypes = getRegisteredMimetypes();
+      expect(mimetypes).toContain('application/pdf');
+    });
+  });
+});

--- a/packages/kolibri/utils/__tests__/objectSpecs.spec.js
+++ b/packages/kolibri/utils/__tests__/objectSpecs.spec.js
@@ -184,15 +184,26 @@ describe('validateObject rejects bad specs', () => {
     };
     expect(validateObject(obj, badSpec)).toBe(false);
   });
-  it('A specced array rejects an array even if any value is bad', () => {
+  it('rejects array with wrong-type primitives', () => {
     const badNumArrayObj = {
+      str1: 'A',
       arrayOfNum: [1, 2, 3, 4, 5, 'A'],
     };
     expect(validateObject(badNumArrayObj, simpleSpec)).toBe(false);
+  });
+  it('rejects array with bad object element', () => {
     const badObjArrayObj = {
-      arrayOfObj: [{ foo: 'bar', prop_c: 'val_c' }],
+      str1: 'A',
+      arrayOfObj: [{ prop_C: 123 }],
     };
     expect(validateObject(badObjArrayObj, simpleSpec)).toBe(false);
+  });
+  it('accepts array of valid primitives', () => {
+    const goodNumArrayObj = {
+      str1: 'A',
+      arrayOfNum: [1, 2, 3, 4, 5],
+    };
+    expect(validateObject(goodNumArrayObj, simpleSpec)).toBe(true);
   });
 });
 

--- a/packages/kolibri/utils/mimetypes.js
+++ b/packages/kolibri/utils/mimetypes.js
@@ -1,0 +1,86 @@
+/**
+ * Utility functions for mapping MIME types to content presets.
+ *
+ * These mappings are used when handling DOM elements (like <object> tags)
+ * that specify content by MIME type rather than Kolibri's preset system.
+ *
+ * The mappings should stay in sync with the presets defined in le_utils
+ * and the file formats registered in the content viewer hooks.
+ */
+
+/**
+ * Map of MIME types to their corresponding Kolibri content presets.
+ * This is used when rendering embedded content specified via object tags
+ * or other DOM elements that use MIME types.
+ */
+const MIMETYPE_TO_PRESET_MAP = {
+  // Video formats
+  'video/mp4': 'high_res_video',
+  'video/webm': 'high_res_video',
+  'video/ogg': 'high_res_video',
+
+  // Audio formats
+  'audio/mp3': 'audio',
+  'audio/mpeg': 'audio',
+  'audio/ogg': 'audio',
+
+  // Document formats
+  'application/pdf': 'document',
+
+  // HTML5/Zip content
+  'application/epub+zip': 'epub',
+  'application/bloompub+zip': 'bloompub',
+  'application/kpub+zip': 'kpub',
+  'application/perseus+zip': 'exercise',
+  'application/zip': 'html5_zip',
+  'application/x-zip-compressed': 'html5_zip',
+  'application/vnd.h5p': 'h5p',
+  'application/h5p+zip': 'h5p',
+};
+
+/**
+ * Default preset to use when a MIME type is not recognized.
+ */
+const DEFAULT_PRESET = 'document';
+
+/**
+ * Infer content preset from a MIME type.
+ *
+ * This is primarily used when handling embedded content specified via
+ * <object type="..."> tags or similar DOM elements where content is
+ * identified by MIME type rather than Kolibri's preset system.
+ * @param {string} mimetype - The MIME type to look up
+ * @returns {string} The corresponding content preset, or 'document' as fallback
+ * @example
+ * // Returns 'high_res_video'
+ * inferPresetFromMimetype('video/mp4');
+ * @example
+ * // Returns 'document' (default fallback)
+ * inferPresetFromMimetype('application/unknown');
+ */
+export function inferPresetFromMimetype(mimetype) {
+  return MIMETYPE_TO_PRESET_MAP[mimetype] || DEFAULT_PRESET;
+}
+
+/**
+ * Check if a MIME type has a known preset mapping.
+ * @param {string} mimetype - The MIME type to check
+ * @returns {boolean} True if the MIME type has a known preset
+ */
+export function hasPresetForMimetype(mimetype) {
+  return mimetype in MIMETYPE_TO_PRESET_MAP;
+}
+
+/**
+ * Get all registered MIME types.
+ * @returns {string[]} Array of all registered MIME types
+ */
+export function getRegisteredMimetypes() {
+  return Object.keys(MIMETYPE_TO_PRESET_MAP);
+}
+
+export default {
+  inferPresetFromMimetype,
+  hasPresetForMimetype,
+  getRegisteredMimetypes,
+};

--- a/packages/kolibri/utils/objectSpecs.js
+++ b/packages/kolibri/utils/objectSpecs.js
@@ -32,6 +32,11 @@
     In situations where objects are nested, this property can be used to define
     a "sub-spec" for objects within objects recursively. Note that either a spec
     or a validator function can be provided for nested objects, but not both.
+
+    For Array types, `spec` describes each element and takes one of two forms:
+      - an options descriptor with its own `type`, e.g. { type: String } or
+        { type: Object, spec: {...} }
+      - a bare field-spec (no `type`), applied to each element as an object
 */
 
 import logger from 'kolibri-logging';
@@ -48,6 +53,8 @@ import isSymbol from 'lodash/isSymbol';
 import isUndefined from 'lodash/isUndefined';
 
 const logging = logger.getLogger(__filename);
+
+const KNOWN_TYPES = [Array, Boolean, Date, Function, Object, Number, String, Symbol];
 
 function _fail(msg, dataKey, data) {
   logging.error(`Problem with key '${dataKey}': ${msg}`);
@@ -79,11 +86,14 @@ function _validateObjectData(data, options, dataKey) {
       return _fail('Only objects or arrays can have sub-specs', dataKey, data);
     }
 
-    // If it is an array, we will validate each item in the array
     if (isArray(data)) {
+      // Legacy bare field-specs (no own `type`) describe object elements
+      const itemOptions = KNOWN_TYPES.includes(options.spec.type)
+        ? options.spec
+        : { type: Object, required: true, spec: options.spec };
       for (const item of data) {
-        if (!validateObject(item, options.spec.spec)) {
-          return _fail('Object in Array sub-spec failed', dataKey, item);
+        if (!_validateObjectData(item, itemOptions, dataKey)) {
+          return _fail('Item in Array sub-spec failed', dataKey, item);
         }
       }
     }
@@ -96,7 +106,6 @@ function _validateObjectData(data, options, dataKey) {
   }
 
   // Check types
-  const KNOWN_TYPES = [Array, Boolean, Date, Function, Object, Number, String, Symbol];
   if (isUndefined(options.type)) {
     return _fail('No type information provided', dataKey, data);
   } else if (!KNOWN_TYPES.includes(options.type)) {


### PR DESCRIPTION
## Summary

Refactor ContentViewer and useContentViewer composables to allow flexible handling of either a contentNode or element prop.
Enhance content viewer hook mechanisms to allow registering CSS selectors to inject content viewers into HTML rendering.
Update SafeHTML helper to leverage this functionality.

## References

Split from #14548 — the first of several incremental PRs carving up that branch for reviewability.
Partial work towards #13824.

## Reviewer guidance

- Refactor of how viewer components receive data: `useContentViewer` injection in place of props.
- Fixes the shared `objectSpecs` array-element validator.
- `objectSpecs.js` now validates array element specs that were a silent no-op before (dev/test-only).
- `SafeHTML` injects registered content viewers into sanitized HTML via registered CSS selectors from `hooks.py`.

Embedded viewers enabled and working (screenshots from #14548):

| View | Screenshot |
|------|------------|
| Embedded PDF | ![Embedded PDF](https://i.imgur.com/XIA1zAn.png) |
| Embedded EPUB | ![Embedded EPUB](https://i.imgur.com/ZgyNopx.png) |

Video and audio will not work properly just yet - will fix in follow up!

## AI usage

Used Claude Code (Opus) extensively: rebasing this branch onto latest `develop`, resolving conflicts, addressing review comments, implementing the `objectSpecs` array-element validation fix, and cleaning up jsdoc/lint per commit. I directed the approach (declarative element spec over a custom validator; backward-compatible support for both spec forms), reviewed every diff and the per-commit history, and verified with the jest and pytest suites before splitting out this PR.
