### PR TITLE
test: migrate ChannelTokenModal.spec.js from VTU to VTL (#14261)

### DIFF
--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -1,139 +1,44 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, fireEvent } from '@testing-library/vue';
+import { defineComponent } from 'vue';
 import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
+import { createTranslator } from 'kolibri/utils/i18n';
+import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
 
-function makeWrapper(options = {}) {
-  return mount(ChannelTokenModal, { ...options, attrs: { disabled: false } });
-}
+jest.mock('../../modules/wizard/utils', () => ({
+  getRemoteChannelBundleByToken: jest.fn(),
+}));
 
-function getElements(wrapper) {
-  return {
-    cancelButton: () => wrapper.find('button[name="cancel"]'),
-    tokenTextbox: () => wrapper.findComponent({ name: 'KTextbox' }),
-    networkErrorAlert: () => wrapper.findComponent({ name: 'ui-alert' }),
-    lookupTokenStub: () => {
-      wrapper.vm.lookupToken = jest.fn();
-      return wrapper.vm.lookupToken;
-    },
+import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
+
+const { enterChannelToken$, tokenExplanation$, channelTokenLabel$, invalidTokenMessage$, networkErrorMessage$ } = createTranslator(ChannelTokenModal.name, ChannelTokenModal.$trs);
+const { continueAction$, cancelAction$ } = commonCoreStrings;
+
+describe('ChannelTokenModal component', () => {
+  let mockSubmit;
+  let mockCancel;
+
+  const renderComponent = (props = {}) => {
+    mockSubmit = jest.fn();
+    mockCancel = jest.fn();
+
+    const Wrapper = defineComponent({
+      components: { ChannelTokenModal },
+      template: '<ChannelTokenModal @cancel="mockCancel" @submit="mockSubmit" />',
+      methods: { mockCancel, mockSubmit },
+    });
+
+    return render(Wrapper);
   };
-}
-
-describe('channelTokenModal component', () => {
-  let wrapper;
 
   beforeEach(() => {
-    wrapper = makeWrapper();
+    jest.clearAllMocks();
+    getRemoteChannelBundleByToken.mockClear();
   });
 
   it('pressing "cancel" emits a "cancel" event', () => {
-    const cancelListener = jest.fn();
-    wrapper = makeWrapper({
-      listeners: {
-        cancel: cancelListener,
-      },
-    });
-    const { cancelButton } = getElements(wrapper);
-    cancelButton().trigger('click');
-    expect(cancelListener).toHaveBeenCalled();
-  });
-
-  describe('submitting a token', () => {
-    async function inputToken(wrapper, token) {
-      const textbox = getElements(wrapper).tokenTextbox();
-      textbox.vm.$emit('input', token);
-      await wrapper.vm.$nextTick();
-      expect(textbox.props().value).toEqual(token.trim());
-    }
-
-    function assertTextboxInvalid(wrapper) {
-      const textbox = getElements(wrapper).tokenTextbox();
-      expect(textbox.props().invalid).toEqual(true);
-      expect(textbox.props().invalidText).toEqual('Check whether you entered token correctly');
-    }
-
-    it('if user has not interacted with the form, then no validation messages appear', () => {
-      const { tokenTextbox, networkErrorAlert } = getElements(wrapper);
-      expect(tokenTextbox().props().invalid).toEqual(false);
-      expect(networkErrorAlert().exists()).toEqual(false);
-    });
-
-    it('disables the form while waiting for a response from the server', () => {
-      //...then re-enables it afterwards
-      const { lookupTokenStub } = getElements(wrapper);
-      const lookupStub = lookupTokenStub();
-      const disabledSpy = jest.fn();
-      wrapper.vm.$watch('formIsDisabled', disabledSpy);
-      // not checking the Promise.reject case
-      lookupStub.mockResolvedValue([]);
-      return inputToken(wrapper, 'toka-toka-token')
-        .then(() => {
-          wrapper.vm.submitForm();
-        })
-        .then(() => {
-          expect(disabledSpy.mock.calls[0][0]).toEqual(true);
-          expect(disabledSpy.mock.calls[0][1]).toBeFalsy();
-        });
-    });
-
-    it('emits a "submit" event if token lookup is successful', () => {
-      const tokenPayload = { token: 'toka-toka-token', channels: [{ id: 'toka-toka-token' }] };
-      const { lookupTokenStub } = getElements(wrapper);
-      const lookupStub = lookupTokenStub();
-      lookupStub.mockResolvedValue(tokenPayload.channels);
-      return inputToken(wrapper, 'toka-toka-token')
-        .then(() => {
-          wrapper.vm.submitForm();
-        })
-        .then(() => {
-          expect(lookupStub).toHaveBeenCalledWith('toka-toka-token');
-          expect(wrapper.emitted().submit).toEqual([[tokenPayload]]);
-        });
-    });
-
-    it('on submit, shows a validation message when token code is empty', () => {
-      return inputToken(wrapper, '    ')
-        .then(() => {
-          // HACK: Clicking the submit button does not propagate to the form, so calling
-          // submit method directly
-          return wrapper.vm.submitForm();
-        })
-        .then(() => {
-          assertTextboxInvalid(wrapper);
-        });
-    });
-
-    it('on blur, shows a validation message when token code is empty', async () => {
-      const textbox = getElements(wrapper).tokenTextbox();
-      await inputToken(wrapper, '    ');
-      // Reaching into ui-textbox's blur to trigger it on k-textbox
-      textbox.vm.$refs.textbox.$emit('blur');
-      await wrapper.vm.$nextTick();
-      assertTextboxInvalid(wrapper);
-    });
-
-    it('if the token does not point to a channel (404 code), shows a validation message', async () => {
-      const tokenPayload = { response: { status: 404 } };
-      const { lookupTokenStub } = getElements(wrapper);
-      const lookupStub = lookupTokenStub();
-      lookupStub.mockRejectedValue(tokenPayload);
-      await inputToken(wrapper, 'toka-toka-token');
-      await wrapper.vm.submitForm();
-      expect(lookupStub).toHaveBeenCalledWith('toka-toka-token');
-      expect(wrapper.emitted().submit).toBeUndefined();
-      assertTextboxInvalid(wrapper);
-    });
-
-    it('shows an ui-alert error if there is a generic network error (other error code)', async () => {
-      const tokenPayload = { response: { status: 500 } };
-      const { tokenTextbox, networkErrorAlert, lookupTokenStub } = getElements(wrapper);
-      const textbox = tokenTextbox();
-      const lookupStub = lookupTokenStub();
-      lookupStub.mockRejectedValue(tokenPayload);
-      await inputToken(wrapper, 'toka-toka-token');
-      await wrapper.vm.submitForm();
-      expect(lookupStub).toHaveBeenCalledWith('toka-toka-token');
-      expect(wrapper.emitted().submit).toBeUndefined();
-      expect(textbox.props().invalid).toEqual(false);
-      expect(networkErrorAlert().exists()).toEqual(true);
-    });
+    renderComponent();
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelButton);
+    expect(mockCancel).toHaveBeenCalled();
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/vue';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import { defineComponent } from 'vue';
 import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
 import { createTranslator } from 'kolibri/utils/i18n';
@@ -10,8 +10,8 @@ jest.mock('../../modules/wizard/utils', () => ({
 
 import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
 
-const { enterChannelToken$, tokenExplanation$, channelTokenLabel$, invalidTokenMessage$, networkErrorMessage$ } = createTranslator(ChannelTokenModal.name, ChannelTokenModal.$trs);
-const { continueAction$, cancelAction$ } = commonCoreStrings;
+const { channelTokenLabel$, invalidTokenMessage$, networkErrorMessage$ } = createTranslator(ChannelTokenModal.name, ChannelTokenModal.$trs);
+const { cancelAction$ } = commonCoreStrings;
 
 describe('ChannelTokenModal component', () => {
   let mockSubmit;
@@ -40,5 +40,32 @@ describe('ChannelTokenModal component', () => {
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
     fireEvent.click(cancelButton);
     expect(mockCancel).toHaveBeenCalled();
+  });
+
+  describe('submitting a token', () => {
+    it('if user has not interacted with the form, then no validation messages appear', () => {
+      renderComponent();
+      expect(screen.queryByText(/check whether you entered/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/unable to connect/i)).not.toBeInTheDocument();
+    });
+
+    it('on submit, shows a validation message when token code is empty', async () => {
+      renderComponent();
+      const submitButton = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(submitButton);
+      await waitFor(() => {
+        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+      });
+    });
+
+    it('on blur, shows a validation message when token code is empty', async () => {
+      renderComponent();
+      const textbox = screen.getByDisplayValue('');
+      fireEvent.focus(textbox);
+      fireEvent.blur(textbox);
+      await waitFor(() => {
+        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -67,5 +67,59 @@ describe('ChannelTokenModal component', () => {
         expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
       });
     });
+
+    it('emits a "submit" event if token lookup is successful', async () => {
+      renderComponent();
+      const tokenPayload = { token: 'valid-token-123', channels: [{ id: 'channel-1' }] };
+      getRemoteChannelBundleByToken.mockResolvedValue(tokenPayload.channels);
+
+      const textbox = screen.getByDisplayValue('');
+      await fireEvent.update(textbox, 'valid-token-123');
+      
+      const submitButton = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('valid-token-123');
+        expect(mockSubmit).toHaveBeenCalledWith({
+          token: 'valid-token-123',
+          channels: tokenPayload.channels,
+        });
+      });
+    });
+
+    it('if the token does not point to a channel (404 code), shows a validation message', async () => {
+      renderComponent();
+      const error = { response: { status: 404 } };
+      getRemoteChannelBundleByToken.mockRejectedValue(error);
+
+      const textbox = screen.getByDisplayValue('');
+      await fireEvent.update(textbox, 'invalid-token');
+      
+      const submitButton = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('invalid-token');
+        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows an ui-alert error if there is a generic network error (other error code)', async () => {
+      renderComponent();
+      const error = { response: { status: 500 } };
+      getRemoteChannelBundleByToken.mockRejectedValue(error);
+
+      const textbox = screen.getByDisplayValue('');
+      await fireEvent.update(textbox, 'valid-token');
+      
+      const submitButton = screen.getByRole('button', { name: /continue/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('valid-token');
+        expect(screen.getByText(/unable to connect/i)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -9,7 +9,7 @@ jest.mock('../../modules/wizard/utils', () => ({
   getRemoteChannelBundleByToken: jest.fn(),
 }));
 
-const { invalidTokenMessage$, networkErrorMessage$ } = createTranslator(
+const { invalidTokenMessage$, networkErrorMessage$, channelTokenLabel$ } = createTranslator(
   ChannelTokenModal.name,
   ChannelTokenModal.$trs,
 );
@@ -54,7 +54,7 @@ describe('ChannelTokenModal component', () => {
 
     it('on blur, shows a validation message when token code is empty', async () => {
       renderComponent();
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('textbox', { name: channelTokenLabel$() });
       fireEvent.focus(textbox);
       fireEvent.blur(textbox);
       await waitFor(() => {
@@ -70,7 +70,7 @@ describe('ChannelTokenModal component', () => {
         }),
       );
       renderComponent();
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('textbox', { name: channelTokenLabel$() });
       await fireEvent.update(textbox, 'some-token');
       const submitButton = screen.getByRole('button', { name: continueAction$() });
       fireEvent.click(submitButton);
@@ -86,7 +86,7 @@ describe('ChannelTokenModal component', () => {
       const tokenPayload = { token: 'valid-token-123', channels: [{ id: 'channel-1' }] };
       getRemoteChannelBundleByToken.mockResolvedValue(tokenPayload.channels);
 
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('textbox', { name: channelTokenLabel$() });
       await fireEvent.update(textbox, 'valid-token-123');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });
@@ -107,7 +107,7 @@ describe('ChannelTokenModal component', () => {
       const error = { response: { status: 404 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('textbox', { name: channelTokenLabel$() });
       await fireEvent.update(textbox, 'invalid-token');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });
@@ -125,7 +125,7 @@ describe('ChannelTokenModal component', () => {
       const error = { response: { status: 500 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('textbox', { name: channelTokenLabel$() });
       await fireEvent.update(textbox, 'valid-token');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });

--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -1,30 +1,31 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import { defineComponent } from 'vue';
-import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
 import { createTranslator } from 'kolibri/utils/i18n';
-import commonCoreStrings from 'kolibri/uiText/commonCoreStrings';
+import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
+
+import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
 
 jest.mock('../../modules/wizard/utils', () => ({
   getRemoteChannelBundleByToken: jest.fn(),
 }));
 
-import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
-
-const { channelTokenLabel$, invalidTokenMessage$, networkErrorMessage$ } = createTranslator(ChannelTokenModal.name, ChannelTokenModal.$trs);
-const { cancelAction$ } = commonCoreStrings;
+const { invalidTokenMessage$, networkErrorMessage$ } = createTranslator(
+  ChannelTokenModal.name,
+  ChannelTokenModal.$trs,
+);
 
 describe('ChannelTokenModal component', () => {
   let mockSubmit;
   let mockCancel;
 
-  const renderComponent = (props = {}) => {
+  const renderComponent = () => {
     mockSubmit = jest.fn();
     mockCancel = jest.fn();
 
     const Wrapper = defineComponent({
       components: { ChannelTokenModal },
-      template: '<ChannelTokenModal @cancel="mockCancel" @submit="mockSubmit" />',
       methods: { mockCancel, mockSubmit },
+      template: '<ChannelTokenModal @cancel="mockCancel" @submit="mockSubmit" />',
     });
 
     return render(Wrapper);
@@ -37,7 +38,8 @@ describe('ChannelTokenModal component', () => {
 
   it('pressing "cancel" emits a "cancel" event', () => {
     renderComponent();
-    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    const buttons = screen.getAllByRole('button');
+    const cancelButton = buttons[0];
     fireEvent.click(cancelButton);
     expect(mockCancel).toHaveBeenCalled();
   });
@@ -45,26 +47,27 @@ describe('ChannelTokenModal component', () => {
   describe('submitting a token', () => {
     it('if user has not interacted with the form, then no validation messages appear', () => {
       renderComponent();
-      expect(screen.queryByText(/check whether you entered/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/unable to connect/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(invalidTokenMessage$())).not.toBeInTheDocument();
+      expect(screen.queryByText(networkErrorMessage$())).not.toBeInTheDocument();
     });
 
     it('on submit, shows a validation message when token code is empty', async () => {
       renderComponent();
-      const submitButton = screen.getByRole('button', { name: /continue/i });
+      const buttons = screen.getAllByRole('button');
+      const submitButton = buttons[1];
       fireEvent.click(submitButton);
       await waitFor(() => {
-        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+        expect(screen.getByText(invalidTokenMessage$())).toBeInTheDocument();
       });
     });
 
     it('on blur, shows a validation message when token code is empty', async () => {
       renderComponent();
-      const textbox = screen.getByDisplayValue('');
+      const textbox = screen.getByRole('textbox');
       fireEvent.focus(textbox);
       fireEvent.blur(textbox);
       await waitFor(() => {
-        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+        expect(screen.getByText(invalidTokenMessage$())).toBeInTheDocument();
       });
     });
 
@@ -73,10 +76,11 @@ describe('ChannelTokenModal component', () => {
       const tokenPayload = { token: 'valid-token-123', channels: [{ id: 'channel-1' }] };
       getRemoteChannelBundleByToken.mockResolvedValue(tokenPayload.channels);
 
-      const textbox = screen.getByDisplayValue('');
+      const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'valid-token-123');
-      
-      const submitButton = screen.getByRole('button', { name: /continue/i });
+
+      const buttons = screen.getAllByRole('button');
+      const submitButton = buttons[1];
       fireEvent.click(submitButton);
 
       await waitFor(() => {
@@ -93,15 +97,16 @@ describe('ChannelTokenModal component', () => {
       const error = { response: { status: 404 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
-      const textbox = screen.getByDisplayValue('');
+      const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'invalid-token');
-      
-      const submitButton = screen.getByRole('button', { name: /continue/i });
+
+      const buttons = screen.getAllByRole('button');
+      const submitButton = buttons[1];
       fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('invalid-token');
-        expect(screen.getByText(/check whether you entered/i)).toBeInTheDocument();
+        expect(screen.getByText(invalidTokenMessage$())).toBeInTheDocument();
       });
     });
 
@@ -110,15 +115,16 @@ describe('ChannelTokenModal component', () => {
       const error = { response: { status: 500 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
-      const textbox = screen.getByDisplayValue('');
+      const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'valid-token');
-      
-      const submitButton = screen.getByRole('button', { name: /continue/i });
+
+      const buttons = screen.getAllByRole('button');
+      const submitButton = buttons[1];
       fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('valid-token');
-        expect(screen.getByText(/unable to connect/i)).toBeInTheDocument();
+        expect(screen.getByText(networkErrorMessage$())).toBeInTheDocument();
       });
     });
   });

--- a/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
-import { defineComponent } from 'vue';
 import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
 
 import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
@@ -13,35 +13,27 @@ const { invalidTokenMessage$, networkErrorMessage$ } = createTranslator(
   ChannelTokenModal.name,
   ChannelTokenModal.$trs,
 );
+const { cancelAction$, continueAction$ } = coreStrings;
 
 describe('ChannelTokenModal component', () => {
-  let mockSubmit;
-  let mockCancel;
-
   const renderComponent = () => {
-    mockSubmit = jest.fn();
-    mockCancel = jest.fn();
-
-    const Wrapper = defineComponent({
-      components: { ChannelTokenModal },
-      methods: { mockCancel, mockSubmit },
-      template: '<ChannelTokenModal @cancel="mockCancel" @submit="mockSubmit" />',
+    return render(ChannelTokenModal, {
+      listeners: {
+        cancel: jest.fn(),
+        submit: jest.fn(),
+      },
     });
-
-    return render(Wrapper);
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    getRemoteChannelBundleByToken.mockClear();
   });
 
   it('pressing "cancel" emits a "cancel" event', () => {
-    renderComponent();
-    const buttons = screen.getAllByRole('button');
-    const cancelButton = buttons[0];
+    const { emitted } = renderComponent();
+    const cancelButton = screen.getByRole('button', { name: cancelAction$() });
     fireEvent.click(cancelButton);
-    expect(mockCancel).toHaveBeenCalled();
+    expect(emitted().cancel).toBeTruthy();
   });
 
   describe('submitting a token', () => {
@@ -53,8 +45,7 @@ describe('ChannelTokenModal component', () => {
 
     it('on submit, shows a validation message when token code is empty', async () => {
       renderComponent();
-      const buttons = screen.getAllByRole('button');
-      const submitButton = buttons[1];
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
       fireEvent.click(submitButton);
       await waitFor(() => {
         expect(screen.getByText(invalidTokenMessage$())).toBeInTheDocument();
@@ -71,21 +62,40 @@ describe('ChannelTokenModal component', () => {
       });
     });
 
-    it('emits a "submit" event if token lookup is successful', async () => {
+    it('disables submit and cancel while token lookup is in progress', async () => {
+      let resolvePromise;
+      getRemoteChannelBundleByToken.mockReturnValue(
+        new Promise(r => {
+          resolvePromise = r;
+        }),
+      );
       renderComponent();
+      const textbox = screen.getByRole('textbox');
+      await fireEvent.update(textbox, 'some-token');
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
+      fireEvent.click(submitButton);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: cancelAction$() })).toBeDisabled();
+        expect(submitButton).toBeDisabled();
+      });
+      resolvePromise([]);
+    });
+
+    it('emits a "submit" event if token lookup is successful', async () => {
+      const { emitted } = renderComponent();
       const tokenPayload = { token: 'valid-token-123', channels: [{ id: 'channel-1' }] };
       getRemoteChannelBundleByToken.mockResolvedValue(tokenPayload.channels);
 
       const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'valid-token-123');
 
-      const buttons = screen.getAllByRole('button');
-      const submitButton = buttons[1];
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
       fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('valid-token-123');
-        expect(mockSubmit).toHaveBeenCalledWith({
+        expect(emitted().submit).toBeTruthy();
+        expect(emitted().submit[0][0]).toEqual({
           token: 'valid-token-123',
           channels: tokenPayload.channels,
         });
@@ -93,38 +103,38 @@ describe('ChannelTokenModal component', () => {
     });
 
     it('if the token does not point to a channel (404 code), shows a validation message', async () => {
-      renderComponent();
+      const { emitted } = renderComponent();
       const error = { response: { status: 404 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
       const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'invalid-token');
 
-      const buttons = screen.getAllByRole('button');
-      const submitButton = buttons[1];
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
       fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('invalid-token');
         expect(screen.getByText(invalidTokenMessage$())).toBeInTheDocument();
+        expect(emitted().submit).toBeFalsy();
       });
     });
 
     it('shows an ui-alert error if there is a generic network error (other error code)', async () => {
-      renderComponent();
+      const { emitted } = renderComponent();
       const error = { response: { status: 500 } };
       getRemoteChannelBundleByToken.mockRejectedValue(error);
 
       const textbox = screen.getByRole('textbox');
       await fireEvent.update(textbox, 'valid-token');
 
-      const buttons = screen.getAllByRole('button');
-      const submitButton = buttons[1];
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
       fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(getRemoteChannelBundleByToken).toHaveBeenCalledWith('valid-token');
         expect(screen.getByText(networkErrorMessage$())).toBeInTheDocument();
+        expect(emitted().submit).toBeFalsy();
       });
     });
   });


### PR DESCRIPTION
## Summary

Migrate `ChannelTokenModal.spec.js` to Vue Testing Library as part of issue #14261.

This is **Part 1 of 4** of the device plugin test migration:
- ✅ ChannelTokenModal.spec.js (this PR)
- ⏳ RearrangeChannelsPage.spec.js (next)
- ⏳ AvailableChannelsPage.spec.js (hardest - router, store, filters)
- ⏳ NewChannelVersionPage.spec.js

**Motivation:** VTL provides better testing by querying the DOM as users interact with it, rather than relying on component internals. This improves test maintainability and aligns with best practices.

**Approach:** 
- Converted VTU `mount()` to VTL `render()` with a wrapper component pattern for emitted event testing
- Mocked `getRemoteChannelBundleByToken` before render using `jest.mock()`
- Replaced VTU-specific queries (`findComponent`, `trigger`, `wrapper.vm`) with VTL DOM queries (`getByRole`, `getByDisplayValue`, `fireEvent`)
- Used regex patterns for UI text matching to avoid translation string issues
- - All 8 tests passing with no console warnings


## References

- Fixes #14261 (Part 1: ChannelTokenModal migration - simplest file, no router/store)
- Related: PR #14563 (DeviceTransferModal migration - reference for patterns)

## Reviewer guidance

**Manual verification:**
- ✅ All 8 tests pass locally: `pnpm run test-jest kolibri/plugins/device/frontend/views/__tests__/ChannelTokenModal.spec.js`
- ✅ No console warnings or deprecation notices
- ✅ Test patterns follow PR #14563 conventions

**Testing approach:**
1. Cancel button click → emits cancel event
2. Form validation → no errors on initial load, errors on empty submit/blur
3. Successful token lookup → emits submit with token + channels payload
4. 404 error → shows validation message "Check whether you entered token correctly"
5. Network error (500) → shows ui-alert "Unable to connect to token"

**Open question:** None - simple migration with no complex dependencies.

## AI usage

I used Claude AI as a learning tool and coding assistant during this VTL migration, but the approach, debugging, and refinement were my own work.

**DISCLOSE — How I used AI:**
- Discussed VTL migration strategy and patterns from PR #14563
- Got suggestions on VTL query methods (getByRole, fireEvent, waitFor)
- Debugged issues: fireEvent.change deprecated → use fireEvent.update()

**ENGAGE CRITICALLY — What I verified:**
- Analyzed original VTU test to ensure all test cases migrated
- Tested each batch locally (4 → 7 tests passing)
- Verified no console warnings or test failures

**EDIT — Refinements I made:**
- Changed wrapper component pattern after AI suggestion (more VTL-idiomatic)
- Updated textbox queries to use translation keys (channelTokenLabel$()) instead of regex for Kolibri linting compliance
- Organized commits logically (skeleton → validation → async)

**PROCESS SHARING — My approach:**
1. Read old VTU test (understand coverage)
2. Analyze source Vue component (understand behavior)
3. Suggest VTL pattern to AI (get baseline)
4. Debug failures myself (fireEvent.change warning)
5. Test incrementally (7 tests in 3 commits)
6. Follow PR #14563 conventions for consistency

This iterative approach helped me learn VTL patterns while maintaining code quality and GSoC integrity.

## Why Sequential PRs for Each File?

Rather than migrating all 4 files in one large PR, we're using a sequential approach:
- **Easier review** — Smaller, focused changes are less overwhelming for reviewers
- **Faster feedback** — Issues are isolated to one file, quicker to fix
- **Lower risk** — A bug in one file doesn't block the other 3
- **Better learning** — Each file teaches patterns for the next one
- **Stronger GSoC narrative** — Multiple merged PRs show incremental progress

This PR handles **Part 1/4 (ChannelTokenModal)** — the simplest file. 
Next PR will be **Part 2/4 (RearrangeChannelsPage)** with more complexity.