### PR TITLE
Memoize DeviceSettings reads in process memory

### DIFF
--- a/kolibri/conftest.py
+++ b/kolibri/conftest.py
@@ -108,6 +108,10 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def clear_process_cache():
     process_cache.clear()
+    # Reset the in-process memo too, so a value cached in one test can't leak.
+    from kolibri.core.device.models import clear_device_settings_memo
+
+    clear_device_settings_memo()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -9,6 +9,7 @@ from rest_framework.test import APITestCase
 from rest_framework.test import APITransactionTestCase
 
 from kolibri.core.auth.constants import role_kinds
+from kolibri.core.device.models import clear_device_settings_memo
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import provision_device as _provision_device  # noqa
 
@@ -22,6 +23,7 @@ DUMMY_PASSWORD = "password"
 
 
 def clear_process_cache():
+    clear_device_settings_memo()
     try:
         process_cache = caches["process_cache"]
         process_cache.clear()

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -1,5 +1,6 @@
 import platform
 import time
+from copy import deepcopy
 from uuid import uuid4
 
 from django.conf import settings
@@ -61,25 +62,63 @@ class DevicePermissions(models.Model):
 
 DEVICE_SETTINGS_CACHE_KEY = "device_settings_cache_key"
 
+# DeviceSettings is read many times per request (e.g. locale middleware); each
+# process_cache read costs. Memoize in-process on top of it. Writes clear the
+# memo; the TTL bounds staleness from writes in other processes.
+_DEVICE_SETTINGS_MEMO_TTL = 1.0
+
+
+class _DeviceSettingsMemo(object):
+    # Deep copies in and out so each caller gets its own instance, as deserializing
+    # from process_cache did — callers mutate the model in place before saving,
+    # including in-place mutation of the extra_settings dict.
+    def __init__(self):
+        self._value = None
+        self._expires_at = 0.0
+
+    def get(self):
+        if self._value is not None and time.monotonic() < self._expires_at:
+            return deepcopy(self._value)
+        return None
+
+    def set(self, value):
+        self._value = deepcopy(value)
+        self._expires_at = time.monotonic() + _DEVICE_SETTINGS_MEMO_TTL
+
+    def clear(self):
+        self._value = None
+        self._expires_at = 0.0
+
+
+_device_settings_memo = _DeviceSettingsMemo()
+
+
+def clear_device_settings_memo():
+    """Drop the in-process memo. Lets the test suite reset it alongside process_cache."""
+    _device_settings_memo.clear()
+
 
 class DeviceSettingsQuerySet(QuerySet):
     def delete(self, **kwargs):
+        _device_settings_memo.clear()
         cache.delete(DEVICE_SETTINGS_CACHE_KEY)
         return super().delete(**kwargs)
 
 
 class DeviceSettingsManager(models.Manager.from_queryset(DeviceSettingsQuerySet)):
     def get(self, **kwargs):
-        model = None
+        model = _device_settings_memo.get()
+        if isinstance(model, DeviceSettings):
+            return model
 
-        # load from cache
-        if DEVICE_SETTINGS_CACHE_KEY in cache:
-            model = cache.get(DEVICE_SETTINGS_CACHE_KEY)
+        # Single get; a miss returns None and falls through to the DB below.
+        model = cache.get(DEVICE_SETTINGS_CACHE_KEY)
 
         # ensure cached value is of correct type, otherwise allow .get to raise if not created
         if not isinstance(model, DeviceSettings):
             model = super().get(**kwargs)
             cache.set(DEVICE_SETTINGS_CACHE_KEY, model, 600)
+        _device_settings_memo.set(model)
         return model
 
 
@@ -175,6 +214,8 @@ class DeviceSettings(models.Model):
     )
 
     def save(self, *args, **kwargs):
+        # Clear up front so a failed full_clean leaves no stale memo behind.
+        _device_settings_memo.clear()
         self.pk = 1
         self.full_clean()
         out = super().save(*args, **kwargs)
@@ -182,6 +223,7 @@ class DeviceSettings(models.Model):
         return out
 
     def delete(self, *args, **kwargs):
+        _device_settings_memo.clear()
         out = super().delete(*args, **kwargs)
         cache.delete(DEVICE_SETTINGS_CACHE_KEY)
         return out

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
+import kolibri.core.device.models as device_models
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.device.models import get_device_hostname
 from kolibri.core.device.utils import get_device_setting
@@ -22,6 +25,46 @@ class DeviceSettingsTestCase(TestCase):
         ds = DeviceSettings.objects.create()
         ds2 = DeviceSettings.objects.get()
         self.assertEqual(ds, ds2)
+
+    def test_repeated_gets_served_from_in_process_memo(self):
+        DeviceSettings.objects.create()
+        with mock.patch.object(
+            device_models, "cache", wraps=device_models.cache
+        ) as cache_spy:
+            DeviceSettings.objects.get()
+            DeviceSettings.objects.get()
+            DeviceSettings.objects.get()
+        # First read populates the in-process memo; the rest are served from it
+        # without touching the process_cache backend.
+        self.assertEqual(cache_spy.get.call_count, 1)
+
+    def test_memo_does_not_share_mutable_fields(self):
+        DeviceSettings.objects.create()
+        ds = DeviceSettings.objects.get()
+        # Mutating a JSON field in place must not reach the memoized instance.
+        ds.extra_settings["enable_automatic_download"] = "mutated"
+        self.assertNotEqual(
+            DeviceSettings.objects.get().extra_settings["enable_automatic_download"],
+            "mutated",
+        )
+
+    def test_save_invalidates_in_process_memo(self):
+        DeviceSettings.objects.create(language_id="en")
+        # Populate the memo, then save through an instance fetched off the
+        # memoized path, so the assertion can only pass if save() cleared it.
+        DeviceSettings.objects.get()
+        ds = DeviceSettings.objects.filter(pk=1).first()
+        ds.language_id = "es"
+        ds.save()
+        self.assertEqual(DeviceSettings.objects.get().language_id, "es")
+
+    def test_delete_invalidates_in_process_memo(self):
+        DeviceSettings.objects.create()
+        # Populate the memo before deleting.
+        DeviceSettings.objects.get()
+        DeviceSettings.objects.all().delete()
+        with self.assertRaises(DeviceSettings.DoesNotExist):
+            DeviceSettings.objects.get()
 
     def test_delete_setting(self):
         ds = DeviceSettings.objects.create()


### PR DESCRIPTION
## Summary

Memoizes device settings in process memory for 1s.

Nearly every request reads device settings, so even cached it means a disk read each time.

In-process memo means that under heavy load Kolibri does one disk read per second for it, not hundreds.

## References

None - testing a range of performance optimizations showed this as a clear and easy winner.

## Reviewer guidance

Load testing results (learner focused flow):

Online pod (Postgres, 200 users, 3 min):

- With `develop` the pod reliably fails: ~14k requests, p99 69s - cascading login failure results in requests never happening.
- This change alone prevents failure: ~23k requests (+63% throughput), p99 21s, and the flow completes.

Invalidation and test isolation:

- `save()` clears the memo up front, so a failed `full_clean()` leaves nothing stale.
- `delete()` clears it too, on both the model and the queryset.
- The 1s TTL limits staleness from writes in other processes.
- `conftest.py`'s autouse fixture clears the memo alongside `process_cache`, to reset per test.

## AI usage

Implemented with Claude Code from an approach I specified; I reviewed the code and tests and measured the results myself.