### PR TITLE
Add jest patterns to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       khanacademy:
         patterns:
           - "@khanacademy/*"
+      jest:
+        patterns:
+          - "jest*"
   # Maintain dependencies for Python (uv)
   - package-ecosystem: "uv"
     directory: "/"


### PR DESCRIPTION
## Summary
Add jest patterns to the dependabot configuration.
Copied from Studio to avoid failing jest upgrades
