### PR TITLE
feat(common/sortable): Add item-aware reorder announcements

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
@@ -37,9 +37,6 @@
     <DragContainer
       key="drag-container"
       :items="questions"
-      :getItemLabel="
-        question => getDisplayQuestionTitle(question, getQuestionContent(question)?.title)
-      "
       @sort="handleQuestionOrderChange"
       @dragStart="handleDragStart"
     >

--- a/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
+++ b/kolibri/plugins/coach/frontend/views/common/QuestionsAccordion.vue
@@ -37,6 +37,9 @@
     <DragContainer
       key="drag-container"
       :items="questions"
+      :getItemLabel="
+        question => getDisplayQuestionTitle(question, getQuestionContent(question)?.title)
+      "
       @sort="handleQuestionOrderChange"
       @dragStart="handleDragStart"
     >
@@ -67,6 +70,11 @@
                     :noDrag="true"
                     :isFirst="index === 0"
                     :isLast="index === questions.length - 1"
+                    :itemLabel="
+                      getDisplayQuestionTitle(question, getQuestionContent(question)?.title)
+                    "
+                    :position="index + 1"
+                    :total="questions.length"
                     @moveUp="() => handleKeyboardDragUp(index)"
                     @moveDown="() => handleKeyboardDragDown(index)"
                   />

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
@@ -10,6 +10,7 @@
     <template #tbody>
       <DragContainer
         :items="entries"
+        :getItemLabel="tableRow => tableRow.title"
         @sort="handleResourcesOrderChange"
       >
         <transition-group
@@ -29,6 +30,9 @@
                       class="sort-widget"
                       :isFirst="index === 0"
                       :isLast="index === entries.length - 1"
+                      :itemLabel="tableRow.title"
+                      :position="index + 1"
+                      :total="entries.length"
                       @moveUp="moveUpOne(index)"
                       @moveDown="moveDownOne(index)"
                       @mousedown.prevent

--- a/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
+++ b/kolibri/plugins/coach/frontend/views/lessons/LessonSummaryPage/tables/LessonResourcesTable.vue
@@ -10,7 +10,6 @@
     <template #tbody>
       <DragContainer
         :items="entries"
-        :getItemLabel="tableRow => tableRow.title"
         @sort="handleResourcesOrderChange"
       >
         <transition-group

--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
@@ -7,7 +7,6 @@
     <DragContainer
       v-if="sectionOrderList.length > 0"
       :items="sectionOrderList"
-      :getItemLabel="section => sectionOrderingTitle(section)"
       @sort="handleSectionSort"
     >
       <transition-group>

--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
@@ -7,6 +7,7 @@
     <DragContainer
       v-if="sectionOrderList.length > 0"
       :items="sectionOrderList"
+      :getItemLabel="section => sectionOrderingTitle(section)"
       @sort="handleSectionSort"
     >
       <transition-group>
@@ -27,6 +28,9 @@
                 :noDrag="true"
                 :isFirst="index === 0"
                 :isLast="index === sectionOrderList.length - 1"
+                :itemLabel="sectionOrderingTitle(section)"
+                :position="index + 1"
+                :total="sectionOrderList.length"
                 @moveUp="() => handleKeyboardDragUp(index, sectionOrderList)"
                 @moveDown="() => handleKeyboardDragDown(index, sectionOrderList)"
               />

--- a/kolibri/plugins/device/frontend/views/RearrangeChannelsPage.vue
+++ b/kolibri/plugins/device/frontend/views/RearrangeChannelsPage.vue
@@ -18,7 +18,6 @@
         <DragContainer
           class="container"
           :items="channels"
-          :getItemLabel="channel => channel.name"
           @sort="handleOrderChange"
         >
           <transition-group

--- a/kolibri/plugins/device/frontend/views/RearrangeChannelsPage.vue
+++ b/kolibri/plugins/device/frontend/views/RearrangeChannelsPage.vue
@@ -18,6 +18,7 @@
         <DragContainer
           class="container"
           :items="channels"
+          :getItemLabel="channel => channel.name"
           @sort="handleOrderChange"
         >
           <transition-group
@@ -37,6 +38,9 @@
                 >
                   <DragSortWidget
                     class="sort-widget"
+                    :itemLabel="channel.name"
+                    :position="index + 1"
+                    :total="channels.length"
                     :isFirst="index === 0"
                     :isLast="index === channels.length - 1"
                     @moveUp="shiftOne(index, -1)"

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/OrderInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/OrderInteraction.vue
@@ -234,7 +234,6 @@
             {
               props: {
                 items,
-                getItemLabel: item => textByIdentifier[item.identifier],
               },
               on: { sort: handleSort },
             },

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/OrderInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/OrderInteraction.vue
@@ -84,6 +84,30 @@
       }, {});
       const allIdentifiers = choiceVNodes.map(vnode => vnode.componentOptions.propsData.identifier);
 
+      // Plain-text label per choice, used for move-button and full-order a11y announcements.
+      function vnodeToText(vnode) {
+        if (!vnode) {
+          return '';
+        }
+        if (vnode.text) {
+          return vnode.text.trim();
+        }
+        if (vnode.children) {
+          return vnode.children.map(vnodeToText).join(' ').trim();
+        }
+        return '';
+      }
+
+      const textByIdentifier = {};
+      choiceVNodes.forEach(vnode => {
+        const identifier = vnode.componentOptions.propsData.identifier;
+        textByIdentifier[identifier] = vnode.componentOptions.children
+          .map(vnodeToText)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+      });
+
       function getVariable() {
         return responses[responseIdentifier.value];
       }
@@ -208,7 +232,10 @@
           h(
             DragContainer,
             {
-              props: { items },
+              props: {
+                items,
+                getItemLabel: item => textByIdentifier[item.identifier],
+              },
               on: { sort: handleSort },
             },
             [
@@ -233,6 +260,9 @@
                                 isFirst: index === 0,
                                 isLast: index === items.length - 1,
                                 horizontal: isHorizontal.value,
+                                itemLabel: textByIdentifier[item.identifier],
+                                position: index + 1,
+                                total: items.length,
                               },
                               on: {
                                 moveUp: () => moveItem(item.identifier, -1),

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/OrderInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/OrderInteraction.spec.js
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/vue';
-import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import { dragSortStrings } from 'kolibri-common/components/sortable/dragSortStrings';
 import items from '../../__fixtures__/items';
 import { renderAssessmentItem } from '../../__tests__/helpers';
 import { answerGuideStrings } from '../../AnswerGuide.vue';
@@ -9,6 +9,8 @@ const smokeFixtures = [
   ['q15-order-example-3', 3],
   ['q15-order-example-4', 9],
 ];
+
+const { moveItemLeftLabel$ } = dragSortStrings;
 
 describe('Smoke', () => {
   it.each(smokeFixtures)('%s renders %d ordered choices', (id, choiceCount) => {
@@ -64,7 +66,9 @@ describe('Reordering', () => {
     ]);
 
     await fireEvent.click(
-      within(rowsBefore[1]).getByRole('button', { name: coreStrings.moveLeftLabel$() }),
+      within(rowsBefore[1]).getByRole('button', {
+        name: moveItemLeftLabel$({ item: 'Jenson Button' }),
+      }),
     );
 
     await waitFor(() => {

--- a/packages/kolibri-common/components/sortable/DragContainer.vue
+++ b/packages/kolibri-common/components/sortable/DragContainer.vue
@@ -19,21 +19,26 @@
       const { currentOrder$ } = dragSortStrings;
       return { sendPoliteMessage, currentOrder$ };
     },
+    provide() {
+      return {
+        registerSortItem: this.registerSortItem,
+        unregisterSortItem: this.unregisterSortItem,
+      };
+    },
     props: {
       items: {
         type: Array,
         required: true,
-      },
-      // (item) => String, used to announce full order when focus leaves the list
-      getItemLabel: {
-        type: Function,
-        default: null,
       },
     },
     data() {
       return {
         sortable: null,
       };
+    },
+    created() {
+      // doesn't need reactivity tracking.
+      this.registeredItems = {};
     },
     mounted() {
       // next tick just to be safe
@@ -93,6 +98,12 @@
         this.$emit('sort', { newArray, oldIndex, newIndex });
         // document.removeEventListener('keyup', this.triggerMouseUpOnESC);
       },
+      registerSortItem(uid, label, position) {
+        this.registeredItems[uid] = { label, position };
+      },
+      unregisterSortItem(uid) {
+        delete this.registeredItems[uid];
+      },
       handleFocusOut(event) {
         // window/tab blur: relatedTarget is null but focus hasn't actually left
         if (!document.hasFocus()) {
@@ -102,11 +113,13 @@
         if (event.relatedTarget && this.$el.contains(event.relatedTarget)) {
           return;
         }
-        if (!this.getItemLabel) {
+        const entries = Object.values(this.registeredItems);
+        if (!entries.length) {
           return;
         }
-        const order = this.items
-          .map((item, index) => `${index + 1}. ${this.getItemLabel(item)}`)
+        const order = entries
+          .sort((a, b) => a.position - b.position)
+          .map((entry, index) => `${index + 1}. ${entry.label}`)
           .join(', ');
         this.sendPoliteMessage(this.currentOrder$({ order }));
       },

--- a/packages/kolibri-common/components/sortable/DragContainer.vue
+++ b/packages/kolibri-common/components/sortable/DragContainer.vue
@@ -8,14 +8,26 @@
     Plugins,
     Draggable,
   } from '@shopify/draggable/lib/es5/draggable.bundle.legacy.js';
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { SORTABLE_CLASS, HANDLE_CLASS } from './classDefinitions';
+  import { dragSortStrings } from './dragSortStrings';
 
   export default {
     name: 'DragContainer',
+    setup() {
+      const { sendPoliteMessage } = useKLiveRegion();
+      const { itemMovedToPosition$ } = dragSortStrings;
+      return { sendPoliteMessage, itemMovedToPosition$ };
+    },
     props: {
       items: {
         type: Array,
         required: true,
+      },
+      // (item) => String, used to announce full order when focus leaves the list
+      getItemLabel: {
+        type: Function,
+        default: null,
       },
     },
     data() {
@@ -29,6 +41,7 @@
     },
     beforeDestroy() {
       this.sortable.destroy();
+      this.$el.removeEventListener('focusout', this.handleFocusOut);
     },
     methods: {
       initialize() {
@@ -54,6 +67,8 @@
         this.sortable.on('sortable:stop', this.handleStop);
         this.sortable.on('sortable:moveDown', this.moveDownOne);
         this.sortable.on('sortable:moveUp', this.moveUpOne);
+
+        this.$el.addEventListener('focusout', this.handleFocusOut);
       },
       handleStart() {
         // handle cancelation of drags
@@ -77,6 +92,21 @@
         ];
         this.$emit('sort', { newArray, oldIndex, newIndex });
         // document.removeEventListener('keyup', this.triggerMouseUpOnESC);
+      },
+      handleFocusOut(event) {
+        // focus moved to another row inside this container: not a list-exit, don't announce
+        if (event.relatedTarget && this.$el.contains(event.relatedTarget)) {
+          return;
+        }
+        if (!this.getItemLabel) {
+          return;
+        }
+        const order = this.items
+          .map((item, index) => `${index + 1}. ${this.getItemLabel(item)}`)
+          .join(', ');
+        this.sendPoliteMessage(
+          this.itemMovedToPosition$({ item: order, position: 0, total: this.items.length }),
+        );
       },
     },
     triggerMouseUpOnESC(event) {

--- a/packages/kolibri-common/components/sortable/DragContainer.vue
+++ b/packages/kolibri-common/components/sortable/DragContainer.vue
@@ -16,8 +16,8 @@
     name: 'DragContainer',
     setup() {
       const { sendPoliteMessage } = useKLiveRegion();
-      const { itemMovedToPosition$ } = dragSortStrings;
-      return { sendPoliteMessage, itemMovedToPosition$ };
+      const { currentOrder$ } = dragSortStrings;
+      return { sendPoliteMessage, currentOrder$ };
     },
     props: {
       items: {
@@ -94,6 +94,10 @@
         // document.removeEventListener('keyup', this.triggerMouseUpOnESC);
       },
       handleFocusOut(event) {
+        // window/tab blur: relatedTarget is null but focus hasn't actually left
+        if (!document.hasFocus()) {
+          return;
+        }
         // focus moved to another row inside this container: not a list-exit, don't announce
         if (event.relatedTarget && this.$el.contains(event.relatedTarget)) {
           return;
@@ -104,9 +108,7 @@
         const order = this.items
           .map((item, index) => `${index + 1}. ${this.getItemLabel(item)}`)
           .join(', ');
-        this.sendPoliteMessage(
-          this.itemMovedToPosition$({ item: order, position: 0, total: this.items.length }),
-        );
+        this.sendPoliteMessage(this.currentOrder$({ order }));
       },
     },
     triggerMouseUpOnESC(event) {

--- a/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
+++ b/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
@@ -15,7 +15,7 @@
       :icon="horizontal ? 'chevronLeft' : 'chevronUp'"
       class="btn up"
       size="mini"
-      :ariaLabel="moveForward$()"
+      :ariaLabel="moveUpAriaLabel"
       :class="{ visuallyhidden: !hasFocus && !horizontal }"
       @click="clickUp"
       @keyup.space="clickUp"
@@ -36,7 +36,7 @@
       :icon="horizontal ? 'chevronRight' : 'chevronDown'"
       class="btn dn"
       size="mini"
-      :ariaLabel="moveBackward$()"
+      :ariaLabel="moveDownAriaLabel"
       :class="{ visuallyhidden: !hasFocus && !horizontal }"
       @click="clickDown"
       @keyup.space="clickDown"
@@ -51,11 +51,21 @@
   import { computed } from 'vue';
   import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
   import { currentLanguage, isRtl } from 'kolibri/utils/i18n';
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+  import { dragSortStrings } from '../dragSortStrings';
 
   export default {
     name: 'DragSortWidget',
     setup(props) {
       const { moveUpLabel$, moveDownLabel$, moveLeftLabel$, moveRightLabel$ } = coreStrings;
+      const {
+        moveItemUpLabel$,
+        moveItemDownLabel$,
+        moveItemLeftLabel$,
+        moveItemRightLabel$,
+        itemMovedToPosition$,
+      } = dragSortStrings;
+      const { sendPoliteMessage } = useKLiveRegion();
 
       const isRtlValue = isRtl(currentLanguage);
 
@@ -75,7 +85,32 @@
         return isRtlValue ? moveLeftLabel$ : moveRightLabel$;
       });
 
-      return { moveForward$, moveBackward$ };
+      // Item-specific labels, Direction-aware
+      const moveUpAriaLabel = computed(() => {
+        if (!props.itemLabel) {
+          return moveUpOrLeftLabel$.value();
+        }
+        if (!props.horizontal) {
+          return moveItemUpLabel$({ item: props.itemLabel });
+        }
+        return isRtlValue
+          ? moveItemRightLabel$({ item: props.itemLabel })
+          : moveItemLeftLabel$({ item: props.itemLabel });
+      });
+
+      const moveDownAriaLabel = computed(() => {
+        if (!props.itemLabel) {
+          return moveDownOrRightLabel$.value();
+        }
+        if (!props.horizontal) {
+          return moveItemDownLabel$({ item: props.itemLabel });
+        }
+        return isRtlValue
+          ? moveItemLeftLabel$({ item: props.itemLabel })
+          : moveItemRightLabel$({ item: props.itemLabel });
+      });
+
+      return { moveUpAriaLabel, moveDownAriaLabel, itemMovedToPosition$, sendPoliteMessage };
     },
     props: {
       isFirst: {
@@ -90,6 +125,21 @@
       horizontal: {
         type: Boolean,
         default: false,
+      },
+      // Human-readable name of this item
+      itemLabel: {
+        type: String,
+        default: null,
+      },
+      // indexed current position of this item in the list
+      // 1-based
+      position: {
+        type: Number,
+        default: null,
+      },
+      total: {
+        type: Number,
+        default: null,
       },
     },
     data() {
@@ -114,8 +164,21 @@
           document.activeElement,
         );
       },
+      announceMove(newPosition) {
+        if (!this.itemLabel || this.total == null) {
+          return;
+        }
+        this.sendPoliteMessage(
+          this.itemMovedToPosition$({
+            item: this.itemLabel,
+            position: newPosition,
+            total: this.total,
+          }),
+        );
+      },
       clickDown() {
         this.$emit('moveDown');
+        this.announceMove(this.position + 1);
         this.$nextTick(() => {
           if (this.isLast) {
             this.$refs.upBtn.$el.focus();
@@ -126,6 +189,7 @@
       },
       clickUp() {
         this.$emit('moveUp');
+        this.announceMove(this.position - 1);
         this.$nextTick(() => {
           if (this.isFirst) {
             this.$refs.dnBtn.$el.focus();

--- a/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
+++ b/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
@@ -88,7 +88,7 @@
       // Item-specific labels, Direction-aware
       const moveUpAriaLabel = computed(() => {
         if (!props.itemLabel) {
-          return moveUpOrLeftLabel$.value();
+          return moveForward$.value();
         }
         if (!props.horizontal) {
           return moveItemUpLabel$({ item: props.itemLabel });
@@ -100,7 +100,7 @@
 
       const moveDownAriaLabel = computed(() => {
         if (!props.itemLabel) {
-          return moveDownOrRightLabel$.value();
+          return moveBackward$.value();
         }
         if (!props.horizontal) {
           return moveItemDownLabel$({ item: props.itemLabel });

--- a/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
+++ b/packages/kolibri-common/components/sortable/DragSortWidget/index.vue
@@ -56,6 +56,10 @@
 
   export default {
     name: 'DragSortWidget',
+    inject: {
+      registerSortItem: { default: null },
+      unregisterSortItem: { default: null },
+    },
     setup(props) {
       const { moveUpLabel$, moveDownLabel$, moveLeftLabel$, moveRightLabel$ } = coreStrings;
       const {
@@ -147,18 +151,36 @@
         hasFocus: false,
       };
     },
+    watch: {
+      itemLabel() {
+        this.syncRegistration();
+      },
+      position() {
+        this.syncRegistration();
+      },
+    },
     mounted() {
       // no need to track focus for horizontal mode, since the buttons are always visible
       if (!this.horizontal) {
         window.addEventListener('focus', this.updateFocus, true);
       }
+      this.syncRegistration();
     },
     destroyed() {
       if (!this.horizontal) {
         window.removeEventListener('focus', this.updateFocus, true);
       }
+      if (this.unregisterSortItem) {
+        this.unregisterSortItem(this._uid);
+      }
     },
     methods: {
+      // Registers this item's label/position
+      syncRegistration() {
+        if (this.registerSortItem && this.itemLabel != null && this.position != null) {
+          this.registerSortItem(this._uid, this.itemLabel, this.position);
+        }
+      },
       updateFocus() {
         this.hasFocus = [this.$refs.dnBtn.$el, this.$refs.upBtn.$el].includes(
           document.activeElement,

--- a/packages/kolibri-common/components/sortable/__tests__/DragContainer.spec.js
+++ b/packages/kolibri-common/components/sortable/__tests__/DragContainer.spec.js
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils';
+import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+import DragContainer from '../DragContainer.vue';
+
+jest.mock('kolibri-design-system/lib/composables/useKLiveRegion');
+
+// Real @shopify/draggable manipulates mouse/pointer events in ways jsdom doesn't
+// support; only its constructor shape matters for these tests.
+jest.mock('@shopify/draggable/lib/es5/draggable.bundle.legacy.js', () => ({
+  Sortable: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    removePlugin: jest.fn(),
+    destroy: jest.fn(),
+  })),
+  Plugins: { SwapAnimation: 'SwapAnimation' },
+  Draggable: { Plugins: { Focusable: 'Focusable' } },
+}));
+
+describe('DragContainer', () => {
+  let sendPoliteMessage;
+  const items = [
+    { id: 1, title: 'First' },
+    { id: 2, title: 'Second' },
+    { id: 3, title: 'Third' },
+  ];
+
+  beforeEach(() => {
+    sendPoliteMessage = jest.fn();
+    useKLiveRegion.mockReturnValue({ sendPoliteMessage });
+  });
+
+  async function makeWrapper(propsData = {}) {
+    const wrapper = mount(DragContainer, {
+      propsData: { items, ...propsData },
+      slots: {
+        default: `
+          <div>
+            <div tabindex="0" class="row" data-test="row-0"></div>
+            <div tabindex="0" class="row" data-test="row-1"></div>
+            <div tabindex="0" class="row" data-test="row-2"></div>
+          </div>
+        `,
+      },
+    });
+    // initialize() runs on $nextTick after mount, and is what registers
+    // the focusout listener we're testing against
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  }
+
+  describe('full-order announcement on focus-exit', () => {
+    it('announces the full current order when focus moves outside the container', async () => {
+      document.hasFocus = jest.fn(() => true);
+      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const outsideEl = document.createElement('button');
+      document.body.appendChild(outsideEl);
+
+      await wrapper.trigger('focusout', { relatedTarget: outsideEl });
+
+      expect(sendPoliteMessage).toHaveBeenCalledWith(
+        'Current order: 1. First, 2. Second, 3. Third',
+      );
+      document.body.removeChild(outsideEl);
+    });
+
+    it('announces the full order even when relatedTarget is null, provided the window is still focused', async () => {
+      document.hasFocus = jest.fn(() => true);
+      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+
+      await wrapper.trigger('focusout', { relatedTarget: null });
+
+      expect(sendPoliteMessage).toHaveBeenCalledWith(expect.stringContaining('Current order:'));
+    });
+
+    it('does not announce anything when getItemLabel is not provided', async () => {
+      document.hasFocus = jest.fn(() => true);
+      const wrapper = await makeWrapper();
+      const outsideEl = document.createElement('button');
+      document.body.appendChild(outsideEl);
+
+      await wrapper.trigger('focusout', { relatedTarget: outsideEl });
+
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+      document.body.removeChild(outsideEl);
+    });
+  });
+
+  describe('no announcement on row-to-row focus movement', () => {
+    it('does not announce when focus moves to another row inside the container', async () => {
+      document.hasFocus = jest.fn(() => true);
+      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const rowB = wrapper.find('[data-test="row-1"]').element;
+
+      await wrapper.trigger('focusout', { relatedTarget: rowB });
+
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('window/tab blur', () => {
+    it('does not announce on window blur, even with a null relatedTarget', async () => {
+      document.hasFocus = jest.fn(() => false);
+      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+
+      await wrapper.trigger('focusout', { relatedTarget: null });
+
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/kolibri-common/components/sortable/__tests__/DragContainer.spec.js
+++ b/packages/kolibri-common/components/sortable/__tests__/DragContainer.spec.js
@@ -48,10 +48,17 @@ describe('DragContainer', () => {
     return wrapper;
   }
 
+  function registerItems(wrapper, labeledItems) {
+    labeledItems.forEach((item, index) => {
+      wrapper.vm.registerSortItem(index, item.title, index + 1);
+    });
+  }
+
   describe('full-order announcement on focus-exit', () => {
     it('announces the full current order when focus moves outside the container', async () => {
       document.hasFocus = jest.fn(() => true);
-      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const wrapper = await makeWrapper();
+      registerItems(wrapper, items);
       const outsideEl = document.createElement('button');
       document.body.appendChild(outsideEl);
 
@@ -65,16 +72,31 @@ describe('DragContainer', () => {
 
     it('announces the full order even when relatedTarget is null, provided the window is still focused', async () => {
       document.hasFocus = jest.fn(() => true);
-      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const wrapper = await makeWrapper();
+      registerItems(wrapper, items);
 
       await wrapper.trigger('focusout', { relatedTarget: null });
 
       expect(sendPoliteMessage).toHaveBeenCalledWith(expect.stringContaining('Current order:'));
     });
 
-    it('does not announce anything when getItemLabel is not provided', async () => {
+    it('does not announce anything when no items are registered', async () => {
       document.hasFocus = jest.fn(() => true);
       const wrapper = await makeWrapper();
+      const outsideEl = document.createElement('button');
+      document.body.appendChild(outsideEl);
+
+      await wrapper.trigger('focusout', { relatedTarget: outsideEl });
+
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+      document.body.removeChild(outsideEl);
+    });
+
+    it('does not announce anything for items that have been unregistered', async () => {
+      document.hasFocus = jest.fn(() => true);
+      const wrapper = await makeWrapper();
+      registerItems(wrapper, items);
+      items.forEach((item, index) => wrapper.vm.unregisterSortItem(index));
       const outsideEl = document.createElement('button');
       document.body.appendChild(outsideEl);
 
@@ -88,7 +110,8 @@ describe('DragContainer', () => {
   describe('no announcement on row-to-row focus movement', () => {
     it('does not announce when focus moves to another row inside the container', async () => {
       document.hasFocus = jest.fn(() => true);
-      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const wrapper = await makeWrapper();
+      registerItems(wrapper, items);
       const rowB = wrapper.find('[data-test="row-1"]').element;
 
       await wrapper.trigger('focusout', { relatedTarget: rowB });
@@ -100,7 +123,8 @@ describe('DragContainer', () => {
   describe('window/tab blur', () => {
     it('does not announce on window blur, even with a null relatedTarget', async () => {
       document.hasFocus = jest.fn(() => false);
-      const wrapper = await makeWrapper({ getItemLabel: item => item.title });
+      const wrapper = await makeWrapper();
+      registerItems(wrapper, items);
 
       await wrapper.trigger('focusout', { relatedTarget: null });
 

--- a/packages/kolibri-common/components/sortable/__tests__/DragSortWidget.spec.js
+++ b/packages/kolibri-common/components/sortable/__tests__/DragSortWidget.spec.js
@@ -1,0 +1,68 @@
+import { mount } from '@vue/test-utils';
+import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+import DragSortWidget from '../DragSortWidget/index.vue';
+
+jest.mock('kolibri-design-system/lib/composables/useKLiveRegion');
+
+describe('DragSortWidget', () => {
+  let sendPoliteMessage;
+
+  beforeEach(() => {
+    sendPoliteMessage = jest.fn();
+    useKLiveRegion.mockReturnValue({ sendPoliteMessage });
+  });
+
+  function makeWrapper(propsData = {}) {
+    return mount(DragSortWidget, {
+      propsData: {
+        isFirst: false,
+        isLast: false,
+        ...propsData,
+      },
+    });
+  }
+
+  describe('move-button announcements', () => {
+    it('announces the item and its new position on move up', async () => {
+      const wrapper = makeWrapper({ itemLabel: 'Rubens Barrichello', position: 2, total: 3 });
+      await wrapper.findComponent({ ref: 'upBtn' }).vm.$emit('click');
+      expect(sendPoliteMessage).toHaveBeenCalledWith('Rubens Barrichello moved to position 1 of 3');
+    });
+
+    it('announces the item and its new position on move down', async () => {
+      const wrapper = makeWrapper({ itemLabel: 'Rubens Barrichello', position: 2, total: 3 });
+      await wrapper.findComponent({ ref: 'dnBtn' }).vm.$emit('click');
+      expect(sendPoliteMessage).toHaveBeenCalledWith('Rubens Barrichello moved to position 3 of 3');
+    });
+
+    it('does not announce when itemLabel is not provided', async () => {
+      const wrapper = makeWrapper({ position: 2, total: 3 });
+      await wrapper.findComponent({ ref: 'upBtn' }).vm.$emit('click');
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not announce when total is not provided', async () => {
+      const wrapper = makeWrapper({ itemLabel: 'Rubens Barrichello', position: 2 });
+      await wrapper.findComponent({ ref: 'upBtn' }).vm.$emit('click');
+      expect(sendPoliteMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('item-specific aria-labels', () => {
+    it('uses the item label in vertical mode', () => {
+      const wrapper = makeWrapper({ itemLabel: 'Rubens Barrichello', position: 2, total: 3 });
+      expect(wrapper.findComponent({ ref: 'upBtn' }).props('ariaLabel')).toBe(
+        'Move Rubens Barrichello up',
+      );
+      expect(wrapper.findComponent({ ref: 'dnBtn' }).props('ariaLabel')).toBe(
+        'Move Rubens Barrichello down',
+      );
+    });
+
+    it('falls back to the generic label when no itemLabel is given', () => {
+      const wrapper = makeWrapper();
+      expect(wrapper.findComponent({ ref: 'upBtn' }).props('ariaLabel')).toBe('Move up');
+      expect(wrapper.findComponent({ ref: 'dnBtn' }).props('ariaLabel')).toBe('Move down');
+    });
+  });
+});

--- a/packages/kolibri-common/components/sortable/dragSortStrings.js
+++ b/packages/kolibri-common/components/sortable/dragSortStrings.js
@@ -18,7 +18,7 @@ export const dragSortStrings = createTranslator('DragSortStrings', {
     context: 'Button label to move a specific item right in a horizontal reorderable list',
   },
   itemMovedToPosition: {
-    message: '{item} moved to position {position} of {total}',
+    message: '{item} moved to position {position, number} of {total, number}',
     context: 'Live region announcement after moving an item in a reorderable list',
   },
   currentOrder: {

--- a/packages/kolibri-common/components/sortable/dragSortStrings.js
+++ b/packages/kolibri-common/components/sortable/dragSortStrings.js
@@ -1,0 +1,29 @@
+import { createTranslator } from 'kolibri/utils/i18n';
+
+export const dragSortStrings = createTranslator('DragSortStrings', {
+  moveItemUpLabel: {
+    message: 'Move {item} up',
+    context: 'Button label to move a specific item up in a vertical reorderable list',
+  },
+  moveItemDownLabel: {
+    message: 'Move {item} down',
+    context: 'Button label to move a specific item down in a vertical reorderable list',
+  },
+  moveItemLeftLabel: {
+    message: 'Move {item} left',
+    context: 'Button label to move a specific item left in a horizontal reorderable list',
+  },
+  moveItemRightLabel: {
+    message: 'Move {item} right',
+    context: 'Button label to move a specific item right in a horizontal reorderable list',
+  },
+  itemMovedToPosition: {
+    message: '{item} moved to position {position} of {total}',
+    context: 'Live region announcement after moving an item in a reorderable list',
+  },
+  currentOrder: {
+    message: 'Current order: {order}',
+    context:
+      'Live region announcement of the full list order after focus leaves the reorderable list',
+  },
+});


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
This PR enhances `kolibri-common/components/sortable` with more descriptive screen reader announcements for keyboard reordering and provides users with the final ordering context when leaving a sortable list.

### Changes

- Added itemLabel, position, and total props to DragSortWidget to support:
- Item-specific move button labels (e.g. "Move Rubens Barrichello up")
- Reorder announcements (e.g. "Rubens Barrichello moved to position 2 of 3")
- Added getItemLabel prop to DragContainer.
- Added a focusout handler that announces the full current order when focus leaves the sortable container, while avoiding announcements when focus moves between items inside the list.
- Integrated announcements using KDS's useKLiveRegion and the existing #k-live-region.
- Updated all existing consumers to provide the data needed for item-aware announcements.

This implementation addresses the accessibility feedback discussed in the product issue #14882  and subsequent review comments. In particular, it satisfies the request to read the complete ordered list before the "Check" button is activated.

We announces the full order whenever focus exits the sortable container, which is a superset of the original suggestion to announce specifically when moving from the list to the "Check" button:
1. Focus leaves the ordered list (focusout fires).
2. The current order is announced.
3. Focus moves to the next element (typically the "Check" button).
4. The user activates the button.

This approach also covers other cases, such as tabbing backwards or clicking elsewhere on the page, without changing existing focus or drag behavior.

---

## References
- fixes #14888 

---

## Reviewer guidance

> [!NOTE] 
> ~~This PR is based on #14897 and should be rebased before merging~~

---

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Used claude to decide on a middle-ground approach for the exact scenario that should be followed wrt where the focus is.