### PR TITLE
Migrate pre-0.17 FKs to have deferrable flags

### DIFF
--- a/kolibri/core/auth/test/test_deferrable_foreign_keys.py
+++ b/kolibri/core/auth/test/test_deferrable_foreign_keys.py
@@ -1,0 +1,53 @@
+import pytest
+from django.conf import settings
+from django.db import connection
+from django.test import TransactionTestCase
+from morango.deferrable_foreign_keys import _get_table_sql
+
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.upgrade import make_foreign_keys_deferrable
+
+
+class DeferrableForeignKeysTestCase(TransactionTestCase):
+    def _rewrite_collection_fk_immediate(self):
+        table = Collection._meta.db_table
+        sql = _get_table_sql(connection, table)
+        immediate = sql.replace(" DEFERRABLE INITIALLY DEFERRED", "")
+        assert "DEFERRABLE" not in immediate
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=%s AND sql IS NOT NULL",
+                [table],
+            )
+            indexes = [r[0] for r in cursor.fetchall()]
+            cursor.execute("PRAGMA foreign_keys = OFF")
+            cursor.execute("DROP TABLE {}".format(table))
+            cursor.execute(immediate)
+            for idx in indexes:
+                cursor.execute(idx)
+            cursor.execute("PRAGMA foreign_keys = ON")
+
+    @pytest.mark.skipif(
+        "sqlite3" not in settings.DATABASES["default"]["ENGINE"],
+        reason="sqlite3 only",
+    )
+    def test_remake_makes_deferrable_and_preserves_data(self):
+        table = Collection._meta.db_table
+        # fresh schema should be deferrable
+        self.assertIn("DEFERRABLE", _get_table_sql(connection, table))
+
+        # downgrade schema to immediate FK (table is rebuilt empty)
+        self._rewrite_collection_fk_immediate()
+        self.assertNotIn("DEFERRABLE", _get_table_sql(connection, table))
+
+        # create some data on the immediate-FK schema
+        f = Facility.objects.create(name="testfac")
+        f_id = f.id
+        self.assertTrue(Collection.objects.filter(id=f_id).exists())
+
+        make_foreign_keys_deferrable()
+
+        # now deferrable again, and data preserved
+        self.assertIn("DEFERRABLE", _get_table_sql(connection, table))
+        self.assertTrue(Collection.objects.filter(id=f_id).exists())

--- a/kolibri/core/auth/upgrade.py
+++ b/kolibri/core/auth/upgrade.py
@@ -57,3 +57,30 @@ def enqueue_kdp_sync_for_registered_facilities():
     """
     for facility in Facility.objects.filter(dataset__registered=True):
         enqueue_automatic_kdp_sync(facility)
+
+
+@version_upgrade(old_version="<0.19.5")
+def make_foreign_keys_deferrable():
+    """
+    Prior to Django 2.0, SQLite tables were created with immediate foreign key constraints, e.g.::
+
+        "parent_id" char(32) NULL REFERENCES "kolibriauth_collection" ("id")
+
+    Since Kolibri upgraded to Django 3.2 (straight from 1.11) the same column is created as::
+
+        "parent_id" char(32) NULL REFERENCES "kolibriauth_collection" ("id") DEFERRABLE INITIALLY DEFERRED
+
+    Django relies on deferred constraint checking for correct cascade-deletion ordering. Databases
+    created before Kolibri 0.17 (Django 1.11) therefore retain immediate constraints, which can
+    raise ``IntegrityError: FOREIGN KEY constraint failed`` during operations such as sync
+    deserialization once foreign key enforcement is enabled at the database level (the default since
+    Django 2.0).
+
+    Kolibri 0.17 saw the Django upgrade, but for this version upgrade, we apply it based on the
+    version of its release, so we can ensure all databases are migrated properly.
+    """
+    from morango.deferrable_foreign_keys import MakeForeignKeysDeferrable
+
+    # morango takes care of itself, through its own migration
+    op = MakeForeignKeysDeferrable(exclude_app_labels=["morango"])
+    op.run()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.17
 jsonfield==3.1.0
-morango==0.8.12
+morango==0.8.14
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
- Upgrades morango to [v0.8.14](https://github.com/learningequality/morango/releases/tag/v0.8.14) which contains:
  - enhanced protection against flaky connections 
  - a utility that migrates FKs to have deferrable flag, which Django relies upon
  - a Django DB migration which leverages the utility explicitly for morango models
- Adds a Kolibri version upgrade migration which leverages morango's utility to migrate all FKs (except for morango models) to have the deferrable flag

## References
<!--
 * references to related issues and PRs
-->
Closes https://github.com/learningequality/kolibri/issues/14884


## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
I performed a few different checks:
- I created a Kolibri database with 0.16 and ran this against it. I then checked the database to see whether there were any non-deferrable FKs: `sqlite3 .kolibri_home/db.sqlite3 ".schema" | grep REFERENCES | grep -v DEFERRABLE` and found none
- I migrated a broken implementer's DB and ran the same check above. The database was quite large, and it took a minute for the morango DB migration to run, but it completed successfully
- I checked all other DB's other than the main `db.sqlite3` and found no FKs in need of migration
- Ran the morango integration tests

I can provide my 0.16 Kolibri home upon request.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI was used on morango's side, and the tests for the migration were first implemented there, then copied to Kolibri to perform a similar test on the version upgrade migration.