### PR TITLE
Declare task startup schedules on the task itself

### DIFF
--- a/kolibri/core/analytics/tasks.py
+++ b/kolibri/core/analytics/tasks.py
@@ -13,7 +13,8 @@ from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseF
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseTimeout
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobRunning
-from kolibri.core.tasks.main import job_storage
+from kolibri.core.tasks.schedules import EnqueueIn
+from kolibri.core.tasks.utils import get_current_job
 from kolibri.utils import conf
 from kolibri.utils.time_utils import local_now
 
@@ -25,8 +26,25 @@ DEFAULT_PING_CHECKRATE = 15
 DEFAULT_PING_INTERVAL = 24 * 60
 
 
-@register_task(job_id=DEFAULT_PING_JOB_ID)
-def _ping(started, server, checkrate):
+class PingAtStartup(EnqueueIn):
+    def apply(self, task):
+        self.kwargs = dict(self.kwargs, started=local_now().isoformat())
+        super().apply(task)
+
+
+@register_task(
+    job_id=DEFAULT_PING_JOB_ID,
+    schedule=PingAtStartup(
+        timedelta(0),
+        interval=DEFAULT_PING_INTERVAL * 60,
+        repeat=None,
+        retry_interval=DEFAULT_PING_CHECKRATE * 60,
+    ),
+)
+def _ping(started, server=DEFAULT_SERVER_URL, checkrate=DEFAULT_PING_CHECKRATE):
+    if conf.OPTIONS["Deployment"]["DISABLE_PING"]:
+        get_current_job().stop_repeating()
+        return
     try:
         ping_once(started, server=server)
     except NetworkLocationConnectionFailure:
@@ -57,23 +75,18 @@ def schedule_ping(
     checkrate=DEFAULT_PING_CHECKRATE,
     interval=DEFAULT_PING_INTERVAL,
 ):
-    # If pinging is not disabled by the environment
-    if not conf.OPTIONS["Deployment"]["DISABLE_PING"]:
-        # Scheduler needs datetime object, but job needs (serializable) string
-        now = local_now()
-        started = now.isoformat()
-        try:
-            _ping.enqueue_at(
-                now,
-                interval=interval * 60,
-                retry_interval=checkrate * 60,
-                repeat=None,
-                kwargs=dict(started=started, server=server, checkrate=checkrate),
-            )
-        except JobRunning:
-            pass
-    elif conf.OPTIONS["Deployment"]["DISABLE_PING"]:
-        job_storage.clear(job_id=DEFAULT_PING_JOB_ID)
+    # Scheduler needs a datetime object, but the job needs a serializable string.
+    now = local_now()
+    try:
+        _ping.enqueue_at(
+            now,
+            interval=interval * 60,
+            repeat=None,
+            retry_interval=checkrate * 60,
+            kwargs=dict(started=now.isoformat(), server=server, checkrate=checkrate),
+        )
+    except JobRunning:
+        pass
 
 
 LOCAL_NOTIFICATION_JOB_ID = "local-notifications"
@@ -93,13 +106,9 @@ def _run_local_notification_generation():
         _generate_local_notifications.enqueue_in(next_run)
 
 
-@register_task(job_id=LOCAL_NOTIFICATION_JOB_ID)
+@register_task(
+    job_id=LOCAL_NOTIFICATION_JOB_ID,
+    schedule=EnqueueIn(timedelta(days=DEFAULT_CADENCE_DAYS)),
+)
 def _generate_local_notifications():
     _run_local_notification_generation()
-
-
-def schedule_local_notification_generation():
-    try:
-        _generate_local_notifications.enqueue_in(timedelta(days=DEFAULT_CADENCE_DAYS))
-    except JobRunning:
-        pass

--- a/kolibri/core/analytics/test/test_local_notification.py
+++ b/kolibri/core/analytics/test/test_local_notification.py
@@ -20,7 +20,6 @@ from ..models import LocalNotification
 from ..tasks import _run_local_notification_generation
 from ..tasks import COOLDOWN_DAYS
 from ..tasks import DEFAULT_CADENCE_DAYS
-from ..tasks import schedule_local_notification_generation
 
 
 class LocalNotificationAPITestCase(APITestCase):
@@ -188,9 +187,4 @@ class LocalNotificationTaskTests(TestCase):
         self, mock_create, mock_enqueue
     ):
         _run_local_notification_generation()
-        mock_enqueue.assert_called_once_with(timedelta(days=DEFAULT_CADENCE_DAYS))
-
-    @mock.patch("kolibri.core.analytics.tasks._generate_local_notifications.enqueue_in")
-    def test_schedule_helper_enqueues_default_cadence(self, mock_enqueue):
-        schedule_local_notification_generation()
         mock_enqueue.assert_called_once_with(timedelta(days=DEFAULT_CADENCE_DAYS))

--- a/kolibri/core/analytics/test/test_ping.py
+++ b/kolibri/core/analytics/test/test_ping.py
@@ -1,11 +1,18 @@
 import json
 import zlib
+from datetime import timedelta
 
 import mock
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 from requests.models import Response
+
+from kolibri.core.analytics.tasks import _ping
+from kolibri.core.analytics.tasks import DEFAULT_PING_CHECKRATE
+from kolibri.core.analytics.tasks import DEFAULT_SERVER_URL
+from kolibri.core.analytics.tasks import PingAtStartup
+from kolibri.utils import conf
 
 from .test_utils import BaseDeviceSetupMixin
 
@@ -36,6 +43,43 @@ def mocked_network_client_post_wrapper(json_data, status_code):
         return MockResponse()
 
     return mocked_network_client_post
+
+
+DEFAULT_PING_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+class PingTaskTestCase(TestCase):
+    def test_ping_at_startup_apply_stamps_started(self):
+        fake_now_str = "2026-01-01T00:00:00+00:00"
+        task = mock.MagicMock()
+        schedule = PingAtStartup(
+            timedelta(0),
+            interval=DEFAULT_PING_INTERVAL_SECONDS,
+            repeat=None,
+            retry_interval=DEFAULT_PING_CHECKRATE * 60,
+        )
+        with mock.patch("kolibri.core.analytics.tasks.local_now") as mock_local_now:
+            mock_local_now.return_value.isoformat.return_value = fake_now_str
+            schedule.apply(task)
+        task.enqueue_in.assert_called_once()
+        _, call_kwargs = task.enqueue_in.call_args
+        assert call_kwargs["kwargs"]["started"] == fake_now_str
+
+    @mock.patch("kolibri.core.analytics.tasks.ping_once")
+    @mock.patch("kolibri.core.analytics.tasks.get_current_job")
+    def test_ping_disabled_stops_repeating(self, mock_get_job, mock_ping_once):
+        with mock.patch.dict(conf.OPTIONS["Deployment"], {"DISABLE_PING": True}):
+            _ping("t", DEFAULT_SERVER_URL, DEFAULT_PING_CHECKRATE)
+        mock_get_job.return_value.stop_repeating.assert_called_once()
+        mock_ping_once.assert_not_called()
+
+    @mock.patch("kolibri.core.analytics.tasks.ping_once")
+    @mock.patch("kolibri.core.analytics.tasks.get_current_job")
+    def test_ping_enabled_calls_ping_once(self, mock_get_job, mock_ping_once):
+        with mock.patch.dict(conf.OPTIONS["Deployment"], {"DISABLE_PING": False}):
+            _ping("t", DEFAULT_SERVER_URL, DEFAULT_PING_CHECKRATE)
+        mock_get_job.return_value.stop_repeating.assert_not_called()
+        mock_ping_once.assert_called_once()
 
 
 class PingCommandTestCase(BaseDeviceSetupMixin, TestCase):

--- a/kolibri/core/deviceadmin/tasks.py
+++ b/kolibri/core/deviceadmin/tasks.py
@@ -1,15 +1,13 @@
 import logging
-from datetime import timedelta
 
 from django import db
 from django.apps import apps
 
 from kolibri.core.tasks.decorators import register_task
-from kolibri.core.tasks.exceptions import JobRunning
+from kolibri.core.tasks.schedules import Cron
 from kolibri.core.utils.lock import db_lock
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
-from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +15,7 @@ logger = logging.getLogger(__name__)
 SCH_VACUUM_JOB_ID = "1"
 
 
-@register_task(job_id=SCH_VACUUM_JOB_ID)
+@register_task(job_id=SCH_VACUUM_JOB_ID, schedule=Cron(hour=3))
 def perform_vacuum(database=db.DEFAULT_DB_ALIAS, full=False):
     connection = db.connections[database]
     if connection.vendor == "sqlite":
@@ -59,33 +57,11 @@ def perform_vacuum(database=db.DEFAULT_DB_ALIAS, full=False):
         connection.close()
 
 
-def schedule_vacuum():
-    current_dt = local_now()
-    vacuum_time = current_dt.replace(hour=3, minute=0, second=0, microsecond=0)
-    if vacuum_time < current_dt:
-        # If it is past 3AM, change the day to tomorrow.
-        vacuum_time = vacuum_time + timedelta(days=1)
-    # Repeat indefinitely
-    try:
-        perform_vacuum.enqueue_at(vacuum_time, repeat=None, interval=24 * 60 * 60)
-    except JobRunning:
-        pass
-
-
 # Constant job id for streamed cache cleanup task
 STREAMED_CACHE_CLEANUP_JOB_ID = "streamed_cache_cleanup"
 
 
-@register_task(job_id=STREAMED_CACHE_CLEANUP_JOB_ID)
+@register_task(job_id=STREAMED_CACHE_CLEANUP_JOB_ID, schedule=Cron(minute=0))
 def streamed_cache_cleanup():
     manager = ChunkedFileDirectoryManager(OPTIONS["Paths"]["CONTENT_DIR"])
     manager.limit_files(OPTIONS["Cache"]["STREAMED_FILE_CACHE_SIZE"])
-
-
-def schedule_streamed_cache_cleanup():
-    try:
-        streamed_cache_cleanup.enqueue_in(
-            timedelta(hours=1), repeat=None, interval=60 * 60
-        )
-    except JobRunning:
-        pass

--- a/kolibri/core/tasks/decorators.py
+++ b/kolibri/core/tasks/decorators.py
@@ -18,6 +18,7 @@ def register_task(
     long_running=False,
     status_fn=None,
     retry_on=None,
+    schedule=None,
 ):
     """
     Registers the decorated function as task.
@@ -38,6 +39,7 @@ def register_task(
             long_running=long_running,
             status_fn=status_fn,
             retry_on=retry_on,
+            schedule=schedule,
         )
 
     return RegisteredTask(
@@ -52,4 +54,5 @@ def register_task(
         long_running=long_running,
         status_fn=status_fn,
         retry_on=retry_on,
+        schedule=schedule,
     )

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -361,6 +361,13 @@ class Job:
             expected_supervisor_id=self._supervisor_id,
         )
 
+    def stop_repeating(self):
+        if getattr(current_state_tracker, "job", None) is not self:
+            raise JobNotRunning(
+                "stop_repeating can only be called from within a running job about the currently running job"
+            )
+        self.storage._update_job(self.job_id, repeat=0)
+
     def retry_in(self, dt, **kwargs):
         if getattr(current_state_tracker, "job", None) is not self:
             raise JobNotRunning(

--- a/kolibri/core/tasks/kolibri_plugin.py
+++ b/kolibri/core/tasks/kolibri_plugin.py
@@ -1,0 +1,17 @@
+from magicbus.plugins import SimplePlugin
+
+from kolibri.plugins.hooks import register_hook
+from kolibri.utils.server.hooks import KolibriProcessHook
+
+
+class ScheduledTasksPlugin(SimplePlugin):
+    def START(self):
+        from kolibri.core.tasks.registry import TaskRegistry
+
+        TaskRegistry.apply_schedules()
+
+
+@register_hook
+class ScheduledTasksProcessHook(KolibriProcessHook):
+    # Apply every task's declared schedule once the server enters START.
+    MagicBusPluginClass = ScheduledTasksPlugin

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -8,9 +8,11 @@ from rest_framework.exceptions import PermissionDenied
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.constants import Priority
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.permissions import BasePermission
+from kolibri.core.tasks.schedules import Schedule
 from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.validation import JobValidator
 
@@ -120,6 +122,15 @@ class _registry(dict):
             )
         return self[task]
 
+    def apply_schedules(self):
+        self._initialize()
+        for task in list(self.values()):
+            if task.schedule is not None:
+                try:
+                    task.schedule.apply(task)
+                except JobRunning:
+                    pass
+
 
 TaskRegistry = _registry()
 
@@ -155,6 +166,7 @@ class RegisteredTask:
         long_running=False,
         status_fn=None,
         retry_on=None,
+        schedule=None,
     ):
         """
         :param func: Function to be wrapped as a Registered task
@@ -185,6 +197,8 @@ class RegisteredTask:
         text describing the status of the job to an end user. Should use string wrapping, as it will
         usually be invoked in a context where internationalization is being used.
         :type status_fn: function
+        :param schedule: Schedule to apply at startup, defaults to None
+        :type schedule: Schedule or None
         """
         if permission_classes is None:
             permission_classes = []
@@ -202,6 +216,8 @@ class RegisteredTask:
             raise TypeError("track_progress must be of bool type.")
         if not isinstance(long_running, bool):
             raise TypeError("long_running must be of bool type.")
+        if schedule is not None and not isinstance(schedule, Schedule):
+            raise TypeError("schedule must be a Schedule instance or None.")
         if status_fn is not None and not callable(status_fn):
             raise TypeError("status_fn must be callable.")
         if long_running and status_fn is None:
@@ -226,6 +242,7 @@ class RegisteredTask:
         self.long_running = long_running
         self._status_fn = status_fn
         self.retry_on = self._validate_retry_on(retry_on)
+        self.schedule = schedule
 
         # Make this wrapper object look seamlessly like the wrapped function
         update_wrapper(self, func)

--- a/kolibri/core/tasks/schedules.py
+++ b/kolibri/core/tasks/schedules.py
@@ -1,0 +1,128 @@
+"""
+Declarative schedules for registered tasks.
+
+A schedule describes *when* a task should first be enqueued. Tasks declare one
+at registration via ``register_task(schedule=…)``; ``TaskRegistry`` applies it
+on server start. Each subclass wraps one of the ``enqueue_*`` methods on the
+task (see ``kolibri.core.tasks.registry.RegisteredTask``), so the schedule
+classes are the declarative front end to that imperative storage API.
+"""
+
+from datetime import timedelta
+
+from kolibri.utils.time_utils import local_now
+
+MINUTE = 60
+HOUR = 60 * MINUTE
+DAY = 24 * HOUR
+WEEK = 7 * DAY
+
+
+class Schedule:
+    """
+    Base schedule. Holds the args/kwargs the task will be called with; each
+    subclass' ``apply`` enqueues the task with its own timing semantics.
+    """
+
+    def __init__(self, args=None, kwargs=None):
+        self.args = args if args is not None else ()
+        self.kwargs = kwargs if kwargs is not None else {}
+
+    def apply(self, task):
+        raise NotImplementedError
+
+
+class Enqueue(Schedule):
+    """Enqueue the task once, immediately, on apply."""
+
+    def apply(self, task):
+        task.enqueue(args=self.args, kwargs=self.kwargs)
+
+
+class EnqueueIn(Schedule):
+    """
+    Enqueue the task ``delta`` from now. ``interval``/``repeat`` make it recur;
+    ``retry_interval`` sets the delay before a failed run is retried.
+    """
+
+    def __init__(
+        self, delta, interval=0, repeat=0, retry_interval=None, args=None, kwargs=None
+    ):
+        super().__init__(args=args, kwargs=kwargs)
+        self.delta = delta
+        self.interval = interval
+        self.repeat = repeat
+        self.retry_interval = retry_interval
+
+    def apply(self, task):
+        task.enqueue_in(
+            self.delta,
+            interval=self.interval,
+            repeat=self.repeat,
+            retry_interval=self.retry_interval,
+            args=self.args,
+            kwargs=self.kwargs,
+        )
+
+
+class Cron(Schedule):
+    """
+    Schedule a task at a calendar-aligned time.
+
+    Fields (set from coarsest to finest): day_of_week (0=Monday), hour, minute.
+    Cadence: day_of_week set → WEEK; hour set → DAY; minute set → HOUR.
+    """
+
+    def __init__(
+        self,
+        minute=None,
+        hour=None,
+        day_of_week=None,
+        repeat=None,
+        retry_interval=None,
+        args=None,
+        kwargs=None,
+    ):
+        super().__init__(args=args, kwargs=kwargs)
+        self.minute = minute
+        self.hour = hour
+        self.day_of_week = day_of_week
+        self.repeat = repeat
+        self.retry_interval = retry_interval
+
+    def _interval(self):
+        if self.day_of_week is not None:
+            return WEEK
+        if self.hour is not None:
+            return DAY
+        return HOUR
+
+    def _next_occurrence(self, interval):
+        now = local_now()
+        candidate = now.replace(
+            hour=self.hour if self.hour is not None else now.hour,
+            minute=self.minute if self.minute is not None else 0,
+            second=0,
+            microsecond=0,
+        )
+        if self.day_of_week is not None:
+            days_ahead = (self.day_of_week - now.weekday()) % 7
+            candidate = candidate + timedelta(days=days_ahead)
+
+        # A candidate that already passed rolls forward by exactly one cadence.
+        if candidate <= now:
+            candidate = candidate + timedelta(seconds=interval)
+
+        return candidate
+
+    def apply(self, task):
+        interval = self._interval()
+        when = self._next_occurrence(interval)
+        task.enqueue_at(
+            when,
+            interval=interval,
+            repeat=self.repeat,
+            retry_interval=self.retry_interval,
+            args=self.args,
+            kwargs=self.kwargs,
+        )

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -791,6 +791,7 @@ class Storage:
         state=None,
         supervisor_id=None,
         expected_supervisor_id=NO_VALUE,
+        repeat=NO_VALUE,
         **kwargs,
     ):
         """
@@ -814,7 +815,7 @@ class Storage:
             if handled:
                 return result
 
-            self._write_job_update(job, orm_job, state, supervisor_id, kwargs)
+            self._write_job_update(job, orm_job, state, supervisor_id, kwargs, repeat)
             for hook in self._hooks:
                 hook.update(job, orm_job, state=state, **kwargs)
             return True
@@ -842,7 +843,9 @@ class Storage:
             return True, False
         return False, None
 
-    def _write_job_update(self, job, orm_job, state, supervisor_id, kwargs):
+    def _write_job_update(
+        self, job, orm_job, state, supervisor_id, kwargs, repeat=NO_VALUE
+    ):
         if state is not None:
             orm_job.state = job.state = state
             # Ownership exists only in supervised states; a bare re-mark
@@ -852,6 +855,9 @@ class Storage:
                     orm_job.supervisor_id = supervisor_id
             else:
                 orm_job.supervisor_id = None
+        # repeat is nullable, so None is a real value; NO_VALUE means "leave it".
+        if repeat is not NO_VALUE:
+            orm_job.repeat = repeat
         for kwarg in kwargs:
             if kwarg in Job.UPDATEABLE_KEYS:
                 setattr(job, kwarg, kwargs[kwarg])

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -797,3 +797,28 @@ class TestBackend:
         assert requeued_orm_job.priority == priority
         assert requeued_orm_job.repeat == repeat - 1
         assert requeued_orm_job.retry_interval == retry_interval
+
+    def test_update_job_repeat_zero_prevents_reschedule(
+        self, defaultbackend, simplejob
+    ):
+        # Enqueue a forever-repeating job, complete it, then persist repeat=0 via
+        # _update_job and confirm reschedule_finished_job_if_needed does not re-arm it.
+        job_id = defaultbackend.schedule(
+            defaultbackend._now(), simplejob, queue=QUEUE, repeat=None, interval=1
+        )
+        defaultbackend.complete_job(job_id)
+
+        # Persist repeat=0 directly on the orm row (the new _update_job param).
+        defaultbackend._update_job(job_id, repeat=0)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        assert orm_job.repeat == 0
+
+        defaultbackend.reschedule_finished_job_if_needed(job_id)
+
+        final_orm_job = defaultbackend.get_orm_job(job_id)
+        final_job = defaultbackend.get_job(job_id)
+
+        # The job must stay completed — not re-queued.
+        assert final_job.state == State.COMPLETED
+        assert final_orm_job.repeat == 0

--- a/kolibri/core/tasks/test/test_decorators.py
+++ b/kolibri/core/tasks/test/test_decorators.py
@@ -41,6 +41,7 @@ class TestTaskDecorators(TestCase):
             long_running=False,
             status_fn=status_fn,
             retry_on=[],
+            schedule=None,
         )
 
     def test_register_decorator_registers_without_args(self):

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -442,6 +442,10 @@ class JobTest(TestCase):
         )
         self.assertEqual(self.job.extra_metadata["step"], 4)
 
+    def test_job_stop_repeating_not_running(self):
+        with self.assertRaises(JobNotRunning):
+            self.job.stop_repeating()
+
     # End of generated tests
 
 

--- a/kolibri/core/tasks/test/test_kolibri_plugin.py
+++ b/kolibri/core/tasks/test/test_kolibri_plugin.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+
+from kolibri.core.analytics.tasks import DEFAULT_PING_JOB_ID
+from kolibri.core.analytics.tasks import LOCAL_NOTIFICATION_JOB_ID
+from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
+from kolibri.core.deviceadmin.tasks import STREAMED_CACHE_CLEANUP_JOB_ID
+from kolibri.core.tasks.job import Job
+from kolibri.core.tasks.kolibri_plugin import ScheduledTasksPlugin
+from kolibri.core.tasks.registry import TaskRegistry
+from kolibri.core.tasks.storage import Storage
+from kolibri.utils.time_utils import local_now
+
+
+@pytest.fixture
+def job_storage():
+    s = Storage()
+    s.clear()
+    yield s
+    s.clear()
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+class TestScheduledTasksPlugin:
+    def test_scheduled_jobs_persist_on_restart(self, job_storage):
+        with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
+            # Schedule two user-defined jobs alongside the declared ones.
+            schedule_time = local_now() + timedelta(hours=1)
+            test1 = job_storage.schedule(schedule_time, Job(id))
+            test2 = job_storage.schedule(schedule_time, Job(id))
+
+            scheduled_tasks_plugin = ScheduledTasksPlugin(mock.MagicMock(name="bus"))
+            scheduled_tasks_plugin.START()
+
+            # START must enqueue every task that declares a schedule, on top of
+            # the two user-defined jobs above.
+            scheduled = [t for t in TaskRegistry.values() if t.schedule is not None]
+            assert len(job_storage) == 2 + len(scheduled)
+            assert job_storage.get_job(test1) is not None
+            assert job_storage.get_job(test2) is not None
+            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
+            assert job_storage.get_job(LOCAL_NOTIFICATION_JOB_ID) is not None
+            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
+            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
+
+            # A restart re-runs START; already-scheduled jobs must not duplicate.
+            scheduled_tasks_plugin.START()
+
+            assert len(job_storage) == 2 + len(scheduled)
+            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
+            assert job_storage.get_job(LOCAL_NOTIFICATION_JOB_ID) is not None
+            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
+            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None

--- a/kolibri/core/tasks/test/test_registry.py
+++ b/kolibri/core/tasks/test/test_registry.py
@@ -1,7 +1,12 @@
+from unittest import mock
+
 from django.test import TestCase
 
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.registry import _registry
 from kolibri.core.tasks.registry import RegisteredTask
+from kolibri.core.tasks.schedules import Enqueue
+from kolibri.core.tasks.schedules import Schedule
 
 
 def _task():
@@ -31,3 +36,41 @@ class TestRegistryUpdate(TestCase):
 
         with self.assertRaises(TypeError):
             reg.update({"k": "not a RegisteredTask"})
+
+
+class TestScheduleAttr(TestCase):
+    def test_schedule_stored(self):
+        s = Enqueue()
+        self.assertIs(RegisteredTask(lambda: None, schedule=s).schedule, s)
+
+    def test_schedule_must_be_schedule_or_none(self):
+        with self.assertRaises(TypeError):
+            RegisteredTask(lambda: None, schedule=True)
+
+
+class TestApplySchedules(TestCase):
+    def _reg_with_tasks(self, *tasks):
+        reg = _registry()
+        for i, task in enumerate(tasks):
+            dict.__setitem__(reg, str(i), task)
+        return reg
+
+    def test_skips_tasks_with_no_schedule(self):
+        s = mock.create_autospec(Schedule, instance=True)
+        scheduled = RegisteredTask(lambda: None, schedule=s)
+        plain = RegisteredTask(lambda: None)
+        reg = self._reg_with_tasks(scheduled, plain)
+
+        with mock.patch.object(reg, "_initialize"):
+            reg.apply_schedules()
+
+        s.apply.assert_called_once_with(scheduled)
+
+    def test_swallows_job_running(self):
+        s = mock.create_autospec(Schedule, instance=True)
+        s.apply.side_effect = JobRunning
+        task = RegisteredTask(lambda: None, schedule=s)
+        reg = self._reg_with_tasks(task)
+
+        with mock.patch.object(reg, "_initialize"):
+            reg.apply_schedules()  # must not raise

--- a/kolibri/core/tasks/test/test_schedules.py
+++ b/kolibri/core/tasks/test/test_schedules.py
@@ -1,0 +1,161 @@
+from datetime import datetime
+from datetime import timedelta
+from unittest import mock
+
+from kolibri.core.tasks.schedules import Cron
+from kolibri.core.tasks.schedules import DAY
+from kolibri.core.tasks.schedules import Enqueue
+from kolibri.core.tasks.schedules import EnqueueIn
+from kolibri.core.tasks.schedules import HOUR
+from kolibri.core.tasks.schedules import WEEK
+
+
+class TestEnqueue:
+    def test_forwards_args_kwargs(self):
+        task = mock.Mock()
+        Enqueue(args=(1, 2), kwargs={"x": 3}).apply(task)
+        task.enqueue.assert_called_once_with(args=(1, 2), kwargs={"x": 3})
+
+
+class TestEnqueueIn:
+    def test_forwards_all_params(self):
+        task = mock.Mock()
+        EnqueueIn(
+            timedelta(hours=1),
+            interval=HOUR,
+            repeat=None,
+            retry_interval=60,
+            args=(5,),
+            kwargs={"x": 1},
+        ).apply(task)
+        task.enqueue_in.assert_called_once_with(
+            timedelta(hours=1),
+            interval=HOUR,
+            repeat=None,
+            retry_interval=60,
+            args=(5,),
+            kwargs={"x": 1},
+        )
+
+
+class TestCron:
+    # Fixed "now": Tuesday 2026-06-30 04:15:30 local time
+    # weekday() == 1 (Tuesday)
+    FIXED_NOW = datetime(2026, 6, 30, 4, 15, 30)
+
+    def _patch_now(self, dt=None):
+        return mock.patch(
+            "kolibri.core.tasks.schedules.local_now",
+            return_value=dt or self.FIXED_NOW,
+        )
+
+    def test_daily_future_hour(self):
+        task = mock.Mock()
+        with self._patch_now():
+            Cron(hour=5).apply(task)
+        expected = self.FIXED_NOW.replace(hour=5, minute=0, second=0, microsecond=0)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=DAY,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_daily_past_hour_rolls_to_tomorrow(self):
+        task = mock.Mock()
+        with self._patch_now():
+            # hour=3 is before now (04:00), so must roll to tomorrow
+            Cron(hour=3).apply(task)
+        expected = self.FIXED_NOW.replace(
+            hour=3, minute=0, second=0, microsecond=0
+        ) + timedelta(days=1)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=DAY,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_hourly_future_minute(self):
+        task = mock.Mock()
+        with self._patch_now():
+            # minute=30, now is 04:15:30 → next is 04:30
+            Cron(minute=30).apply(task)
+        expected = self.FIXED_NOW.replace(minute=30, second=0, microsecond=0)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=HOUR,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_hourly_past_minute_rolls_to_next_hour(self):
+        task = mock.Mock()
+        # now is 04:30, minute=0 is past → next is 05:00
+        now = datetime(2026, 6, 30, 4, 30, 0)
+        with self._patch_now(now):
+            Cron(minute=0).apply(task)
+        expected = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=HOUR,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_weekly_future_weekday(self):
+        task = mock.Mock()
+        # now is Tuesday; Monday (0) is in future (next Monday)
+        with self._patch_now():
+            Cron(day_of_week=0, hour=3).apply(task)
+        # today is Tuesday (weekday=1); Monday (0) is 6 days ahead
+        days_ahead = 6
+        expected = self.FIXED_NOW.replace(
+            hour=3, minute=0, second=0, microsecond=0
+        ) + timedelta(days=days_ahead)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=WEEK,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_weekly_same_weekday_past_hour(self):
+        task = mock.Mock()
+        # now is Tuesday 04:00; Tuesday at 03:00 is past → next Tuesday
+        with self._patch_now():
+            Cron(day_of_week=1, hour=3).apply(task)
+        days_ahead = 7  # same weekday but time passed → skip to next week
+        expected = self.FIXED_NOW.replace(
+            hour=3, minute=0, second=0, microsecond=0
+        ) + timedelta(days=days_ahead)
+        task.enqueue_at.assert_called_once_with(
+            expected,
+            interval=WEEK,
+            repeat=None,
+            retry_interval=None,
+            args=(),
+            kwargs={},
+        )
+
+    def test_forwards_repeat_retry_interval_args_kwargs(self):
+        task = mock.Mock()
+        with self._patch_now():
+            Cron(
+                hour=5, repeat=10, retry_interval=30, args=(1,), kwargs={"a": 2}
+            ).apply(task)
+        _, kwargs = task.enqueue_at.call_args
+        assert kwargs["repeat"] == 10
+        assert kwargs["retry_interval"] == 30
+        assert kwargs["args"] == (1,)
+        assert kwargs["kwargs"] == {"a": 2}

--- a/kolibri/utils/server/__init__.py
+++ b/kolibri/utils/server/__init__.py
@@ -256,26 +256,6 @@ class ZipContentServerPlugin(ServerPlugin):
     START.priority = 75
 
 
-class DefaultScheduledTasksPlugin(SimplePlugin):
-    def START(self):
-        from kolibri.core.analytics.tasks import schedule_local_notification_generation
-        from kolibri.core.analytics.tasks import schedule_ping
-        from kolibri.core.deviceadmin.tasks import schedule_streamed_cache_cleanup
-        from kolibri.core.deviceadmin.tasks import schedule_vacuum
-
-        # schedule the pingback job if not already scheduled
-        schedule_ping()
-
-        # schedule the local-notification generator (impact-stories) if not already scheduled
-        schedule_local_notification_generation()
-
-        # schedule the vacuum job if not already scheduled
-        schedule_vacuum()
-
-        # schedule the streamed cache cleanup job if not already scheduled
-        schedule_streamed_cache_cleanup()
-
-
 class ServicesPlugin(SimplePlugin):
     def __init__(self, bus):
         self.bus = bus
@@ -788,8 +768,10 @@ class BaseKolibriProcessBus(ProcessBus):
         reload_plugin = ProcessControlPlugin(self)
         reload_plugin.subscribe()
 
-        default_scheduled_tasks_plugin = DefaultScheduledTasksPlugin(self)
-        default_scheduled_tasks_plugin.subscribe()
+        # Subscribe process hooks on the base bus so they run under the
+        # services-only bus (e.g. task scheduling) as well as the full server.
+        for process_hook in KolibriProcessHook.registered_hooks:
+            process_hook.MagicBusPluginClass(self).subscribe()
 
     def run(self):
         self.graceful()
@@ -909,10 +891,6 @@ class KolibriProcessBus(KolibriServicesProcessBus):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        for process_hook in KolibriProcessHook.registered_hooks:
-            process_plugin = process_hook.MagicBusPluginClass(self)
-            process_plugin.subscribe()
 
         kolibri_server = KolibriServerPlugin(
             self,

--- a/kolibri/utils/server/hooks.py
+++ b/kolibri/utils/server/hooks.py
@@ -6,7 +6,8 @@ from kolibri.plugins.hooks import KolibriHook
 
 @define_hook
 class KolibriProcessHook(KolibriHook):
-    # A hook to add a magicbus plugin to the full server lifecycle
+    # A hook to add a magicbus plugin to every Kolibri process bus lifecycle
+    # (the services-only bus as well as the full server)
 
     @property
     @abstractmethod

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -8,8 +8,6 @@ from unittest import TestCase
 import mock
 import pytest
 
-from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.storage import Storage
 from kolibri.utils import server
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.constants import installation_types
@@ -80,16 +78,7 @@ class TestServerInstallation:
         )
 
 
-@pytest.fixture
-def job_storage():
-    s = Storage()
-    s.clear()
-    yield s
-    s.clear()
-
-
 class TestServerServices:
-    @mock.patch("kolibri.core.deviceadmin.tasks.schedule_vacuum")
     @mock.patch("kolibri.core.analytics.tasks.schedule_ping")
     @mock.patch("kolibri.core.tasks.main.initialize_workers")
     @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
@@ -98,7 +87,6 @@ class TestServerServices:
         mock_kolibri_broadcast,
         initialize_workers,
         schedule_ping,
-        schedule_vacuum,
     ):
         # Start server services
         services_plugin = server.ServicesPlugin(mock.MagicMock(name="bus"))
@@ -129,57 +117,20 @@ class TestServerServices:
         ]
 
 
-@pytest.mark.django_db(databases="__all__", transaction=True)
-class TestServerDefaultScheduledTasks:
-    @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
-    def test_scheduled_jobs_persist_on_restart(
-        self,
-        mock_kolibri_broadcast,
-        job_storage,
-    ):
-        with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
-            # Schedule two userdefined jobs
-            from datetime import timedelta
+class TestProcessHookWiring:
+    @mock.patch("kolibri.utils.server.KolibriProcessHook")
+    def test_hooks_subscribe_on_services_bus(self, mock_process_hook, tmp_path):
+        # Process hooks must wire onto the services bus, not only the full server
+        # bus, so plugins like task scheduling run under `kolibri services` too.
+        plugin = mock.MagicMock()
+        hook = mock.MagicMock()
+        hook.MagicBusPluginClass.return_value = plugin
+        mock_process_hook.registered_hooks = [hook]
 
-            from kolibri.utils.time_utils import local_now
+        bus = server.KolibriServicesProcessBus(pid_file=str(tmp_path / "pid"))
 
-            schedule_time = local_now() + timedelta(hours=1)
-            test1 = job_storage.schedule(schedule_time, Job(id))
-            test2 = job_storage.schedule(schedule_time, Job(id))
-
-            # Now, start services plugin
-            default_scheduled_tasks_plugin = server.DefaultScheduledTasksPlugin(
-                mock.MagicMock(name="bus")
-            )
-            default_scheduled_tasks_plugin.START()
-
-            # We must have exactly six scheduled jobs: the two user-defined
-            # jobs above plus four server-defined jobs (pingback, local
-            # notifications, vacuum, and streamed cache cleanup).
-            from kolibri.core.analytics.tasks import DEFAULT_PING_JOB_ID
-            from kolibri.core.analytics.tasks import LOCAL_NOTIFICATION_JOB_ID
-            from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
-            from kolibri.core.deviceadmin.tasks import STREAMED_CACHE_CLEANUP_JOB_ID
-
-            assert len(job_storage) == 6
-            assert job_storage.get_job(test1) is not None
-            assert job_storage.get_job(test2) is not None
-            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
-            assert job_storage.get_job(LOCAL_NOTIFICATION_JOB_ID) is not None
-            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
-            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
-
-            # Restart services
-            default_scheduled_tasks_plugin.START()
-
-            # Make sure all scheduled jobs persist after restart
-            assert len(job_storage) == 6
-            assert job_storage.get_job(test1) is not None
-            assert job_storage.get_job(test2) is not None
-            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
-            assert job_storage.get_job(LOCAL_NOTIFICATION_JOB_ID) is not None
-            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
-            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
+        hook.MagicBusPluginClass.assert_called_once_with(bus)
+        plugin.subscribe.assert_called_once_with()
 
 
 class TestZeroConfPlugin:


### PR DESCRIPTION
## Summary
* Introduce a "Schedule" primitive to allow individual jobs to specify their repeated run conditions declaratively rather than having to inject themselves into the "DefaultTaskSchedulerPlugin".
* Adds a "Cron" schedule type (but without class crontab six digit syntax because it confuses me) for flexible, repeating scheduling
* Migrates all of our existing "start at startup" tasks to use this
* Moves the DefaultTaskSchedule plugin from server/__init__.py into the tasks module using the server hook


Note: this was primarily motivated by some follow up work for thundering herd protection when doing load testing - split it out for ease of review as a self contained and understandable refactor.

## References
None

## Reviewer guidance
There is a small change in semantics for the task startups where some might run earlier than they did because of a switch from enqueue_in to cron - I made the change because it didn't really seem to matter and it was easier to understand when using the "at a certain time" schedule.

Generally just confirming that after startup tasks are properly enqueued in the task DB should be sufficient here!

## AI usage

I used Claude to do this refactor while working on an implementation that added _yet another_ startup task. It extracted it into a standalone PR for easier review. I used Claude to research other Python task implementations to decide on the final API design - finding that the 'Cron' type construct was very commonly used, with the more user friendly interface of day of month, time of day, etc.