### PR TITLE
Scoped field updates in custom Morango sync ops

### DIFF
--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -123,7 +123,7 @@ class KolibriNetworkInitializeOperation(NetworkInitializeOperation):
             # session and context objects to reflect the change
             context.update(sync_filter=response_filter)
             context.transfer_session.filter = str(response_filter)
-            context.transfer_session.save()
+            context.transfer_session.save(update_fields=["filter"])
 
         return response_data
 
@@ -202,7 +202,7 @@ class KolibriSyncOperationMixin(BaseOperation):
         extra_fields = self._get_storage(context)
         extra_fields.update(**storage)
         context.sync_session.extra_fields = json.dumps(extra_fields)
-        context.sync_session.save()
+        context.sync_session.save(update_fields=["extra_fields"])
 
     def has_handled(self, context):
         """

--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -112,7 +112,9 @@ class KolibriSyncOperationMixinTestCase(SimpleTestCase):
         self.operation._update_storage(self.context, {"appended": 1})
         actual_json = json.loads(self.context.sync_session.extra_fields)
         self.assertEqual({"test": True, "appended": 1}, actual_json)
-        self.context.sync_session.save.assert_called_once_with()
+        self.context.sync_session.save.assert_called_once_with(
+            update_fields=["extra_fields"]
+        )
 
     @mock.patch(
         "kolibri.core.auth.sync_operations.KolibriSyncOperationMixin._get_storage"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.17
 jsonfield==3.1.0
-morango==0.8.14
+morango==0.8.15
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
- Updates morango model saves in Kolibri's sync operations to scope the saves to only the updated fields, similar to the corresponding morango PR (referenced below)
- Upgrades morango to v0.8.15

## References
<!--
 * references to related issues and PRs
-->

Related to this investigation:
- https://github.com/learningequality/kolibri-sync-extras-plugin/issues/14
- https://github.com/learningequality/kolibri-sync-extras-plugin/pull/15

Also, this corresponding morango update:
- https://github.com/learningequality/morango/pull/346

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
The guidance in https://github.com/learningequality/kolibri-sync-extras-plugin/pull/15 is sufficient. Morango integ tests pass

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
None