### PR TITLE
test: migrate RearrangeChannelsPage, AvailableChannelsPage, NewChannelVersionPage from VTU to VTL (Part 2-4/4) (#14261)

### DIFF
--- a/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
+++ b/kolibri/plugins/device/frontend/__tests__/utils/makeStore.js
@@ -71,7 +71,7 @@ export default function makeStore() {
 }
 // Use for availableChannelsPage and all children:
 // channel-list-item
-export function makeAvailableChannelsPageStore({ channelList } = {}) {
+export function makeAvailableChannelsPageStore({ channelList, transferType = 'localimport' } = {}) {
   const store = createStore(cloneDeep(pluginModule));
   store.state.manageContent.channelList =
     channelList !== undefined ? channelList : [...channelsOnDevice];
@@ -87,7 +87,7 @@ export function makeAvailableChannelsPageStore({ channelList } = {}) {
       },
     ],
     availableChannels: [...allChannels],
-    transferType: 'localimport',
+    transferType,
   });
   return store;
 }

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -1,15 +1,21 @@
 import { render, screen, waitFor, within, fireEvent } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import { createTranslator } from 'kolibri/utils/i18n';
+import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
 import AvailableChannelsPage from '../AvailableChannelsPage';
+import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
 import FilteredChannelListContainer from '../ManageContentPage/FilteredChannelListContainer';
 import WithImportDetails from '../ManageContentPage/ChannelPanel/WithImportDetails';
 import { makeAvailableChannelsPageStore } from '../../__tests__/utils/makeStore';
+import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
 import { PageNames } from '../../constants';
 
 jest.mock('kolibri/urls');
 jest.mock('kolibri/client');
 jest.mock('kolibri-common/composables/usePageLoading');
+jest.mock('../../modules/wizard/utils', () => ({
+  getRemoteChannelBundleByToken: jest.fn(),
+}));
 
 const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
   AvailableChannelsPage.name,
@@ -25,6 +31,8 @@ const { onYourDevice$, selectResourcesAction$ } = createTranslator(
   WithImportDetails.name,
   WithImportDetails.$trs,
 );
+const { channelTokenLabel$ } = createTranslator(ChannelTokenModal.name, ChannelTokenModal.$trs);
+const { continueAction$ } = coreStrings;
 
 function createRouter() {
   return new VueRouter({
@@ -43,10 +51,13 @@ function createRouter() {
 async function renderComponent({ store } = {}) {
   const router = createRouter();
   await router.push({ name: 'AVAILABLE_CHANNELS' });
-  return render(AvailableChannelsPage, {
+  const result = render(AvailableChannelsPage, {
     store: store || makeAvailableChannelsPageStore(),
     router,
   });
+  // Return the router alongside the usual render result so tests can inspect
+  // navigation (route name/params) after actions like submitting a token.
+  return { ...result, router };
 }
 
 describe('AvailableChannelsPage', () => {
@@ -265,5 +276,89 @@ describe('AvailableChannelsPage', () => {
       'href',
       expect.stringContaining('/content/channel/awesome_channel'),
     );
+  });
+
+  describe('submitting an unlisted channel token', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('navigates to the select content page for a new (not-yet-installed) channel', async () => {
+      const store = makeAvailableChannelsPageStore();
+      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+      const { router } = await renderComponent({ store });
+
+      const newChannel = { id: 'new_channel', version: 1 };
+      getRemoteChannelBundleByToken.mockResolvedValue([newChannel]);
+
+      // Open the token modal via the "unlisted channel" button.
+      const tokenButton = screen.getByText(channelTokenButtonLabel$());
+      await fireEvent.click(tokenButton);
+
+      const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
+      await fireEvent.update(textbox, 'some-token');
+
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
+      await fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(router.currentRoute.name).toEqual('SELECT_CONTENT');
+        expect(router.currentRoute.params.channel_id).toEqual('new_channel');
+      });
+    });
+
+    it('adds the token to the url query when it points to multiple channels', async () => {
+      const store = makeAvailableChannelsPageStore();
+      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+      const { router } = await renderComponent({ store });
+
+      const collectionChannels = [
+        { id: 'collection_channel_1', version: 1 },
+        { id: 'collection_channel_2', version: 1 },
+      ];
+      getRemoteChannelBundleByToken.mockResolvedValue(collectionChannels);
+
+      const tokenButton = screen.getByText(channelTokenButtonLabel$());
+      await fireEvent.click(tokenButton);
+
+      const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
+      await fireEvent.update(textbox, 'collection-token');
+
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
+      await fireEvent.click(submitButton);
+
+      // No page redirect happens for a collection token — instead the token is
+      // added to the current page's own url query so the channel list can use it.
+      await waitFor(() => {
+        expect(router.currentRoute.name).toEqual('AVAILABLE_CHANNELS');
+        expect(router.currentRoute.query.token).toEqual('collection-token');
+      });
+    });
+
+    it('navigates to the new channel version page when an installed channel has a newer version', async () => {
+      const store = makeAvailableChannelsPageStore();
+      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+      const { router } = await renderComponent({ store });
+
+      // Awesome Channel is already installed at version 10 in the fixture data;
+      // a token pointing to a newer version of the same channel should redirect
+      // to the version-upgrade page rather than straight to select content.
+      const updatedChannel = { id: 'awesome_channel', version: 11 };
+      getRemoteChannelBundleByToken.mockResolvedValue([updatedChannel]);
+
+      const tokenButton = screen.getByText(channelTokenButtonLabel$());
+      await fireEvent.click(tokenButton);
+
+      const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
+      await fireEvent.update(textbox, 'update-token');
+
+      const submitButton = screen.getByRole('button', { name: continueAction$() });
+      await fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(router.currentRoute.name).toEqual('NEW_CHANNEL_VERSION_PAGE');
+        expect(router.currentRoute.params.channel_id).toEqual('awesome_channel');
+      });
+    });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -16,7 +16,7 @@ const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
   AvailableChannelsPage.$trs,
 );
 
-const { numChannelsAvailable$ } = createTranslator(
+const { numChannelsAvailable$, allLanguages$ } = createTranslator(
   FilteredChannelListContainer.name,
   FilteredChannelListContainer.$trs,
 );
@@ -117,5 +117,24 @@ describe('AvailableChannelsPage', () => {
     // Bird (available: false) and Hunden (not in installed channelList) should not show it
     expect(isOnDevice('Bird Channel')).toBe(false);
     expect(isOnDevice('Hunden Channel')).toBe(false);
+  });
+  it('shows the correct language filter options', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    // The dropdown's currently-selected value is also rendered separately from the
+    // options list, so we scope our search to just the options list to avoid duplicates.
+    const optionsList = document.querySelector('.ui-select-options');
+    // These language names come from fixture data (lang_name), not app translations,
+    // so we store them in variables rather than passing literals directly to getByText.
+    const englishLanguageName = 'English';
+    const germanLanguageName = 'German';
+    expect(within(optionsList).getByText(allLanguages$())).toBeInTheDocument();
+    expect(within(optionsList).getByText(englishLanguageName)).toBeInTheDocument();
+    expect(within(optionsList).getByText(germanLanguageName)).toBeInTheDocument();
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -1,21 +1,20 @@
-import { render, screen, waitFor, within, fireEvent } from '@testing-library/vue';
+import { render, screen, waitFor, within } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 import { createTranslator } from 'kolibri/utils/i18n';
 import { coreStrings } from 'kolibri/uiText/commonCoreStrings';
+import RemoteChannelResource from 'kolibri-common/apiResources/RemoteChannelResource';
 import AvailableChannelsPage from '../AvailableChannelsPage';
 import ChannelTokenModal from '../AvailableChannelsPage/ChannelTokenModal';
 import FilteredChannelListContainer from '../ManageContentPage/FilteredChannelListContainer';
 import WithImportDetails from '../ManageContentPage/ChannelPanel/WithImportDetails';
 import { makeAvailableChannelsPageStore } from '../../__tests__/utils/makeStore';
-import { getRemoteChannelBundleByToken } from '../../modules/wizard/utils';
 import { PageNames } from '../../constants';
 
 jest.mock('kolibri/urls');
 jest.mock('kolibri/client');
 jest.mock('kolibri-common/composables/usePageLoading');
-jest.mock('../../modules/wizard/utils', () => ({
-  getRemoteChannelBundleByToken: jest.fn(),
-}));
+jest.mock('kolibri-common/apiResources/RemoteChannelResource');
 
 const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
   AvailableChannelsPage.name,
@@ -62,8 +61,7 @@ async function renderComponent({ store } = {}) {
 
 describe('AvailableChannelsPage', () => {
   it('in REMOTEIMPORT mode, the unlisted channel button is available', async () => {
-    const store = makeAvailableChannelsPageStore();
-    store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+    const store = makeAvailableChannelsPageStore({ transferType: 'remoteimport' });
     await renderComponent({ store });
 
     await waitFor(() => {
@@ -72,8 +70,7 @@ describe('AvailableChannelsPage', () => {
   });
 
   it('in LOCALIMPORT mode, the unlisted channel button is not available', async () => {
-    const store = makeAvailableChannelsPageStore();
-    store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'localimport');
+    const store = makeAvailableChannelsPageStore({ transferType: 'localimport' });
     await renderComponent({ store });
 
     await waitFor(() => {
@@ -163,12 +160,13 @@ describe('AvailableChannelsPage', () => {
 
     // KSelect is a custom dropdown, not a native <select>: clicking its label
     // toggles the options list open, same as a real user would.
+    const user = userEvent.setup();
     const dropdownLabel = document.querySelector('.ui-select-label');
-    await fireEvent.click(dropdownLabel);
+    await user.click(dropdownLabel);
 
     const optionsList = document.querySelector('.ui-select-options');
     const germanLanguageName = 'German';
-    await fireEvent.click(within(optionsList).getByText(germanLanguageName));
+    await user.click(within(optionsList).getByText(germanLanguageName));
 
     // Only Hunden and Kaetze channels have lang_code 'de' in the fixture data.
     await waitFor(() => {
@@ -198,8 +196,9 @@ describe('AvailableChannelsPage', () => {
       expect(screen.getByTestId('available')).toBeInTheDocument();
     });
 
+    const user = userEvent.setup();
     const searchInput = screen.getByPlaceholderText(titleFilterPlaceholder$());
-    await fireEvent.update(searchInput, 'Bird');
+    await user.type(searchInput, 'Bird');
 
     await waitFor(() => {
       expect(screen.getByTestId('available')).toHaveTextContent(
@@ -225,12 +224,13 @@ describe('AvailableChannelsPage', () => {
       expect(screen.getByTestId('available')).toBeInTheDocument();
     });
 
+    const user = userEvent.setup();
     // Select German in the language filter first.
     const dropdownLabel = document.querySelector('.ui-select-label');
-    await fireEvent.click(dropdownLabel);
+    await user.click(dropdownLabel);
     const optionsList = document.querySelector('.ui-select-options');
     const germanLanguageName = 'German';
-    await fireEvent.click(within(optionsList).getByText(germanLanguageName));
+    await user.click(within(optionsList).getByText(germanLanguageName));
 
     await waitFor(() => {
       expect(screen.getByTestId('available')).toHaveTextContent(
@@ -241,7 +241,7 @@ describe('AvailableChannelsPage', () => {
     // Then narrow further by keyword. Both Hunden and Kaetze are German, but
     // only Kaetze should remain once we filter by name too.
     const searchInput = screen.getByPlaceholderText(titleFilterPlaceholder$());
-    await fireEvent.update(searchInput, 'Kaetze');
+    await user.type(searchInput, 'Kaetze');
 
     await waitFor(() => {
       expect(screen.getByTestId('available')).toHaveTextContent(
@@ -284,22 +284,22 @@ describe('AvailableChannelsPage', () => {
     });
 
     it('navigates to the select content page for a new (not-yet-installed) channel', async () => {
-      const store = makeAvailableChannelsPageStore();
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+      const store = makeAvailableChannelsPageStore({ transferType: 'remoteimport' });
       const { router } = await renderComponent({ store });
 
+      const user = userEvent.setup();
       const newChannel = { id: 'new_channel', version: 1 };
-      getRemoteChannelBundleByToken.mockResolvedValue([newChannel]);
+      RemoteChannelResource.list.mockResolvedValue([newChannel]);
 
       // Open the token modal via the "unlisted channel" button.
       const tokenButton = screen.getByText(channelTokenButtonLabel$());
-      await fireEvent.click(tokenButton);
+      await user.click(tokenButton);
 
       const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
-      await fireEvent.update(textbox, 'some-token');
+      await user.type(textbox, 'some-token');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });
-      await fireEvent.click(submitButton);
+      await user.click(submitButton);
 
       await waitFor(() => {
         expect(router.currentRoute.name).toEqual('SELECT_CONTENT');
@@ -312,20 +312,21 @@ describe('AvailableChannelsPage', () => {
       store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
       const { router } = await renderComponent({ store });
 
+      const user = userEvent.setup();
       const collectionChannels = [
         { id: 'collection_channel_1', version: 1 },
         { id: 'collection_channel_2', version: 1 },
       ];
-      getRemoteChannelBundleByToken.mockResolvedValue(collectionChannels);
+      RemoteChannelResource.list.mockResolvedValue(collectionChannels);
 
       const tokenButton = screen.getByText(channelTokenButtonLabel$());
-      await fireEvent.click(tokenButton);
+      await user.click(tokenButton);
 
       const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
-      await fireEvent.update(textbox, 'collection-token');
+      await user.type(textbox, 'collection-token');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });
-      await fireEvent.click(submitButton);
+      await user.click(submitButton);
 
       // No page redirect happens for a collection token — instead the token is
       // added to the current page's own url query so the channel list can use it.
@@ -336,24 +337,24 @@ describe('AvailableChannelsPage', () => {
     });
 
     it('navigates to the new channel version page when an installed channel has a newer version', async () => {
-      const store = makeAvailableChannelsPageStore();
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+      const store = makeAvailableChannelsPageStore({ transferType: 'remoteimport' });
       const { router } = await renderComponent({ store });
 
       // Awesome Channel is already installed at version 10 in the fixture data;
       // a token pointing to a newer version of the same channel should redirect
       // to the version-upgrade page rather than straight to select content.
+      const user = userEvent.setup();
       const updatedChannel = { id: 'awesome_channel', version: 11 };
-      getRemoteChannelBundleByToken.mockResolvedValue([updatedChannel]);
+      RemoteChannelResource.list.mockResolvedValue([updatedChannel]);
 
       const tokenButton = screen.getByText(channelTokenButtonLabel$());
-      await fireEvent.click(tokenButton);
+      await user.click(tokenButton);
 
       const textbox = await screen.findByRole('textbox', { name: channelTokenLabel$() });
-      await fireEvent.update(textbox, 'update-token');
+      await user.type(textbox, 'update-token');
 
       const submitButton = screen.getByRole('button', { name: continueAction$() });
-      await fireEvent.click(submitButton);
+      await user.click(submitButton);
 
       await waitFor(() => {
         expect(router.currentRoute.name).toEqual('NEW_CHANNEL_VERSION_PAGE');

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/vue';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import { createTranslator } from 'kolibri/utils/i18n';
 import AvailableChannelsPage from '../AvailableChannelsPage';
@@ -136,5 +136,42 @@ describe('AvailableChannelsPage', () => {
     expect(within(optionsList).getByText(allLanguages$())).toBeInTheDocument();
     expect(within(optionsList).getByText(englishLanguageName)).toBeInTheDocument();
     expect(within(optionsList).getByText(germanLanguageName)).toBeInTheDocument();
+  });
+
+  it('filters the channel list when a language filter option is selected', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    // KSelect is a custom dropdown, not a native <select>: clicking its label
+    // toggles the options list open, same as a real user would.
+    const dropdownLabel = document.querySelector('.ui-select-label');
+    await fireEvent.click(dropdownLabel);
+
+    const optionsList = document.querySelector('.ui-select-options');
+    const germanLanguageName = 'German';
+    await fireEvent.click(within(optionsList).getByText(germanLanguageName));
+
+    // Only Hunden and Kaetze channels have lang_code 'de' in the fixture data.
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toHaveTextContent(
+        numChannelsAvailable$({ count: 2 }),
+      );
+    });
+
+    const awesomeChannelName = 'Awesome Channel';
+    const birdChannelName = 'Bird Channel';
+    const hundenChannelName = 'Hunden Channel';
+    const kaetzeChannelName = 'Kaetze Channel';
+    // The component uses v-show (not v-if) to filter, so hidden channels stay in
+    // the DOM with display: none rather than being removed — we must check
+    // visibility, not just presence.
+    expect(screen.getByText(awesomeChannelName)).not.toBeVisible();
+    expect(screen.getByText(birdChannelName)).not.toBeVisible();
+    expect(screen.getByText(hundenChannelName)).toBeVisible();
+    expect(screen.getByText(kaetzeChannelName)).toBeVisible();
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -16,11 +16,15 @@ const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
   AvailableChannelsPage.$trs,
 );
 
-const { numChannelsAvailable$, allLanguages$ } = createTranslator(
+const { numChannelsAvailable$, allLanguages$, titleFilterPlaceholder$ } = createTranslator(
   FilteredChannelListContainer.name,
   FilteredChannelListContainer.$trs,
 );
-const { onYourDevice$ } = createTranslator(WithImportDetails.name, WithImportDetails.$trs);
+
+const { onYourDevice$, selectResourcesAction$ } = createTranslator(
+  WithImportDetails.name,
+  WithImportDetails.$trs,
+);
 
 function createRouter() {
   return new VueRouter({
@@ -173,5 +177,93 @@ describe('AvailableChannelsPage', () => {
     expect(screen.getByText(birdChannelName)).not.toBeVisible();
     expect(screen.getByText(hundenChannelName)).toBeVisible();
     expect(screen.getByText(kaetzeChannelName)).toBeVisible();
+  });
+
+  it('filters the channel list by keyword when the title filter is used', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText(titleFilterPlaceholder$());
+    await fireEvent.update(searchInput, 'Bird');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toHaveTextContent(
+        numChannelsAvailable$({ count: 1 }),
+      );
+    });
+
+    const awesomeChannelName = 'Awesome Channel';
+    const birdChannelName = 'Bird Channel';
+    const hundenChannelName = 'Hunden Channel';
+    const kaetzeChannelName = 'Kaetze Channel';
+    expect(screen.getByText(birdChannelName)).toBeVisible();
+    expect(screen.getByText(awesomeChannelName)).not.toBeVisible();
+    expect(screen.getByText(hundenChannelName)).not.toBeVisible();
+    expect(screen.getByText(kaetzeChannelName)).not.toBeVisible();
+  });
+
+  it('filters the channel list using the language and title filters together', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    // Select German in the language filter first.
+    const dropdownLabel = document.querySelector('.ui-select-label');
+    await fireEvent.click(dropdownLabel);
+    const optionsList = document.querySelector('.ui-select-options');
+    const germanLanguageName = 'German';
+    await fireEvent.click(within(optionsList).getByText(germanLanguageName));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toHaveTextContent(
+        numChannelsAvailable$({ count: 2 }),
+      );
+    });
+
+    // Then narrow further by keyword. Both Hunden and Kaetze are German, but
+    // only Kaetze should remain once we filter by name too.
+    const searchInput = screen.getByPlaceholderText(titleFilterPlaceholder$());
+    await fireEvent.update(searchInput, 'Kaetze');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toHaveTextContent(
+        numChannelsAvailable$({ count: 1 }),
+      );
+    });
+
+    const awesomeChannelName = 'Awesome Channel';
+    const birdChannelName = 'Bird Channel';
+    const hundenChannelName = 'Hunden Channel';
+    const kaetzeChannelName = 'Kaetze Channel';
+    expect(screen.getByText(kaetzeChannelName)).toBeVisible();
+    expect(screen.getByText(awesomeChannelName)).not.toBeVisible();
+    expect(screen.getByText(birdChannelName)).not.toBeVisible();
+    expect(screen.getByText(hundenChannelName)).not.toBeVisible();
+  });
+
+  it('links each channel to its select resources page', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    const awesomeChannelName = 'Awesome Channel';
+    const channelBox = screen.getByText(awesomeChannelName).closest('.channel-list-item');
+    const selectLink = within(channelBox).getByRole('link', { name: selectResourcesAction$() });
+
+    // The link's :to prop resolves to the SELECT_CONTENT route with this channel's id.
+    expect(selectLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('/content/channel/awesome_channel'),
+    );
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, within } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import { createTranslator } from 'kolibri/utils/i18n';
 import AvailableChannelsPage from '../AvailableChannelsPage';
 import FilteredChannelListContainer from '../ManageContentPage/FilteredChannelListContainer';
+import WithImportDetails from '../ManageContentPage/ChannelPanel/WithImportDetails';
 import { makeAvailableChannelsPageStore } from '../../__tests__/utils/makeStore';
 import { PageNames } from '../../constants';
 
@@ -14,10 +15,12 @@ const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
   AvailableChannelsPage.name,
   AvailableChannelsPage.$trs,
 );
+
 const { numChannelsAvailable$ } = createTranslator(
   FilteredChannelListContainer.name,
   FilteredChannelListContainer.$trs,
 );
+const { onYourDevice$ } = createTranslator(WithImportDetails.name, WithImportDetails.$trs);
 
 function createRouter() {
   return new VueRouter({
@@ -81,5 +84,38 @@ describe('AvailableChannelsPage', () => {
         numChannelsAvailable$({ count: 4 }),
       );
     });
+  });
+
+  it('if there are no channels, then filters do not appear', async () => {
+    const store = makeAvailableChannelsPageStore();
+    store.commit('manageContent/wizard/SET_AVAILABLE_CHANNELS', []);
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('shows the "on device" indicator only for channels that are installed', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toBeInTheDocument();
+    });
+
+    // Scoped check: find each channel's own box, then look only inside it
+    function isOnDevice(channelName) {
+      const channelBox = screen.getByText(channelName).closest('.channel-list-item');
+      return within(channelBox).queryByText(onYourDevice$()) !== null;
+    }
+
+    // Awesome and Kaetze are installed (available: true in fixture data)
+    expect(isOnDevice('Awesome Channel')).toBe(true);
+    expect(isOnDevice('Kaetze Channel')).toBe(true);
+    // Bird (available: false) and Hunden (not in installed channelList) should not show it
+    expect(isOnDevice('Bird Channel')).toBe(false);
+    expect(isOnDevice('Hunden Channel')).toBe(false);
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/AvailableChannelsPage.spec.js
@@ -1,317 +1,85 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import { createTranslator } from 'kolibri/utils/i18n';
 import AvailableChannelsPage from '../AvailableChannelsPage';
+import FilteredChannelListContainer from '../ManageContentPage/FilteredChannelListContainer';
 import { makeAvailableChannelsPageStore } from '../../__tests__/utils/makeStore';
-import router from './testRouter';
+import { PageNames } from '../../constants';
 
 jest.mock('kolibri/urls');
 jest.mock('kolibri/client');
 jest.mock('kolibri-common/composables/usePageLoading');
 
-function makeWrapper(options = {}) {
-  const { store, props = {} } = options;
-  const defaultProps = {};
-  const node = document.createElement('div');
-  document.body.appendChild(node);
-  return mount(AvailableChannelsPage, {
-    propsData: { ...defaultProps, ...props },
+const { channelTokenButtonLabel$, importResourcesHeader$ } = createTranslator(
+  AvailableChannelsPage.name,
+  AvailableChannelsPage.$trs,
+);
+const { numChannelsAvailable$ } = createTranslator(
+  FilteredChannelListContainer.name,
+  FilteredChannelListContainer.$trs,
+);
+
+function createRouter() {
+  return new VueRouter({
+    routes: [
+      { name: 'AVAILABLE_CHANNELS', path: '/content/channels' },
+      { name: PageNames.MANAGE_CONTENT_PAGE, path: '/content' },
+      { name: 'SELECT_CONTENT', path: '/content/channel/:channel_id?' },
+      {
+        name: PageNames.NEW_CHANNEL_VERSION_PAGE,
+        path: '/content/manage_channel/:channel_id/upgrade',
+      },
+    ],
+  });
+}
+
+async function renderComponent({ store } = {}) {
+  const router = createRouter();
+  await router.push({ name: 'AVAILABLE_CHANNELS' });
+  return render(AvailableChannelsPage, {
     store: store || makeAvailableChannelsPageStore(),
-    ...router,
-    attachTo: node,
+    router,
   });
 }
 
-// prettier-ignore
-function getElements(wrapper) {
-  return {
-    noChannels: () => wrapper.find('.no-channels'),
-    channelsList: () => wrapper.find('.channels-list'),
-    channelsAvailableText: () => wrapper.find('[data-testid="available"]').text().trim(),
-    channelListItems: () => wrapper.findAllComponents({ name: 'WithImportDetails' }),
-    ChannelTokenModal: () => wrapper.findComponent({ name: 'ChannelTokenModal' }),
-    filters: () => wrapper.find('.filters'),
-    languageFilter: () => wrapper.findComponent({ name: 'KSelect' }),
-    titleText: () => wrapper.find('[data-testid="title"]').text().trim(),
-    titleFilter: () => wrapper.findComponent({ name: 'FilterTextbox' }),
-    unlistedChannelsButton: () => wrapper.find('[data-testid="token-button"]'),
-    filterComponent: () => wrapper.findComponent({name: 'FilteredChannelListContainer'}),
-  }
-}
-
-function testChannelVisibility(wrapper, visibilities) {
-  const channels = getElements(wrapper).channelListItems();
-  visibilities.forEach((v, i) => {
-    if (v) {
-      expect(channels.at(i).element).toBeVisible();
-    } else {
-      expect(channels.at(i).element).not.toBeVisible();
-    }
-  });
-}
-
-describe('availableChannelsPage', () => {
-  let store;
-
-  beforeEach(() => {
-    store = makeAvailableChannelsPageStore();
-  });
-
-  function setTransferType(transferType) {
-    store.commit('manageContent/wizard/SET_TRANSFER_TYPE', transferType);
-  }
-
+describe('AvailableChannelsPage', () => {
   it('in REMOTEIMPORT mode, the unlisted channel button is available', async () => {
-    // ...and clicking it opens the channel token modal
-    setTransferType('remoteimport');
-    const wrapper = makeWrapper({ store });
-    const { unlistedChannelsButton, ChannelTokenModal } = getElements(wrapper);
-    // prettier-ignore
-    const button = unlistedChannelsButton();
-    button.trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(ChannelTokenModal().exists()).toEqual(true);
-  });
+    const store = makeAvailableChannelsPageStore();
+    store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
+    await renderComponent({ store });
 
-  it('in LOCALIMPORT mode, the unlisted channel button is not available', () => {
-    setTransferType('localexport');
-    const wrapper = makeWrapper({ store });
-    const { unlistedChannelsButton } = getElements(wrapper);
-    expect(unlistedChannelsButton().exists()).toBe(false);
-  });
-
-  it('in LOCALIMPORT mode, the back link text and title are correct', () => {
-    setTransferType('localimport');
-    const selectedDrive = store.state.manageContent.wizard.driveList.find(
-      ({ id }) => id === 'f9e29616935fbff37913ed46bf20e2c0',
-    );
-    store.state.manageContent.wizard.selectedDrive = selectedDrive;
-    const wrapper = makeWrapper({ store });
-    const { titleText } = getElements(wrapper);
-    expect(titleText()).toEqual('Select resources for import');
-  });
-
-  it('in REMOTEIMPORT mode, the back link text and title are correct', () => {
-    setTransferType('remoteimport');
-    const wrapper = makeWrapper({ store });
-    const { titleText } = getElements(wrapper);
-    expect(titleText()).toEqual('Select resources for import');
-  });
-
-  it('in REMOTEIMPORT/LOCALIMPORT shows the correct number of channels available message', () => {
-    setTransferType('localimport');
-    const wrapper = makeWrapper({ store });
-    const { channelsAvailableText, noChannels } = getElements(wrapper);
-    expect(channelsAvailableText()).toEqual('4 channels available');
-    expect(noChannels().exists()).toEqual(false);
-  });
-
-  it('if there are no channels, then filters do not appear', () => {
-    store.commit('manageContent/wizard/SET_AVAILABLE_CHANNELS', []);
-    const wrapper = makeWrapper({ store });
-    const { filters } = getElements(wrapper);
-    expect(filters().exists()).toEqual(false);
-  });
-
-  it('in LOCALIMPORT/REMOTEIMPORT, channel item (not) on device has the correct props', () => {
-    const wrapper = makeWrapper();
-    const { channelListItems } = getElements(wrapper);
-    const channels = channelListItems();
-    const channelNProps = n => channels.at(n).props();
-    expect(channelNProps(0).onDevice).toEqual(true);
-    expect(channelNProps(1).onDevice).toEqual(true);
-    expect(channelNProps(2).onDevice).toEqual(false);
-    expect(channelNProps(3).onDevice).toEqual(false);
-  });
-
-  it('IN LOCALIMPORT/REMOTEIMPORT, with no filters, all appear', () => {
-    setTransferType('localimport');
-    const wrapper = makeWrapper({ store });
-    const { filterComponent } = getElements(wrapper);
-    const { titleFilter, languageFilter } = filterComponent().vm;
-    expect(titleFilter).toEqual('');
-    expect(languageFilter.value).toEqual('ALL');
-    testChannelVisibility(wrapper, [true, true, true, true]);
-  });
-
-  it('the correct language filter options appear', () => {
-    const wrapper = makeWrapper();
-    const { languageFilter } = getElements(wrapper);
-    // Fake labels for now
-    const expected = [
-      { label: 'All languages', value: 'ALL' },
-      { label: 'English', value: 'en' },
-      { label: 'German', value: 'de' },
-    ];
-    expect(languageFilter().props().options).toEqual(expected);
-  });
-
-  it('with language filter, the correct channels appear', async () => {
-    const wrapper = makeWrapper();
-    const { languageFilter } = getElements(wrapper);
-    const filter = languageFilter();
-    await wrapper.vm.$nextTick();
-    filter.vm.selection = { label: 'English', value: 'en' };
-
-    await wrapper.vm.$nextTick();
-    testChannelVisibility(wrapper, [true, false, false, false]);
-  });
-
-  it('with keyword filter, the correct channels appear', async () => {
-    const wrapper = makeWrapper();
-    const { titleFilter, filterComponent } = getElements(wrapper);
-    const filter = titleFilter();
-    // Can't trigger 'input' event; need to set new value manually
-    filter.vm.model = 'bir ch';
-    await wrapper.vm.$nextTick();
-    expect(filterComponent().vm.titleFilter).toEqual('bir ch');
-    testChannelVisibility(wrapper, [false, false, true, false]);
-  });
-
-  it('with both filters, the correct channels appear', async () => {
-    const wrapper = makeWrapper();
-    const { languageFilter, titleFilter } = getElements(wrapper);
-    const lFilter = languageFilter();
-    const tFilter = titleFilter();
-    tFilter.vm.model = 'hund';
-    await wrapper.vm.$nextTick();
-    lFilter.vm.selection = { label: 'German', value: 'de' };
-    await wrapper.vm.$nextTick();
-    testChannelVisibility(wrapper, [false, false, false, true]);
-  });
-
-  it('the "select" link goes to the correct place', () => {
-    const wrapper = makeWrapper();
-    const { channelListItems } = getElements(wrapper);
-    const channels = channelListItems();
-    // prettier-ignore
-    const link = channels.at(0).findComponent({ name: 'KRouterLink' });
-    expect(link.props().to).toMatchObject({
-      name: 'SELECT_CONTENT',
-      params: {
-        channel_id: 'awesome_channel',
-      },
-      query: {
-        drive_id: undefined,
-      },
+    await waitFor(() => {
+      expect(screen.getByText(channelTokenButtonLabel$())).toBeInTheDocument();
     });
   });
 
-  describe('handleSubmitToken', () => {
-    let wrapper;
-    let pushSpy;
+  it('in LOCALIMPORT mode, the unlisted channel button is not available', async () => {
+    const store = makeAvailableChannelsPageStore();
+    store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'localimport');
+    await renderComponent({ store });
 
-    beforeEach(() => {
-      store = makeAvailableChannelsPageStore();
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
-      wrapper = makeWrapper({ store });
-      pushSpy = jest.spyOn(wrapper.vm.$router, 'push').mockResolvedValue();
+    await waitFor(() => {
+      expect(screen.queryByText(channelTokenButtonLabel$())).not.toBeInTheDocument();
     });
+  });
 
-    afterEach(() => {
-      pushSpy.mockRestore();
-      wrapper.destroy();
+  it('shows the correct title', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(importResourcesHeader$());
     });
+  });
 
-    it('single-channel token: routes to selectContentPage with token in query', () => {
-      wrapper.vm.handleSubmitToken({ token: 'test-token-xyz', channels: [{ id: 'channel-abc' }] });
-      expect(pushSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'SELECT_CONTENT',
-          query: expect.objectContaining({ token: 'test-token-xyz' }),
-        }),
+  it('shows the correct number of channels available message', async () => {
+    const store = makeAvailableChannelsPageStore();
+    await renderComponent({ store });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('available')).toHaveTextContent(
+        numChannelsAvailable$({ count: 4 }),
       );
-    });
-
-    it('collection token (multiple channels): does not route to SELECT_CONTENT', () => {
-      wrapper.vm.handleSubmitToken({
-        token: 'collection-token',
-        channels: [{ id: 'ch-1' }, { id: 'ch-2' }],
-      });
-      expect(pushSpy).toHaveBeenCalledTimes(1);
-      const pushed = pushSpy.mock.calls[0][0];
-      expect(pushed.name).not.toBe('SELECT_CONTENT');
-      expect(pushed.query).toMatchObject({ token: 'collection-token' });
-    });
-  });
-
-  describe('handleSubmitToken redirect', () => {
-    beforeEach(async () => {
-      // Reset shared router to AVAILABLE_CHANNELS so each navigation test starts fresh
-      await router.router.push({ name: 'AVAILABLE_CHANNELS' }).catch(() => {});
-    });
-
-    it('redirects to NewChannelVersionPage when token-resolved version differs from installed', async () => {
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
-      const wrapper = makeWrapper({ store });
-
-      // awesome_channel is installed at version 10 (from test data in makeStore)
-      // Token resolves to version 11 — a different version
-      await wrapper.vm.handleSubmitToken({
-        token: 'my-token',
-        channels: [{ id: 'awesome_channel', version: 11 }],
-      });
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.vm.$route.name).toBe('NEW_CHANNEL_VERSION_PAGE');
-      expect(wrapper.vm.$route.params.channel_id).toBe('awesome_channel');
-      expect(wrapper.vm.$route.query.token).toBe('my-token');
-    });
-
-    it('redirects to NewChannelVersionPage for an installed draft (version 0) even when versions match', async () => {
-      // A draft always reports version 0, so an installed draft has the same version
-      // number as a changed draft. The version-difference check alone would skip the
-      // upgrade flow, so drafts must always route to it.
-      const draftStore = makeAvailableChannelsPageStore({
-        channelList: [
-          {
-            id: 'draft_channel',
-            name: 'Draft',
-            version: 0,
-            available: true,
-            on_device_resources: 5,
-            on_device_file_size: 100,
-          },
-        ],
-      });
-      draftStore.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
-      const wrapper = makeWrapper({ store: draftStore });
-
-      await wrapper.vm.handleSubmitToken({
-        token: 'my-token',
-        channels: [{ id: 'draft_channel', version: 0 }],
-      });
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.vm.$route.name).toBe('NEW_CHANNEL_VERSION_PAGE');
-      expect(wrapper.vm.$route.params.channel_id).toBe('draft_channel');
-      expect(wrapper.vm.$route.query.token).toBe('my-token');
-    });
-
-    it('goes to SelectContentPage when token-resolved version matches installed', async () => {
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
-      const wrapper = makeWrapper({ store });
-
-      // awesome_channel is installed at version 10; token also resolves to version 10
-      await wrapper.vm.handleSubmitToken({
-        token: 'my-token',
-        channels: [{ id: 'awesome_channel', version: 10 }],
-      });
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.vm.$route.name).toBe('SELECT_CONTENT');
-    });
-
-    it('goes to SelectContentPage when channel is not installed', async () => {
-      store.commit('manageContent/wizard/SET_TRANSFER_TYPE', 'remoteimport');
-      const wrapper = makeWrapper({ store });
-
-      // new_uninstalled_channel is not in channelsOnDevice
-      await wrapper.vm.handleSubmitToken({
-        token: 'my-token',
-        channels: [{ id: 'new_uninstalled_channel', version: 1 }],
-      });
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.vm.$route.name).toBe('SELECT_CONTENT');
     });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/NewChannelVersionPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/NewChannelVersionPage.spec.js
@@ -1,6 +1,7 @@
-import { createLocalVue, mount } from '@vue/test-utils';
+import { render, waitFor } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import NewChannelVersionPage from '../ManageContentPage/NewChannelVersionPage';
+import { fetchChannelAtSource } from '../ManageContentPage/api';
 import { makeSelectContentPageStore } from '../../__tests__/utils/makeStore';
 
 jest.mock('kolibri/urls');
@@ -26,37 +27,52 @@ jest.mock('kolibri/apiResources/TaskResource', () => ({
   startTask: jest.fn().mockResolvedValue({ id: 'task-1', extra_metadata: {} }),
 }));
 
-const localVue = createLocalVue();
-localVue.use(VueRouter);
-
-function makeWrapper(routeQuery = {}) {
-  const store = makeSelectContentPageStore();
-  const router = new VueRouter({
+function createRouter() {
+  return new VueRouter({
     routes: [
-      {
-        name: 'NEW_CHANNEL_VERSION_PAGE',
-        path: '/content/manage_channel/:channel_id/upgrade',
-      },
+      { name: 'NEW_CHANNEL_VERSION_PAGE', path: '/content/manage_channel/:channel_id/upgrade' },
       { name: 'MANAGE_CONTENT_PAGE', path: '/content' },
       { name: 'MANAGE_TASKS', path: '/content/tasks' },
     ],
   });
-  router.push({
+}
+
+async function renderComponent(routeQuery = {}) {
+  const store = makeSelectContentPageStore();
+  const router = createRouter();
+  await router.push({
     name: 'NEW_CHANNEL_VERSION_PAGE',
     params: { channel_id: 'awesome_channel' },
     query: routeQuery,
   });
-  return mount(NewChannelVersionPage, { localVue, store, router });
+  return render(NewChannelVersionPage, { store, router });
 }
 
 describe('NewChannelVersionPage', () => {
-  it('includes token in params when token is in route query', () => {
-    const wrapper = makeWrapper({ token: 'my-special-token' });
-    expect(wrapper.vm.params.token).toEqual('my-special-token');
+  beforeEach(() => {
+    // Mock call history isn't automatically reset between tests, so without this
+    // the second test could see stale calls left over from the first.
+    jest.clearAllMocks();
   });
 
-  it('does not include token in params when token is absent from route query', () => {
-    const wrapper = makeWrapper({});
-    expect(wrapper.vm.params.token).toBeUndefined();
+  it('includes the token in the channel lookup params when a token is present in the route query', async () => {
+    await renderComponent({ token: 'my-special-token' });
+
+    await waitFor(() => {
+      expect(fetchChannelAtSource).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'my-special-token' }),
+      );
+    });
+  });
+
+  it('does not include a token in the channel lookup params when the route query has no token', async () => {
+    await renderComponent({});
+
+    await waitFor(() => {
+      expect(fetchChannelAtSource).toHaveBeenCalled();
+    });
+
+    const calledParams = fetchChannelAtSource.mock.calls[0][0];
+    expect(calledParams.token).toBeUndefined();
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -3,7 +3,7 @@ import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
 import { createTranslator } from 'kolibri/utils/i18n';
-import { dragSortStrings } from 'kolibri-common/components/sortable/dragSortStrings';
+import { dragSortStrings } from 'kolibri-common/components/draggable/dragSortStrings';
 import client from 'kolibri/client';
 import urls from 'kolibri/urls';
 import RearrangeChannelsPage from '../RearrangeChannelsPage';
@@ -57,7 +57,7 @@ describe('RearrangeChannelsPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    DeviceChannelResource.fetchCollection.mockResolvedValue(MOCK_CHANNELS);
+    DeviceChannelResource.list.mockResolvedValue(MOCK_CHANNELS);
     urls.__setUrl('/fake/url/');
     client.mockResolvedValue({});
   });
@@ -78,7 +78,7 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('shows a message when there are no channels', async () => {
-    DeviceChannelResource.fetchCollection.mockResolvedValue([]);
+    DeviceChannelResource.list.mockResolvedValue([]);
     await renderComponent();
     await waitFor(() => {
       expect(screen.getByText(noChannels$())).toBeInTheDocument();

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -8,7 +8,7 @@ import RearrangeChannelsPage from '../RearrangeChannelsPage';
 import makeStore from '../../__tests__/utils/makeStore';
 import { PageNames } from '../../constants';
 
-const { moveItemUpLabel$ } = dragSortStrings;
+const { moveItemUpLabel$, moveItemDownLabel$ } = dragSortStrings;
 
 const { instructions$, noChannels$, successNotification$ } = createTranslator(
   RearrangeChannelsPage.name,
@@ -113,6 +113,24 @@ describe('RearrangeChannelsPage', () => {
       name: moveItemUpLabel$({ item: MOCK_CHANNELS[1].name }),
     });
     await fireEvent.click(upButtons[0]);
+
+    await waitFor(() => {
+      expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
+    });
+    const channelNames = MOCK_CHANNELS.map(channel => channel.name);
+    const matchesChannelName = text => channelNames.includes(text.trim());
+    const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
+    expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
+  });
+
+  it('handles a moveDown event properly', async () => {
+    await renderComponent();
+    await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+    const downButtons = screen.getAllByRole('button', {
+      name: moveItemDownLabel$({ item: MOCK_CHANNELS[0].name }),
+    });
+    await fireEvent.click(downButtons[0]);
 
     await waitFor(() => {
       expect(createSnackbar).toHaveBeenCalledWith(successNotification$());

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -90,12 +90,17 @@ describe('RearrangeChannelsPage', () => {
     const Sortable = require('sortablejs');
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
-
+    // DragContainer creates the Sortable instance inside mounted() -> $nextTick(),
+    // which is one tick after the channel list itself renders. On a slow/busy CI
+    // machine this can still be pending when the line above resolves, so we wait
+    // for it explicitly instead of assuming it already happened.
+    await waitFor(() => {
+      expect(Sortable.mock.results.length).toBeGreaterThan(0);
+    });
     // Simulate the drag ending by calling the onEnd callback SortableJS
     // would normally call itself once the pointer is released.
     const { onEnd } = Sortable.mock.results[0].value.options;
     onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
-
     await waitFor(() => {
       expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
     });
@@ -128,6 +133,13 @@ describe('RearrangeChannelsPage', () => {
     RearrangeChannelsPage.methods.postNewOrder = () => Promise.reject();
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+    // See comment in the "successful @sort event" test above — Sortable is
+    // constructed one tick after the channel list renders, so we wait for it
+    // explicitly to avoid a race on slow/busy CI machines.
+    await waitFor(() => {
+      expect(Sortable.mock.results.length).toBeGreaterThan(0);
+    });
 
     const { onEnd } = Sortable.mock.results[0].value.options;
     onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -4,7 +4,10 @@ import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-di
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
 import { createTranslator } from 'kolibri/utils/i18n';
 import { dragSortStrings } from 'kolibri-common/components/sortable/dragSortStrings';
+import client from 'kolibri/client';
+import urls from 'kolibri/urls';
 import RearrangeChannelsPage from '../RearrangeChannelsPage';
+import DeviceChannelResource from '../../apiResources/deviceChannel';
 import makeStore from '../../__tests__/utils/makeStore';
 import { PageNames } from '../../constants';
 
@@ -20,6 +23,9 @@ jest.mock('kolibri-common/composables/usePageLoading');
 
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
+jest.mock('kolibri/client');
+jest.mock('kolibri/urls');
+jest.mock('../../apiResources/deviceChannel');
 
 function createRouter() {
   return new VueRouter({
@@ -51,8 +57,9 @@ describe('RearrangeChannelsPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve(MOCK_CHANNELS);
-    RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
+    DeviceChannelResource.fetchCollection.mockResolvedValue(MOCK_CHANNELS);
+    urls.__setUrl('/fake/url/');
+    client.mockResolvedValue({});
   });
 
   it('loads the data on mount', async () => {
@@ -71,7 +78,7 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('shows a message when there are no channels', async () => {
-    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
+    DeviceChannelResource.fetchCollection.mockResolvedValue([]);
     await renderComponent();
     await waitFor(() => {
       expect(screen.getByText(noChannels$())).toBeInTheDocument();
@@ -95,7 +102,7 @@ describe('RearrangeChannelsPage', () => {
     const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
     expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
   });
-  
+
   it('handles a moveUp event properly', async () => {
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
@@ -115,7 +122,7 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('handles a failed @sort event properly', async () => {
-    RearrangeChannelsPage.methods.postNewOrder = () => Promise.reject();
+    client.mockRejectedValue({});
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
 

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -10,7 +10,7 @@ import { PageNames } from '../../constants';
 
 const { moveItemUpLabel$, moveItemDownLabel$ } = dragSortStrings;
 
-const { instructions$, noChannels$, successNotification$ } = createTranslator(
+const { instructions$, noChannels$, successNotification$, failureNotification$ } = createTranslator(
   RearrangeChannelsPage.name,
   RearrangeChannelsPage.$trs,
 );
@@ -121,6 +121,26 @@ describe('RearrangeChannelsPage', () => {
     const matchesChannelName = text => channelNames.includes(text.trim());
     const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
     expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
+  });
+
+  it('handles a failed @sort event properly', async () => {
+    const Sortable = require('sortablejs');
+    RearrangeChannelsPage.methods.postNewOrder = () => Promise.reject();
+    await renderComponent();
+    await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+    const { onEnd } = Sortable.mock.results[0].value.options;
+    onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
+
+    await waitFor(() => {
+      expect(createSnackbar).toHaveBeenCalledWith(failureNotification$());
+    });
+    await waitFor(() => {
+      const channelNames = MOCK_CHANNELS.map(channel => channel.name);
+      const matchesChannelName = text => channelNames.includes(text.trim());
+      const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
+      expect(titles).toEqual([MOCK_CHANNELS[0].name, MOCK_CHANNELS[1].name]);
+    });
   });
 
   it('handles a moveDown event properly', async () => {

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
+import { render, screen, waitFor } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
@@ -14,21 +14,15 @@ const { instructions$, noChannels$, successNotification$ } = createTranslator(
 
 jest.mock('../../composables/useContentTasks');
 jest.mock('kolibri-common/composables/usePageLoading');
-jest.mock('kolibri-common/components/sortable/DragContainer', () => ({
-  default: {
-    name: 'DragContainer',
-    props: ['items'],
-    template: `
-      <div>
-        <button data-testid="trigger-sort" @click="$emit('sort', { newArray: [items[1], items[0]] })">
-          Trigger Sort
-        </button>
-        <slot />
-      </div>
-    `,
-  },
- }
-));
+jest.mock(
+  'sortablejs',
+  () =>
+    jest.fn().mockImplementation((el, options) => ({
+      destroy: jest.fn(),
+      options,
+    })),
+  { virtual: true },
+);
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
 
@@ -82,25 +76,29 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('shows a message when there are no channels', async () => {
-      RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
-      await renderComponent();
-      await waitFor(() => {
-        expect(screen.getByText(noChannels$())).toBeInTheDocument();
-      });
-    });
-
-    it('handles a successful @sort event properly', async () => {
-      await renderComponent();
-      await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
-
-      await fireEvent.click(screen.getByTestId('trigger-sort'));
-
-      await waitFor(() => {
-        expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
-      });
-      const titles = screen
-        .getAllByText(new RegExp(`^(${MOCK_CHANNELS[0].name}|${MOCK_CHANNELS[1].name})$`))
-        .map(el => el.textContent);
-      expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
+    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
+    await renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(noChannels$())).toBeInTheDocument();
     });
   });
+
+  it('handles a successful @sort event properly', async () => {
+    const Sortable = require('sortablejs');
+    await renderComponent();
+    await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+    // Simulate the drag ending by calling the onEnd callback SortableJS
+    // would normally call itself once the pointer is released.
+    const { onEnd } = Sortable.mock.results[0].value.options;
+    onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
+
+    await waitFor(() => {
+      expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
+    });
+    const channelNames = MOCK_CHANNELS.map(channel => channel.name);
+    const matchesChannelName = text => channelNames.includes(text.trim());
+    const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
+    expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
+  });
+});

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
@@ -7,12 +7,28 @@ import RearrangeChannelsPage from '../RearrangeChannelsPage';
 import makeStore from '../../__tests__/utils/makeStore';
 import { PageNames } from '../../constants';
 
-const { instructions$, noChannels$ } = createTranslator(
+const { instructions$, noChannels$, successNotification$ } = createTranslator(
   RearrangeChannelsPage.name,
   RearrangeChannelsPage.$trs,
 );
 
 jest.mock('../../composables/useContentTasks');
+jest.mock('kolibri-common/composables/usePageLoading');
+jest.mock('kolibri-common/components/sortable/DragContainer', () => ({
+  default: {
+    name: 'DragContainer',
+    props: ['items'],
+    template: `
+      <div>
+        <button data-testid="trigger-sort" @click="$emit('sort', { newArray: [items[1], items[0]] })">
+          Trigger Sort
+        </button>
+        <slot />
+      </div>
+    `,
+  },
+ }
+));
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
 
@@ -30,9 +46,6 @@ const MOCK_CHANNELS = [
   { id: '2', name: 'Channel 2' },
 ];
 
-RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
-RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve(MOCK_CHANNELS);
-
 describe('RearrangeChannelsPage', () => {
   let createSnackbar;
 
@@ -49,6 +62,8 @@ describe('RearrangeChannelsPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve(MOCK_CHANNELS);
+    RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
   });
 
   it('loads the data on mount', async () => {
@@ -67,10 +82,25 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('shows a message when there are no channels', async () => {
-    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
-    await renderComponent();
-    await waitFor(() => {
-      expect(screen.getByText(noChannels$())).toBeInTheDocument();
+      RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
+      await renderComponent();
+      await waitFor(() => {
+        expect(screen.getByText(noChannels$())).toBeInTheDocument();
+      });
+    });
+
+    it('handles a successful @sort event properly', async () => {
+      await renderComponent();
+      await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+      await fireEvent.click(screen.getByTestId('trigger-sort'));
+
+      await waitFor(() => {
+        expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
+      });
+      const titles = screen
+        .getAllByText(new RegExp(`^(${MOCK_CHANNELS[0].name}|${MOCK_CHANNELS[1].name})$`))
+        .map(el => el.textContent);
+      expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
     });
   });
-});

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -1,11 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, fireEvent } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
 import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
 import { createTranslator } from 'kolibri/utils/i18n';
+import { dragSortStrings } from 'kolibri-common/components/sortable/dragSortStrings';
 import RearrangeChannelsPage from '../RearrangeChannelsPage';
 import makeStore from '../../__tests__/utils/makeStore';
 import { PageNames } from '../../constants';
+
+const { moveItemUpLabel$ } = dragSortStrings;
 
 const { instructions$, noChannels$, successNotification$ } = createTranslator(
   RearrangeChannelsPage.name,
@@ -92,6 +95,24 @@ describe('RearrangeChannelsPage', () => {
     // would normally call itself once the pointer is released.
     const { onEnd } = Sortable.mock.results[0].value.options;
     onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
+
+    await waitFor(() => {
+      expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
+    });
+    const channelNames = MOCK_CHANNELS.map(channel => channel.name);
+    const matchesChannelName = text => channelNames.includes(text.trim());
+    const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
+    expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
+  });
+
+  it('handles a moveUp event properly', async () => {
+    await renderComponent();
+    await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
+
+    const upButtons = screen.getAllByRole('button', {
+      name: moveItemUpLabel$({ item: MOCK_CHANNELS[1].name }),
+    });
+    await fireEvent.click(upButtons[0]);
 
     await waitFor(() => {
       expect(createSnackbar).toHaveBeenCalledWith(successNotification$());

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -1,92 +1,76 @@
-import { shallowMount } from '@vue/test-utils';
-import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line
-import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line
-import makeStore from '../../__tests__/utils/makeStore';
+import { render, screen, waitFor } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import useUser, { useUserMock } from 'kolibri/composables/useUser'; // eslint-disable-line import-x/named
+import useSnackbar, { useSnackbarMock } from 'kolibri/composables/useSnackbar'; // eslint-disable-line import-x/named
+import { createTranslator } from 'kolibri/utils/i18n';
 import RearrangeChannelsPage from '../RearrangeChannelsPage';
+import makeStore from '../../__tests__/utils/makeStore';
+import { PageNames } from '../../constants';
+
+const { instructions$, noChannels$ } = createTranslator(
+  RearrangeChannelsPage.name,
+  RearrangeChannelsPage.$trs,
+);
 
 jest.mock('../../composables/useContentTasks');
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
 
-RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
-RearrangeChannelsPage.methods.fetchChannels = () => {
-  return Promise.resolve([
-    { id: '1', name: 'Channel 1' },
-    { id: '2', name: 'Channel 2' },
-  ]);
-};
-async function makeWrapper() {
-  const store = makeStore();
-  useUser.mockImplementation(() => useUserMock({ canManageContent: true }));
-  const wrapper = shallowMount(RearrangeChannelsPage, {
-    store,
+function createRouter() {
+  return new VueRouter({
+    routes: [
+      { name: PageNames.REARRANGE_CHANNELS, path: '/content/reorder_channels' },
+      { name: PageNames.MANAGE_CONTENT_PAGE, path: '/content' },
+    ],
   });
-  // Have to wait to let the channels data load
-  await global.flushPromises();
-  return { wrapper };
 }
 
-describe('RearrangeChannelsPage', () => {
-  const createSnackbar = jest.fn();
-  beforeAll(() => {
-    useSnackbar.mockImplementation(() => useSnackbarMock({ createSnackbar }));
-  });
+const MOCK_CHANNELS = [
+  { id: '1', name: 'Channel 1' },
+  { id: '2', name: 'Channel 2' },
+];
 
-  async function simulateSort(wrapper) {
-    const region = wrapper.findComponent({ name: 'DraggableRegion' });
-    region.vm.$emit('update:items', [wrapper.vm.channels[1], wrapper.vm.channels[0]]);
-    expect(wrapper.vm.postNewOrder).toHaveBeenCalledWith(['2', '1']);
-    await global.flushPromises();
-  }
+RearrangeChannelsPage.methods.postNewOrder = () => Promise.resolve();
+RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve(MOCK_CHANNELS);
+
+describe('RearrangeChannelsPage', () => {
+  let createSnackbar;
+
+  const renderComponent = async () => {
+    createSnackbar = jest.fn();
+    useUser.mockImplementation(() => useUserMock({ canManageContent: true }));
+    useSnackbar.mockImplementation(() => useSnackbarMock({ createSnackbar }));
+
+    const store = makeStore();
+    const router = createRouter();
+    await router.push({ name: PageNames.REARRANGE_CHANNELS });
+    return render(RearrangeChannelsPage, { store, router });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('loads the data on mount', async () => {
-    const { wrapper } = await makeWrapper();
-    expect(wrapper.vm.loading).toBe(false);
-    expect(wrapper.vm.channels).toHaveLength(2);
+    await renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_CHANNELS[0].name)).toBeInTheDocument();
+      expect(screen.getByText(MOCK_CHANNELS[1].name)).toBeInTheDocument();
+    });
   });
 
-  it('handles a successful @sort event properly', async () => {
-    const { wrapper } = await makeWrapper();
-    wrapper.vm.postNewOrder = jest.fn().mockResolvedValue();
-    wrapper.vm.$store.dispatch = jest.fn();
-    await simulateSort(wrapper);
-    expect(createSnackbar).toHaveBeenCalledWith('Channel order saved');
-    expect(wrapper.vm.channels[0].id).toEqual('2');
-    expect(wrapper.vm.channels[1].id).toEqual('1');
+  it('shows the instructions text', async () => {
+    await renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(instructions$())).toBeInTheDocument();
+    });
   });
 
-  it('handles a failed @sort event properly', async () => {
-    const { wrapper } = await makeWrapper();
-    wrapper.vm.postNewOrder = jest.fn().mockRejectedValue();
-    wrapper.vm.$store.dispatch = jest.fn();
-    await simulateSort(wrapper);
-    expect(createSnackbar).toHaveBeenCalledWith('There was a problem reordering the channels');
-    // Channels array is reset after an error
-    expect(wrapper.vm.channels[0].id).toEqual('1');
-    expect(wrapper.vm.channels[1].id).toEqual('2');
-  });
-
-  // Will mock the handleOrderChange method to test these cases synchronousy,
-  // since that method should be tested by the previous tests.
-  it('handles a @moveUp event properly', async () => {
-    const { wrapper } = await makeWrapper();
-    const spy = (wrapper.vm.handleOrderChange = jest.fn());
-    const dragSortWidget = wrapper.findAllComponents({ name: 'DragSortWidget' }).at(1);
-    dragSortWidget.vm.$emit('moveUp');
-    expect(spy).toHaveBeenCalledWith([
-      { id: '2', name: 'Channel 2' },
-      { id: '1', name: 'Channel 1' },
-    ]);
-  });
-
-  it('handles a @moveDown event properly', async () => {
-    const { wrapper } = await makeWrapper();
-    const spy = (wrapper.vm.handleOrderChange = jest.fn());
-    const dragSortWidget = wrapper.findAllComponents({ name: 'DragSortWidget' }).at(0);
-    dragSortWidget.vm.$emit('moveDown');
-    expect(spy).toHaveBeenCalledWith([
-      { id: '2', name: 'Channel 2' },
-      { id: '1', name: 'Channel 1' },
-    ]);
+  it('shows a message when there are no channels', async () => {
+    RearrangeChannelsPage.methods.fetchChannels = () => Promise.resolve([]);
+    await renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(noChannels$())).toBeInTheDocument();
+    });
   });
 });

--- a/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/frontend/views/__tests__/RearrangeChannelsPage.spec.js
@@ -17,15 +17,7 @@ const { instructions$, noChannels$, successNotification$, failureNotification$ }
 
 jest.mock('../../composables/useContentTasks');
 jest.mock('kolibri-common/composables/usePageLoading');
-jest.mock(
-  'sortablejs',
-  () =>
-    jest.fn().mockImplementation((el, options) => ({
-      destroy: jest.fn(),
-      options,
-    })),
-  { virtual: true },
-);
+
 jest.mock('kolibri/composables/useUser');
 jest.mock('kolibri/composables/useSnackbar');
 
@@ -87,20 +79,14 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('handles a successful @sort event properly', async () => {
-    const Sortable = require('sortablejs');
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
-    // DragContainer creates the Sortable instance inside mounted() -> $nextTick(),
-    // which is one tick after the channel list itself renders. On a slow/busy CI
-    // machine this can still be pending when the line above resolves, so we wait
-    // for it explicitly instead of assuming it already happened.
-    await waitFor(() => {
-      expect(Sortable.mock.results.length).toBeGreaterThan(0);
+    // Move the first channel down using its accessible reorder button,
+    // instead of simulating a sortablejs drag-and-drop event.
+    const moveDownBtn = screen.getByRole('button', {
+      name: moveItemDownLabel$({ item: MOCK_CHANNELS[0].name }),
     });
-    // Simulate the drag ending by calling the onEnd callback SortableJS
-    // would normally call itself once the pointer is released.
-    const { onEnd } = Sortable.mock.results[0].value.options;
-    onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
+    await fireEvent.click(moveDownBtn);
     await waitFor(() => {
       expect(createSnackbar).toHaveBeenCalledWith(successNotification$());
     });
@@ -109,7 +95,7 @@ describe('RearrangeChannelsPage', () => {
     const titles = screen.getAllByText(matchesChannelName).map(el => el.textContent.trim());
     expect(titles).toEqual([MOCK_CHANNELS[1].name, MOCK_CHANNELS[0].name]);
   });
-
+  
   it('handles a moveUp event properly', async () => {
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
@@ -129,20 +115,14 @@ describe('RearrangeChannelsPage', () => {
   });
 
   it('handles a failed @sort event properly', async () => {
-    const Sortable = require('sortablejs');
     RearrangeChannelsPage.methods.postNewOrder = () => Promise.reject();
     await renderComponent();
     await waitFor(() => screen.getByText(MOCK_CHANNELS[0].name));
 
-    // See comment in the "successful @sort event" test above — Sortable is
-    // constructed one tick after the channel list renders, so we wait for it
-    // explicitly to avoid a race on slow/busy CI machines.
-    await waitFor(() => {
-      expect(Sortable.mock.results.length).toBeGreaterThan(0);
+    const moveDownBtn = screen.getByRole('button', {
+      name: moveItemDownLabel$({ item: MOCK_CHANNELS[0].name }),
     });
-
-    const { onEnd } = Sortable.mock.results[0].value.options;
-    onEnd({ oldIndex: 0, newIndex: 1, item: document.createElement('div') });
+    await fireEvent.click(moveDownBtn);
 
     await waitFor(() => {
       expect(createSnackbar).toHaveBeenCalledWith(failureNotification$());

--- a/kolibri/plugins/device/package.json
+++ b/kolibri/plugins/device/package.json
@@ -22,6 +22,7 @@
         "@testing-library/jest-dom": "catalog:",
         "@testing-library/user-event": "catalog:",
         "@testing-library/vue": "catalog:",
-        "@vue/test-utils": "catalog:"
+        "@vue/test-utils": "catalog:",
+        "sortablejs": "1.15.7"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ importers:
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 1.3.6(vue-template-compiler@2.7.16)(vue@2.7.16)
+      sortablejs:
+        specifier: 1.15.7
+        version: 1.15.7
 
   kolibri/plugins/epub_viewer:
     dependencies:


### PR DESCRIPTION
## Summary
Migrate remaining device plugin tests to Vue Testing Library as part of issue #14261.
This is **Part 2-4 of 4** — consolidated into a single PR per reviewer guidance on PR #14883:
- ChannelTokenModal.spec.js (merged in #14883)
- RearrangeChannelsPage.spec.js (in progress — this PR)
- AvailableChannelsPage.spec.js
- NewChannelVersionPage.spec.js

Each file has its own commit(s) for easier review.

## Status
This is a **draft/work-in-progress PR** opened early to get feedback on an open question 
(see comment below) before continuing with the remaining files.

## Open question
I'm stuck on mocking `DragContainer` for RearrangeChannelsPage — see comment below for details.

## AI usage
I used Claude AI as a learning tool and coding assistant during this VTL migration, 
consistent with the approach disclosed in PR #14883.