### PR TITLE
Add id-token permission to container image publish

### DIFF
--- a/.github/workflows/container_image_publish.yml
+++ b/.github/workflows/container_image_publish.yml
@@ -20,6 +20,7 @@ env:
 permissions:
   contents: read
   packages: write
+  id-token: write
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
Adds missing `id-token: write` permission to container image publish workflow

## References
<!--
 * references to related issues and PRs
-->
https://github.com/learningequality/kolibri/actions/runs/29341997363/job/87115902742


