### PR TITLE
0.19 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 List of the most important changes for each release.
 
+## 0.19.5
+
+### High-level overview
+
+A maintenance patch focused on database and sync reliability, with no user-facing changes.
+
+### Changed
+* Migrate pre-0.17 FKs to have deferrable flags by @bjester in https://github.com/learningequality/kolibri/pull/14981
+* Scoped field updates in custom Morango sync ops by @bjester in https://github.com/learningequality/kolibri/pull/14985
+* Seed reserved NetworkLocation rows via post_migrate in DiscoveryConfig by @rtibblesbot in https://github.com/learningequality/kolibri/pull/14887
+* Standardize pnpm CI pattern: action-setup@v6.0.8 before setup-node with cache: pnpm by @rtibblesbot in https://github.com/learningequality/kolibri/pull/14764
+
 ## 0.19.4
 
 ### High-level overview

--- a/build_tools/preseed_home.sh
+++ b/build_tools/preseed_home.sh
@@ -31,7 +31,7 @@ set +x
 declare -A QUERY_MATRIX
 QUERY_MATRIX["select count(*) from morango_databaseidmodel;"]="db.sqlite3"
 QUERY_MATRIX["select count(*) from morango_instanceidmodel;"]="db.sqlite3"
-QUERY_MATRIX["select count(*) from discovery_networklocation;"]="networklocation.sqlite3"
+QUERY_MATRIX["select count(*) from discovery_networklocation where location_type != 'reserved';"]="networklocation.sqlite3"
 QUERY_MATRIX["select count(*) from jobs;"]="job_storage.sqlite3"
 
 echo "Verifying databases..."

--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -123,7 +123,7 @@ class KolibriNetworkInitializeOperation(NetworkInitializeOperation):
             # session and context objects to reflect the change
             context.update(sync_filter=response_filter)
             context.transfer_session.filter = str(response_filter)
-            context.transfer_session.save()
+            context.transfer_session.save(update_fields=["filter"])
 
         return response_data
 
@@ -202,7 +202,7 @@ class KolibriSyncOperationMixin(BaseOperation):
         extra_fields = self._get_storage(context)
         extra_fields.update(**storage)
         context.sync_session.extra_fields = json.dumps(extra_fields)
-        context.sync_session.save()
+        context.sync_session.save(update_fields=["extra_fields"])
 
     def has_handled(self, context):
         """

--- a/kolibri/core/auth/test/test_deferrable_foreign_keys.py
+++ b/kolibri/core/auth/test/test_deferrable_foreign_keys.py
@@ -1,0 +1,53 @@
+import pytest
+from django.conf import settings
+from django.db import connection
+from django.test import TransactionTestCase
+from morango.deferrable_foreign_keys import _get_table_sql
+
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.upgrade import make_foreign_keys_deferrable
+
+
+class DeferrableForeignKeysTestCase(TransactionTestCase):
+    def _rewrite_collection_fk_immediate(self):
+        table = Collection._meta.db_table
+        sql = _get_table_sql(connection, table)
+        immediate = sql.replace(" DEFERRABLE INITIALLY DEFERRED", "")
+        assert "DEFERRABLE" not in immediate
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=%s AND sql IS NOT NULL",
+                [table],
+            )
+            indexes = [r[0] for r in cursor.fetchall()]
+            cursor.execute("PRAGMA foreign_keys = OFF")
+            cursor.execute("DROP TABLE {}".format(table))
+            cursor.execute(immediate)
+            for idx in indexes:
+                cursor.execute(idx)
+            cursor.execute("PRAGMA foreign_keys = ON")
+
+    @pytest.mark.skipif(
+        "sqlite3" not in settings.DATABASES["default"]["ENGINE"],
+        reason="sqlite3 only",
+    )
+    def test_remake_makes_deferrable_and_preserves_data(self):
+        table = Collection._meta.db_table
+        # fresh schema should be deferrable
+        self.assertIn("DEFERRABLE", _get_table_sql(connection, table))
+
+        # downgrade schema to immediate FK (table is rebuilt empty)
+        self._rewrite_collection_fk_immediate()
+        self.assertNotIn("DEFERRABLE", _get_table_sql(connection, table))
+
+        # create some data on the immediate-FK schema
+        f = Facility.objects.create(name="testfac")
+        f_id = f.id
+        self.assertTrue(Collection.objects.filter(id=f_id).exists())
+
+        make_foreign_keys_deferrable()
+
+        # now deferrable again, and data preserved
+        self.assertIn("DEFERRABLE", _get_table_sql(connection, table))
+        self.assertTrue(Collection.objects.filter(id=f_id).exists())

--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -112,7 +112,9 @@ class KolibriSyncOperationMixinTestCase(SimpleTestCase):
         self.operation._update_storage(self.context, {"appended": 1})
         actual_json = json.loads(self.context.sync_session.extra_fields)
         self.assertEqual({"test": True, "appended": 1}, actual_json)
-        self.context.sync_session.save.assert_called_once_with()
+        self.context.sync_session.save.assert_called_once_with(
+            update_fields=["extra_fields"]
+        )
 
     @mock.patch(
         "kolibri.core.auth.sync_operations.KolibriSyncOperationMixin._get_storage"

--- a/kolibri/core/auth/upgrade.py
+++ b/kolibri/core/auth/upgrade.py
@@ -57,3 +57,30 @@ def enqueue_kdp_sync_for_registered_facilities():
     """
     for facility in Facility.objects.filter(dataset__registered=True):
         enqueue_automatic_kdp_sync(facility)
+
+
+@version_upgrade(old_version="<0.19.5")
+def make_foreign_keys_deferrable():
+    """
+    Prior to Django 2.0, SQLite tables were created with immediate foreign key constraints, e.g.::
+
+        "parent_id" char(32) NULL REFERENCES "kolibriauth_collection" ("id")
+
+    Since Kolibri upgraded to Django 3.2 (straight from 1.11) the same column is created as::
+
+        "parent_id" char(32) NULL REFERENCES "kolibriauth_collection" ("id") DEFERRABLE INITIALLY DEFERRED
+
+    Django relies on deferred constraint checking for correct cascade-deletion ordering. Databases
+    created before Kolibri 0.17 (Django 1.11) therefore retain immediate constraints, which can
+    raise ``IntegrityError: FOREIGN KEY constraint failed`` during operations such as sync
+    deserialization once foreign key enforcement is enabled at the database level (the default since
+    Django 2.0).
+
+    Kolibri 0.17 saw the Django upgrade, but for this version upgrade, we apply it based on the
+    version of its release, so we can ensure all databases are migrated properly.
+    """
+    from morango.deferrable_foreign_keys import MakeForeignKeysDeferrable
+
+    # morango takes care of itself, through its own migration
+    op = MakeForeignKeysDeferrable(exclude_app_labels=["morango"])
+    op.run()

--- a/kolibri/core/discovery/apps.py
+++ b/kolibri/core/discovery/apps.py
@@ -1,0 +1,28 @@
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+
+def _seed_reserved_locations(sender, **kwargs):
+    from django.db import router
+
+    from kolibri.core.discovery.models import NetworkLocation
+
+    using = kwargs.get("using", "default")
+    if (router.db_for_write(NetworkLocation) or "default") != using:
+        return
+    from kolibri.core.discovery.tasks import _refresh_reserved_locations
+
+    _refresh_reserved_locations()
+
+
+class DiscoveryConfig(AppConfig):
+    name = "kolibri.core.discovery"
+    label = "discovery"
+    verbose_name = "Kolibri Discovery"
+
+    def ready(self):
+        post_migrate.connect(
+            _seed_reserved_locations,
+            sender=self,
+            dispatch_uid="discovery_seed_reserved_locations",
+        )

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -45,15 +45,19 @@ class NetworkLocationAPITestCase(APITestCase):
         cls.existing_sad_netloc = models.NetworkLocation.objects.create(
             base_url="https://sadurl.qqq/"
         )
-        cls.kdp_reserved_location = models.NetworkLocation.objects.create(
+        cls.kdp_reserved_location, _ = models.NetworkLocation.objects.get_or_create(
             id=DATA_PORTAL_BASE_INSTANCE_ID,
-            base_url=DATA_PORTAL_SYNCING_BASE_URL,
-            location_type=models.LocationTypes.Reserved,
+            defaults={
+                "base_url": DATA_PORTAL_SYNCING_BASE_URL,
+                "location_type": models.LocationTypes.Reserved,
+            },
         )
-        cls.studio_reserved_location = models.NetworkLocation.objects.create(
+        cls.studio_reserved_location, _ = models.NetworkLocation.objects.get_or_create(
             id=CENTRAL_CONTENT_BASE_INSTANCE_ID,
-            base_url=CENTRAL_CONTENT_BASE_URL,
-            location_type=models.LocationTypes.Reserved,
+            defaults={
+                "base_url": CENTRAL_CONTENT_BASE_URL,
+                "location_type": models.LocationTypes.Reserved,
+            },
         )
         cls.dynamic_location = models.DynamicNetworkLocation.objects.create(
             id="a" * 32,

--- a/kolibri/core/discovery/test/test_apps.py
+++ b/kolibri/core/discovery/test/test_apps.py
@@ -1,0 +1,81 @@
+import mock
+from django.apps import apps
+from django.db import router
+from django.db.models.signals import post_migrate
+from django.test import TestCase
+
+from ..models import LocationTypes
+from ..models import NetworkLocation
+from ..tasks import _refresh_reserved_locations
+from ..well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
+from ..well_known import DATA_PORTAL_BASE_INSTANCE_ID
+
+
+class RefreshReservedLocationsTestCase(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        NetworkLocation.objects.filter(location_type=LocationTypes.Reserved).delete()
+
+    def test_creates_studio_location(self):
+        _refresh_reserved_locations()
+        self.assertTrue(
+            NetworkLocation.objects.filter(
+                id=CENTRAL_CONTENT_BASE_INSTANCE_ID,
+                location_type=LocationTypes.Reserved,
+            ).exists()
+        )
+
+    def test_creates_kdp_location(self):
+        _refresh_reserved_locations()
+        self.assertTrue(
+            NetworkLocation.objects.filter(
+                id=DATA_PORTAL_BASE_INSTANCE_ID,
+                location_type=LocationTypes.Reserved,
+            ).exists()
+        )
+
+    def test_is_idempotent(self):
+        _refresh_reserved_locations()
+        _refresh_reserved_locations()
+        self.assertEqual(
+            NetworkLocation.objects.filter(
+                location_type=LocationTypes.Reserved
+            ).count(),
+            2,
+        )
+
+
+def _send_post_migrate(config, using):
+    post_migrate.send(
+        sender=config,
+        app_config=config,
+        verbosity=0,
+        interactive=False,
+        using=using,
+        stdout=None,
+    )
+
+
+class DiscoveryAppConfigTestCase(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.config = apps.get_app_config("discovery")
+        self.using_db = router.db_for_write(NetworkLocation) or "default"
+
+    @mock.patch("kolibri.core.discovery.tasks._refresh_reserved_locations")
+    def test_post_migrate_correct_db_calls_refresh(self, mock_refresh):
+        _send_post_migrate(self.config, using=self.using_db)
+        mock_refresh.assert_called_once()
+
+    @mock.patch("kolibri.core.discovery.tasks._refresh_reserved_locations")
+    def test_post_migrate_wrong_db_noop(self, mock_refresh):
+        # Patch the router so the handler sees a different "right" db than the
+        # one the signal carries — without passing a non-existent alias to
+        # post_migrate.send(), which would crash Django's built-in receivers.
+        with mock.patch.object(
+            router, "db_for_write", return_value="not_" + self.using_db
+        ):
+            _send_post_migrate(self.config, using=self.using_db)
+        mock_refresh.assert_not_called()

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -18,14 +18,19 @@ from kolibri.core.discovery.test.helpers import mock_response
 
 def mock_external_request(session, method, url, *args, **kwargs):
     """
-    Give any outbound HTTP request a successful empty response, so that views
+    Give any outbound HTTP request a successful response, so that views
     proxying to external services (the Kolibri Data Portal token validation,
     the Studio remote channel lookup) can be smoke tested without depending
     on those services.
+
+    The device-info endpoint returns an object, which NetworkClient.connect()
+    parses when validating a reserved peer like Studio; every other proxied
+    endpoint returns a list.
     """
     response = mock_response(200)
     response.url = url
-    response.json.return_value = []
+    if "api/public/info" not in url:
+        response.json.return_value = []
     return response
 
 

--- a/packages/kolibri-build/src/__tests__/webpackRtlPlugin.spec.js
+++ b/packages/kolibri-build/src/__tests__/webpackRtlPlugin.spec.js
@@ -12,9 +12,6 @@ if (typeof setImmediate === 'undefined') {
   global.clearImmediate = (id) => clearTimeout(id);
 }
 
-/**
- * Helper to compile a webpack bundle and return the output
- */
 function compileBundle(config) {
   return new Promise((resolve, reject) => {
     const compiler = webpack(config);
@@ -32,9 +29,6 @@ function compileBundle(config) {
   });
 }
 
-/**
- * Helper to create test files for webpack compilation
- */
 function createTestFiles(tempDir) {
   const entryFile = path.join(tempDir, 'entry.js');
   const cssFile = path.join(tempDir, 'styles.css');
@@ -60,6 +54,9 @@ describe('WebpackRTLPlugin', () => {
 
   describe('RTL CSS file generation', () => {
     it('should generate .rtl.css files with RTL-transformed styles', async () => {
+      // This test triggers swc-compiler's browserslist import, which warns about
+      // version staleness. Silence it — the version check is irrelevant here.
+      jest.spyOn(console, 'warn').mockImplementation();
       const testDir = path.join(tempDir, 'rtl-generation');
       fs.mkdirSync(testDir, { recursive: true });
       const { entryFile } = createTestFiles(testDir);

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.17
 jsonfield==3.1.0
-morango==0.8.14
+morango==0.8.15
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cheroot==10.0.1
 magicbus==4.1.2
 le-utils==0.2.17
 jsonfield==3.1.0
-morango==0.8.12
+morango==0.8.14
 tzlocal==4.2
 pytz==2024.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
Merge up
Conflicts in requirements/base.txt - morango upgrade consolidated into pyproject.toml and uv.lock
Conflict in WebpackRTLPlugin spec - this was a backported fix from develop, so just preferred develop.
Adds small tweak to request mocking to handle device info requests.

## AI usage
Used Claude to identify why key urls request mocking was breaking now, added a small tweak to the mocking to handle the device info special case.