### PR TITLE
feat(QTI): implement inline choice viewer

### DIFF
--- a/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
@@ -40,7 +40,7 @@
       context: 'Tells the learner how to reorder the answer choices using the keyboard',
     },
     inlineChoice: {
-      message: 'Choose the best inline option for each gap.',
+      message: 'Choose the best inline option for {count, plural, one {the} other {each}} gap.',
       context:
         'Tells the learner to complete the passage by choosing an option in each inline dropdown gap',
     },

--- a/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
@@ -39,6 +39,11 @@
       message: 'Use the right/left buttons to reorder:',
       context: 'Tells the learner how to reorder the answer choices using the keyboard',
     },
+    inlineChoice: {
+      message: 'Choose the best inline option for each gap.',
+      context:
+        'Tells the learner to complete the passage by choosing an option in each inline dropdown gap',
+    },
   });
 
   export default {

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -3,20 +3,16 @@
   <div>
     <template v-if="itemBody">
       <AnswerGuide
-        v-if="hasInlineChoice"
-        :text="inlineChoiceGuideText"
+        v-for="text in guides"
+        :key="text"
+        :text="text"
       />
       <div
-        v-if="hasInlineChoice"
-        class="qti-passage"
+        :class="{ 'qti-passage': guides.length }"
         :style="passageStyles"
       >
         <SafeHTML :html="itemBodyMarkup" />
       </div>
-      <SafeHTML
-        v-else
-        :html="itemBodyMarkup"
-      />
     </template>
   </div>
 
@@ -31,7 +27,8 @@
   import { useQTIContext } from '../composables/useQTIContext';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import { QTIVariable } from '../utils/qti/declarations';
-  import AnswerGuide, { answerGuideStrings } from './AnswerGuide.vue';
+  import { getItemBodyGuides } from '../utils/itemBodyGuidance';
+  import AnswerGuide from './AnswerGuide.vue';
   import ChoiceInteraction from './interactions/ChoiceInteraction.vue';
   import Prompt from './Prompt.vue';
   import SimpleChoice from './interactions/SimpleChoice.vue';
@@ -108,16 +105,14 @@
         return itemBody.value?.innerHTML || '';
       });
 
-      // Inline-choice gaps are inline within the passage, so a single guide is shown once
-      // above the whole passage rather than per gap.
-      const hasInlineChoice = computed(() =>
-        Boolean(itemBody.value?.querySelector('qti-inline-choice-interaction')),
+      // Guides shown once above the passage for inline interactions that cannot render their
+      // own block-level guide
+      const guides = computed(() => getItemBodyGuides(itemBody.value));
+      const passageStyles = computed(() =>
+        guides.value.length
+          ? { borderColor: $themeTokens.fineLine, color: $themeTokens.text }
+          : null,
       );
-      const inlineChoiceGuideText = computed(() => answerGuideStrings.inlineChoice$());
-      const passageStyles = computed(() => ({
-        borderColor: $themeTokens.fineLine,
-        color: $themeTokens.text,
-      }));
 
       const { interaction, registerCheckAnswer } = inject('handlers');
       const QTI_CONTEXT = inject('QTI_CONTEXT');
@@ -182,8 +177,7 @@
       return {
         itemBody,
         itemBodyMarkup,
-        hasInlineChoice,
-        inlineChoiceGuideText,
+        guides,
         passageStyles,
       };
     },

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -24,9 +24,8 @@
   import { computed, inject, provide, watch } from 'vue';
   import cloneDeep from 'lodash/cloneDeep';
   import { createSafeHTML } from 'kolibri-common/components/SafeHTML';
-  import { useQTIContext } from '../composables/useQTIContext';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
-  import { QTIVariable } from '../utils/qti/declarations';
+  import { useQTIContext } from '../composables/useQTIContext';
   import { getItemBodyGuides, numberPassageGaps } from '../utils/itemBodyGuidance';
   import AnswerGuide from './AnswerGuide.vue';
   import ChoiceInteraction from './interactions/ChoiceInteraction.vue';
@@ -36,33 +35,6 @@
   import OrderInteraction from './interactions/OrderInteraction.vue';
   import InlineChoiceInteraction from './interactions/InlineChoiceInteraction.vue';
   import InlineChoice from './interactions/InlineChoice.vue';
-
-  /**
-   * Extract QTI declarations of a specific type from an XML document.
-   * @param {Document} xmlDocument - The QTI XML document.
-   * @param {string} declarationType - 'response', 'outcome', or 'context'.
-   * @param {Function} interactionHandler - A function called when a variable value is set.
-   * @returns {object} Map of identifier to QTIVariable.
-   */
-  function getQTIDeclarations(xmlDocument, declarationType, interactionHandler) {
-    const declarations = {};
-
-    const selector = `qti-${declarationType}-declaration`;
-
-    const nodes = xmlDocument.querySelectorAll(selector);
-
-    for (const node of nodes) {
-      const variable = new QTIVariable(node, interactionHandler);
-      declarations[variable.identifier] = variable;
-    }
-    return declarations;
-  }
-
-  function clearObject(obj) {
-    for (const key in obj) {
-      delete obj[key];
-    }
-  }
 
   const $themeTokens = themeTokens();
 

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -21,6 +21,8 @@
   import SimpleChoice from './interactions/SimpleChoice.vue';
   import TextEntryInteraction from './interactions/TextEntryInteraction.vue';
   import OrderInteraction from './interactions/OrderInteraction.vue';
+  import InlineChoiceInteraction from './interactions/InlineChoiceInteraction.vue';
+  import InlineChoice from './interactions/InlineChoice.vue';
 
   const SafeHTML = createSafeHTML({
     [ChoiceInteraction.tag]: ChoiceInteraction,
@@ -28,6 +30,8 @@
     [SimpleChoice.tag]: SimpleChoice,
     [TextEntryInteraction.tag]: TextEntryInteraction,
     [OrderInteraction.tag]: OrderInteraction,
+    [InlineChoiceInteraction.tag]: InlineChoiceInteraction,
+    [InlineChoice.tag]: InlineChoice,
   });
 
   /** @typedef {import('../utils/qti/values.js').QTIValue} QTIValue */

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -27,7 +27,7 @@
   import { useQTIContext } from '../composables/useQTIContext';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import { QTIVariable } from '../utils/qti/declarations';
-  import { getItemBodyGuides } from '../utils/itemBodyGuidance';
+  import { getItemBodyGuides, numberPassageGaps } from '../utils/itemBodyGuidance';
   import AnswerGuide from './AnswerGuide.vue';
   import ChoiceInteraction from './interactions/ChoiceInteraction.vue';
   import Prompt from './Prompt.vue';
@@ -100,10 +100,9 @@
         return props.xmlDoc.querySelector('qti-item-body');
       });
 
-      // Process item body for display
-      const itemBodyMarkup = computed(() => {
-        return itemBody.value?.innerHTML || '';
-      });
+      // Process item body for display. Inline gaps are annotated with their passage position so
+      // each can render a distinct accessible name; item bodies without gaps pass through as-is.
+      const itemBodyMarkup = computed(() => numberPassageGaps(itemBody.value));
 
       // Guides shown once above the passage for inline interactions that cannot render their
       // own block-level guide

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -1,10 +1,23 @@
 <template>
 
   <div>
-    <SafeHTML
-      v-if="itemBody"
-      :html="itemBodyMarkup"
-    />
+    <template v-if="itemBody">
+      <AnswerGuide
+        v-if="hasInlineChoice"
+        :text="inlineChoiceGuideText"
+      />
+      <div
+        v-if="hasInlineChoice"
+        class="qti-passage"
+        :style="passageStyles"
+      >
+        <SafeHTML :html="itemBodyMarkup" />
+      </div>
+      <SafeHTML
+        v-else
+        :html="itemBodyMarkup"
+      />
+    </template>
   </div>
 
 </template>
@@ -16,6 +29,9 @@
   import cloneDeep from 'lodash/cloneDeep';
   import { createSafeHTML } from 'kolibri-common/components/SafeHTML';
   import { useQTIContext } from '../composables/useQTIContext';
+  import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
+  import { QTIVariable } from '../utils/qti/declarations';
+  import AnswerGuide, { answerGuideStrings } from './AnswerGuide.vue';
   import ChoiceInteraction from './interactions/ChoiceInteraction.vue';
   import Prompt from './Prompt.vue';
   import SimpleChoice from './interactions/SimpleChoice.vue';
@@ -23,6 +39,35 @@
   import OrderInteraction from './interactions/OrderInteraction.vue';
   import InlineChoiceInteraction from './interactions/InlineChoiceInteraction.vue';
   import InlineChoice from './interactions/InlineChoice.vue';
+
+  /**
+   * Extract QTI declarations of a specific type from an XML document.
+   * @param {Document} xmlDocument - The QTI XML document.
+   * @param {string} declarationType - 'response', 'outcome', or 'context'.
+   * @param {Function} interactionHandler - A function called when a variable value is set.
+   * @returns {object} Map of identifier to QTIVariable.
+   */
+  function getQTIDeclarations(xmlDocument, declarationType, interactionHandler) {
+    const declarations = {};
+
+    const selector = `qti-${declarationType}-declaration`;
+
+    const nodes = xmlDocument.querySelectorAll(selector);
+
+    for (const node of nodes) {
+      const variable = new QTIVariable(node, interactionHandler);
+      declarations[variable.identifier] = variable;
+    }
+    return declarations;
+  }
+
+  function clearObject(obj) {
+    for (const key in obj) {
+      delete obj[key];
+    }
+  }
+
+  const $themeTokens = themeTokens();
 
   const SafeHTML = createSafeHTML({
     [ChoiceInteraction.tag]: ChoiceInteraction,
@@ -50,6 +95,7 @@
   export default {
     name: 'AssessmentItem',
     components: {
+      AnswerGuide,
       SafeHTML,
     },
     setup(props) {
@@ -61,6 +107,17 @@
       const itemBodyMarkup = computed(() => {
         return itemBody.value?.innerHTML || '';
       });
+
+      // Inline-choice gaps are inline within the passage, so a single guide is shown once
+      // above the whole passage rather than per gap.
+      const hasInlineChoice = computed(() =>
+        Boolean(itemBody.value?.querySelector('qti-inline-choice-interaction')),
+      );
+      const inlineChoiceGuideText = computed(() => answerGuideStrings.inlineChoice$());
+      const passageStyles = computed(() => ({
+        borderColor: $themeTokens.fineLine,
+        color: $themeTokens.text,
+      }));
 
       const { interaction, registerCheckAnswer } = inject('handlers');
       const QTI_CONTEXT = inject('QTI_CONTEXT');
@@ -125,6 +182,9 @@
       return {
         itemBody,
         itemBodyMarkup,
+        hasInlineChoice,
+        inlineChoiceGuideText,
+        passageStyles,
       };
     },
     props: {
@@ -136,3 +196,16 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .qti-passage {
+    padding: 1rem 1.125rem;
+    line-height: 2.25;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/items.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/items.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c3aa54a6b3c4fbd42adcafdbbdc7fbaa8e327282dff4a72f65bf0f953f5830f
-size 864015
+oid sha256:581072841c36d499fa9401c73cb6a9ef87b298d9e86cf76be420c7101eeb80ba
+size 864016

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoice.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoice.vue
@@ -7,7 +7,10 @@
     `componentOptions.propsData`/`children` off each choice vnode, and so DOMPurify
     keeps the tag and its text content when sanitizing the item body.
   -->
-  <span class="qti-inline-choice"><slot></slot></span>
+  <span
+    class="qti-inline-choice"
+    dir="auto"
+  ><slot></slot></span>
 
 </template>
 

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoice.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoice.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <!--
+    Rendered indirectly: the parent InlineChoiceInteraction reads these vnodes to
+    build its dropdown options, so this component is not mounted on its own. This
+    stateful (non-functional) definition is required so the parent can read
+    `componentOptions.propsData`/`children` off each choice vnode, and so DOMPurify
+    keeps the tag and its text content when sanitizing the item body.
+  -->
+  <span class="qti-inline-choice"><slot></slot></span>
+
+</template>
+
+
+<script>
+
+  import { BooleanProp, QTIIdentifierProp } from '../../utils/props';
+
+  export default {
+    name: 'InlineChoice',
+    tag: 'qti-inline-choice',
+    setup() {
+      return {};
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      identifier: QTIIdentifierProp(true),
+      fixed: BooleanProp(false, false),
+      /* eslint-enable */
+    },
+  };
+
+</script>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -133,7 +133,7 @@
             vnode.componentOptions.propsData.fixed === true,
         }));
 
-      const variable = computed(() => responses[typedProps.responseIdentifier.value]);
+      const variable = computed(() => responses.value[typedProps.responseIdentifier.value]);
       const selectedValue = computed(() => variable.value?.value ?? null);
 
       const orderedChoices = computed(() => {

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -27,8 +27,19 @@
         :options="options"
         @select="onSelect"
       >
+        <!--
+          The slot is overridden only to set dir="auto", so that a choice written in a
+          right-to-left script reads correctly. Overriding it replaces UiMenuOption's own
+          markup, so the two layout classes it supplies (row height, padding, truncation)
+          have to be reproduced here or every option loses its alignment.
+        -->
         <template #option="{ option }">
-          <span dir="auto">{{ option.label }}</span>
+          <div
+            class="ui-menu-option-content"
+            dir="auto"
+          >
+            <div class="ui-menu-option-text">{{ option.label }}</div>
+          </div>
         </template>
       </KDropdownMenu>
     </button>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -15,7 +15,10 @@
       :style="triggerStyles"
       :aria-label="triggerAriaLabel"
     >
-      <span class="qti-inline-choice-label">{{ triggerLabel }}</span>
+      <span
+        class="qti-inline-choice-label"
+        dir="auto"
+      >{{ triggerLabel }}</span>
       <KIcon
         icon="dropdown"
         class="qti-inline-choice-arrow"
@@ -23,11 +26,16 @@
       <KDropdownMenu
         :options="options"
         @select="onSelect"
-      />
+      >
+        <template #option="{ option }">
+          <span dir="auto">{{ option.label }}</span>
+        </template>
+      </KDropdownMenu>
     </button>
     <span
       v-else
       class="qti-inline-choice-report qti-inline-choice-trigger"
+      dir="auto"
       :style="triggerStyles"
     >{{ triggerLabel }}</span>
   </span>
@@ -42,7 +50,12 @@
   import { computed, inject } from 'vue';
   import { themeTokens, themeOutlineStyle } from 'kolibri-design-system/lib/styles/theme';
   import { createTranslator } from 'kolibri/utils/i18n';
-  import { BooleanProp, QTIIdentifierProp, StringProp } from '../../utils/props';
+  import {
+    BooleanProp,
+    NonNegativeIntProp,
+    QTIIdentifierProp,
+    StringProp,
+  } from '../../utils/props';
   import useTypedProps from '../../composables/useTypedProps';
 
   export const inlineChoiceStrings = createTranslator('InlineChoiceInteractionStrings', {
@@ -59,9 +72,20 @@
       message: 'Selected: {selection}. Activate to change your answer.',
       context: 'Accessible label for an inline dropdown gap that has been answered',
     },
+    notAnsweredGap: {
+      message: 'Gap {number} of {total}: not answered. Activate to choose an answer.',
+      context:
+        'Accessible label for an unanswered inline dropdown gap when a passage has several gaps, so a screen-reader user can tell the gaps apart',
+    },
+    answeredGap: {
+      message: 'Gap {number} of {total}: selected {selection}. Activate to change your answer.',
+      context:
+        'Accessible label for an answered inline dropdown gap when a passage has several gaps, so a screen-reader user can tell the gaps apart',
+    },
   });
 
-  const { placeholder$, notAnswered$, answered$ } = inlineChoiceStrings;
+  const { placeholder$, notAnswered$, answered$, notAnsweredGap$, answeredGap$ } =
+    inlineChoiceStrings;
 
   const $themeTokens = themeTokens();
 
@@ -139,9 +163,19 @@
       const triggerLabel = computed(() =>
         isAnswered.value ? selectedText.value : placeholder.value,
       );
-      const triggerAriaLabel = computed(() =>
-        isAnswered.value ? answered$({ selection: selectedText.value }) : notAnswered$(),
-      );
+      // When a passage has several gaps, each accessible name is prefixed with the gap's
+      // position ("gap 2 of 3")
+      // A lone gap keeps the shorter, unnumbered wording.
+      const triggerAriaLabel = computed(() => {
+        const number = typedProps.dataGapNumber.value;
+        const total = typedProps.dataGapCount.value;
+        const numbered = total > 1;
+        if (isAnswered.value) {
+          const selection = selectedText.value;
+          return numbered ? answeredGap$({ number, total, selection }) : answered$({ selection });
+        }
+        return numbered ? notAnsweredGap$({ number, total }) : notAnswered$();
+      });
 
       const rootStyles = computed(() => ({ color: $themeTokens.text }));
       const triggerStyles = computed(() => ({
@@ -177,6 +211,10 @@
       responseIdentifier: QTIIdentifierProp(true),
       shuffle: BooleanProp(false, false),
       dataPrompt: StringProp(false),
+      // Position of this gap and the total gap count in the passage, injected by AssessmentItem
+      // (numberPassageGaps) purely to build a distinct accessible name per gap.
+      dataGapNumber: NonNegativeIntProp(false, 0),
+      dataGapCount: NonNegativeIntProp(false, 0),
       /* eslint-enable */
     },
   };

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -2,7 +2,7 @@
 
   <span
     class="qti-inline-choice-interaction"
-    :style="{ color: $themeTokens.text }"
+    :style="rootStyles"
   >
     <button
       v-if="interactive"
@@ -143,6 +143,7 @@
         isAnswered.value ? answered$({ selection: selectedText.value }) : notAnswered$(),
       );
 
+      const rootStyles = computed(() => ({ color: $themeTokens.text }));
       const triggerStyles = computed(() => ({
         color: $themeTokens.text,
         backgroundColor: $themeTokens.surface,
@@ -160,13 +161,13 @@
       }
 
       return {
-        $themeTokens,
         coreOutline: themeOutlineStyle(),
         interactive,
         options,
         isAnswered,
         triggerLabel,
         triggerAriaLabel,
+        rootStyles,
         triggerStyles,
         onSelect,
       };

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -1,0 +1,252 @@
+<template>
+
+  <span
+    class="qti-inline-choice-interaction"
+    :style="{ color: $themeTokens.text }"
+  >
+    <button
+      v-if="interactive"
+      type="button"
+      class="qti-inline-choice-trigger"
+      :class="[
+        $computedClass({ ':focus': coreOutline }),
+        { 'qti-inline-choice-answered': isAnswered },
+      ]"
+      :style="triggerStyles"
+      :aria-label="triggerAriaLabel"
+    >
+      <span class="qti-inline-choice-label">{{ triggerLabel }}</span>
+      <KIcon
+        icon="dropdown"
+        class="qti-inline-choice-arrow"
+      />
+      <KDropdownMenu
+        :options="options"
+        @select="onSelect"
+      />
+    </button>
+    <span
+      v-else
+      class="qti-inline-choice-report qti-inline-choice-trigger"
+      :style="triggerStyles"
+    >{{ triggerLabel }}</span>
+  </span>
+
+</template>
+
+
+<script>
+
+  import get from 'lodash/get';
+  import shuffled from 'kolibri-common/utils/shuffled';
+  import { computed, inject } from 'vue';
+  import { themeTokens, themeOutlineStyle } from 'kolibri-design-system/lib/styles/theme';
+  import { createTranslator } from 'kolibri/utils/i18n';
+  import { BooleanProp, QTIIdentifierProp, StringProp } from '../../utils/props';
+  import useTypedProps from '../../composables/useTypedProps';
+
+  export const inlineChoiceStrings = createTranslator('InlineChoiceInteractionStrings', {
+    placeholder: {
+      message: 'Choose…',
+      context:
+        'Placeholder shown in an inline dropdown gap before the learner has chosen an answer',
+    },
+    notAnswered: {
+      message: 'Not answered. Activate to choose an answer.',
+      context: 'Accessible label for an inline dropdown gap that has not been answered yet',
+    },
+    answered: {
+      message: 'Selected: {selection}. Activate to change your answer.',
+      context: 'Accessible label for an inline dropdown gap that has been answered',
+    },
+  });
+
+  const { placeholder$, notAnswered$, answered$ } = inlineChoiceStrings;
+
+  const $themeTokens = themeTokens();
+
+  function getComponentTag(vnode) {
+    return get(vnode, ['componentOptions', 'Ctor', 'extendOptions', 'tag']);
+  }
+
+  // Plain-text label for a choice, joined from its (text) child vnodes.
+  function vnodeToText(vnode) {
+    if (!vnode) {
+      return '';
+    }
+    if (vnode.text) {
+      return vnode.text.trim();
+    }
+    if (vnode.children) {
+      return vnode.children.map(vnodeToText).join(' ').trim();
+    }
+    return '';
+  }
+
+  export default {
+    name: 'InlineChoiceInteraction',
+    tag: 'qti-inline-choice-interaction',
+
+    setup(props, { slots }) {
+      const responses = inject('responses');
+      const QTI_CONTEXT = inject('QTI_CONTEXT');
+      const interactive = inject('interactive');
+      const typedProps = useTypedProps(props);
+
+      // Choices are static: parse the slot vnodes once rather than on every render.
+      const allContent = (slots.default && slots.default()) || [];
+      const choices = allContent
+        .filter(vnode => getComponentTag(vnode) === 'qti-inline-choice')
+        .map(vnode => ({
+          identifier: vnode.componentOptions.propsData.identifier,
+          text: (vnode.componentOptions.children || [])
+            .map(vnodeToText)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim(),
+          fixed:
+            vnode.componentOptions.propsData.fixed === 'true' ||
+            vnode.componentOptions.propsData.fixed === true,
+        }));
+
+      const variable = computed(() => responses[typedProps.responseIdentifier.value]);
+      const selectedValue = computed(() => variable.value?.value ?? null);
+
+      const orderedChoices = computed(() => {
+        if (!typedProps.shuffle.value) {
+          return choices;
+        }
+        // Shuffle is seeded by the candidate so it is consistent for a given learner,
+        // and choices with fixed="true" keep their original positions.
+        const shuffleable = shuffled(
+          choices.filter(choice => !choice.fixed),
+          QTI_CONTEXT.value.candidateIdentifier,
+        );
+        return choices.map(choice => (choice.fixed ? choice : shuffleable.shift()));
+      });
+
+      const options = computed(() =>
+        orderedChoices.value.map(choice => ({ label: choice.text, value: choice.identifier })),
+      );
+
+      const selectedText = computed(() => {
+        const found = choices.find(choice => choice.identifier === selectedValue.value);
+        return found ? found.text : '';
+      });
+      const isAnswered = computed(() => Boolean(selectedText.value));
+
+      const placeholder = computed(() => typedProps.dataPrompt.value || placeholder$());
+      const triggerLabel = computed(() =>
+        isAnswered.value ? selectedText.value : placeholder.value,
+      );
+      const triggerAriaLabel = computed(() =>
+        isAnswered.value ? answered$({ selection: selectedText.value }) : notAnswered$(),
+      );
+
+      const triggerStyles = computed(() => ({
+        color: $themeTokens.text,
+        backgroundColor: $themeTokens.surface,
+        borderColor: isAnswered.value ? $themeTokens.primary : $themeTokens.fineLine,
+      }));
+
+      function onSelect(option) {
+        if (!interactive.value) {
+          return;
+        }
+        const responseVariable = variable.value;
+        if (responseVariable) {
+          responseVariable.value = option.value;
+        }
+      }
+
+      return {
+        $themeTokens,
+        coreOutline: themeOutlineStyle(),
+        interactive,
+        options,
+        isAnswered,
+        triggerLabel,
+        triggerAriaLabel,
+        triggerStyles,
+        onSelect,
+      };
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      responseIdentifier: QTIIdentifierProp(true),
+      shuffle: BooleanProp(false, false),
+      dataPrompt: StringProp(false),
+      /* eslint-enable */
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .qti-inline-choice-interaction {
+    // Flow inline within the surrounding sentence, without stretching the line box.
+    display: inline-flex;
+    max-width: 100%;
+    vertical-align: baseline;
+  }
+
+  .qti-inline-choice-trigger {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    padding: 2px 4px 2px 10px;
+    margin: 0;
+    font: inherit;
+    line-height: inherit;
+    text-align: start;
+    cursor: pointer;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 6px;
+    transition:
+      border-color 0.2s ease,
+      background-color 0.2s ease;
+  }
+
+  .qti-inline-choice-answered {
+    font-weight: 600;
+  }
+
+  .qti-inline-choice-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .qti-inline-choice-arrow {
+    flex-shrink: 0;
+  }
+
+  .qti-inline-choice-report {
+    cursor: default;
+  }
+
+  // QTI shared vocabulary: qti-input-width-N sizes the gap to roughly N characters.
+  // We treat it as a minimum so a longer selected answer never breaks the line layout.
+  @for $i from 1 through 40 {
+    .qti-inline-choice-interaction.qti-input-width-#{$i} .qti-inline-choice-trigger {
+      min-width: #{$i}ch;
+    }
+  }
+
+  // QTI shared vocabulary: vertical alignment of the gap within the line.
+  .qti-inline-choice-interaction.qti-valign-top {
+    vertical-align: top;
+  }
+
+  .qti-inline-choice-interaction.qti-valign-middle {
+    vertical-align: middle;
+  }
+
+  .qti-inline-choice-interaction.qti-valign-baseline {
+    vertical-align: baseline;
+  }
+
+</style>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/InlineChoiceInteraction.vue
@@ -93,20 +93,6 @@
     return get(vnode, ['componentOptions', 'Ctor', 'extendOptions', 'tag']);
   }
 
-  // Plain-text label for a choice, joined from its (text) child vnodes.
-  function vnodeToText(vnode) {
-    if (!vnode) {
-      return '';
-    }
-    if (vnode.text) {
-      return vnode.text.trim();
-    }
-    if (vnode.children) {
-      return vnode.children.map(vnodeToText).join(' ').trim();
-    }
-    return '';
-  }
-
   export default {
     name: 'InlineChoiceInteraction',
     tag: 'qti-inline-choice-interaction',
@@ -123,8 +109,9 @@
         .filter(vnode => getComponentTag(vnode) === 'qti-inline-choice')
         .map(vnode => ({
           identifier: vnode.componentOptions.propsData.identifier,
+          // An inline choice is strictly plain text, so its children are only ever text vnodes.
           text: (vnode.componentOptions.children || [])
-            .map(vnodeToText)
+            .map(child => child.text || '')
             .join(' ')
             .replace(/\s+/g, ' ')
             .trim(),

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
@@ -50,7 +50,8 @@ describe('Smoke', () => {
 describe('Answer guide', () => {
   it('renders the inline-choice guide once above the passage', () => {
     renderAssessmentItem(items['shakespeare-biography'].xml);
-    expect(screen.getAllByText(answerGuideStrings.inlineChoice$())).toHaveLength(1);
+    // the shakespeare-biography passage has two gaps
+    expect(screen.getAllByText(answerGuideStrings.inlineChoice$({ count: 2 }))).toHaveLength(1);
   });
 
   it('wraps the passage in a bordered box', () => {
@@ -83,6 +84,19 @@ describe('Unanswered gap', () => {
       { label: 'Lancaster', value: 'L' },
       { label: 'York', value: 'Y' },
     ]);
+  });
+
+  // We override KDropdownMenu's `option` slot
+  it('renders each option with the menu layout classes and a direction-aware wrapper', () => {
+    renderAssessmentItem(xml());
+    const [menu] = findKDropdownMenus();
+    const vnode = menu.$scopedSlots.option({ option: menu.options[0] })[0];
+
+    expect(vnode.data.staticClass).toBe('ui-menu-option-content');
+    expect(vnode.data.attrs.dir).toBe('auto');
+    const [text] = vnode.children;
+    expect(text.data.staticClass).toBe('ui-menu-option-text');
+    expect(text.children[0].text).toBe('Gloucester');
   });
 });
 

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
@@ -9,6 +9,7 @@ const smokeFixtures = [
   ['q12-inline-choice-interaction', 1],
   ['shakespeare-biography', 2],
   ['vertical-inlinechoice-16', 1],
+  ['q12-inline-choice-sv-1', 17],
 ];
 
 // tippy-based popovers do not open in jsdom, so the option list is never rendered to

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
@@ -1,0 +1,200 @@
+import { screen, waitFor } from '@testing-library/vue';
+import shuffled from 'kolibri-common/utils/shuffled';
+import items from '../../__fixtures__/items';
+import { renderAssessmentItem } from '../../__tests__/helpers';
+import { inlineChoiceStrings } from '../InlineChoiceInteraction.vue';
+
+const smokeFixtures = [
+  ['q12-inline-choice-interaction', 1],
+  ['shakespeare-biography', 2],
+  ['vertical-inlinechoice-16', 1],
+];
+
+// tippy-based popovers do not open in jsdom, so the option list is never rendered to
+// the DOM. To exercise a learner selecting an option we reach the KDropdownMenu
+// instances and replay the `select` event they emit when an option is chosen — the
+// same event our component listens to in production.
+function findKDropdownMenus() {
+  const withVue = Array.from(document.body.querySelectorAll('*')).find(el => el.__vue__);
+  const root = withVue && withVue.__vue__.$root;
+  const menus = [];
+  const walk = vm => {
+    if (!vm) {
+      return;
+    }
+    if (vm.$options.name === 'KDropdownMenu') {
+      menus.push(vm);
+    }
+    (vm.$children || []).forEach(walk);
+  };
+  walk(root);
+  return menus;
+}
+
+async function selectOption(menuIndex, value) {
+  const menu = findKDropdownMenus()[menuIndex];
+  const option = menu.options.find(o => o.value === value);
+  menu.$emit('select', option);
+  await menu.$nextTick();
+}
+
+describe('Smoke', () => {
+  it.each(smokeFixtures)('%s renders %d inline-choice trigger(s)', (id, gapCount) => {
+    renderAssessmentItem(items[id].xml);
+    expect(screen.getAllByRole('button')).toHaveLength(gapCount);
+  });
+});
+
+describe('Unanswered gap', () => {
+  const xml = () => items['q12-inline-choice-interaction'].xml;
+
+  it('shows the placeholder in the trigger', () => {
+    renderAssessmentItem(xml());
+    expect(screen.getByRole('button')).toHaveTextContent(inlineChoiceStrings.placeholder$());
+  });
+
+  it('exposes an accessible name describing the not-answered state', () => {
+    renderAssessmentItem(xml());
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      inlineChoiceStrings.notAnswered$(),
+    );
+  });
+
+  it('wires the choice options into the dropdown in document order', () => {
+    renderAssessmentItem(xml());
+    const [menu] = findKDropdownMenus();
+    expect(menu.options).toEqual([
+      { label: 'Gloucester', value: 'G' },
+      { label: 'Lancaster', value: 'L' },
+      { label: 'York', value: 'Y' },
+    ]);
+  });
+});
+
+describe('Selecting an option', () => {
+  const xml = () => items['q12-inline-choice-interaction'].xml;
+
+  it('updates the trigger to show the selected choice text', async () => {
+    renderAssessmentItem(xml());
+    await selectOption(0, 'Y');
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('York');
+    expect(button).not.toHaveTextContent(inlineChoiceStrings.placeholder$());
+  });
+
+  it('updates the accessible name to reflect the answered state', async () => {
+    renderAssessmentItem(xml());
+    await selectOption(0, 'Y');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      inlineChoiceStrings.answered$({ selection: 'York' }),
+    );
+  });
+
+  it('stores the selected identifier in the response, readable via checkAnswer', async () => {
+    const { checkAnswer } = renderAssessmentItem(xml());
+    await selectOption(0, 'Y');
+    expect(checkAnswer().answerState.RESPONSE).toBe('Y');
+  });
+});
+
+describe('Multiple gaps', () => {
+  const xml = () => items['shakespeare-biography'].xml;
+
+  it('render and are answerable independently', async () => {
+    renderAssessmentItem(xml());
+    // Selecting in the first gap leaves the second gap on its placeholder.
+    await selectOption(0, 'choice_1');
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveTextContent('26 April 1564');
+    expect(buttons[1]).toHaveTextContent(inlineChoiceStrings.placeholder$());
+
+    await selectOption(1, 'choice_4');
+    expect(buttons[0]).toHaveTextContent('26 April 1564');
+    expect(buttons[1]).toHaveTextContent('23 April 1616');
+  });
+});
+
+describe('Answer state', () => {
+  const xml = () => items['q12-inline-choice-interaction'].xml;
+
+  it('restores the selected choice from injected answerState on mount', () => {
+    renderAssessmentItem(xml(), { answerState: { RESPONSE: 'Y' } });
+    expect(screen.getByRole('button')).toHaveTextContent('York');
+  });
+
+  it('reacts to external setAnswerState changes', async () => {
+    const { setAnswerState } = renderAssessmentItem(xml());
+    setAnswerState({ RESPONSE: 'L' });
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('Lancaster'));
+  });
+
+  it('round-trips a selection through checkAnswer and setAnswerState', async () => {
+    const { checkAnswer, setAnswerState } = renderAssessmentItem(xml());
+    await selectOption(0, 'Y');
+    const result = checkAnswer();
+
+    setAnswerState({});
+    await waitFor(() =>
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        inlineChoiceStrings.notAnswered$(),
+      ),
+    );
+
+    setAnswerState(result.answerState);
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('York'));
+  });
+});
+
+describe('Non-interactive (report) mode', () => {
+  const xml = () => items['q12-inline-choice-interaction'].xml;
+
+  it('renders the selected answer as static text without a dropdown trigger', () => {
+    const { container } = renderAssessmentItem(xml(), {
+      interactive: false,
+      answerState: { RESPONSE: 'Y' },
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(container.querySelector('.qti-inline-choice-report')).toHaveTextContent('York');
+  });
+});
+
+describe('Shuffle', () => {
+  const candidateIdentifier = 'shuffle-seed-001';
+  const sourceIds = ['A', 'B', 'C', 'D'];
+  const shuffleXml = `<qti-assessment-item
+      xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+      identifier="inline-shuffle" title="Shuffle" adaptive="false" time-dependent="false">
+      <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="identifier"/>
+      <qti-item-body>
+        <p>Pick <qti-inline-choice-interaction response-identifier="RESPONSE" shuffle="true">
+          <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+          <qti-inline-choice identifier="B">Bravo</qti-inline-choice>
+          <qti-inline-choice identifier="C">Charlie</qti-inline-choice>
+          <qti-inline-choice identifier="D" fixed="true">Delta</qti-inline-choice>
+        </qti-inline-choice-interaction>.</p>
+      </qti-item-body>
+    </qti-assessment-item>`;
+
+  it('applies a seeded order that is consistent for a given candidate', () => {
+    renderAssessmentItem(shuffleXml, { candidateIdentifier });
+    const renderedIds = findKDropdownMenus()[0].options.map(o => o.value);
+
+    // Deterministic: the same candidate seed reproduces the same order.
+    const shuffleable = shuffled(['A', 'B', 'C'], candidateIdentifier);
+    const expected = ['A', 'B', 'C', 'D'].map(id => (id === 'D' ? 'D' : shuffleable.shift()));
+    expect(renderedIds).toEqual(expected);
+
+    // The shuffle actually reorders relative to source (guards against a no-op).
+    expect(renderedIds).not.toEqual(sourceIds);
+  });
+
+  it('keeps fixed choices in their original position', () => {
+    renderAssessmentItem(shuffleXml, { candidateIdentifier });
+    const renderedIds = findKDropdownMenus()[0].options.map(o => o.value);
+    // 'D' is fixed at the last position.
+    expect(renderedIds[renderedIds.length - 1]).toBe('D');
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/vue';
 import shuffled from 'kolibri-common/utils/shuffled';
 import items from '../../__fixtures__/items';
 import { renderAssessmentItem } from '../../__tests__/helpers';
+import { answerGuideStrings } from '../../AnswerGuide.vue';
 import { inlineChoiceStrings } from '../InlineChoiceInteraction.vue';
 
 const smokeFixtures = [
@@ -42,6 +43,18 @@ describe('Smoke', () => {
   it.each(smokeFixtures)('%s renders %d inline-choice trigger(s)', (id, gapCount) => {
     renderAssessmentItem(items[id].xml);
     expect(screen.getAllByRole('button')).toHaveLength(gapCount);
+  });
+});
+
+describe('Answer guide', () => {
+  it('renders the inline-choice guide once above the passage', () => {
+    renderAssessmentItem(items['shakespeare-biography'].xml);
+    expect(screen.getAllByText(answerGuideStrings.inlineChoice$())).toHaveLength(1);
+  });
+
+  it('wraps the passage in a bordered box', () => {
+    const { container } = renderAssessmentItem(items['q12-inline-choice-interaction'].xml);
+    expect(container.querySelector('.qti-passage')).toBeInTheDocument();
   });
 });
 

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/InlineChoiceInteraction.spec.js
@@ -128,6 +128,43 @@ describe('Multiple gaps', () => {
     expect(buttons[0]).toHaveTextContent('26 April 1564');
     expect(buttons[1]).toHaveTextContent('23 April 1616');
   });
+
+  it('gives each gap a distinct, numbered accessible name', async () => {
+    renderAssessmentItem(xml());
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveAttribute(
+      'aria-label',
+      inlineChoiceStrings.notAnsweredGap$({ number: 1, total: 2 }),
+    );
+    expect(buttons[1]).toHaveAttribute(
+      'aria-label',
+      inlineChoiceStrings.notAnsweredGap$({ number: 2, total: 2 }),
+    );
+
+    // The number carries into the answered state too.
+    await selectOption(0, 'choice_1');
+    expect(screen.getAllByRole('button')[0]).toHaveAttribute(
+      'aria-label',
+      inlineChoiceStrings.answeredGap$({ number: 1, total: 2, selection: '26 April 1564' }),
+    );
+  });
+});
+
+describe('Content direction', () => {
+  // QTI choice text is content-derived, so its direction must be resolved from the content
+  // itself (dir="auto") rather than the app language. See docs/i18n.rst.
+  it('marks the interactive trigger label with dir="auto"', () => {
+    const { container } = renderAssessmentItem(items['q12-inline-choice-interaction'].xml);
+    expect(container.querySelector('.qti-inline-choice-label')).toHaveAttribute('dir', 'auto');
+  });
+
+  it('marks the report-mode text with dir="auto"', () => {
+    const { container } = renderAssessmentItem(items['q12-inline-choice-interaction'].xml, {
+      interactive: false,
+      answerState: { RESPONSE: 'Y' },
+    });
+    expect(container.querySelector('.qti-inline-choice-report')).toHaveAttribute('dir', 'auto');
+  });
 });
 
 describe('Answer state', () => {

--- a/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
@@ -1,5 +1,5 @@
 import { parseXML } from '../xml';
-import { getItemBodyGuides } from '../itemBodyGuidance';
+import { getItemBodyGuides, numberPassageGaps } from '../itemBodyGuidance';
 import { answerGuideStrings } from '../../components/AnswerGuide.vue';
 
 function itemBody(innerXML) {
@@ -29,5 +29,44 @@ describe('getItemBodyGuides', () => {
 
   it('returns an empty list when given no item body node', () => {
     expect(getItemBodyGuides(null)).toEqual([]);
+  });
+});
+
+describe('numberPassageGaps', () => {
+  // Parse the returned markup back and read the position attributes off each gap.
+  function gapAttrs(markup) {
+    const gaps = parseXML(`<root>${markup}</root>`).querySelectorAll(
+      'qti-inline-choice-interaction',
+    );
+    return Array.from(gaps).map(el => [
+      el.getAttribute('data-gap-number'),
+      el.getAttribute('data-gap-count'),
+    ]);
+  }
+
+  it('tags each gap with its 1-based position and the total gap count, in document order', () => {
+    const body = itemBody(`
+      <p>A <qti-inline-choice-interaction response-identifier="R1">
+        <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+      </qti-inline-choice-interaction>
+      and B <qti-inline-choice-interaction response-identifier="R2">
+        <qti-inline-choice identifier="B">Bravo</qti-inline-choice>
+      </qti-inline-choice-interaction>.</p>
+    `);
+    expect(gapAttrs(numberPassageGaps(body))).toEqual([
+      ['1', '2'],
+      ['2', '2'],
+    ]);
+  });
+
+  it('leaves markup without inline-choice gaps unchanged', () => {
+    const body = itemBody('<p>No interactions here.</p>');
+    const markup = numberPassageGaps(body);
+    expect(markup).toContain('No interactions here.');
+    expect(markup).not.toContain('data-gap-number');
+  });
+
+  it('returns an empty string when given no item body node', () => {
+    expect(numberPassageGaps(null)).toBe('');
   });
 });

--- a/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
@@ -1,0 +1,33 @@
+import { parseXML } from '../xml';
+import { getItemBodyGuides } from '../itemBodyGuidance';
+import { answerGuideStrings } from '../../components/AnswerGuide.vue';
+
+function itemBody(innerXML) {
+  const xml = `<qti-assessment-item
+      xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+      identifier="t" title="t" adaptive="false" time-dependent="false">
+      <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="identifier"/>
+      <qti-item-body>${innerXML}</qti-item-body>
+    </qti-assessment-item>`;
+  return parseXML(xml).querySelector('qti-item-body');
+}
+
+describe('getItemBodyGuides', () => {
+  it('returns the inline-choice guide when the item body contains an inline-choice gap', () => {
+    const body = itemBody(`
+      <p>Pick <qti-inline-choice-interaction response-identifier="RESPONSE">
+        <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+      </qti-inline-choice-interaction>.</p>
+    `);
+    expect(getItemBodyGuides(body)).toEqual([answerGuideStrings.inlineChoice$()]);
+  });
+
+  it('returns no guide for an item body without inline interactions', () => {
+    const body = itemBody('<p>Just a passage with no interactions.</p>');
+    expect(getItemBodyGuides(body)).toEqual([]);
+  });
+
+  it('returns an empty list when given no item body node', () => {
+    expect(getItemBodyGuides(null)).toEqual([]);
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/__tests__/itemBodyGuidance.spec.js
@@ -19,7 +19,16 @@ describe('getItemBodyGuides', () => {
         <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
       </qti-inline-choice-interaction>.</p>
     `);
-    expect(getItemBodyGuides(body)).toEqual([answerGuideStrings.inlineChoice$()]);
+    expect(getItemBodyGuides(body)).toEqual([answerGuideStrings.inlineChoice$({ count: 1 })]);
+  });
+
+  it('pluralises the inline-choice guide over the number of gaps in the passage', () => {
+    const gap = id =>
+      `<qti-inline-choice-interaction response-identifier="${id}">
+        <qti-inline-choice identifier="A">Alpha</qti-inline-choice>
+      </qti-inline-choice-interaction>`;
+    const body = itemBody(`<p>Pick ${gap('R1')} and ${gap('R2')}.</p>`);
+    expect(getItemBodyGuides(body)).toEqual([answerGuideStrings.inlineChoice$({ count: 2 })]);
   });
 
   it('returns no guide for an item body without inline interactions', () => {

--- a/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
@@ -2,21 +2,50 @@ import InlineChoiceInteraction from '../components/interactions/InlineChoiceInte
 import { answerGuideStrings } from '../components/AnswerGuide.vue';
 
 // Guides for inlines only, block interactions handle their own
-const INLINE_INTERACTION_GUIDES = [
-  { tag: InlineChoiceInteraction.tag, text: () => answerGuideStrings.inlineChoice$() },
+// Each entry: { tag, guide? } where `guide` (optional) returns the translated string to hoist
+// above the passage when that interaction is present.
+const INLINE_INTERACTIONS = [
+  { tag: InlineChoiceInteraction.tag, guide: () => answerGuideStrings.inlineChoice$() },
 ];
 
+// A single selector matching every inline gap, so gaps are numbered across interaction types
+const GAP_SELECTOR = INLINE_INTERACTIONS.map(interaction => interaction.tag).join(',');
+
 /**
- * Determine the guide(s) to render once above an item body's passage, based on the inline
- * interactions it contains.
+ * The guide(s) to render once above an item body's passage, based on the inline interactions
+ * it contains.
  * @param {Element|null} itemBodyNode - The qti-item-body element (or null).
- * @returns {string[]} Translated guide strings, in table order (empty when none apply).
+ * @returns {string[]} Translated guide strings, in registry order (empty when none apply).
  */
 export function getItemBodyGuides(itemBodyNode) {
   if (!itemBodyNode) {
     return [];
   }
-  return INLINE_INTERACTION_GUIDES.filter(guide => itemBodyNode.querySelector(guide.tag)).map(
-    guide => guide.text(),
-  );
+  return INLINE_INTERACTIONS.filter(
+    interaction => interaction.guide && itemBodyNode.querySelector(interaction.tag),
+  ).map(interaction => interaction.guide());
+}
+
+/**
+ * Return the item body's markup with each inline gap tagged with its 1-based position
+ * (data-gap-number) and the total number of gaps in the passage (data-gap-count), numbered
+ * across all inline interaction types in document order. Each gap needs this to render a
+ * distinct accessible name ("gap 2 of 3"), which it cannot derive on its own since gaps are
+ * rendered independently from the passage markup. Item bodies with no inline gaps are returned
+ * unchanged.
+ * @param {Element|null} itemBodyNode - The qti-item-body element (or null).
+ * @returns {string} The (possibly annotated) item body inner markup.
+ */
+export function numberPassageGaps(itemBodyNode) {
+  if (!itemBodyNode) {
+    return '';
+  }
+  // Clone so we annotate a throwaway copy rather than mutating the parsed document.
+  const clone = itemBodyNode.cloneNode(true);
+  const gaps = clone.querySelectorAll(GAP_SELECTOR);
+  gaps.forEach((gap, index) => {
+    gap.setAttribute('data-gap-number', String(index + 1));
+    gap.setAttribute('data-gap-count', String(gaps.length));
+  });
+  return clone.innerHTML;
 }

--- a/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
@@ -1,0 +1,22 @@
+import InlineChoiceInteraction from '../components/interactions/InlineChoiceInteraction.vue';
+import { answerGuideStrings } from '../components/AnswerGuide.vue';
+
+// Guides for inlines only, block interactions handle their own
+const INLINE_INTERACTION_GUIDES = [
+  { tag: InlineChoiceInteraction.tag, text: () => answerGuideStrings.inlineChoice$() },
+];
+
+/**
+ * Determine the guide(s) to render once above an item body's passage, based on the inline
+ * interactions it contains.
+ * @param {Element|null} itemBodyNode - The qti-item-body element (or null).
+ * @returns {string[]} Translated guide strings, in table order (empty when none apply).
+ */
+export function getItemBodyGuides(itemBodyNode) {
+  if (!itemBodyNode) {
+    return [];
+  }
+  return INLINE_INTERACTION_GUIDES.filter(guide => itemBodyNode.querySelector(guide.tag)).map(
+    guide => guide.text(),
+  );
+}

--- a/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/itemBodyGuidance.js
@@ -2,10 +2,14 @@ import InlineChoiceInteraction from '../components/interactions/InlineChoiceInte
 import { answerGuideStrings } from '../components/AnswerGuide.vue';
 
 // Guides for inlines only, block interactions handle their own
-// Each entry: { tag, guide? } where `guide` (optional) returns the translated string to hoist
-// above the passage when that interaction is present.
+// Each entry: { tag, guide? } where `guide` (optional) takes the number of gaps that
+// interaction contributes to the passage — the guide wording is pluralised on it — and
+// returns the translated string to hoist above the passage when that interaction is present.
 const INLINE_INTERACTIONS = [
-  { tag: InlineChoiceInteraction.tag, guide: () => answerGuideStrings.inlineChoice$() },
+  {
+    tag: InlineChoiceInteraction.tag,
+    guide: count => answerGuideStrings.inlineChoice$({ count }),
+  },
 ];
 
 // A single selector matching every inline gap, so gaps are numbered across interaction types
@@ -23,7 +27,7 @@ export function getItemBodyGuides(itemBodyNode) {
   }
   return INLINE_INTERACTIONS.filter(
     interaction => interaction.guide && itemBodyNode.querySelector(interaction.tag),
-  ).map(interaction => interaction.guide());
+  ).map(interaction => interaction.guide(itemBodyNode.querySelectorAll(interaction.tag).length));
 }
 
 /**


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
This pr implements learner-facing rendering for qti-inline-choice-interaction (QTI 3.0 inline/cloze dropdowns) in the Kolibri QTI viewer.

- InlineChoiceInteraction.vue -> dropdown trigger (KDropdownMenu) embedded inline within sentence text; placeholder vs. answered states with per-gap accessible labels, shuffle support (seeded per candidate, respects fixed), non-interactive/report mode renders static selected text with no dropdown
- InlineChoice.vue -> registers the qti-inline-choice tag so option identifier/text can be read into the parent dropdown
- AssessmentItem.vue -> wires both into the SafeHTML tag map; wraps inline-choice item bodies in a bordered .qti-passage, with a single answer-guide instruction shown once above the passage rather than per gap


## Visuals:

| Description | Screenshot |
|---|---|
| Learner sees one or more dropdown gaps embedded inline within sentence text, each showing a placeholder until answered | <img width="666" height="395" alt="image" src="https://github.com/user-attachments/assets/14f5b95d-39a2-4198-aa71-c2837953e5ff" /> |
| Multiple gaps within the same passage, each independently answerable | <img width="666" height="395" alt="image" src="https://github.com/user-attachments/assets/1b888efa-3c1c-4afa-880d-2e00816fdcb9" /> |
| Custom Prompt | <img width="665" height="155" alt="image" src="https://github.com/user-attachments/assets/97e7eb2c-f6eb-4586-b2cc-b8ad2c3e2e53" /> |
| Custom Widths | <img width="658" height="544" alt="image" src="https://github.com/user-attachments/assets/1874fbde-37b2-4a00-8565-64396f219a47" /> |

---

## References
- fixes: #15007 

---

## Reviewer guidance
Navigate to `http://localhost:8000/en/learn/#/qti_sandbox/` and try all inline choice examples

---

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude to draft an initial implementation and to draft this PR/issue description from the diff. The first draft didn't match what was intended so I kept editing on it by hand till we reached a fully working version 🎉 

Also all the unit tests are ai-generated because they keep repeating for every new interaction I build with small differences