### PR TITLE
Prevent class/style pollution in SafeHTML rendering

### DIFF
--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlImage.vue
@@ -12,6 +12,7 @@
         @click="openLightbox"
       >
         <img
+          class="safe-html"
           :src="src"
           :alt="alt"
           :style="[contentStyle, imageStyle]"

--- a/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
+++ b/packages/kolibri-common/components/SafeHTML/SafeHtmlTable.vue
@@ -5,6 +5,7 @@
     data-testid="table-container"
   >
     <table
+      class="safe-html"
       v-bind="$attrs"
       :style="[contentStyle, tableStyle]"
     >

--- a/packages/kolibri-common/components/SafeHTML/__tests__/SafeHTML.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/SafeHTML.spec.js
@@ -188,6 +188,61 @@ describe('SafeHTML', () => {
     });
   });
 
+  describe('custom components', () => {
+    // Mirrors the QTI interaction components: classes and styles its own root,
+    // and re-renders off its own reactive state rather than a prop.
+    const CustomChoice = {
+      name: 'CustomChoice',
+      props: { identifier: { type: String, default: '' } },
+      data() {
+        return { selected: false };
+      },
+      render(h) {
+        return h(
+          'li',
+          {
+            class: ['custom-choice', this.selected ? 'is-selected' : ''],
+            on: { click: () => (this.selected = true) },
+          },
+          this.$slots.default,
+        );
+      },
+    };
+
+    function renderChoice() {
+      const SafeHTMLWithCustom = createSafeHTML({ 'custom-choice': CustomChoice });
+      return render(SafeHTMLWithCustom, {
+        props: { html: `<custom-choice identifier="A">${CONTENT_TEXT}</custom-choice>` },
+      });
+    }
+
+    it('keeps the component class on first render rather than overwriting it', () => {
+      renderChoice();
+      expect(screen.getByText(CONTENT_TEXT)).toHaveClass('custom-choice');
+    });
+
+    it('leaves the component to opt into safe-html itself', () => {
+      renderChoice();
+      expect(screen.getByText(CONTENT_TEXT)).not.toHaveClass('safe-html');
+    });
+
+    it('still passes the authored class through for components to read', () => {
+      const seen = [];
+      const ClassReader = {
+        name: 'ClassReader',
+        render(h) {
+          seen.push(this.$attrs.class);
+          return h('div');
+        },
+      };
+      const SafeHTMLWithCustom = createSafeHTML({ 'class-reader': ClassReader });
+      render(SafeHTMLWithCustom, {
+        props: { html: '<class-reader class="qti-labels-decimal"></class-reader>' },
+      });
+      expect(seen).toEqual(['qti-labels-decimal']);
+    });
+  });
+
   describe('object tag handling', () => {
     beforeEach(() => handleObjectTypes());
 

--- a/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlTable.spec.js
+++ b/packages/kolibri-common/components/SafeHTML/__tests__/SafeHtmlTable.spec.js
@@ -55,13 +55,10 @@ const createSampleNode = (m, n) => {
   return table;
 };
 
-const sampleAttributes = { class: 'safe-html' };
-
 const renderComponent = (m, n) => {
   const node = createSampleNode(m, n);
   return render(SafeHtmlTable, {
     props: { node },
-    attrs: sampleAttributes,
     slots: { default: node.innerHTML },
   });
 };

--- a/packages/kolibri-common/components/SafeHTML/index.js
+++ b/packages/kolibri-common/components/SafeHTML/index.js
@@ -137,8 +137,6 @@ export function createSafeHTML(customComponents = {}, { allowedOrigins } = {}) {
             props[propName] = attr.value;
           }
 
-          attrs.class = attrs.class ? `${attrs.class} safe-html` : 'safe-html';
-
           // Check if this is a custom element
           const component =
             customComponents[tagName] ||
@@ -146,6 +144,8 @@ export function createSafeHTML(customComponents = {}, { allowedOrigins } = {}) {
             (kolibri.canHandleElement(node) ? 'ContentViewer' : null);
 
           if (component) {
+            // Components opt into safe-html themselves; setting it here would
+            // overwrite the class they render on their own root.
             const childProps = { ...props };
             // ContentViewer expects the DOM element as `element`, not `node`
             if (component === 'ContentViewer') {
@@ -165,6 +165,7 @@ export function createSafeHTML(customComponents = {}, { allowedOrigins } = {}) {
             return childVNode;
           }
 
+          attrs.class = attrs.class ? `${attrs.class} safe-html` : 'safe-html';
           return h(tagName, { attrs }, mapChildren(node.childNodes));
         }
 


### PR DESCRIPTION
## Summary
Recent updates to simplify/unify rendering paths in SafeHtml resulted in components getting the `safe-html` class when they did not opt into it
Revert this by only adding `safe-html` class to pure html tag elements, and requiring any components to explicitly opt in (SafeHtmlTable, SafeHtmlImage)
Adds tests to ensure that the class does not get added automatically to custom components

## References
Regression from #14880

## Reviewer guidance
Make sure that the regression observed in QTI multiple choice questions is fixed
Is the test coverage sufficient? Is it overboard?

| Before | After |
|--------|-------|
| <img src="https://i.imgur.com/kX7P9Sm.png"> | <img src="https://i.imgur.com/HWspBFt.png"> |

## AI usage
I used Claude Code to pinpoint the cause of the regression, then defined the solution, focused on making safe-html _only_ automatically applied to html tag vnodes, requiring the specific HTML handling SafeHtml components to opt in to using the class.