### PR TITLE
SPA Page caching for surviving thundering herds

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -2,16 +2,30 @@
 Modified and extended from https://github.com/camsaul/django-rest-params/blob/master/django_rest_params/decorators.py
 """
 
+import functools
 import hashlib
-from threading import local
+import logging
+import random
+import re
+import threading
+import time
+from copy import deepcopy
+from io import BytesIO
 
-from django.core.cache import cache
+from django.core.handlers.wsgi import WSGIRequest
+from django.db import connections
+from django.utils import translation
+from django.utils.cache import add_never_cache_headers
+from django.utils.cache import get_conditional_response
 from django.utils.cache import patch_response_headers
-from django.views.decorators.http import etag
+from django.utils.text import compress_string
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 
 from kolibri import __version__ as kolibri_version
+from kolibri.core.utils.cache import process_cache
+
+logger = logging.getLogger(__name__)
 
 TRUE_VALUES = ("1", "true")
 FALSE_VALUES = ("0", "false")
@@ -311,62 +325,199 @@ def query_params_required(**kwargs):  # noqa: C901
     return _params
 
 
-def cache_no_user_data(view_func):
+# Seconds a freshly stored body is served before a refresh is triggered.
+BODY_CACHE_REFRESH = 15
+# Refresh deadlines are jittered back by up to this much, so the bodies warming
+# stores in one burst do not all come due in the same instant.
+BODY_CACHE_REFRESH_JITTER = 5
+# How long the refresh election is held before another request may take it over,
+# in case the elected refresher dies mid-render.
+BODY_CACHE_LOCK_TIMEOUT = 30
+
+
+def _spawn(target):
+    # Seam for the background refresh, so tests can run it synchronously.
+    threading.Thread(target=target, daemon=True).start()
+
+
+_GZIP_RE = re.compile(r"\bgzip\b")
+
+
+def _accepts_gzip(request):
+    # No Accept-Encoding means no preference, so it gets the gzip like everyone
+    # else; only an explicit header without gzip gets the plain body. Mirrors the
+    # negotiation kolibri.utils.kolibri_whitenoise does for static assets.
+    accept_encoding = request.META.get("HTTP_ACCEPT_ENCODING", "*")
+    return accept_encoding == "*" or bool(_GZIP_RE.search(accept_encoding))
+
+
+# Carried from a live request into its off-thread refresh so the refreshed body
+# matches what the request renders. Excludes cookies and other per-user headers -
+# the cached body must stay user-independent.
+_CARRIED_ENVIRON_KEYS = (
+    "SERVER_NAME",
+    "SERVER_PORT",
+    "HTTP_HOST",
+    "wsgi.url_scheme",
+)
+
+
+def _build_request(path, base_environ=None):
+    # Bare GET request for rendering a cached view outside the request cycle.
+    environ = {
+        "REQUEST_METHOD": "GET",
+        "PATH_INFO": path,
+        "SCRIPT_NAME": "",
+        "SERVER_NAME": "localhost",
+        "SERVER_PORT": "80",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "QUERY_STRING": "",
+        "wsgi.url_scheme": "http",
+        "wsgi.input": BytesIO(b""),
+    }
+    if base_environ is not None:
+        for key in _CARRIED_ENVIRON_KEYS:
+            if key in base_environ:
+                environ[key] = base_environ[key]
+    request = WSGIRequest(environ)
+    # The decorator drops the session; give it one to drop.
+    request.session = {}
+    return request
+
+
+class _CachedBody:
     """
-    Set appropriate Vary on headers on a view that specify there is
-    no user specific data being rendered in the view.
-    In order to ensure that the correct Vary headers are set,
-    the session is deleted from the request, as otherwise Vary cookies
-    will always be set by the Django session middleware.
-    This should not be used on any view that bootstraps user specific
-    data into it - this will remove the headers that will make this vary
-    on a per user basis.
+    Serve one view's rendered body from a shared cross-process cache, since the
+    view renders no user-specific data.
     """
 
-    CACHE_TIMEOUT = 15
-    CACHE_KEY_TEMPLATE = "SPA_ETAG_CACHE_{}"
-    _response = local()
+    def __init__(self, view_class):
+        self._view_class = view_class
+        self._dispatch = view_class.dispatch
 
-    def render_and_cache(response, cache_key):
-        if hasattr(response, "render") and callable(response.render):
-            response.render()
-        if response.content:
-            etag = hashlib.md5(
-                kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")
-            ).hexdigest()
-            cache.set(cache_key, etag, CACHE_TIMEOUT)
-            return etag
-        else:
-            return None
-
-    def calculate_spa_etag(*args, **kwargs):
-        # Clear the local thread 'response' property
-        setattr(_response, "response", None)
-
-        request = args[0]
-        etag = cache.get(CACHE_KEY_TEMPLATE.format(request.path))
-
-        # Doing this here - will also be the same in inner_func
-        # required to delete the session for this to work as expected
+    def __call__(self, view, request, *args, **kwargs):
+        # Drop the session so the session middleware does not add Vary: Cookie,
+        # which would split the cache per user.
         del request.session
+        body_key, lock_key = self._keys(request.path)
+        entry = process_cache.get(body_key)
+        if entry is not None:
+            variants, refresh_at = entry
+            if time.time() >= refresh_at and process_cache.add(
+                lock_key, True, BODY_CACHE_LOCK_TIMEOUT
+            ):
+                self._refresh_in_background(request, body_key, lock_key)
+            return self._conditional(request, self._pick(request, variants))
+        # Cold miss: render inline, since there is nothing to serve stale.
+        return self._conditional(
+            request, self._render_and_store(view, request, args, kwargs, body_key)
+        )
 
-        if not etag:
-            response = view_func(*args, **kwargs)
-            setattr(_response, "response", response)
-            etag = render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
-        return etag
+    @staticmethod
+    def _keys(path):
+        # One entry per path; language is carried by the path's i18n prefix.
+        # The entry holds both encodings, so the key does not vary on
+        # Accept-Encoding - it is negotiated at serve time instead.
+        digest = hashlib.md5(
+            "{}:{}".format(kolibri_version, path).encode("utf-8")
+        ).hexdigest()
+        return "VIEW_BODY_CACHE_{}".format(digest), "VIEW_BODY_LOCK_{}".format(digest)
 
-    @etag(calculate_spa_etag)
-    def inner_func(*args, **kwargs):
-        request = args[0]
+    @staticmethod
+    def _conditional(request, response):
+        # Honour If-None-Match so a client past the browser-cache window
+        # revalidates instead of re-fetching the whole body.
+        return (
+            get_conditional_response(
+                request, etag=response.headers.get("ETag"), response=response
+            )
+            or response
+        )
 
-        response = getattr(_response, "response", None)
-        if not response:
-            response = view_func(*args, **kwargs)
+    @staticmethod
+    def _pick(request, variants):
+        plain, gzipped = variants
+        return gzipped if _accepts_gzip(request) else plain
 
-        render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
-        patch_response_headers(response, cache_timeout=CACHE_TIMEOUT)
-        response.headers["Vary"] = "accept-encoding, accept"
+    @staticmethod
+    def _finalize(response, content, encoding=None):
+        response.content = content
+        if encoding:
+            response.headers["Content-Encoding"] = encoding
+        response.headers["Content-Length"] = str(len(content))
+        patch_response_headers(response, cache_timeout=BODY_CACHE_REFRESH)
+        response.headers["Vary"] = "Accept-Encoding"
+        # Content-based ETag, so conditional GETs 304. Distinct per encoding,
+        # since the two representations are different bytes.
+        response.headers["ETag"] = '"{}"'.format(
+            hashlib.md5(kolibri_version.encode("utf-8") + content).hexdigest()
+        )
         return response
 
-    return inner_func
+    def _render_and_store(self, view, request, args, kwargs, body_key):
+        response = self._dispatch(view, request, *args, **kwargs)
+        if hasattr(response, "render") and callable(response.render):
+            response.render()
+        if response.status_code != 200 or not response.content:
+            add_never_cache_headers(response)
+            return response
+        # Both encodings are compressed and stored once here rather than per
+        # request - that drag is what retired the global gzip middleware.
+        gzipped = self._finalize(
+            deepcopy(response), compress_string(response.content), "gzip"
+        )
+        variants = (self._finalize(response, response.content), gzipped)
+        refresh_at = (
+            time.time()
+            + BODY_CACHE_REFRESH
+            - random.uniform(0, BODY_CACHE_REFRESH_JITTER)
+        )
+        # timeout=None: the body never hard-expires, so a stale copy is always
+        # available to serve while one request refreshes it.
+        process_cache.set(body_key, (variants, refresh_at), None)
+        return self._pick(request, variants)
+
+    def _refresh_in_background(self, request, body_key, lock_key):
+        # Off-thread so no request blocks on the render. Build a fresh view and
+        # request rather than sharing the live ones across threads - the view
+        # renders from its own ``request`` attribute, so it needs its own view
+        # instance. Translation is thread-local, so carry the language over.
+        language = translation.get_language()
+        path = request.path
+        base_environ = {
+            key: request.environ[key]
+            for key in _CARRIED_ENVIRON_KEYS
+            if key in request.environ
+        }
+
+        def run():
+            try:
+                with translation.override(language):
+                    fresh_request = _build_request(path, base_environ)
+                    fresh_view = self._view_class()
+                    fresh_view.setup(fresh_request)
+                    self._render_and_store(fresh_view, fresh_request, (), {}, body_key)
+            # Best effort: a thread has no caller to propagate to, and a failed
+            # refresh just means the stale body serves until the next attempt.
+            except Exception:
+                logger.warning("Failed to refresh cached view body", exc_info=True)
+            finally:
+                process_cache.delete(lock_key)
+                connections.close_all()
+
+        _spawn(run)
+
+
+def cache_no_user_data(view_class):
+    """
+    View-class decorator: serve the view's body from a shared cache (see
+    ``_SpaBodyCache``). Must not be used on a view that renders user data.
+    """
+    cache = _CachedBody(view_class)
+
+    @functools.wraps(view_class.dispatch)
+    def dispatch(self, request, *args, **kwargs):
+        return cache(self, request, *args, **kwargs)
+
+    view_class.dispatch = dispatch
+    return view_class

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -14,6 +14,9 @@ from io import BytesIO
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connections
+from django.urls import get_resolver
+from django.urls import reverse
+from django.urls import URLResolver
 from django.utils import translation
 from django.utils.cache import add_never_cache_headers
 from django.utils.cache import get_conditional_response
@@ -23,6 +26,8 @@ from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 
 from kolibri import __version__ as kolibri_version
+from kolibri.core.device.translation import get_device_language
+from kolibri.core.device.translation import get_settings_language
 from kolibri.core.utils.cache import process_cache
 
 logger = logging.getLogger(__name__)
@@ -511,7 +516,8 @@ class _CachedBody:
 def cache_no_user_data(view_class):
     """
     View-class decorator: serve the view's body from a shared cache (see
-    ``_SpaBodyCache``). Must not be used on a view that renders user data.
+    ``_CachedBody``) and register it so the body is warmed in the device
+    language at startup. Must not be used on a view that renders user data.
     """
     cache = _CachedBody(view_class)
 
@@ -520,4 +526,45 @@ def cache_no_user_data(view_class):
         return cache(self, request, *args, **kwargs)
 
     view_class.dispatch = dispatch
+    # Marks the class as opted in, for the resolver walk in _cached_view_targets.
+    view_class._cache_no_user_data = True
     return view_class
+
+
+def _cached_view_targets():
+    # (url name, view callback) for every URL that serves a registered cached view.
+    def walk(resolver, namespaces):
+        for pattern in resolver.url_patterns:
+            if isinstance(pattern, URLResolver):
+                nested = namespaces
+                if pattern.namespace:
+                    nested = namespaces + (pattern.namespace,)
+                yield from walk(pattern, nested)
+            elif pattern.name:
+                yield ":".join(namespaces + (pattern.name,)), pattern.callback
+
+    for name, callback in walk(get_resolver(), ()):
+        view_class = getattr(callback, "view_class", None)
+        if getattr(view_class, "_cache_no_user_data", False):
+            yield name, callback
+
+
+def warm_cached_views():
+    """
+    Render and store every registered cached view for the device's configured
+    language, so the first real request to each is a hit. Runs once at startup.
+
+    Device language only - warming every supported language would render
+    hundreds of bodies, stealing CPU from the startup request burst on
+    low-power targets. Other languages warm lazily on first request.
+    """
+    language = get_device_language() or get_settings_language()
+    try:
+        with translation.override(language):
+            for name, callback in _cached_view_targets():
+                try:
+                    callback(_build_request(reverse(name)))
+                except Exception:
+                    logger.warning("Failed to warm %s", name, exc_info=True)
+    finally:
+        connections.close_all()

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -14,6 +14,9 @@ from io import BytesIO
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connections
+from django.urls import get_resolver
+from django.urls import reverse
+from django.urls import URLResolver
 from django.utils import translation
 from django.utils.cache import add_never_cache_headers
 from django.utils.cache import get_conditional_response
@@ -23,6 +26,8 @@ from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 
 from kolibri import __version__ as kolibri_version
+from kolibri.core.device.translation import get_device_language
+from kolibri.core.device.translation import get_settings_language
 from kolibri.core.utils.cache import process_cache
 
 logger = logging.getLogger(__name__)
@@ -516,7 +521,8 @@ class _CachedBody:
 def cache_no_user_data(view_class):
     """
     View-class decorator: serve the view's body from a shared cache (see
-    ``_SpaBodyCache``). Must not be used on a view that renders user data.
+    ``_CachedBody``) and register it so the body is warmed in the device
+    language at startup. Must not be used on a view that renders user data.
     """
     cache = _CachedBody(view_class)
 
@@ -525,4 +531,45 @@ def cache_no_user_data(view_class):
         return cache(self, request, *args, **kwargs)
 
     view_class.dispatch = dispatch
+    # Marks the class as opted in, for the resolver walk in _cached_view_targets.
+    view_class._cache_no_user_data = True
     return view_class
+
+
+def _cached_view_targets():
+    # (url name, view callback) for every URL that serves a registered cached view.
+    def walk(resolver, namespaces):
+        for pattern in resolver.url_patterns:
+            if isinstance(pattern, URLResolver):
+                nested = namespaces
+                if pattern.namespace:
+                    nested = namespaces + (pattern.namespace,)
+                yield from walk(pattern, nested)
+            elif pattern.name:
+                yield ":".join(namespaces + (pattern.name,)), pattern.callback
+
+    for name, callback in walk(get_resolver(), ()):
+        view_class = getattr(callback, "view_class", None)
+        if getattr(view_class, "_cache_no_user_data", False):
+            yield name, callback
+
+
+def warm_cached_views():
+    """
+    Render and store every registered cached view for the device's configured
+    language, so the first real request to each is a hit. Runs once at startup.
+
+    Device language only - warming every supported language would render
+    hundreds of bodies, stealing CPU from the startup request burst on
+    low-power targets. Other languages warm lazily on first request.
+    """
+    language = get_device_language() or get_settings_language()
+    try:
+        with translation.override(language):
+            for name, callback in _cached_view_targets():
+                try:
+                    callback(_build_request(reverse(name)))
+                except Exception:
+                    logger.warning("Failed to warm %s", name, exc_info=True)
+    finally:
+        connections.close_all()

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -2,16 +2,30 @@
 Modified and extended from https://github.com/camsaul/django-rest-params/blob/master/django_rest_params/decorators.py
 """
 
+import functools
 import hashlib
-from threading import local
+import logging
+import random
+import re
+import threading
+import time
+from copy import deepcopy
+from io import BytesIO
 
-from django.core.cache import cache
+from django.core.handlers.wsgi import WSGIRequest
+from django.db import connections
+from django.utils import translation
+from django.utils.cache import add_never_cache_headers
+from django.utils.cache import get_conditional_response
 from django.utils.cache import patch_response_headers
-from django.views.decorators.http import etag
+from django.utils.text import compress_string
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 
 from kolibri import __version__ as kolibri_version
+from kolibri.core.utils.cache import process_cache
+
+logger = logging.getLogger(__name__)
 
 TRUE_VALUES = ("1", "true")
 FALSE_VALUES = ("0", "false")
@@ -311,62 +325,204 @@ def query_params_required(**kwargs):  # noqa: C901
     return _params
 
 
-def cache_no_user_data(view_func):
+# Seconds a freshly stored body is served before a refresh is triggered.
+BODY_CACHE_REFRESH = 15
+# Refresh deadlines are jittered back by up to this much, so the bodies warming
+# stores in one burst do not all come due in the same instant.
+BODY_CACHE_REFRESH_JITTER = 5
+# How long the refresh election is held before another request may take it over,
+# in case the elected refresher dies mid-render.
+BODY_CACHE_LOCK_TIMEOUT = 30
+# Hard expiry, far beyond the refresh window. Every refresh rewrites the entry,
+# so this only reaps keys nothing asks for any more - a prior kolibri_version, or
+# a language that stopped being served. process_cache is disk- or Redis-backed,
+# so those outlive the process without it.
+BODY_CACHE_TTL = 60 * 60 * 24
+
+
+def _spawn(target):
+    # Seam for the background refresh, so tests can run it synchronously.
+    threading.Thread(target=target, daemon=True).start()
+
+
+_GZIP_RE = re.compile(r"\bgzip\b")
+
+
+def _accepts_gzip(request):
+    # No Accept-Encoding means no preference, so it gets the gzip like everyone
+    # else; only an explicit header without gzip gets the plain body. Mirrors the
+    # negotiation kolibri.utils.kolibri_whitenoise does for static assets.
+    accept_encoding = request.META.get("HTTP_ACCEPT_ENCODING", "*")
+    return accept_encoding == "*" or bool(_GZIP_RE.search(accept_encoding))
+
+
+# Carried from a live request into its off-thread refresh so the refreshed body
+# matches what the request renders. Excludes cookies and other per-user headers -
+# the cached body must stay user-independent.
+_CARRIED_ENVIRON_KEYS = (
+    "SERVER_NAME",
+    "SERVER_PORT",
+    "HTTP_HOST",
+    "wsgi.url_scheme",
+)
+
+
+def _build_request(path, base_environ=None):
+    # Bare GET request for rendering a cached view outside the request cycle.
+    environ = {
+        "REQUEST_METHOD": "GET",
+        "PATH_INFO": path,
+        "SCRIPT_NAME": "",
+        "SERVER_NAME": "localhost",
+        "SERVER_PORT": "80",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "QUERY_STRING": "",
+        "wsgi.url_scheme": "http",
+        "wsgi.input": BytesIO(b""),
+    }
+    if base_environ is not None:
+        for key in _CARRIED_ENVIRON_KEYS:
+            if key in base_environ:
+                environ[key] = base_environ[key]
+    request = WSGIRequest(environ)
+    # The decorator drops the session; give it one to drop.
+    request.session = {}
+    return request
+
+
+class _CachedBody:
     """
-    Set appropriate Vary on headers on a view that specify there is
-    no user specific data being rendered in the view.
-    In order to ensure that the correct Vary headers are set,
-    the session is deleted from the request, as otherwise Vary cookies
-    will always be set by the Django session middleware.
-    This should not be used on any view that bootstraps user specific
-    data into it - this will remove the headers that will make this vary
-    on a per user basis.
+    Serve one view's rendered body from a shared cross-process cache, since the
+    view renders no user-specific data.
     """
 
-    CACHE_TIMEOUT = 15
-    CACHE_KEY_TEMPLATE = "SPA_ETAG_CACHE_{}"
-    _response = local()
+    def __init__(self, view_class):
+        self._view_class = view_class
+        self._dispatch = view_class.dispatch
 
-    def render_and_cache(response, cache_key):
-        if hasattr(response, "render") and callable(response.render):
-            response.render()
-        if response.content:
-            etag = hashlib.md5(
-                kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")
-            ).hexdigest()
-            cache.set(cache_key, etag, CACHE_TIMEOUT)
-            return etag
-        else:
-            return None
-
-    def calculate_spa_etag(*args, **kwargs):
-        # Clear the local thread 'response' property
-        setattr(_response, "response", None)
-
-        request = args[0]
-        etag = cache.get(CACHE_KEY_TEMPLATE.format(request.path))
-
-        # Doing this here - will also be the same in inner_func
-        # required to delete the session for this to work as expected
+    def __call__(self, view, request, *args, **kwargs):
+        # Drop the session so the session middleware does not add Vary: Cookie,
+        # which would split the cache per user.
         del request.session
+        body_key, lock_key = self._keys(request.path)
+        entry = process_cache.get(body_key)
+        if entry is not None:
+            variants, refresh_at = entry
+            if time.time() >= refresh_at and process_cache.add(
+                lock_key, True, BODY_CACHE_LOCK_TIMEOUT
+            ):
+                self._refresh_in_background(request, body_key, lock_key)
+            return self._conditional(request, self._pick(request, variants))
+        # Cold miss: render inline, since there is nothing to serve stale.
+        return self._conditional(
+            request, self._render_and_store(view, request, args, kwargs, body_key)
+        )
 
-        if not etag:
-            response = view_func(*args, **kwargs)
-            setattr(_response, "response", response)
-            etag = render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
-        return etag
+    @staticmethod
+    def _keys(path):
+        # One entry per path; language is carried by the path's i18n prefix.
+        # The entry holds both encodings, so the key does not vary on
+        # Accept-Encoding - it is negotiated at serve time instead.
+        digest = hashlib.md5(
+            "{}:{}".format(kolibri_version, path).encode("utf-8")
+        ).hexdigest()
+        return "VIEW_BODY_CACHE_{}".format(digest), "VIEW_BODY_LOCK_{}".format(digest)
 
-    @etag(calculate_spa_etag)
-    def inner_func(*args, **kwargs):
-        request = args[0]
+    @staticmethod
+    def _conditional(request, response):
+        # Honour If-None-Match so a client past the browser-cache window
+        # revalidates instead of re-fetching the whole body.
+        return (
+            get_conditional_response(
+                request, etag=response.headers.get("ETag"), response=response
+            )
+            or response
+        )
 
-        response = getattr(_response, "response", None)
-        if not response:
-            response = view_func(*args, **kwargs)
+    @staticmethod
+    def _pick(request, variants):
+        plain, gzipped = variants
+        return gzipped if _accepts_gzip(request) else plain
 
-        render_and_cache(response, CACHE_KEY_TEMPLATE.format(request.path))
-        patch_response_headers(response, cache_timeout=CACHE_TIMEOUT)
-        response.headers["Vary"] = "accept-encoding, accept"
+    @staticmethod
+    def _finalize(response, content, encoding=None):
+        response.content = content
+        if encoding:
+            response.headers["Content-Encoding"] = encoding
+        response.headers["Content-Length"] = str(len(content))
+        patch_response_headers(response, cache_timeout=BODY_CACHE_REFRESH)
+        response.headers["Vary"] = "Accept-Encoding"
+        # Content-based ETag, so conditional GETs 304. Distinct per encoding,
+        # since the two representations are different bytes.
+        response.headers["ETag"] = '"{}"'.format(
+            hashlib.md5(kolibri_version.encode("utf-8") + content).hexdigest()
+        )
         return response
 
-    return inner_func
+    def _render_and_store(self, view, request, args, kwargs, body_key):
+        response = self._dispatch(view, request, *args, **kwargs)
+        if hasattr(response, "render") and callable(response.render):
+            response.render()
+        if response.status_code != 200 or not response.content:
+            add_never_cache_headers(response)
+            return response
+        # Both encodings are compressed and stored once here rather than per
+        # request - that drag is what retired the global gzip middleware.
+        gzipped = self._finalize(
+            deepcopy(response), compress_string(response.content), "gzip"
+        )
+        variants = (self._finalize(response, response.content), gzipped)
+        refresh_at = (
+            time.time()
+            + BODY_CACHE_REFRESH
+            - random.uniform(0, BODY_CACHE_REFRESH_JITTER)
+        )
+        # Expiry is BODY_CACHE_TTL, not BODY_CACHE_REFRESH, so a stale copy is
+        # always available to serve while one request refreshes it.
+        process_cache.set(body_key, (variants, refresh_at), BODY_CACHE_TTL)
+        return self._pick(request, variants)
+
+    def _refresh_in_background(self, request, body_key, lock_key):
+        # Off-thread so no request blocks on the render. Build a fresh view and
+        # request rather than sharing the live ones across threads - the view
+        # renders from its own ``request`` attribute, so it needs its own view
+        # instance. Translation is thread-local, so carry the language over.
+        language = translation.get_language()
+        path = request.path
+        base_environ = {
+            key: request.environ[key]
+            for key in _CARRIED_ENVIRON_KEYS
+            if key in request.environ
+        }
+
+        def run():
+            try:
+                with translation.override(language):
+                    fresh_request = _build_request(path, base_environ)
+                    fresh_view = self._view_class()
+                    fresh_view.setup(fresh_request)
+                    self._render_and_store(fresh_view, fresh_request, (), {}, body_key)
+            # Best effort: a thread has no caller to propagate to, and a failed
+            # refresh just means the stale body serves until the next attempt.
+            except Exception:
+                logger.warning("Failed to refresh cached view body", exc_info=True)
+            finally:
+                process_cache.delete(lock_key)
+                connections.close_all()
+
+        _spawn(run)
+
+
+def cache_no_user_data(view_class):
+    """
+    View-class decorator: serve the view's body from a shared cache (see
+    ``_SpaBodyCache``). Must not be used on a view that renders user data.
+    """
+    cache = _CachedBody(view_class)
+
+    @functools.wraps(view_class.dispatch)
+    def dispatch(self, request, *args, **kwargs):
+        return cache(self, request, *args, **kwargs)
+
+    view_class.dispatch = dispatch
+    return view_class

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -28,6 +28,7 @@ from rest_framework.views import APIView
 from kolibri import __version__ as kolibri_version
 from kolibri.core.device.translation import get_device_language
 from kolibri.core.device.translation import get_settings_language
+from kolibri.core.device.utils import get_device_setting
 from kolibri.core.utils.cache import process_cache
 
 logger = logging.getLogger(__name__)
@@ -413,12 +414,16 @@ class _CachedBody:
         entry = process_cache.get(body_key)
         if entry is not None:
             variants, refresh_at = entry
-            if time.time() >= refresh_at and process_cache.add(
-                lock_key, True, BODY_CACHE_LOCK_TIMEOUT
-            ):
-                self._refresh_in_background(request, body_key, lock_key)
-            return self._conditional(request, self._pick(request, variants))
-        # Cold miss: render inline, since there is nothing to serve stale.
+            if time.time() < refresh_at:
+                return self._conditional(request, self._pick(request, variants))
+            # Past the deadline: serve the stale copy and refresh off-thread. A
+            # device serving one user has no herd to shield from the render, and
+            # would rather have the fresh page than the fast one.
+            if not get_device_setting("subset_of_users_device"):
+                if process_cache.add(lock_key, True, BODY_CACHE_LOCK_TIMEOUT):
+                    self._refresh_in_background(request, body_key, lock_key)
+                return self._conditional(request, self._pick(request, variants))
+        # Cold miss, or stale with nobody to shield: render inline.
         return self._conditional(
             request, self._render_and_store(view, request, args, kwargs, body_key)
         )
@@ -562,7 +567,12 @@ def warm_cached_views():
     Device language only - warming every supported language would render
     hundreds of bodies, stealing CPU from the startup request burst on
     low-power targets. Other languages warm lazily on first request.
+
+    Skipped entirely on a device serving one user, which has no startup burst
+    to get ahead of and pays the renders out of its own responsiveness.
     """
+    if get_device_setting("subset_of_users_device"):
+        return
     language = get_device_language() or get_settings_language()
     try:
         with translation.override(language):

--- a/kolibri/core/device/signals.py
+++ b/kolibri/core/device/signals.py
@@ -1,8 +1,10 @@
 from django.db import transaction
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
+from .models import DeviceSettings
 from .models import SyncQueue
 from .models import UserSyncStatus
 
@@ -31,3 +33,35 @@ def sync_queue_save_update_user_sync_status(sender, instance=None, *args, **kwar
         UserSyncStatus.update_status(instance.user_id)
 
     transaction.on_commit(update_status_after_commit)
+
+
+@receiver(pre_save, sender=DeviceSettings)
+def stash_previous_device_language(sender, instance=None, *args, **kwargs):
+    """
+    Record the persisted display language before the save so the post_save
+    handler can tell whether this save changed it.
+    """
+    instance._previous_language_id = (
+        DeviceSettings.objects.filter(pk=instance.pk)
+        .values_list("language_id", flat=True)
+        .first()
+    )
+
+
+@receiver(post_save, sender=DeviceSettings)
+def warm_cached_views_on_language_change(sender, instance=None, *args, **kwargs):
+    """
+    The display language is baked into every cached SPA shell, so re-warm them
+    when it is reconfigured. Only on a genuine change to a non-empty language:
+    the initial provisioning set (no previous language) is warmed at startup.
+    """
+    previous_language_id = getattr(instance, "_previous_language_id", None)
+    if (
+        previous_language_id
+        and instance.language_id
+        and instance.language_id != previous_language_id
+    ):
+        # Inline import: kolibri.core.device.tasks imports from this app.
+        from kolibri.core.device.tasks import warm_cached_views
+
+        transaction.on_commit(warm_cached_views.enqueue_if_not)

--- a/kolibri/core/device/signals.py
+++ b/kolibri/core/device/signals.py
@@ -1,10 +1,13 @@
 from django.db import transaction
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
+from .models import DeviceSettings
 from .models import SyncQueue
 from .models import UserSyncStatus
+from .translation import get_settings_language
 
 
 @receiver(post_delete, sender=SyncQueue)
@@ -31,3 +34,35 @@ def sync_queue_save_update_user_sync_status(sender, instance=None, *args, **kwar
         UserSyncStatus.update_status(instance.user_id)
 
     transaction.on_commit(update_status_after_commit)
+
+
+@receiver(pre_save, sender=DeviceSettings)
+def stash_previous_device_language(sender, instance=None, *args, **kwargs):
+    """
+    Record the persisted display language before the save so the post_save
+    handler can tell whether this save changed it.
+    """
+    instance._previous_language_id = (
+        DeviceSettings.objects.filter(pk=instance.pk)
+        .values_list("language_id", flat=True)
+        .first()
+    )
+
+
+@receiver(post_save, sender=DeviceSettings)
+def warm_cached_views_on_language_change(sender, instance=None, *args, **kwargs):
+    """
+    The display language is baked into every cached SPA shell, so re-warm them
+    when it is reconfigured. Compares the language the shells were rendered in,
+    not the stored column: an unset language means the settings language, so
+    clearing it, or setting it to the settings language, changes nothing.
+    """
+    settings_language = get_settings_language()
+    previous_language_id = getattr(instance, "_previous_language_id", None)
+    if (previous_language_id or settings_language) != (
+        instance.language_id or settings_language
+    ):
+        # Inline import: kolibri.core.device.tasks imports from this app.
+        from kolibri.core.device.tasks import warm_cached_views
+
+        transaction.on_commit(warm_cached_views.enqueue_if_not)

--- a/kolibri/core/device/tasks.py
+++ b/kolibri/core/device/tasks.py
@@ -11,6 +11,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.utils.deprovision import deprovision
 from kolibri.core.auth.viewsets.facility import FacilitySerializer
+from kolibri.core.decorators import warm_cached_views as warm_cached_view_bodies
 from kolibri.core.device.hooks import GetOSUserHook
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import OSUser
@@ -23,6 +24,7 @@ from kolibri.core.device.viewsets.initialize_app import NoFacilityFacilityUserSe
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.permissions import FirstProvisioning
 from kolibri.core.tasks.permissions import IsDeviceUnusable
+from kolibri.core.tasks.schedules import Enqueue
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.tasks.validation import JobValidator
 from kolibri.core.utils.token_generator import TokenGenerator
@@ -31,6 +33,11 @@ logger = logging.getLogger(__name__)
 
 PROVISION_TASK_QUEUE = "device_provision"
 DEPROVISION_TASK_QUEUE = "device_deprovision"
+
+
+@register_task(job_id="warm_cached_views", schedule=Enqueue())
+def warm_cached_views():
+    warm_cached_view_bodies()
 
 
 class DeviceProvisionValidator(DeviceSerializerMixin, JobValidator):

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -1,6 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from mock import patch
 
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.device.models import get_device_hostname
@@ -40,6 +41,43 @@ class DeviceSettingsTestCase(TestCase):
         DeviceSettings.objects.delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_language_change_warms_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = "fr"
+            ds.save()
+
+        mock_enqueue.assert_called_once()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_unchanged_language_does_not_warm_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = "en"
+            ds.save()
+
+        mock_enqueue.assert_not_called()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_language_cleared_does_not_warm_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = None
+            ds.save()
+
+        mock_enqueue.assert_not_called()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_initial_language_does_not_warm_cached_views(self, mock_enqueue):
+        with self.captureOnCommitCallbacks(execute=True):
+            DeviceSettings.objects.create(language_id="en")
+
+        mock_enqueue.assert_not_called()
 
     @pytest.mark.skip(
         reason="Other tests enabling the App plugin are not properly isolated"

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from mock import patch
 
 import kolibri.core.device.models as device_models
 from kolibri.core.device.models import DeviceSettings
@@ -83,6 +85,55 @@ class DeviceSettingsTestCase(TestCase):
         DeviceSettings.objects.delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_language_change_warms_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = "fr"
+            ds.save()
+
+        mock_enqueue.assert_called_once()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_unchanged_language_does_not_warm_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = "en"
+            ds.save()
+
+        mock_enqueue.assert_not_called()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_language_cleared_does_not_warm_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id="en")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = None
+            ds.save()
+
+        mock_enqueue.assert_not_called()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_initial_language_does_not_warm_cached_views(self, mock_enqueue):
+        with self.captureOnCommitCallbacks(execute=True):
+            DeviceSettings.objects.create(language_id=settings.LANGUAGE_CODE)
+
+        mock_enqueue.assert_not_called()
+
+    @patch("kolibri.core.device.tasks.warm_cached_views.enqueue_if_not")
+    def test_language_set_from_unset_warms_cached_views(self, mock_enqueue):
+        ds = DeviceSettings.objects.create(language_id=None)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ds.language_id = "fr"
+            ds.save()
+
+        # Unset means the settings language, so this is a genuine change - it is
+        # reachable from the device settings page, not only at provisioning.
+        mock_enqueue.assert_called_once()
 
     @pytest.mark.skip(
         reason="Other tests enabling the App plugin are not properly isolated"

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -6,14 +6,23 @@ from django.template import engines
 from django.template.response import TemplateResponse
 from django.test import RequestFactory
 from django.test import SimpleTestCase
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import translation
 from django.views.generic.base import View
 
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.decorators import _cached_view_targets
 from kolibri.core.decorators import _CachedBody
 from kolibri.core.decorators import BODY_CACHE_REFRESH
 from kolibri.core.decorators import cache_no_user_data
 from kolibri.core.decorators import InvalidQueryParamsException
 from kolibri.core.decorators import ParamValidator
+from kolibri.core.decorators import warm_cached_views
 from kolibri.core.utils.cache import process_cache
+from kolibri.plugins.user_auth.views import UserAuthView
+
+USER_AUTH_VIEW_NAME = "kolibri:kolibri.plugins.user_auth:user_auth"
 
 
 def run_inline(target):
@@ -191,3 +200,80 @@ class CacheNoUserDataTestCase(SimpleTestCase):
         # A gzip client holding the plain ETag must get the body, not a 304.
         self.assertEqual(crossed.status_code, 200)
         self.assertEqual(gzip.decompress(crossed.content), b"body-1")
+
+
+class CachedViewTargetsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+    def test_discovers_registered_views_from_the_urlconf(self):
+        targets = dict(_cached_view_targets())
+
+        # Decorated views across plugins must be discoverable for warming.
+        for name in (
+            USER_AUTH_VIEW_NAME,
+            "kolibri:kolibri.plugins.learn:learn",
+            "kolibri:kolibri.plugins.device:device_management",
+        ):
+            self.assertIn(name, targets)
+        self.assertIs(targets[USER_AUTH_VIEW_NAME].view_class, UserAuthView)
+
+    def test_every_discovered_name_is_reversible(self):
+        # Bad namespace assembly would make reverse() raise and silently skip the
+        # view at warm time.
+        with translation.override("en"):
+            for name, _callback in _cached_view_targets():
+                reverse(name)
+
+
+class WarmCachedViewsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+    def setUp(self):
+        process_cache.clear()
+
+    def test_warms_each_view_once_in_the_device_language(self):
+        calls = []
+
+        def callback(request):
+            calls.append((request.path, translation.get_language()))
+            return HttpResponse("shell")
+
+        def fake_reverse(name):
+            return "/{}/{}/".format(translation.get_language(), name)
+
+        with mock.patch(
+            "kolibri.core.decorators._cached_view_targets",
+            return_value=[("learn", callback), ("auth", callback)],
+        ), mock.patch("kolibri.core.decorators.reverse", fake_reverse), mock.patch(
+            "kolibri.core.decorators.get_device_language", return_value="es-es"
+        ), mock.patch("kolibri.core.decorators.connections"):
+            warm_cached_views()
+
+        # Each cached view is warmed exactly once, in the device language.
+        # Other languages are not warmed at startup; they load lazily.
+        self.assertEqual(calls, [("/es-es/learn/", "es-es"), ("/es-es/auth/", "es-es")])
+
+    def test_falls_back_to_settings_language_when_device_language_missing(self):
+        calls = []
+
+        def callback(request):
+            calls.append(translation.get_language())
+            return HttpResponse("shell")
+
+        with mock.patch(
+            "kolibri.core.decorators._cached_view_targets",
+            return_value=[("learn", callback)],
+        ), mock.patch(
+            "kolibri.core.decorators.reverse", return_value="/x/"
+        ), mock.patch(
+            "kolibri.core.decorators.get_device_language", return_value=None
+        ), mock.patch(
+            "kolibri.core.decorators.get_settings_language", return_value="ar"
+        ), mock.patch("kolibri.core.decorators.connections"):
+            warm_cached_views()
+
+        self.assertEqual(calls, ["ar"])

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -1,7 +1,23 @@
-from django.test import SimpleTestCase
+import gzip
+from unittest import mock
 
+from django.http import HttpResponse
+from django.template import engines
+from django.template.response import TemplateResponse
+from django.test import RequestFactory
+from django.test import SimpleTestCase
+from django.views.generic.base import View
+
+from kolibri.core.decorators import _CachedBody
+from kolibri.core.decorators import BODY_CACHE_REFRESH
+from kolibri.core.decorators import cache_no_user_data
 from kolibri.core.decorators import InvalidQueryParamsException
 from kolibri.core.decorators import ParamValidator
+from kolibri.core.utils.cache import process_cache
+
+
+def run_inline(target):
+    target()
 
 
 class ParamValidatorTestCase(SimpleTestCase):
@@ -21,3 +37,157 @@ class ParamValidatorTestCase(SimpleTestCase):
 
         with self.assertRaises(InvalidQueryParamsException):
             validator.check_non_tuple_types("yes")
+
+
+class CacheNoUserDataTestCase(SimpleTestCase):
+    def setUp(self):
+        process_cache.clear()
+        self.factory = RequestFactory()
+
+    def _request(self, path="/en/learn/", **extra):
+        request = self.factory.get(path, **extra)
+        request.session = {}
+        return request
+
+    def _view(self):
+        # Each render returns a distinct body, so a stale read is distinguishable
+        # from a fresh one.
+        render_count = []
+
+        @cache_no_user_data
+        class CachedView(View):
+            def dispatch(self, request, *args, **kwargs):
+                render_count.append(1)
+                return HttpResponse("body-{}".format(len(render_count)))
+
+        return CachedView().dispatch, render_count
+
+    def _template_view(self):
+        # The real cached views all return an unrendered TemplateResponse.
+        @cache_no_user_data
+        class CachedTemplateView(View):
+            def dispatch(self, request, *args, **kwargs):
+                return TemplateResponse(
+                    request, engines["django"].from_string("body-{{ n }}"), {"n": 1}
+                )
+
+        return CachedTemplateView().dispatch
+
+    def test_renders_once_then_serves_the_shared_body(self):
+        view, render_count = self._view()
+
+        first = view(self._request())
+        second = view(self._request())
+
+        self.assertEqual(gzip.decompress(first.content), b"body-1")
+        self.assertEqual(gzip.decompress(second.content), b"body-1")
+        self.assertEqual(second["Vary"], "Accept-Encoding")
+        self.assertEqual(len(render_count), 1)
+
+        # A different path is cached separately.
+        view(self._request("/en/coach/"))
+        self.assertEqual(len(render_count), 2)
+
+    def test_serves_stale_body_while_refreshing_in_background(self):
+        view, render_count = self._view()
+        base = 1000.0
+        stale = base + BODY_CACHE_REFRESH + 100  # well past the refresh deadline
+
+        with mock.patch("kolibri.core.decorators._spawn", run_inline):
+            with mock.patch("kolibri.core.decorators.time.time", return_value=base):
+                view(self._request())  # caches body-1
+            with mock.patch("kolibri.core.decorators.time.time", return_value=stale):
+                served = view(self._request())
+            with mock.patch(
+                "kolibri.core.decorators.time.time", return_value=stale + 1
+            ):
+                after = view(self._request())
+
+        # Entry never hard-expires: stale is served past the deadline, then replaced.
+        self.assertEqual(gzip.decompress(served.content), b"body-1")
+        self.assertEqual(gzip.decompress(after.content), b"body-2")
+        self.assertEqual(len(render_count), 2)
+
+    def test_refresh_deadline_is_jittered_back_from_the_full_window(self):
+        view, _ = self._view()
+
+        with mock.patch("kolibri.core.decorators.time.time", return_value=1000.0):
+            with mock.patch("kolibri.core.decorators.random.uniform", return_value=2.0):
+                view(self._request())
+
+        # Bodies stored in one burst must not all come due in the same instant.
+        _, refresh_at = process_cache.get(_CachedBody._keys("/en/learn/")[0])
+        self.assertEqual(refresh_at, 1000.0 + BODY_CACHE_REFRESH - 2.0)
+
+    def test_serves_304_to_a_client_that_already_has_the_body(self):
+        view, render_count = self._view()
+
+        first = view(self._request())
+        etag = first["ETag"]
+        conditional = view(self._request(HTTP_IF_NONE_MATCH=etag))
+
+        # Client already holds the body: revalidate to 304, no re-fetch, no re-render.
+        self.assertEqual(conditional.status_code, 304)
+        self.assertFalse(conditional.content)
+        self.assertEqual(len(render_count), 1)
+
+    def test_stores_and_serves_a_gzipped_body(self):
+        view, _ = self._view()
+
+        response = view(self._request())
+
+        self.assertEqual(response["Content-Encoding"], "gzip")
+        self.assertEqual(response["Content-Length"], str(len(response.content)))
+        self.assertEqual(gzip.decompress(response.content), b"body-1")
+
+    def test_serves_the_plain_body_to_a_client_that_does_not_accept_gzip(self):
+        view, render_count = self._view()
+
+        view(self._request())
+        response = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # Both encodings come from one stored render, as for static assets.
+        self.assertFalse(response.has_header("Content-Encoding"))
+        self.assertEqual(response.content, b"body-1")
+        self.assertEqual(response["Content-Length"], str(len(b"body-1")))
+        self.assertEqual(len(render_count), 1)
+
+    def test_each_encoding_gets_its_own_etag(self):
+        view, _ = self._view()
+
+        gzipped = view(self._request())
+        plain = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # Distinct representations must not share an ETag, or a conditional GET
+        # would 304 a client holding the other encoding.
+        self.assertNotEqual(gzipped["ETag"], plain["ETag"])
+        self.assertEqual(gzipped["Vary"], "Accept-Encoding")
+        self.assertEqual(plain["Vary"], "Accept-Encoding")
+
+    def test_renders_and_stores_both_encodings_of_a_template_response(self):
+        view = self._template_view()
+
+        gzipped = view(self._request())
+        plain = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # An unrendered TemplateResponse must survive rendering, copying for the
+        # second encoding, and the round trip through the cache.
+        self.assertEqual(gzip.decompress(gzipped.content), b"body-1")
+        self.assertEqual(plain.content, b"body-1")
+        self.assertNotEqual(gzipped["ETag"], plain["ETag"])
+
+    def test_conditional_get_matches_only_the_encoding_the_client_holds(self):
+        view, _ = self._view()
+
+        plain_etag = view(self._request(HTTP_ACCEPT_ENCODING="identity"))["ETag"]
+        revalidated = view(
+            self._request(
+                HTTP_ACCEPT_ENCODING="identity", HTTP_IF_NONE_MATCH=plain_etag
+            )
+        )
+        crossed = view(self._request(HTTP_IF_NONE_MATCH=plain_etag))
+
+        self.assertEqual(revalidated.status_code, 304)
+        # A gzip client holding the plain ETag must get the body, not a 304.
+        self.assertEqual(crossed.status_code, 200)
+        self.assertEqual(gzip.decompress(crossed.content), b"body-1")

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -1,7 +1,24 @@
-from django.test import SimpleTestCase
+import gzip
+from unittest import mock
 
+from django.http import HttpResponse
+from django.template import engines
+from django.template.response import TemplateResponse
+from django.test import RequestFactory
+from django.test import SimpleTestCase
+from django.views.generic.base import View
+
+from kolibri.core.decorators import _CachedBody
+from kolibri.core.decorators import BODY_CACHE_REFRESH
+from kolibri.core.decorators import BODY_CACHE_TTL
+from kolibri.core.decorators import cache_no_user_data
 from kolibri.core.decorators import InvalidQueryParamsException
 from kolibri.core.decorators import ParamValidator
+from kolibri.core.utils.cache import process_cache
+
+
+def run_inline(target):
+    target()
 
 
 class ParamValidatorTestCase(SimpleTestCase):
@@ -21,3 +38,170 @@ class ParamValidatorTestCase(SimpleTestCase):
 
         with self.assertRaises(InvalidQueryParamsException):
             validator.check_non_tuple_types("yes")
+
+
+class CacheNoUserDataTestCase(SimpleTestCase):
+    def setUp(self):
+        process_cache.clear()
+        self.factory = RequestFactory()
+
+    def _request(self, path="/en/learn/", **extra):
+        request = self.factory.get(path, **extra)
+        request.session = {}
+        return request
+
+    def _view(self):
+        # Each render returns a distinct body, so a stale read is distinguishable
+        # from a fresh one.
+        render_count = []
+
+        @cache_no_user_data
+        class CachedView(View):
+            def dispatch(self, request, *args, **kwargs):
+                render_count.append(1)
+                return HttpResponse("body-{}".format(len(render_count)))
+
+        return CachedView().dispatch, render_count
+
+    def _template_view(self):
+        # The real cached views all return an unrendered TemplateResponse.
+        @cache_no_user_data
+        class CachedTemplateView(View):
+            def dispatch(self, request, *args, **kwargs):
+                return TemplateResponse(
+                    request, engines["django"].from_string("body-{{ n }}"), {"n": 1}
+                )
+
+        return CachedTemplateView().dispatch
+
+    def test_renders_once_then_serves_the_shared_body(self):
+        view, render_count = self._view()
+
+        first = view(self._request())
+        second = view(self._request())
+
+        self.assertEqual(gzip.decompress(first.content), b"body-1")
+        self.assertEqual(gzip.decompress(second.content), b"body-1")
+        self.assertEqual(second["Vary"], "Accept-Encoding")
+        self.assertEqual(len(render_count), 1)
+
+        # A different path is cached separately.
+        view(self._request("/en/coach/"))
+        self.assertEqual(len(render_count), 2)
+
+    def test_serves_stale_body_while_refreshing_in_background(self):
+        view, render_count = self._view()
+        base = 1000.0
+        stale = base + BODY_CACHE_REFRESH + 100  # well past the refresh deadline
+
+        with mock.patch("kolibri.core.decorators._spawn", run_inline):
+            with mock.patch("kolibri.core.decorators.time.time", return_value=base):
+                view(self._request())  # caches body-1
+            with mock.patch("kolibri.core.decorators.time.time", return_value=stale):
+                served = view(self._request())
+            with mock.patch(
+                "kolibri.core.decorators.time.time", return_value=stale + 1
+            ):
+                after = view(self._request())
+
+        # Entry never hard-expires: stale is served past the deadline, then replaced.
+        self.assertEqual(gzip.decompress(served.content), b"body-1")
+        self.assertEqual(gzip.decompress(after.content), b"body-2")
+        self.assertEqual(len(render_count), 2)
+
+    def test_stored_body_hard_expires_so_orphaned_entries_do_not_accumulate(self):
+        view, _ = self._view()
+
+        with mock.patch.object(
+            process_cache, "set", wraps=process_cache.set
+        ) as cache_set:
+            view(self._request())
+
+        # process_cache is disk- or Redis-backed, so a body stored without a
+        # timeout would outlive both the version and the language that keyed it.
+        self.assertEqual(cache_set.call_args[0][2], BODY_CACHE_TTL)
+
+    def test_refresh_deadline_is_jittered_back_from_the_full_window(self):
+        view, _ = self._view()
+
+        # Read under the same patched clock the entry was stored with, or its
+        # BODY_CACHE_TTL expiry reads as long past.
+        with mock.patch("kolibri.core.decorators.time.time", return_value=1000.0):
+            with mock.patch("kolibri.core.decorators.random.uniform", return_value=2.0):
+                view(self._request())
+            # Bodies stored in one burst must not all come due in the same instant.
+            _, refresh_at = process_cache.get(_CachedBody._keys("/en/learn/")[0])
+        self.assertEqual(refresh_at, 1000.0 + BODY_CACHE_REFRESH - 2.0)
+
+    def test_serves_304_to_a_client_that_already_has_the_body(self):
+        view, render_count = self._view()
+
+        first = view(self._request())
+        etag = first["ETag"]
+        conditional = view(self._request(HTTP_IF_NONE_MATCH=etag))
+
+        # Client already holds the body: revalidate to 304, no re-fetch, no re-render.
+        self.assertEqual(conditional.status_code, 304)
+        self.assertFalse(conditional.content)
+        self.assertEqual(len(render_count), 1)
+
+    def test_stores_and_serves_a_gzipped_body(self):
+        view, _ = self._view()
+
+        response = view(self._request())
+
+        self.assertEqual(response["Content-Encoding"], "gzip")
+        self.assertEqual(response["Content-Length"], str(len(response.content)))
+        self.assertEqual(gzip.decompress(response.content), b"body-1")
+
+    def test_serves_the_plain_body_to_a_client_that_does_not_accept_gzip(self):
+        view, render_count = self._view()
+
+        view(self._request())
+        response = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # Both encodings come from one stored render, as for static assets.
+        self.assertFalse(response.has_header("Content-Encoding"))
+        self.assertEqual(response.content, b"body-1")
+        self.assertEqual(response["Content-Length"], str(len(b"body-1")))
+        self.assertEqual(len(render_count), 1)
+
+    def test_each_encoding_gets_its_own_etag(self):
+        view, _ = self._view()
+
+        gzipped = view(self._request())
+        plain = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # Distinct representations must not share an ETag, or a conditional GET
+        # would 304 a client holding the other encoding.
+        self.assertNotEqual(gzipped["ETag"], plain["ETag"])
+        self.assertEqual(gzipped["Vary"], "Accept-Encoding")
+        self.assertEqual(plain["Vary"], "Accept-Encoding")
+
+    def test_renders_and_stores_both_encodings_of_a_template_response(self):
+        view = self._template_view()
+
+        gzipped = view(self._request())
+        plain = view(self._request(HTTP_ACCEPT_ENCODING="identity"))
+
+        # An unrendered TemplateResponse must survive rendering, copying for the
+        # second encoding, and the round trip through the cache.
+        self.assertEqual(gzip.decompress(gzipped.content), b"body-1")
+        self.assertEqual(plain.content, b"body-1")
+        self.assertNotEqual(gzipped["ETag"], plain["ETag"])
+
+    def test_conditional_get_matches_only_the_encoding_the_client_holds(self):
+        view, _ = self._view()
+
+        plain_etag = view(self._request(HTTP_ACCEPT_ENCODING="identity"))["ETag"]
+        revalidated = view(
+            self._request(
+                HTTP_ACCEPT_ENCODING="identity", HTTP_IF_NONE_MATCH=plain_etag
+            )
+        )
+        crossed = view(self._request(HTTP_IF_NONE_MATCH=plain_etag))
+
+        self.assertEqual(revalidated.status_code, 304)
+        # A gzip client holding the plain ETag must get the body, not a 304.
+        self.assertEqual(crossed.status_code, 200)
+        self.assertEqual(gzip.decompress(crossed.content), b"body-1")

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -53,6 +53,11 @@ class CacheNoUserDataTestCase(SimpleTestCase):
     def setUp(self):
         process_cache.clear()
         self.factory = RequestFactory()
+        device_setting = mock.patch(
+            "kolibri.core.decorators.get_device_setting", return_value=False
+        )
+        self.get_device_setting = device_setting.start()
+        self.addCleanup(device_setting.stop)
 
     def _request(self, path="/en/learn/", **extra):
         request = self.factory.get(path, **extra)
@@ -117,6 +122,23 @@ class CacheNoUserDataTestCase(SimpleTestCase):
         self.assertEqual(gzip.decompress(served.content), b"body-1")
         self.assertEqual(gzip.decompress(after.content), b"body-2")
         self.assertEqual(len(render_count), 2)
+
+    def test_a_single_user_device_re_renders_rather_than_serving_stale(self):
+        view, render_count = self._view()
+        self.get_device_setting.return_value = True
+        base = 1000.0
+        stale = base + BODY_CACHE_REFRESH + 100
+
+        with mock.patch("kolibri.core.decorators._spawn") as spawn:
+            with mock.patch("kolibri.core.decorators.time.time", return_value=base):
+                view(self._request())
+            with mock.patch("kolibri.core.decorators.time.time", return_value=stale):
+                served = view(self._request())
+
+        # No herd to shield, so the single user gets the fresh body inline.
+        self.assertEqual(gzip.decompress(served.content), b"body-2")
+        self.assertEqual(len(render_count), 2)
+        spawn.assert_not_called()
 
     def test_stored_body_hard_expires_so_orphaned_entries_do_not_accumulate(self):
         view, _ = self._view()
@@ -270,6 +292,27 @@ class WarmCachedViewsTestCase(TestCase):
         # Each cached view is warmed exactly once, in the device language.
         # Other languages are not warmed at startup; they load lazily.
         self.assertEqual(calls, [("/es-es/learn/", "es-es"), ("/es-es/auth/", "es-es")])
+
+    def test_does_not_warm_on_a_single_user_device(self):
+        calls = []
+
+        def callback(request):
+            calls.append(request.path)
+            return HttpResponse("shell")
+
+        with mock.patch(
+            "kolibri.core.decorators._cached_view_targets",
+            return_value=[("learn", callback)],
+        ), mock.patch(
+            "kolibri.core.decorators.reverse", return_value="/x/"
+        ), mock.patch(
+            "kolibri.core.decorators.get_device_setting", return_value=True
+        ), mock.patch("kolibri.core.decorators.connections"):
+            warm_cached_views()
+
+        # One user, no startup burst: the renders would come out of their own
+        # responsiveness, and the cold-miss path serves them fresh anyway.
+        self.assertEqual(calls, [])
 
     def test_falls_back_to_settings_language_when_device_language_missing(self):
         calls = []

--- a/kolibri/core/test/test_decorators.py
+++ b/kolibri/core/test/test_decorators.py
@@ -6,15 +6,24 @@ from django.template import engines
 from django.template.response import TemplateResponse
 from django.test import RequestFactory
 from django.test import SimpleTestCase
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import translation
 from django.views.generic.base import View
 
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.decorators import _cached_view_targets
 from kolibri.core.decorators import _CachedBody
 from kolibri.core.decorators import BODY_CACHE_REFRESH
 from kolibri.core.decorators import BODY_CACHE_TTL
 from kolibri.core.decorators import cache_no_user_data
 from kolibri.core.decorators import InvalidQueryParamsException
 from kolibri.core.decorators import ParamValidator
+from kolibri.core.decorators import warm_cached_views
 from kolibri.core.utils.cache import process_cache
+from kolibri.plugins.user_auth.views import UserAuthView
+
+USER_AUTH_VIEW_NAME = "kolibri:kolibri.plugins.user_auth:user_auth"
 
 
 def run_inline(target):
@@ -205,3 +214,80 @@ class CacheNoUserDataTestCase(SimpleTestCase):
         # A gzip client holding the plain ETag must get the body, not a 304.
         self.assertEqual(crossed.status_code, 200)
         self.assertEqual(gzip.decompress(crossed.content), b"body-1")
+
+
+class CachedViewTargetsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+    def test_discovers_registered_views_from_the_urlconf(self):
+        targets = dict(_cached_view_targets())
+
+        # Decorated views across plugins must be discoverable for warming.
+        for name in (
+            USER_AUTH_VIEW_NAME,
+            "kolibri:kolibri.plugins.learn:learn",
+            "kolibri:kolibri.plugins.device:device_management",
+        ):
+            self.assertIn(name, targets)
+        self.assertIs(targets[USER_AUTH_VIEW_NAME].view_class, UserAuthView)
+
+    def test_every_discovered_name_is_reversible(self):
+        # Bad namespace assembly would make reverse() raise and silently skip the
+        # view at warm time.
+        with translation.override("en"):
+            for name, _callback in _cached_view_targets():
+                reverse(name)
+
+
+class WarmCachedViewsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+
+    def setUp(self):
+        process_cache.clear()
+
+    def test_warms_each_view_once_in_the_device_language(self):
+        calls = []
+
+        def callback(request):
+            calls.append((request.path, translation.get_language()))
+            return HttpResponse("shell")
+
+        def fake_reverse(name):
+            return "/{}/{}/".format(translation.get_language(), name)
+
+        with mock.patch(
+            "kolibri.core.decorators._cached_view_targets",
+            return_value=[("learn", callback), ("auth", callback)],
+        ), mock.patch("kolibri.core.decorators.reverse", fake_reverse), mock.patch(
+            "kolibri.core.decorators.get_device_language", return_value="es-es"
+        ), mock.patch("kolibri.core.decorators.connections"):
+            warm_cached_views()
+
+        # Each cached view is warmed exactly once, in the device language.
+        # Other languages are not warmed at startup; they load lazily.
+        self.assertEqual(calls, [("/es-es/learn/", "es-es"), ("/es-es/auth/", "es-es")])
+
+    def test_falls_back_to_settings_language_when_device_language_missing(self):
+        calls = []
+
+        def callback(request):
+            calls.append(translation.get_language())
+            return HttpResponse("shell")
+
+        with mock.patch(
+            "kolibri.core.decorators._cached_view_targets",
+            return_value=[("learn", callback)],
+        ), mock.patch(
+            "kolibri.core.decorators.reverse", return_value="/x/"
+        ), mock.patch(
+            "kolibri.core.decorators.get_device_language", return_value=None
+        ), mock.patch(
+            "kolibri.core.decorators.get_settings_language", return_value="ar"
+        ), mock.patch("kolibri.core.decorators.connections"):
+            warm_cached_views()
+
+        self.assertEqual(calls, ["ar"])

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -8,7 +8,6 @@ from django.http import HttpResponseRedirect
 from django.urls import is_valid_path
 from django.urls import reverse
 from django.urls import translate_url
-from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import check_for_language
 from django.utils.translation import gettext_lazy as _
@@ -194,7 +193,7 @@ class GuestRedirectView(RootURLRedirectView):
         return super().get_redirect_url(*args, **kwargs)
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class UnsupportedBrowserView(TemplateView):
     template_name = "kolibri/unsupported_browser.html"
 

--- a/kolibri/plugins/coach/views.py
+++ b/kolibri/plugins/coach/views.py
@@ -1,9 +1,8 @@
-from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from kolibri.core.decorators import cache_no_user_data
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class CoachView(TemplateView):
     template_name = "coach/coach.html"

--- a/kolibri/plugins/device/views.py
+++ b/kolibri/plugins/device/views.py
@@ -1,9 +1,8 @@
-from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from kolibri.core.decorators import cache_no_user_data
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class DeviceManagementView(TemplateView):
     template_name = "device_management.html"

--- a/kolibri/plugins/facility/views.py
+++ b/kolibri/plugins/facility/views.py
@@ -9,7 +9,6 @@ from django.http.response import FileResponse
 from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.utils import translation
-from django.utils.decorators import method_decorator
 from django.utils.translation import get_language_from_request
 from django.utils.translation import pgettext
 from django.views.generic.base import TemplateView
@@ -37,7 +36,7 @@ content_kinds.QUIZ = "quiz"
 logger = logging.getLogger(__name__)
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class FacilityManagementView(TemplateView):
     template_name = "facility_management.html"
 

--- a/kolibri/plugins/learn/views.py
+++ b/kolibri/plugins/learn/views.py
@@ -1,14 +1,13 @@
-from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from kolibri.core.decorators import cache_no_user_data
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class LearnView(TemplateView):
     template_name = "learn/learn.html"
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class MyDownloadsView(TemplateView):
     template_name = "learn/my_downloads.html"

--- a/kolibri/plugins/policies/views.py
+++ b/kolibri/plugins/policies/views.py
@@ -1,9 +1,8 @@
-from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from kolibri.core.decorators import cache_no_user_data
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class PoliciesView(TemplateView):
     template_name = "policies/policies.html"

--- a/kolibri/plugins/pwa/views.py
+++ b/kolibri/plugins/pwa/views.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: MIT
 from urllib.parse import quote
 
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
-from django.views.decorators.gzip import gzip_page
 from django.views.generic.base import TemplateView
 
 import kolibri
@@ -15,8 +12,7 @@ from kolibri.core.theme_hook import ThemeHook
 from kolibri.utils.conf import OPTIONS
 
 
-@method_decorator(gzip_page, name="dispatch")
-@method_decorator(cache_page(60 * 60 * 24 * 7), name="dispatch")
+@cache_no_user_data
 class PwaManifestView(TemplateView):
     template_name = "pwa/manifest.json"
     content_type = "application/manifest+json"
@@ -99,9 +95,7 @@ class PwaManifestView(TemplateView):
         return context
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
-@method_decorator(gzip_page, name="dispatch")
-@method_decorator(cache_page(60 * 60 * 24 * 7), name="dispatch")
+@cache_no_user_data
 class PwaServiceWorkerView(TemplateView):
     template_name = "pwa/sw.js"
     content_type = "application/javascript"

--- a/kolibri/plugins/user_auth/frontend/app.js
+++ b/kolibri/plugins/user_auth/frontend/app.js
@@ -1,7 +1,9 @@
 import { watch } from 'vue';
-import { useWindowFocus } from '@vueuse/core';
+import { get, useWindowFocus } from '@vueuse/core';
 import router from 'kolibri/router';
 import KolibriApp from 'kolibri-app';
+import useUser from 'kolibri/composables/useUser';
+import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import RootVue from './views/UserAuthIndex';
 import routes from './routes';
 import useAuthFlow from './composables/useAuthFlow';
@@ -22,6 +24,14 @@ class UserAuthModule extends KolibriApp {
     // `initialzeFlow` above `super.ready()` causes a delay, showing a white page. putting it after
     // causes the state not to be ready for components
     router.beforeEach(async (to, from, next) => {
+      // Authenticated users have no business on the auth pages; redirect them
+      // to their landing page.
+      const { isUserLoggedIn } = useUser();
+      if (get(isUserLoggedIn)) {
+        redirectBrowser();
+        return;
+      }
+
       await initializeFlow();
       next();
     });

--- a/kolibri/plugins/user_auth/frontend/app.js
+++ b/kolibri/plugins/user_auth/frontend/app.js
@@ -1,7 +1,9 @@
 import { watch } from 'vue';
-import { useWindowFocus } from '@vueuse/core';
+import { get, useWindowFocus } from '@vueuse/core';
 import router from 'kolibri/router';
 import KolibriApp from 'kolibri-app';
+import useUser from 'kolibri/composables/useUser';
+import redirectBrowser from 'kolibri/utils/redirectBrowser';
 import RootVue from './views/UserAuthIndex';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
@@ -26,6 +28,14 @@ class UserAuthModule extends KolibriApp {
     // `initialzeFlow` above `super.ready()` causes a delay, showing a white page. putting it after
     // causes the state not to be ready for components
     router.beforeEach(async (to, from, next) => {
+      // Authenticated users have no business on the auth pages; redirect them
+      // to their landing page.
+      const { isUserLoggedIn } = useUser();
+      if (get(isUserLoggedIn)) {
+        redirectBrowser();
+        return;
+      }
+
       await initializeFlow();
       next();
     });

--- a/kolibri/plugins/user_auth/views.py
+++ b/kolibri/plugins/user_auth/views.py
@@ -1,15 +1,10 @@
 from django.views.generic.base import TemplateView
 
-from kolibri.core.views import RootURLRedirectView
+from kolibri.core.decorators import cache_no_user_data
 
 
+@cache_no_user_data
 class UserAuthView(TemplateView):
-    template_name = "user_auth/user_auth.html"
+    """Authenticated users are redirected away on the frontend, in app.js."""
 
-    def get(self, request):
-        """
-        When authenticated, redirect to the appropriate view
-        """
-        if request.user.is_authenticated:
-            return RootURLRedirectView.as_view()(request)
-        return super().get(request)
+    template_name = "user_auth/user_auth.html"

--- a/kolibri/plugins/user_profile/views.py
+++ b/kolibri/plugins/user_profile/views.py
@@ -1,9 +1,8 @@
-from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 
 from kolibri.core.decorators import cache_no_user_data
 
 
-@method_decorator(cache_no_user_data, name="dispatch")
+@cache_no_user_data
 class UserProfileView(TemplateView):
     template_name = "user_profile/user_profile.html"


### PR DESCRIPTION
## Summary
Our existing caching for SPA pages is incredibly inefficient, with the page getting rerendered on every request, regardless, even if an ETag driven "not modified" is then returned.

This PR changes that around so that we nearly always serve quickly, with cache refreshes happening in two different ways in the background:
* The most common path, is that the page will serve stale-while-revalidate type behaviour, always serving from the cache if it is available, and then opportunistically triggering a cache refresh in a temporary background thread a little bit earlier than cache expiry - this keeps the page fresh but avoids blocking requests for it
* To avoid thundering herd/cold start problems, a "started at startup" populates the cache for all registered SPA pages in the device's default language - this optimization was particularly helpful for the Raspberry Pi in my testing

This PR also updates the user auth page to leverage the "cache no user data" decorator - previously it did not because it initiated redirects in the backend to sign people into the right page. This is an uncommon occurrence, so instead this is deferred to JS in page load instead. This allows the user auth page to be cached also, which helps with the very start of a thundering herd classroom session.

## References
This was one of the more promising avenues for performance improvement while doing load testing 

## Reviewer guidance

Is the code comprehensible? Is the previously desirable caching behaviour maintained, does the new caching behaviour introduce any unexpected side effects?

I thought about making an explicit Kolibri hook for the cache no user decorator in order to collect the views, but it felt like a lot more overhead - but open to making it explicit if helpful.

### Benchmarks

Baseline against `develop`, which already caches the ETag but re-renders the shell on every request.
All figures are deltas against it.

"Rollover" means that the server would at some point fail under the load.

| target | load | p50 | p95 | p99 | reqs | outcome |
|---|---|---|---|---|---|---|
| Pi 4 (SD) | 10u | -29% | -30% | -23% | +1% | both serve |
| Pi 4 (SD) | 50u | — | — | — | +47% | rollover → serving |
| pod (Postgres) | 200u | — | 0% | -75% | +60% | rollover → serving |

This change made the difference for both the online server and the raspberry pi (without kolibri server - using as a low end baseline) to actually serve all clients, albeit slowly.

## AI usage

I used Claude Code extensively for this work, especially the comparative benchmarking to test different changes in a matrix across the different targets. This particular PR was then worked up from those changes in collaboration with Claude Code.