### PR TITLE
Reuse a single per-file diskcache handle when streaming remote files

### DIFF
--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -101,6 +101,11 @@ class ChunkedFileDoesNotExist(Exception):
 
 CHUNK_SUFFIX = ".chunks"
 
+# Marker file used to detect when a chunk directory has been deleted and
+# recreated, on filesystems that do not report a usable inode (see
+# ChunkedFile._chunk_dir_incarnation).
+INCARNATION_MARKER = ".incarnation"
+
 
 class TransferFileBase(BufferedIOBase, ABC):
     """Abstract base class for file transfer destination objects."""
@@ -182,8 +187,17 @@ class ChunkedFileDirectoryManager:
             if file_size <= evicted_file_size:
                 break
             file_stats = chunked_file_stats[chunked_file_dir]
+            try:
+                shutil.rmtree(chunked_file_dir)
+            except OSError as e:
+                # The directory may be in use - for example a diskcache handle
+                # held open while a file is being streamed, which blocks removal
+                # on Windows. Skip it rather than aborting the whole eviction.
+                logger.warning(
+                    "Could not evict chunked file {}: {}".format(chunked_file_dir, e)
+                )
+                continue
             evicted_file_size += file_stats["size"]
-            shutil.rmtree(chunked_file_dir)
         return evicted_file_size
 
     def evict_files(self, file_size):
@@ -213,9 +227,24 @@ class ChunkedFile(TransferFileBase):
     # Set chunk size to 128KB
     chunk_size = 128 * 1024
 
-    def __init__(self, filepath, raise_if_empty=False, raise_if_exists=False):
+    def __init__(
+        self, filepath, raise_if_empty=False, raise_if_exists=False, cache=None
+    ):
         self.filepath = filepath
         self.chunk_dir = filepath + CHUNK_SUFFIX
+        # The diskcache handle is opened lazily and then reused for the lifetime
+        # of this object, rather than being reopened for every cache access.
+        # Opening a diskcache constructs a SQLite connection (with pragmas and
+        # fsyncs), which is cheap on fast storage but very expensive on slow
+        # storage like SD cards, where reopening it per read block made serving
+        # proxied remote files pathologically slow. A caller may inject an
+        # existing handle (see ``cache``) so that related objects for the same
+        # file (e.g. a RemoteFile and the FileDownload streaming into it) share
+        # one handle; an injected handle is not owned and so is not closed here.
+        # These are assigned before the early returns below so that close() on a
+        # partially constructed instance does not raise.
+        self._cache = cache
+        self._owns_cache = cache is None
         if raise_if_empty and not os.path.exists(self.chunk_dir):
             raise FileNotFoundError("Chunked file does not exist")
         if raise_if_exists and os.path.exists(self.filepath):
@@ -224,19 +253,96 @@ class ChunkedFile(TransferFileBase):
         self.position = 0
         self._file_size = None
 
+    def _chunk_dir_incarnation(self):
+        """
+        Return a token identifying the current on-disk incarnation of the chunk
+        directory, so that a deletion + recreation (e.g. streamed cache
+        eviction) can be detected and a stale diskcache handle dropped. Prefers
+        the directory inode (a cheap stat), and falls back to a marker file on
+        filesystems that do not report a usable inode (e.g. FAT/exFAT, some
+        Android storage), where st_ino is 0.
+        """
+        try:
+            inode = os.stat(self.chunk_dir).st_ino
+            if inode:
+                # The inode changes when the directory is deleted and recreated.
+                # We deliberately do not pair it with mtime/ctime: those change
+                # whenever a chunk file is written into the directory, which
+                # would churn the token during normal streaming. The residual
+                # risk is a recreated directory being assigned the exact same
+                # inode number (POSIX inode recycling) while a stale handle is
+                # still held - vanishingly unlikely, and only reachable in the
+                # already-narrow eviction-mid-stream race.
+                return inode
+            marker = os.path.join(self.chunk_dir, INCARNATION_MARKER)
+            try:
+                with open(marker) as f:
+                    return f.read()
+            except FileNotFoundError:
+                token = os.urandom(8).hex()
+                try:
+                    # Atomic create so concurrent openers agree on one token.
+                    with open(marker, "x") as f:
+                        f.write(token)
+                    return token
+                except FileExistsError:
+                    with open(marker) as f:
+                        return f.read()
+        except OSError:
+            # The directory was removed between the _check_for_chunk_dir guard
+            # and here (eviction racing a stream). Normalize to the exception
+            # callers already handle, rather than letting a bare OSError escape
+            # and fail the download hard.
+            raise ChunkedFileDoesNotExist("Chunked file does not exist")
+
+    @contextmanager
     def _open_cache(self):
         self._check_for_chunk_dir()
-        return Cache(self.cache_dir)
+        incarnation = self._chunk_dir_incarnation()
+        if self._cache is not None and (
+            getattr(self._cache, "_kolibri_chunk_incarnation", None) != incarnation
+        ):
+            # The chunk directory was deleted and recreated (e.g. by streamed
+            # cache eviction) since this handle was opened, so it points at the
+            # old, now-deleted diskcache. Drop it and reopen against the live
+            # directory, matching the pre-memoization behaviour of always using
+            # the current cache. This matters for correctness, not just leaks:
+            # chunk locks live as rows in the on-disk SQLite DB, so a stale
+            # handle would silently fail to coordinate with other readers.
+            self._close_cache()
+        if self._cache is None:
+            cache = Cache(self.cache_dir)
+            # Stamp the handle with the incarnation it was opened against so a
+            # later deletion/recreation can be detected.
+            cache._kolibri_chunk_incarnation = incarnation
+            self._cache = cache
+            # We opened this handle, so this instance owns and must close it.
+            self._owns_cache = True
+        yield self._cache
+
+    def get_cache(self):
+        """
+        Return the reused diskcache handle for this file, opening it if needed.
+        Used to share a single handle with a FileDownload for the same file.
+        """
+        with self._open_cache() as cache:
+            return cache
 
     def _initialize(self):
         os.makedirs(self.chunk_dir, exist_ok=True)
         self.cache_dir = os.path.join(self.chunk_dir, ".cache")
-        self.position = 0
+        # NB: do not reset self.position here. _initialize is also invoked by
+        # ensure_writable() to recreate a directory that was cleaned up mid-read,
+        # and resetting the read cursor there would silently rewind an
+        # in-progress read. __init__ sets the initial position separately.
 
     def ensure_writable(self):
         try:
             self._check_for_chunk_dir()
         except ChunkedFileDoesNotExist:
+            # The chunk directory was removed by another process; recreate it.
+            # Any cache handle we still hold is detected as stale and reopened on
+            # next use (see _open_cache), so we don't need to touch it here.
             self._initialize()
 
     @property
@@ -472,10 +578,20 @@ class ChunkedFile(TransferFileBase):
         return md5.hexdigest()
 
     def delete(self):
+        # Release our diskcache handle before removing the directory: on Windows
+        # the open SQLite file would otherwise block removal (WinError 32).
+        self._close_cache()
         shutil.rmtree(self.chunk_dir)
 
+    def _close_cache(self):
+        # Only close a handle we opened ourselves; an injected handle is owned
+        # (and closed) by whoever provided it.
+        if self._owns_cache and self._cache is not None:
+            self._cache.close()
+        self._cache = None
+
     def close(self):
-        pass
+        self._close_cache()
 
     def __enter__(self):
         return self
@@ -772,12 +888,20 @@ class FileDownload(Transfer):
         timeout=Transfer.DEFAULT_TIMEOUT,
         retry_wait=30,
         full_ranges=True,
+        cache=None,
     ):
 
         # Allow an existing requests.Session to be passed in, so it can be
         # reused for speed. The default blocks cross-host redirects so a
         # caller-supplied baseurl can't pivot us onto another host.
         self.session = session or SameHostSession()
+
+        # Allow an existing diskcache handle to be passed in, so the chunked
+        # destination file reuses it rather than opening its own. This lets a
+        # RemoteFile streaming a proxied file share one handle across itself and
+        # every FileDownload it spawns, instead of reopening the diskcache once
+        # per downloaded chunk.
+        self._cache = cache
 
         # A flag to allow the download to remain in the chunked file directory
         # for easier clean up when it is just a temporary download.
@@ -815,6 +939,7 @@ class FileDownload(Transfer):
                 self.dest,
                 raise_if_empty=self.full_ranges,
                 raise_if_exists=self.full_ranges,
+                cache=self._cache,
             )
         except FileNotFoundError:
             # No chunked file exists, use TransferFile for direct download
@@ -1133,6 +1258,11 @@ class RemoteFile(ChunkedFile):
 
     def _start_transfer(self, start=None, end=None):
         if not self.is_complete(start=start, end=end):
+            # Recreate the chunk directory (and drop any stale cache handle) if
+            # it was cleaned up by another process since we opened it, so that
+            # sharing our cache handle below opens against a directory that
+            # exists rather than raising.
+            self.ensure_writable()
             self.transfer = FileDownload(
                 self.remote_url,
                 self.filepath,
@@ -1140,6 +1270,9 @@ class RemoteFile(ChunkedFile):
                 end_range=end,
                 finalize_download=False,
                 full_ranges=False,
+                # Share this file's diskcache handle with the download, so
+                # streaming a file doesn't reopen the diskcache once per chunk.
+                cache=self.get_cache(),
             )
             with self._open_cache() as cache:
                 header_info = cache.get(self.remote_url)
@@ -1171,3 +1304,5 @@ class RemoteFile(ChunkedFile):
             self.transfer.close()
         if self._dest_file_handle:
             self._dest_file_handle.close()
+        # Close the reused diskcache handle shared with any FileDownload.
+        super().close()

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -5,6 +5,8 @@ import shutil
 import tempfile
 import unittest
 
+from mock import patch
+
 from kolibri.utils.file_transfer import CHUNK_SUFFIX
 from kolibri.utils.file_transfer import ChunkedFile
 from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
@@ -48,6 +50,9 @@ class TestChunkedFile(unittest.TestCase):
         self.data = _write_test_data_to_chunked_file(self.chunked_file)
 
     def tearDown(self):
+        # Release the reused diskcache handle before removing the directory, or
+        # the open SQLite file blocks removal on Windows and pollutes later tests.
+        self.chunked_file.close()
         shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
         shutil.rmtree(self.file_path, ignore_errors=True)
 
@@ -167,7 +172,9 @@ class TestChunkedFile(unittest.TestCase):
         self.assertEqual(missing_ranges, expected_ranges)
 
     def test_get_missing_chunk_ranges_slice_no_download(self):
-        # Remove some chunks
+        # Remove some chunks. Release our handle first so the directory can be
+        # removed on Windows (an open SQLite file blocks removal there).
+        self.chunked_file.close()
         shutil.rmtree(self.chunked_file.chunk_dir)
 
         start = self.chunk_size
@@ -182,7 +189,9 @@ class TestChunkedFile(unittest.TestCase):
         self.assertEqual(missing_ranges, expected_ranges)
 
     def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges(self):
-        # Remove some chunks
+        # Remove some chunks. Release our handle first so the directory can be
+        # removed on Windows (an open SQLite file blocks removal there).
+        self.chunked_file.close()
         shutil.rmtree(self.chunked_file.chunk_dir)
 
         start = self.chunk_size // 3
@@ -274,6 +283,9 @@ class TestChunkedFile(unittest.TestCase):
         os.remove(self.file_path)
 
     def test_file_removed_by_parallel_process_after_opening(self):
+        # Release our handle so the directory can actually be removed on Windows
+        # (an open SQLite file blocks removal there).
+        self.chunked_file.close()
         shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
         self.chunked_file._file_size = None
         with self.assertRaises(ChunkedFileDoesNotExist):
@@ -390,6 +402,29 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
             sorted(list(manager._get_chunked_file_dirs())),
             sorted([]),
         )
+
+    def test_evict_files_skips_undeletable_directory(self):
+        # If a directory cannot be removed (e.g. a diskcache handle held open
+        # while streaming, which blocks removal on Windows), eviction must skip
+        # it - not count it as freed, and not abort the whole pass.
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        blocked = sorted(manager._get_chunked_file_dirs())[0]
+        real_rmtree = shutil.rmtree
+
+        def guarded_rmtree(path, *args, **kwargs):
+            if path == blocked:
+                raise OSError("directory in use")
+            return real_rmtree(path, *args, **kwargs)
+
+        with patch(
+            "kolibri.utils.file_transfer.shutil.rmtree", side_effect=guarded_rmtree
+        ):
+            evicted = manager.evict_files(TOTAL_CHUNKED_FILE_SIZE * 3)
+
+        # Two of the three directories are evicted; the blocked one is skipped
+        # and its size is not counted toward the freed total.
+        self.assertEqual(evicted, TOTAL_CHUNKED_FILE_SIZE * 2)
+        self.assertEqual(sorted(manager._get_chunked_file_dirs()), [blocked])
 
     def test_evict_files_exact_file_size(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -3,6 +3,7 @@ import math
 import os
 import shutil
 import tempfile
+import threading
 import unittest
 
 from mock import call
@@ -1023,3 +1024,317 @@ class TestRetryImport(unittest.TestCase):
                 retry_import(e),
                 "Expected no retry for {}".format(exception_class.__name__),
             )
+
+
+class _ThreadSafeRangeSession(object):
+    """
+    A minimal, thread-safe stand-in for a requests Session serving a fixed
+    byte string with HTTP range support. Unlike the MagicMock-based harness
+    above it keeps no shared per-response mutable state, so it can be used by
+    several threads at once (e.g. simulating multiple users streaming the same
+    remote file concurrently). Each response is built fresh per call.
+    """
+
+    def __init__(self, content):
+        self.content = content
+
+    def head(self, url, timeout=None, allow_redirects=False):
+        response = MagicMock()
+        response.url = url
+        response.status_code = 200
+        response.headers = {
+            "content-length": str(len(self.content)),
+            "accept-ranges": "bytes",
+        }
+        return response
+
+    def get(self, url, headers=None, stream=False, timeout=None):
+        start, end = 0, None
+        ranged = bool(headers and "Range" in headers)
+        if ranged:
+            start_s, end_s = headers["Range"].replace("bytes=", "").split("-")
+            start = int(start_s)
+            end = int(end_s) + 1 if end_s else None
+        data = self.content[start:end]
+        response_headers = {
+            "content-length": str(len(data)),
+            "accept-ranges": "bytes",
+        }
+        if end is not None:
+            response_headers["content-range"] = "bytes {}-{}/{}".format(
+                start, end - 1, len(self.content)
+            )
+        response = MagicMock()
+        response.url = url
+        response.status_code = 206 if ranged else 200
+        response.headers = response_headers
+        response.content = data
+
+        def iter_content(chunk_size=1):
+            for i in range(0, len(data), chunk_size):
+                yield data[i : i + chunk_size]
+
+        response.iter_content = iter_content
+        return response
+
+
+class TestRemoteFileDiskCacheReuse(unittest.TestCase):
+    """
+    Regression tests for the per-file chunk diskcache being reopened on every
+    read block while streaming a proxied remote file (see the SD-card slowness
+    issue). Serving a remote file must reuse a single diskcache handle for the
+    request rather than constructing a fresh ``diskcache.Cache`` per chunk.
+    """
+
+    source = "http://testserver/remote_video.mp4"
+
+    def setUp(self):
+        self.destdir = tempfile.mkdtemp()
+        self.dest = os.path.join(self.destdir, "remote_video.mp4")
+
+    def tearDown(self):
+        shutil.rmtree(self.destdir, ignore_errors=True)
+
+    def _make_content(self, num_chunks):
+        # A file spanning ``num_chunks`` chunks, with a partial final chunk so
+        # the file-size / last-chunk handling is exercised exactly.
+        return os.urandom((num_chunks - 1) * ChunkedFile.chunk_size + 731)
+
+    def _read_all(self, remote_file):
+        output = b""
+        chunk = remote_file.read(ChunkedFile.chunk_size)
+        while chunk:
+            output += chunk
+            chunk = remote_file.read(ChunkedFile.chunk_size)
+        return output
+
+    def test_diskcache_not_reopened_per_chunk_when_streaming(self):
+        num_chunks = 40
+        content = self._make_content(num_chunks)
+        session = _ThreadSafeRangeSession(content)
+
+        import kolibri.utils.file_transfer as file_transfer
+
+        real_cache = file_transfer.Cache
+        constructions = []
+
+        def counting_cache(*args, **kwargs):
+            constructions.append(args[0] if args else None)
+            return real_cache(*args, **kwargs)
+
+        with patch(
+            "kolibri.utils.file_transfer.SameHostSession", return_value=session
+        ), patch("kolibri.utils.file_transfer.Cache", side_effect=counting_cache):
+            remote_file = RemoteFile(self.dest, self.source)
+            output = self._read_all(remote_file)
+            remote_file.close()
+
+        self.assertEqual(output, content, "Streamed content does not match")
+        # Before the fix the diskcache is reconstructed several times per chunk,
+        # so this count scales with num_chunks (~3-4x). The per-file cache must
+        # instead be reused for the request, giving a small bound that does not
+        # grow with file size.
+        self.assertLessEqual(
+            len(constructions),
+            5,
+            "diskcache Cache was constructed {} times while streaming a "
+            "{}-chunk file; it must be reused across reads, not reopened per "
+            "chunk".format(len(constructions), num_chunks),
+        )
+
+    def test_concurrent_reads_of_same_remote_file(self):
+        # Simulates multiple users streaming the same remote video at once:
+        # several threads read the SAME dest/source concurrently, contending on
+        # the shared per-file chunk diskcache and chunk locks. This must remain
+        # correct (and must stay correct after the cache-reuse fix).
+        num_chunks = 20
+        content = self._make_content(num_chunks)
+        session = _ThreadSafeRangeSession(content)
+
+        results = {}
+        errors = {}
+
+        def reader(tid):
+            try:
+                remote_file = RemoteFile(self.dest, self.source)
+                results[tid] = self._read_all(remote_file)
+                remote_file.close()
+            except Exception as e:  # noqa: B902
+                errors[tid] = e
+
+        with patch("kolibri.utils.file_transfer.SameHostSession", return_value=session):
+            threads = [threading.Thread(target=reader, args=(i,)) for i in range(6)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(errors, {}, "Concurrent reads raised: {}".format(errors))
+        self.assertEqual(len(results), 6)
+        for tid, output in results.items():
+            self.assertEqual(
+                output, content, "Thread {} read incorrect content".format(tid)
+            )
+
+        # The on-disk chunks must be complete and correct after concurrent
+        # downloads of the same file.
+        chunked_file = ChunkedFile(self.dest)
+        self.assertTrue(chunked_file.is_complete())
+        chunked_file.seek(0)
+        self.assertEqual(chunked_file.read(), content)
+
+    def test_single_read_content_correct(self):
+        # Baseline correctness guard for the streaming read path used above.
+        num_chunks = 5
+        content = self._make_content(num_chunks)
+        session = _ThreadSafeRangeSession(content)
+        with patch("kolibri.utils.file_transfer.SameHostSession", return_value=session):
+            remote_file = RemoteFile(self.dest, self.source)
+            output = self._read_all(remote_file)
+            remote_file.close()
+        self.assertEqual(output, content)
+
+    @unittest.skipIf(
+        os.name == "nt",
+        "This end-to-end flavor deletes a directory whose diskcache is held "
+        "open, which Windows forbids - so the stale-handle race cannot occur "
+        "there (delete() releases the handle first, and external eviction is "
+        "skipped when the file is blocked). The self-heal mechanism itself and "
+        "that safety invariant are covered cross-platform by "
+        "test_open_cache_reopens_when_incarnation_changes and "
+        "test_delete_releases_cache_handle.",
+    )
+    def test_cache_handle_self_heals_after_directory_recreated(self):
+        # A stale diskcache handle (pointing at a deleted, recreated chunk dir)
+        # must be detected and reopened, or chunk-lock coordination silently
+        # breaks (locks live as rows in the on-disk SQLite DB). This is the
+        # streamed-cache-eviction-mid-stream race.
+        from diskcache import Cache
+
+        dest = os.path.join(self.destdir, "self_heal.bin")
+        chunked_file = ChunkedFile(dest)
+        chunked_file.file_size = 5 * ChunkedFile.chunk_size
+        stale_handle = chunked_file.get_cache()
+
+        # Another process evicts and recreates this file's chunk dir.
+        shutil.rmtree(chunked_file.chunk_dir)
+        os.makedirs(chunked_file.chunk_dir)
+        fresh = Cache(chunked_file.cache_dir)
+        fresh.set("probe", 42)
+
+        healed_handle = chunked_file.get_cache()
+        self.assertIsNot(healed_handle, stale_handle, "stale handle was not dropped")
+        self.assertEqual(
+            healed_handle.get("probe"),
+            42,
+            "reopened handle does not see the live diskcache",
+        )
+        fresh.close()
+        chunked_file.close()
+
+    def test_chunk_dir_incarnation_falls_back_to_marker_without_inode(self):
+        # On filesystems that do not report a usable inode (st_ino == 0, e.g.
+        # FAT/exFAT, some Android storage), a marker file provides the same
+        # deletion/recreation signal.
+        dest = os.path.join(self.destdir, "marker.bin")
+        chunked_file = ChunkedFile(dest)
+        marker_path = os.path.join(chunked_file.chunk_dir, ".incarnation")
+
+        with patch(
+            "kolibri.utils.file_transfer.os.stat",
+            return_value=MagicMock(st_ino=0),
+        ):
+            token1 = chunked_file._chunk_dir_incarnation()
+            token2 = chunked_file._chunk_dir_incarnation()
+        # Same directory incarnation -> stable token from the marker file.
+        self.assertEqual(token1, token2)
+        self.assertTrue(os.path.exists(marker_path))
+
+        # Recreated directory -> marker gone -> different token.
+        shutil.rmtree(chunked_file.chunk_dir)
+        os.makedirs(chunked_file.chunk_dir)
+        with patch(
+            "kolibri.utils.file_transfer.os.stat",
+            return_value=MagicMock(st_ino=0),
+        ):
+            token3 = chunked_file._chunk_dir_incarnation()
+        self.assertNotEqual(token1, token3)
+
+    @unittest.skipIf(
+        os.name == "nt",
+        "This end-to-end flavor deletes a directory whose diskcache is held "
+        "open, which Windows forbids - so the stale-handle race cannot occur "
+        "there (delete() releases the handle first, and external eviction is "
+        "skipped when the file is blocked). The self-heal mechanism itself and "
+        "that safety invariant are covered cross-platform by "
+        "test_open_cache_reopens_when_incarnation_changes and "
+        "test_delete_releases_cache_handle.",
+    )
+    def test_stale_injected_cache_handle_is_dropped_not_closed(self):
+        # A borrowed (injected) handle that has gone stale must be dropped
+        # WITHOUT being closed - its owner may still use it - and the borrower
+        # must then take ownership of the fresh handle it opens. This is the
+        # FileDownload-re-injects-RemoteFile's-handle path at the heart of the
+        # eviction race.
+        dest = os.path.join(self.destdir, "injected.bin")
+        owner = ChunkedFile(dest)
+        owner.file_size = 3 * ChunkedFile.chunk_size
+        shared = owner.get_cache()
+
+        borrower = ChunkedFile(dest, cache=shared)
+        self.assertFalse(borrower._owns_cache)
+
+        # The directory is evicted and recreated underneath both objects.
+        shutil.rmtree(owner.chunk_dir)
+        os.makedirs(owner.chunk_dir)
+
+        healed = borrower.get_cache()
+        self.assertIsNot(healed, shared, "stale borrowed handle was not dropped")
+        self.assertTrue(
+            borrower._owns_cache, "borrower did not take ownership of new handle"
+        )
+        # The borrowed handle must not have been closed by the borrower; a
+        # closed diskcache raises on access.
+        try:
+            shared.get("probe")
+        except Exception as e:  # noqa: B902
+            self.fail("borrowed handle was closed by the borrower: {!r}".format(e))
+        owner.close()
+        borrower.close()
+
+    def test_open_cache_reopens_when_incarnation_changes(self):
+        # The self-heal mechanism, tested independently of a real deletion so it
+        # also runs on Windows: when the chunk-dir incarnation token changes
+        # (a deleted+recreated directory), _open_cache must drop the memoized
+        # handle and reopen, re-stamping the new incarnation.
+        dest = os.path.join(self.destdir, "reopen.bin")
+        chunked_file = ChunkedFile(dest)
+        chunked_file.file_size = 2 * ChunkedFile.chunk_size
+        first = chunked_file.get_cache()
+
+        with patch.object(
+            chunked_file, "_chunk_dir_incarnation", return_value="changed-token"
+        ):
+            second = chunked_file.get_cache()
+
+        self.assertIsNot(second, first, "handle was not reopened on incarnation change")
+        self.assertEqual(second._kolibri_chunk_incarnation, "changed-token")
+        chunked_file.close()
+
+    def test_delete_releases_cache_handle(self):
+        # Deleting a chunked file must release the diskcache handle before
+        # removing the directory - on Windows an open SQLite file would block
+        # removal (WinError 32). This invariant is what keeps the memoized
+        # handle safe there, so it is asserted on every platform.
+        dest = os.path.join(self.destdir, "del.bin")
+        chunked_file = ChunkedFile(dest)
+        chunked_file.file_size = ChunkedFile.chunk_size
+        chunked_file.get_cache()
+        self.assertIsNotNone(chunked_file._cache)
+
+        chunked_file.delete()
+
+        self.assertIsNone(
+            chunked_file._cache, "delete() did not release the cache handle"
+        )
+        self.assertFalse(os.path.exists(chunked_file.chunk_dir))


### PR DESCRIPTION
## Summary
Addresses per-chunk disk-based lock cache churn when streaming content from another library, by re-using a cache across operations within a RemoteFile/ChunkedFile. This was most impacting devices with slow disk I/O, like an RPi running off of an SD card, rendering peer or Studio library browsing unusably, unreasonably, and unnecessarily slow.

## References
Fixes #15048.

## Reviewer guidance
- `kolibri/utils/file_transfer.py:299` `_open_cache` — the memoized handle is stamped with a chunk-dir "incarnation" (`_chunk_dir_incarnation`, :256) and dropped/reopened when it changes; confirm the token stays stable while chunk files are written into the dir (it uses the inode alone, deliberately not mtime/ctime, which would churn) yet changes on delete+recreate, and that a *borrowed* handle is dropped without being closed.
- `kolibri/utils/file_transfer.py:331` `_initialize` no longer resets `self.position`; confirm no caller other than `__init__` relied on that reset (it's now reachable mid-read via `ensure_writable`).
- `kolibri/utils/file_transfer.py:179` `_do_file_eviction` now skips a directory it cannot remove; confirm skipped directories aren't counted as freed and the pass still continues.

## AI usage
Used Claude Code to profile the regression on the affected Raspberry Pi, implement the fix, and write the regression tests. Verified with the full `file_transfer` and `chunked_file` test suites, a before/after benchmark on the device, and an adversarial local code review. (I wrote the Summary myself manually using my fingers, as per decree.)
