### PR TITLE
Fix default case-sensitivity of qti-map-entry

### DIFF
--- a/kolibri/plugins/qti_viewer/frontend/utils/qti/__tests__/declarations/mapping.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/qti/__tests__/declarations/mapping.spec.js
@@ -201,12 +201,12 @@ describe('Mapping', () => {
       expect(variable.score('Hello')).toBe(1);
     });
 
-    it('should match case-sensitively by default', () => {
+    it('should match case-insensitively by default', () => {
       const variable = buildMapping({
         mappingAttrs: 'default-value="0"',
         entries: `<qti-map-entry map-key="Hello" mapped-value="1" />`,
       });
-      expect(variable.score('hello')).toBe(0);
+      expect(variable.score('hello')).toBe(1);
       expect(variable.score('Hello')).toBe(1);
     });
 

--- a/kolibri/plugins/qti_viewer/frontend/utils/qti/declarations/mapping.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/qti/declarations/mapping.js
@@ -38,7 +38,7 @@ export default class Mapping extends ScoringDeclaration {
     for (const entry of xmlNode.querySelectorAll('qti-map-entry')) {
       const mapKey = entry.getAttribute('map-key');
       const mappedValue = parseFloat(entry.getAttribute('mapped-value'));
-      if (entry.getAttribute('case-sensitive') === 'false') {
+      if (entry.getAttribute('case-sensitive') !== 'true') {
         this.ciEntries.push({
           key: this._normalizeMapKey(mapKey.toLowerCase()),
           value: mappedValue,


### PR DESCRIPTION
## Summary

Fixes the default case-sensitivity of `qti-map-entry`. The QTI spec defaults `case-sensitive` to `false` when omitted, but the code only treated an explicit `case-sensitive="false"` as case-insensitive — so entries without the attribute were incorrectly matched case-sensitively.

## References

## Reviewer guidance

- Verify `kolibri/plugins/qti_viewer/frontend/utils/qti/declarations/mapping.js:41` — entries without `case-sensitive` should now match case-insensitively.
- `mapping.spec.js:204` was updated to reflect the corrected default behavior.

## AI usage

Used Claude Code to apply the fix and update the affected test (`mapping.spec.js:204`) to match the corrected default behavior; verified with the existing Jest suite (`pnpm test-jest kolibri/plugins/qti_viewer`, 754 passing).