### PR TITLE
Fix missing store.state.route migration to useRoute

### DIFF
--- a/kolibri/plugins/coach/frontend/composables/__tests__/useQuizCreation.spec.js
+++ b/kolibri/plugins/coach/frontend/composables/__tests__/useQuizCreation.spec.js
@@ -1,5 +1,6 @@
 import { nextTick } from 'vue';
 import { get } from '@vueuse/core';
+import * as vueRouterComposables from 'vue-router/composables';
 import ExamResource from 'kolibri-common/apiResources/ExamResource';
 import { objectWithDefaults } from 'kolibri/utils/objectSpecs';
 import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
@@ -7,6 +8,10 @@ import { QuizExercise, QuizQuestion } from '../quizCreationSpecs.js';
 import useQuizCreation from '../useQuizCreation.js';
 
 ExamResource.saveModel = jest.fn(() => Promise.resolve({}));
+
+jest.spyOn(vueRouterComposables, 'useRoute').mockReturnValue({
+  params: {},
+});
 
 const VALID_EXERCISE_ID = 'af26e1b4f3b94f3e8f4f3b4f3e8f4f3a';
 

--- a/kolibri/plugins/coach/frontend/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/frontend/composables/useQuizCreation.js
@@ -1,11 +1,12 @@
 import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
 import uniq from 'lodash/uniq';
+import { useRoute } from 'vue-router/composables';
 import shuffled from 'kolibri-common/utils/shuffled.js';
 import { MAX_QUESTIONS_PER_QUIZ_SECTION } from 'kolibri/constants';
 import ExamResource from 'kolibri-common/apiResources/ExamResource';
 import { validateObject, objectWithDefaults } from 'kolibri/utils/objectSpecs';
 import { get, set } from '@vueuse/core';
-import { computed, ref, provide, inject, getCurrentInstance, watch } from 'vue';
+import { computed, ref, provide, inject, watch } from 'vue';
 import { fetchExamWithContent } from 'kolibri-common/quizzes/utils';
 // TODO: Probably move this to this file's local dir
 import selectQuestions, { exerciseToQuestionArray } from '../utils/selectQuestions.js';
@@ -41,7 +42,7 @@ const fieldsToSave = [
 ];
 
 export default function useQuizCreation() {
-  const store = getCurrentInstance()?.proxy?.$store;
+  const route = useRoute();
   // -----------
   // Local state
   // -----------
@@ -55,7 +56,7 @@ export default function useQuizCreation() {
   const _quiz = ref(objectWithDefaults({}, Quiz));
 
   /** @type {ref<QuizSection>} The section that is currently selected for editing */
-  const activeSectionIndex = computed(() => Number(store?.state?.route?.params?.sectionIndex || 0));
+  const activeSectionIndex = computed(() => Number(route.params.sectionIndex || 0));
 
   /**
    * @type {ref<string[]>} The `QuizQuestion.items` that are currently selected for action in


### PR DESCRIPTION

## Summary


Fixes missing `store.state.route` migration to useRoute


## Reviewer guidance
Play with the quiz creation flow, check that you can add/change sections without errors.
