### PR TITLE
Route course cards to the course welcome page instead of course content

### DIFF
--- a/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
+++ b/kolibri/plugins/learn/frontend/composables/__tests__/useLearnerResources.spec.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 
 import ContentNodeResource from 'kolibri-common/apiResources/ContentNodeResource';
-import { ClassesPageNames } from '../../constants';
+import { ClassesPageNames, PageNames } from '../../constants';
 import { LearnerClassroomResource } from '../../apiResources';
 import useLearnerResources, { setResumableContentNodes } from '../useLearnerResources';
 
@@ -17,6 +17,7 @@ const {
   getClass,
   getClassActiveLessons,
   getClassActiveQuizzes,
+  getClassCourseLink,
   getClassLessonLink,
   getClassQuizLink,
   fetchClasses,
@@ -611,6 +612,22 @@ describe(`useLearnerResources`, () => {
         params: {
           classId: 'class-1',
           lessonId: 'class-1-active-lesson-1',
+        },
+      });
+    });
+  });
+
+  describe(`getClassCourseLink`, () => {
+    it(`returns a vue-router link to the course welcome page`, () => {
+      expect(
+        getClassCourseLink({
+          id: 'class-1-active-course-1',
+          collection: 'class-1',
+        }),
+      ).toEqual({
+        name: PageNames.COURSE_WELCOME,
+        params: {
+          courseSessionId: 'class-1-active-course-1',
         },
       });
     });

--- a/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/frontend/composables/useLearnerResources.js
@@ -272,9 +272,9 @@ export default function useLearnerResources() {
   }
 
   /**
-   * Build a router target for a classroom course page.
+   * Build a router target for a classroom course's welcome page.
    * @param {object} course - Course record from the classroom payload
-   * @returns {object} vue-router link to a course page (placeholder)
+   * @returns {object} vue-router link to the course welcome page
    * @public
    */
   function getClassCourseLink(course) {
@@ -282,9 +282,9 @@ export default function useLearnerResources() {
       return undefined;
     }
     return {
-      name: PageNames.COURSE_CONTENT__COURSE,
+      name: PageNames.COURSE_WELCOME,
       params: {
-        courseId: course.id,
+        courseSessionId: course.id,
       },
     };
   }


### PR DESCRIPTION
## Summary
* Routes course cards to the course welcome page instead of course content
* Adds a regression test

https://github.com/user-attachments/assets/4df9b25d-7361-42b7-bd47-4cd48886f81b


## References
Closes #15160

## Reviewer guidance
* Assign a course to a learner, start the course.
* Look at the course cards on Learn, click on one.
* Verify that it now shows the course welcome page instead of the course unit page.


## AI usage
Asked Claude to update the code and write a test for it. Read the code and manually verified the result