### PR TITLE
Resolve issue blocking automatic content import

### DIFF
--- a/kolibri/core/content/test/utils/test_assignment.py
+++ b/kolibri/core/content/test/utils/test_assignment.py
@@ -1,8 +1,11 @@
 import uuid
 
 import mock
+from django.db.models.functions import NullIf
 from django.test import TestCase
+from morango.models import Store
 
+from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -65,6 +68,7 @@ class ContentAssignmentManagerTestCase(TestCase):
     ):
         store_qs = mock.MagicMock()
         get_modified_store_mock.return_value = store_qs
+        store_qs.annotate.return_value = store_qs
         store_qs.exclude.return_value = store_qs
 
         store_ids = [uuid.uuid4().hex for _ in range(1)]
@@ -80,10 +84,14 @@ class ContentAssignmentManagerTestCase(TestCase):
             self.assertEqual(assignment, self.assignment)
 
         self.assertEqual(count, 1)
+        # empty deserialization errors are normalized to NULL so that they compare the same as
+        # the NULL written by `Store.unset_deserialization_error`
+        annotation = store_qs.annotate.call_args[1]["_deserialization_error"]
+        self.assertIsInstance(annotation, NullIf)
         exclude_q = store_qs.exclude.call_args[0][0]
         self.assertEqual(
             str(exclude_q),
-            "(OR: ('deleted', True), ('hard_deleted', True), (NOT (AND: ('deserialization_error', ''))))",
+            "(OR: ('deleted', True), ('hard_deleted', True), ('_deserialization_error__isnull', False))",
         )
 
         qs = self.model.objects.all.return_value
@@ -624,3 +632,139 @@ class ContentAssignmentManagerIntegrationTestCase(TestCase):
             assignments[0].source_model, IndividualSyncableExam.morango_model_name
         )
         self.assertEqual(assignments[0].metadata, None)
+
+
+class FindDownloadableAssignmentsStoreFilterTestCase(TestCase):
+    """
+    Exercises the `Store` filtering that `find_downloadable_assignments` applies when scoped to a
+    transfer session, against the database rather than a mocked queryset. The SQL semantics of the
+    filter are the point here: `deserialization_error` is nullable, and morango writes NULL to it
+    (via `Store.unset_deserialization_error`) for records that deserialized cleanly, so a
+    comparison against the empty string alone silently drops every valid record.
+    """
+
+    databases = "__all__"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        provision_device()
+        cls.facility = Facility.objects.create(name="My Facility")
+        cls.classroom = Classroom.objects.create(
+            name="My Classroom", parent=cls.facility
+        )
+        cls.admin_user = FacilityUser.objects.create(
+            username="admin", facility=cls.facility
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.transfer_session_id = uuid.uuid4().hex
+
+    def _create_lesson(self, is_active=True):
+        """
+        Creates a lesson with a single, uniquely identified resource
+        """
+        lesson = Lesson(
+            title="My Lesson",
+            collection=self.classroom,
+            created_by=self.admin_user,
+            is_active=is_active,
+            resources=[
+                {
+                    "contentnode_id": uuid.uuid4().hex,
+                    "content_id": uuid.uuid4().hex,
+                    "channel_id": uuid.uuid4().hex,
+                }
+            ],
+        )
+        lesson.save()
+        return lesson
+
+    def _create_store(self, lesson, **overrides):
+        """
+        Creates the `Store` record that a sync would have written for `lesson`
+        """
+        defaults = dict(
+            id=lesson.id,
+            profile=PROFILE_FACILITY_DATA,
+            serialized="",
+            deleted=False,
+            hard_deleted=False,
+            last_saved_instance=uuid.uuid4().hex,
+            last_saved_counter=1,
+            partition="{}:allusers-ro".format(self.facility.dataset_id),
+            source_id=lesson.id,
+            model_name=Lesson.morango_model_name,
+            # morango nulls this field out when deserialization succeeds
+            deserialization_error=None,
+            last_transfer_session_id=self.transfer_session_id,
+        )
+        defaults.update(overrides)
+        return Store.objects.create(**defaults)
+
+    def _downloadable_source_ids(self):
+        return set(
+            assignment.source_id
+            for assignment in Lesson.content_assignments.find_downloadable_assignments(
+                transfer_session_id=self.transfer_session_id
+            )
+        )
+
+    def test_deserialized_without_error(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson)
+        self.assertEqual(self._downloadable_source_ids(), {lesson.id})
+
+    def test_deserialization_error_is_blank(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, deserialization_error="")
+        self.assertEqual(self._downloadable_source_ids(), {lesson.id})
+
+    def test_deserialization_error_is_set(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, deserialization_error="UNIQUE constraint failed")
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_deleted(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, deleted=True)
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_hard_deleted(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, hard_deleted=True)
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_other_transfer_session(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, last_transfer_session_id=uuid.uuid4().hex)
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_other_model_name(self):
+        lesson = self._create_lesson()
+        self._create_store(lesson, model_name=Exam.morango_model_name)
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_model_filters_still_apply(self):
+        lesson = self._create_lesson(is_active=False)
+        self._create_store(lesson)
+        self.assertEqual(self._downloadable_source_ids(), set())
+
+    def test_only_valid_records_of_a_mixed_transfer_session(self):
+        clean = self._create_lesson()
+        self._create_store(clean)
+        blank_error = self._create_lesson()
+        self._create_store(blank_error, deserialization_error="")
+
+        errored = self._create_lesson()
+        self._create_store(errored, deserialization_error="ValidationError")
+        deleted = self._create_lesson()
+        self._create_store(deleted, deleted=True)
+        hard_deleted = self._create_lesson()
+        self._create_store(hard_deleted, hard_deleted=True)
+        inactive = self._create_lesson(is_active=False)
+        self._create_store(inactive)
+
+        self.assertEqual(self._downloadable_source_ids(), {clean.id, blank_error.id})

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -2,7 +2,11 @@ from collections import namedtuple
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+from django.db.models import F
 from django.db.models import Q
+from django.db.models import TextField
+from django.db.models import Value
+from django.db.models.functions import NullIf
 from django.dispatch import receiver
 from morango.models.core import Store
 
@@ -306,8 +310,18 @@ class ContentAssignmentManager:
 
         model_qs = self.model.objects.all()
         if transfer_session_id:
-            modified_store = self._get_modified_store(transfer_session_id).exclude(
-                Q(deleted=True) | Q(hard_deleted=True) | ~Q(deserialization_error="")
+            modified_store = (
+                self._get_modified_store(transfer_session_id)
+                .annotate(
+                    _deserialization_error=NullIf(
+                        F("deserialization_error"), Value(""), output_field=TextField()
+                    )
+                )
+                .exclude(
+                    Q(deleted=True)
+                    | Q(hard_deleted=True)
+                    | Q(_deserialization_error__isnull=False)
+                )
             )
             model_qs = model_qs.filter(
                 pk__in=modified_store.values_list("id", flat=True)


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
Resolves issue with course or lesson resources not being available on LODs, when they should have been automatically imported through the sync hook mechanism.

The issue arose from a Morango update in [v0.8.11](https://github.com/learningequality/morango/releases/tag/v0.8.11) which added a new field `deserialization_exception` and modified the behavior of `deserialization_error`. Previously, `deserialization_error` was either an empty string (no error) or an error string. Morango updated the handling of the field to make it nullable instead of being an empty string.

The primary change is to update the filter against an empty `deserialization_error` to be a null check. For backwards compatibility, empty string values are coalesced to null.

Tests were pushed before the fix, and failed before and after the fix they pass:
<img width="1740" height="143" alt="image" src="https://github.com/user-attachments/assets/0e5f8b9e-a06b-4098-9f7d-08c5e75729e9" />


## References
<!--
 * references to related issues and PRs
-->
Fixes https://github.com/learningequality/kolibri/issues/15157
Depends on https://github.com/learningequality/kolibri/pull/15178 for proper rendering of materials.

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
1. Set up a full-facility device
2. Import the QA channel
3. Create a class for a new learner
4. Assign a course to the class/learner and enable it
5. Set up a LOD instance for the learner
6. Verify after setup the learner can access the course materials

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
AI was used to add comprehensive test coverage over the Store filtering. The tests were reviewed by the human, and duplicative coverage was removed.