### PR TITLE
Confine the drag press-and-hold delay to touch input

### DIFF
--- a/packages/kolibri-common/components/draggable/DraggableUniverse.vue
+++ b/packages/kolibri-common/components/draggable/DraggableUniverse.vue
@@ -22,7 +22,7 @@
         type: String,
         default: null,
       },
-      // Press-and-hold delay (ms) before a drag begins
+      // Press-and-hold delay (ms) before a drag begins (touch input only)
       delay: {
         type: Number,
         default: 250,

--- a/packages/kolibri-common/components/draggable/__tests__/DraggableRegion.spec.js
+++ b/packages/kolibri-common/components/draggable/__tests__/DraggableRegion.spec.js
@@ -56,6 +56,11 @@ describe('DraggableRegion', () => {
     expect(sortable.el).toBe(wrapper.element);
   });
 
+  it('confines the press-and-hold delay to touch, so a mouse drag is not swallowed', async () => {
+    const { options } = await mountRegion();
+    expect(options.delayOnTouchOnly).toBe(true);
+  });
+
   describe('capacity (group.put)', () => {
     it('accepts a drop while below capacity and rejects it once full', async () => {
       const { options } = await mountRegion({ items: [{ id: 'a' }], capacity: 2 });

--- a/packages/kolibri-common/components/draggable/useDraggableUniverse.js
+++ b/packages/kolibri-common/components/draggable/useDraggableUniverse.js
@@ -22,7 +22,8 @@ const DraggableUniverseSymbol = Symbol('draggableUniverse');
  * group name it was created with for its whole lifetime. Regions cannot be moved
  * between groups after mount.
  * @param {number} [options.delay] - initial press-and-hold delay (ms) before a drag
- * begins; set `delay.value` on the returned context to change it afterwards
+ * begins, touch input only; set `delay.value` on the returned context to change it
+ * afterwards
  * @returns {object} the universe context
  */
 export function createDraggableUniverse({ name, delay } = {}) {
@@ -50,6 +51,9 @@ export function createDraggableUniverse({ name, delay } = {}) {
     fallbackOnBody: false, // keep the clone inside the region subtree so overrides still match
     draggable: `.${ITEM_CLASS}`,
     handle: `.${HANDLE_CLASS}`,
+    // A delayed mouse drag is cancelled when the pointer moves, so the delay must
+    // only apply to touch input.
+    delayOnTouchOnly: true,
     fallbackClass: MIRROR_CLASS,
     ghostClass: GHOST_CLASS,
     chosenClass: CHOSEN_CLASS,


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
This PR fixes drag-and-drop reordering of channels with a mouse.

The drag system configures `SortableJS` with a `250ms` press-and-hold delay to prevent touch dragging from interfering with page scrolling. That delay was also being applied to mouse input. Because a mouse drag normally involves pressing and immediately moving, `SortableJS` would cancel the pending drag before it started, making reordering appear broken. The drag would only work if the user held the mouse still for the full `250ms` before moving.

Setting `delayOnTouchOnly: true` limits the delay to touch input, where it is needed, while allowing mouse drags to start immediately.

**Before:**

https://github.com/user-attachments/assets/f0be6a17-ca22-4841-9154-15b17067577b

**After:**

https://github.com/user-attachments/assets/c733f7b8-757c-42a4-8532-0a6e714261f3

## References
<!--
 * references to related issues and PRs
-->
Fixes #15175

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->

1. Sign in as a device admin (or a user with content management permission)
2. Go to Device > Manage channels
3. Click "Edit channel order"
4. Attempt to drag a channel row to reorder it
5. (Additional guidance can be found on #15175)

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage

Used Claude Code to investigate the bug, identify the root cause and propose the fix. It verified the change against a running instance and added a regression test. I reviewed the diagnosis, the fix and the test before opening this PR.
