### PR TITLE
Replace "Resume Course" with "Review Course" once completed

### DIFF
--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -122,11 +122,13 @@ class CourseSession(AbstractFacilityDataModel):
             - started (bool)
             - active_test (dict with unit_id and test_type, or None)
             - resume_position (dict with unit_id, lesson_id, resource_id, or None)
+            - completed (bool)
         """
         result = {
             "started": False,
             "active_test": None,
             "resume_position": None,
+            "completed": False,
         }
 
         unit_test_assignments_qs = self.unit_test_assignments.filter(
@@ -199,7 +201,32 @@ class CourseSession(AbstractFacilityDataModel):
                 "resource_id": None,
             }
 
+        result["completed"] = self._is_completed(unit_test_assignments_qs)
+
         return result
+
+    def _is_completed(self, unit_test_assignments_qs):
+        """
+        Whether the course is marked as completed: determined by whether the
+        last unit's post-test has been assigned and closed.
+        """
+        last_unit = (
+            ContentNode.objects.filter(
+                parent_id=self.course,
+                modality=modalities.UNIT,
+            )
+            .order_by("-lft")
+            .values("id")
+            .first()
+        )
+        if not last_unit:
+            return False
+
+        return unit_test_assignments_qs.filter(
+            unit_contentnode_id=last_unit["id"],
+            test_type=TestType.Post,
+            closed=True,
+        ).exists()
 
     def _get_assigned_user(self):
         """

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -50,6 +50,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
             content_id=uuid.uuid4().hex,
             available=True,
             title="Test Course",
+            modality=modalities.COURSE,
         )
 
         cls.unit_node = ContentNode.objects.create(
@@ -59,6 +60,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
             parent=cls.course_node,
             available=True,
             title="Test Unit",
+            modality=modalities.UNIT,
         )
 
         # A lesson node (child of unit)
@@ -69,6 +71,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
             parent=cls.unit_node,
             available=True,
             title="Test Lesson",
+            modality=modalities.LESSON,
         )
 
         # A resource node (child of lesson, grandchild of unit)
@@ -94,6 +97,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertFalse(result["started"])
         self.assertIsNone(result["active_test"])
         self.assertIsNone(result["resume_position"])
+        self.assertFalse(result["completed"])
 
     def test_active_test_returns_started_with_active_test(self):
         UnitTestAssignment.objects.create(
@@ -111,6 +115,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertEqual(result["active_test"]["unit_id"], self.unit_node.id)
         self.assertEqual(result["active_test"]["test_type"], TestType.Pre)
         self.assertIsNone(result["resume_position"])
+        self.assertFalse(result["completed"])
 
     def test_completed_pre_test_marks_started(self):
         UnitTestAssignment.objects.create(
@@ -273,6 +278,63 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         result = self.course_session.get_resume_data(self.learner)
 
         self.assertEqual(result["resume_position"]["resource_id"], next_incomplete.id)
+
+    def test_not_completed_when_post_test_never_taken(self):
+        """Finishing every resource in the last unit is not completion — the
+        post-test is coach-activated, so this is the ordinary state of a
+        learner waiting for it, not a learner who is done."""
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=self.resource_node.content_id,
+            channel_id=self.resource_node.channel_id,
+            kind="video",
+            progress=1.0,
+            start_timestamp=timezone.now(),
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        # Indistinguishable from completion in resume_position alone.
+        self.assertIsNone(result["resume_position"]["lesson_id"])
+        self.assertFalse(result["completed"])
+
+    def test_completed_even_with_resources_left_incomplete(self):
+        """A coach may run the post-test before every learner has worked
+        through all the resources, so leftover resources do not hold the
+        course open once that post-test is closed."""
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=True,
+            activated_by=self.coach,
+        )
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Post,
+            closed=True,
+            activated_by=self.coach,
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        # The learner still has somewhere to resume, and is still done.
+        self.assertEqual(
+            result["resume_position"]["resource_id"], self.resource_node.id
+        )
+        self.assertTrue(result["completed"])
 
     def test_unassigned_learner_returns_defaults(self):
         """A learner not in the classroom should see no active tests."""

--- a/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
@@ -338,6 +338,7 @@
         postTestLabel$,
         startCourseAction$,
         resumeCourseAction$,
+        reviewCourseAction$,
       } = coursesStrings;
 
       const { expandAll$, collapseAll$ } = enhancedQuizManagementStrings;
@@ -364,6 +365,9 @@
 
         if (onFirstPreTest) {
           return startCourseAction$();
+        }
+        if (progress.completed) {
+          return reviewCourseAction$();
         }
         return resumeCourseAction$();
       });

--- a/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
@@ -6,7 +6,7 @@ import { PageNames } from '../../constants';
 import CourseWelcomePage from '../CourseWelcomePage.vue';
 import useLearnerResources from '../../composables/useLearnerResources';
 
-const { startCourseAction$, resumeCourseAction$ } = coursesStrings;
+const { startCourseAction$, resumeCourseAction$, reviewCourseAction$ } = coursesStrings;
 
 jest.mock('../../composables/useLearnerResources');
 jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow', () => ({
@@ -96,14 +96,17 @@ describe('CourseWelcomePage', () => {
     started = false,
     resume_position = null,
     active_test = null,
+    completed = false,
   } = {}) => ({
     fetchCourse: jest.fn().mockResolvedValue({
       course: mockCourse,
       content: mockCourseContent,
-      progress: { started, resume_position, active_test },
+      progress: { started, resume_position, active_test, completed },
     }),
     getCourseContent: jest.fn().mockReturnValue(mockCourseContent),
-    getCourseProgress: jest.fn().mockReturnValue({ started, resume_position, active_test }),
+    getCourseProgress: jest
+      .fn()
+      .mockReturnValue({ started, resume_position, active_test, completed }),
     getCourseUnits: jest.fn().mockReturnValue(mockUnits),
     isUnitTestAvailable: jest.fn((courseId, unitId, testType) => {
       if (!active_test) return false;
@@ -214,6 +217,32 @@ describe('CourseWelcomePage', () => {
         }),
       );
     });
+  });
+
+  it('labels the action Review when the course is completed', async () => {
+    useResources({
+      started: true,
+      completed: true,
+      resume_position: { unit_id: 'unit-2', lesson_id: null, resource_id: null },
+    });
+    const wrapper = renderComponent();
+
+    await wrapper.findByRole('link', { name: reviewCourseAction$() });
+    expect(wrapper.queryByRole('link', { name: resumeCourseAction$() })).not.toBeInTheDocument();
+  });
+
+  it('labels the action Resume when the last unit is done but the course is not', async () => {
+    // The post-test the learner is waiting on is coach-activated, so this
+    // state is indistinguishable from completion in resume_position alone.
+    useResources({
+      started: true,
+      completed: false,
+      resume_position: { unit_id: 'unit-2', lesson_id: null, resource_id: null },
+    });
+    const wrapper = renderComponent();
+
+    await wrapper.findByRole('link', { name: resumeCourseAction$() });
+    expect(wrapper.queryByRole('link', { name: reviewCourseAction$() })).not.toBeInTheDocument();
   });
 
   it('locks all unit lessons when the course has not started', async () => {

--- a/packages/kolibri-common/strings/coursesStrings.js
+++ b/packages/kolibri-common/strings/coursesStrings.js
@@ -213,6 +213,10 @@ export const coursesStrings = createTranslator('CoursesStrings', {
     message: 'Resume Course',
     context: 'Action label for button to resume a course',
   },
+  reviewCourseAction: {
+    message: 'Review Course',
+    context: 'Action label for button to review a course',
+  },
   previewAction: {
     message: 'Preview',
     context: 'Action label for button to preview course resources before starting or assigning.',


### PR DESCRIPTION

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->

This pull request updates the button for opening a course to be labeled "Review Course" once the course has been completed. The completion status is determined based on whether the coach has assigned and closed the post-test for the final unit within the course, rather than relying on the learner's completion of individual resources.
- Added the `_is_completed` function within the `CourseSession` model to identify the last child with `modality=UNIT` for the course. The function determines whether a closed `test_type=Post` assignment exists for the child within the learner's assignment queryset, and includes the information in the data returned by `get_resume_data` for a given user within the course session.
- New string "Review Course" used for `actionLabel` if `progress.completed`

https://github.com/user-attachments/assets/09ac105d-549b-48a5-a836-6df050422054


## References
<!--
 * references to related issues and PRs
-->

Closes #15161 

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->

I manually assigned a course to a learner and completed both the pre- and post- tests within the unit to verify that the "Review Course" button label is properly displayed.

Steps:
1. Assign a course to a learner
2. Start the pre-test as a coach and complete it as a learner
3. Repeat the same for all pre and post tests in the course

Even though `_compute_course_state` in `course_session.py` already returns `UnitPhase.Complete` after the last unit's post-test closes, I decided against reusing it because that would require significant changes, such as moving the function into the model and updating multiple call sites across three files (~150–200 lines). Checking if the last post-test is closed with two simple lookups is faster; using `_compute_course_state` would result in a heavier query to find the most recent test plus loading all units in a course if not provided, increasing request costs unnecessarily.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude Code to identify the potential areas to update and to add regression tests. The changes were verified against a running instance. I reviewed the changes and updated tests before opening a pull request.