### PR TITLE
Stop cascading logging errors in the Windows desktop app

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -25,6 +25,14 @@ ENVIRONMENT_VARIABLES = {
     "KOLIBRI_NO_FILE_BASED_LOGGING": {
         "description": "Disable file-based logging.",
     },
+    "KOLIBRI_LOG_QUEUE_MAX_SIZE": {
+        "description": """
+            Maximum number of records held in the logging queue. Records logged
+            once the queue is full are dropped, and their number is reported once
+            the queue has room again. Values below 1, and values that are not
+            integers, fall back to the default of 10000.
+        """,
+    },
     "KOLIBRI_APK_VERSION_NAME": {
         "description": "Version name for the Kolibri APK (Android Installer)",
     },

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -1,8 +1,10 @@
 import logging
 import os
+import time
 from logging.handlers import QueueHandler
 from logging.handlers import QueueListener
 from logging.handlers import TimedRotatingFileHandler
+from queue import Full
 from queue import Queue
 from typing import Dict
 from typing import List
@@ -13,6 +15,24 @@ DO_ROLLOVER = "doRollover"
 
 NO_FILE_BASED_LOGGING = os.environ.get("KOLIBRI_NO_FILE_BASED_LOGGING", False)
 DISABLE_REQUEST_LOGGING = os.environ.get("KOLIBRI_DISABLE_REQUEST_LOGGING", False)
+
+DEFAULT_LOG_QUEUE_MAX_SIZE = 10000
+
+
+def _log_queue_max_size() -> int:
+    try:
+        size = int(
+            os.environ.get("KOLIBRI_LOG_QUEUE_MAX_SIZE", DEFAULT_LOG_QUEUE_MAX_SIZE)
+        )
+    except ValueError:
+        # This module is imported before logging is configured, so a typo here
+        # could only be reported as a traceback that does not name the variable.
+        return DEFAULT_LOG_QUEUE_MAX_SIZE
+    # Queue treats any maxsize <= 0 as unbounded, which is what this bounds.
+    return size if size > 0 else DEFAULT_LOG_QUEUE_MAX_SIZE
+
+
+LOG_QUEUE_MAX_SIZE = _log_queue_max_size()
 
 LOG_COLORS = {
     "DEBUG": "blue",
@@ -36,12 +56,49 @@ class LoggerAwareQueueHandler(QueueHandler):
     def __init__(self, queue, logger_name: str):
         super().__init__(queue)
         self.logger_name = logger_name
+        self._dropped = 0
 
     def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
         """Prepare a record for queuing."""
         record = super().prepare(record)
         record._logger_name = self.logger_name
         return record
+
+    def enqueue(self, record: logging.LogRecord) -> None:
+        """
+        Drop the record if the queue is full, counting it so that the loss is
+        reported once the listener has drained enough for it to fit. The base
+        class reports the failure immediately, to stderr, which the desktop app
+        feeds back into logging (learningequality/kolibri#15150).
+        """
+        try:
+            self.queue.put_nowait(record)
+        except Full:
+            self._dropped += 1
+            return
+
+        if self._dropped:
+            self._report_dropped()
+
+    def _report_dropped(self) -> None:
+        try:
+            self.queue.put_nowait(self._dropped_record(self._dropped))
+        except Full:
+            return
+        self._dropped = 0
+
+    def _dropped_record(self, dropped: int) -> logging.LogRecord:
+        return self.prepare(
+            logging.LogRecord(
+                self.logger_name,
+                logging.WARNING,
+                __file__,
+                0,
+                "Dropped %d log records because the logging queue was full",
+                (dropped,),
+                None,
+            )
+        )
 
 
 class LoggerAwareQueueListener(QueueListener):
@@ -50,6 +107,13 @@ class LoggerAwareQueueListener(QueueListener):
     def __init__(self, queue, logger_handlers: LoggerHandlerMap):
         super().__init__(queue)
         self.logger_handlers = logger_handlers
+
+    def enqueue_sentinel(self) -> None:
+        """
+        Wait for room rather than using the base class' put_nowait, which raises
+        on the bounded queue and would leave stop() without a thread to join.
+        """
+        self.queue.put(self._sentinel)
 
     def handle(self, record: logging.LogRecord) -> None:
         """Handle a record by sending it to the original logger's handlers"""
@@ -144,15 +208,37 @@ class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
         be renamed from KOLIBRI_HOME/logs/kolibri.txt.YYYY-MM-DD to
         KOLIBRI_HOME/logs/archive/KOLIBRI-YYYY-MM-DD.txt.
         """
-        super().doRollover()
+        try:
+            super().doRollover()
+        except OSError:
+            # Windows will not rename a file another process holds open. Leaving
+            # rolloverAt in the past makes every subsequent record retry, and the
+            # retries' own error output can feed back into the log
+            # (learningequality/kolibri#15150).
+            self._postpone_rollover()
+            return
+
         filenames = os.listdir(self.dirname)
         prefix = self.basename + "."
 
         # Find all the rotation files in the KOLIBRI_HOME/logs directory and rename
         # them.
-        if not os.path.exists(self.archive_dir):
-            os.mkdir(self.archive_dir)
+        # exist_ok because the desktop app rotates two log files in this
+        # directory from two processes.
+        os.makedirs(self.archive_dir, exist_ok=True)
         self._rotation_files(filenames, prefix)
+
+    def _postpone_rollover(self):
+        """
+        Schedule the next rollover attempt an interval from now, so a rotation
+        that could not complete costs one attempt rather than one per record.
+        """
+        # The failed rollover closed the stream; FileHandler.emit reopens it.
+        current_time = int(time.time())
+        rollover_at = self.computeRollover(current_time)
+        while rollover_at <= current_time:
+            rollover_at += self.interval
+        self.rolloverAt = rollover_at
 
     def _rotation_files(self, filenames, prefix, func=DO_ROLLOVER):
         result = []
@@ -407,7 +493,7 @@ def setup_queue_logging() -> LoggerAwareQueueListener:
     Sets up queue-based logging for the main process.
     Returns the queue listener which can be used to stop logging and clean up.
     """
-    log_queue = Queue()
+    log_queue = Queue(maxsize=LOG_QUEUE_MAX_SIZE)
 
     # Replace handlers and get original configurations
     logger_handlers = _replace_handlers_with_queue(log_queue)

--- a/kolibri/utils/tests/test_handler.py
+++ b/kolibri/utils/tests/test_handler.py
@@ -1,7 +1,12 @@
+import logging
 import os
 import shutil
 import tempfile
+import threading
+from io import StringIO
+from queue import Queue
 from time import sleep
+from time import time
 
 from django.conf import settings
 from django.test import override_settings
@@ -11,6 +16,12 @@ from mock import patch
 from kolibri.utils import cli
 from kolibri.utils.logger import get_logging_config
 from kolibri.utils.logger import KolibriTimedRotatingFileHandler
+from kolibri.utils.logger import LoggerAwareQueueHandler
+from kolibri.utils.logger import LoggerAwareQueueListener
+
+
+def make_record(message):
+    return logging.LogRecord("test", logging.INFO, __file__, 0, message, None, None)
 
 
 class KolibriTimedRotatingFileHandlerTestCase(TestCase):
@@ -61,3 +72,117 @@ class KolibriTimedRotatingFileHandlerTestCase(TestCase):
         except OSError:
             pass
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _handler_due_for_rollover(self):
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir, ignore_errors=True)
+        log_file = os.path.join(temp_dir, "kolibri.txt")
+        handler = KolibriTimedRotatingFileHandler(log_file, when="M")
+        self.addCleanup(handler.close)
+        handler.rolloverAt = time() - 1
+        return handler, log_file
+
+    def test_failed_rollover_is_not_retried_on_the_next_record(self):
+        # Windows refuses to rename a log file another process holds open. If
+        # rolloverAt stays in the past, every subsequent record retries.
+        handler, _ = self._handler_due_for_rollover()
+        locked = PermissionError(32, "The process cannot access the file")
+
+        with patch.object(handler, "rotate", side_effect=locked) as rotate:
+            handler.emit(make_record("first"))
+            handler.emit(make_record("second"))
+
+        self.assertEqual(rotate.call_count, 1)
+        self.assertGreater(handler.rolloverAt, time())
+
+    def test_logging_continues_after_a_failed_rollover(self):
+        handler, log_file = self._handler_due_for_rollover()
+        locked = PermissionError(32, "The process cannot access the file")
+
+        with patch.object(handler, "rotate", side_effect=locked):
+            handler.emit(make_record("written anyway"))
+        handler.flush()
+
+        with open(log_file) as f:
+            self.assertIn("written anyway", f.read())
+
+
+def test_full_queue_does_not_report_drops_to_stderr():
+    # The default report for a dropped record goes to stderr, which the
+    # desktop app pipes straight back into logging.
+    handler = LoggerAwareQueueHandler(Queue(maxsize=1), "test")
+    stderr = StringIO()
+
+    with patch("sys.stderr", stderr):
+        for i in range(5):
+            handler.handle(make_record("message {}".format(i)))
+
+    assert stderr.getvalue() == ""
+
+
+def test_dropped_records_are_reported_once_the_queue_has_room():
+    queue = Queue(maxsize=2)
+    handler = LoggerAwareQueueHandler(queue, "test")
+
+    handler.handle(make_record("first"))
+    handler.handle(make_record("second"))
+    for i in range(3):
+        handler.handle(make_record("dropped {}".format(i)))
+
+    queue.get()
+    queue.get()
+    handler.handle(make_record("room again"))
+
+    assert queue.get().getMessage() == "room again"
+    report = queue.get()
+    assert (
+        report.getMessage()
+        == "Dropped 3 log records because the logging queue was full"
+    )
+    assert report._logger_name == "test"
+    assert report.levelno == logging.WARNING
+
+
+def test_dropped_records_are_reported_only_once():
+    queue = Queue(maxsize=2)
+    handler = LoggerAwareQueueHandler(queue, "test")
+
+    handler.handle(make_record("first"))
+    handler.handle(make_record("second"))
+    handler.handle(make_record("dropped"))
+
+    queue.get()
+    queue.get()
+    handler.handle(make_record("room again"))
+    queue.get()
+    queue.get()
+    handler.handle(make_record("later"))
+
+    assert queue.get().getMessage() == "later"
+    assert queue.empty()
+
+
+def test_listener_stops_while_the_queue_is_full():
+    # QueueListener.stop enqueues its sentinel with put_nowait, which raises on
+    # a bounded queue. Shutdown during a log storm finds it in exactly that state.
+    release = threading.Event()
+    handling = threading.Event()
+
+    class BlockingHandler(logging.Handler):
+        def handle(self, record):
+            handling.set()
+            release.wait(10)
+
+    listener = LoggerAwareQueueListener(Queue(maxsize=1), {"": [BlockingHandler()]})
+    listener.start()
+    try:
+        listener.queue.put(make_record("occupies the handler"))
+        handling.wait(10)
+        listener.queue.put(make_record("fills the queue"))
+
+        threading.Timer(0.25, release.set).start()
+        listener.stop()
+    finally:
+        release.set()
+
+    assert listener._thread is None

--- a/platforms/desktop-app/scripts/smoke_test_windows.sh
+++ b/platforms/desktop-app/scripts/smoke_test_windows.sh
@@ -66,13 +66,14 @@ echo "✓ Kolibri service is running"
 
 # 4. Wait for the service to create logs
 echo "[4/6] Waiting for service logs..."
-KOLIBRI_LOG="/c/ProgramData/kolibri/logs/kolibri-app.txt"
+# The service runs with --run-as-server, which logs to its own file.
+KOLIBRI_LOG="/c/ProgramData/kolibri/logs/kolibri-app-server.txt"
 sleep 10
 
 if [ ! -f "$KOLIBRI_LOG" ]; then
     echo "ERROR: Log file not found at $KOLIBRI_LOG"
     echo "Looking for log file in alternative locations..."
-    find /c/ProgramData -name "kolibri-app.txt" 2>/dev/null || true
+    find /c/ProgramData -name "kolibri-app*.txt" 2>/dev/null || true
     exit 1
 fi
 

--- a/platforms/desktop-app/src/kolibri_app/constants.py
+++ b/platforms/desktop-app/src/kolibri_app/constants.py
@@ -8,6 +8,10 @@ MAC = sys.platform.startswith("darwin")
 
 WINDOWS = sys.platform.startswith("win32")
 
+# True only in the server subprocess the Windows UI process spawns; on POSIX the
+# server runs in a thread of the UI process.
+RUN_AS_SERVER = "--run-as-server" in sys.argv
+
 # Windows specific constants
 TRAY_ICON_ICO = "icons/kolibri.ico"
 SERVICE_NAME = "Kolibri"

--- a/platforms/desktop-app/src/kolibri_app/logger.py
+++ b/platforms/desktop-app/src/kolibri_app/logger.py
@@ -1,45 +1,33 @@
-import io
 import logging as log
 import os
 import sys
 
 from kolibri.utils.conf import LOG_ROOT
 from kolibri.utils.logger import KolibriTimedRotatingFileHandler
+from kolibri_app.constants import RUN_AS_SERVER
+from kolibri_app.streams import LoggerWriter
 
 log.basicConfig(format="%(levelname)s: %(message)s", level=log.INFO)
 logging = log.getLogger("kolibri_app")
 
-log_basename = "kolibri-app.txt"
+# A handler failure otherwise reports itself on sys.stderr, which we point back
+# at logging below. Once the report is queued rather than written inline, the
+# LoggerWriter guard cannot see the cycle, and a persistently failing handler
+# feeds itself for as long as the app runs (learningequality/kolibri#15150).
+# This is module state, so it silences handler failures for every handler in the
+# process, Kolibri's own included. To diagnose one, run `kolibri start` from a
+# console instead: this module is not imported there, and stderr is a terminal.
+log.raiseExceptions = False
+
+# The server subprocess gets its own file: Windows will not rename a log file a
+# second process still holds open, so sharing one breaks rotation for both
+# (learningequality/kolibri#15150).
+log_basename = "kolibri-app-server.txt" if RUN_AS_SERVER else "kolibri-app.txt"
 log_filename = os.path.join(LOG_ROOT, log_basename)
 file_handler = KolibriTimedRotatingFileHandler(
     filename=log_filename, encoding="utf-8", when="midnight", backupCount=30
 )
 logging.addHandler(file_handler)
-
-
-class LoggerWriter(io.IOBase):
-    def __init__(self, writer):
-        self._writer = writer
-        self._msg = ""
-
-    def readable(self):
-        return False
-
-    def writable(self):
-        return True
-
-    def write(self, message):
-        self._msg = self._msg + message
-        while "\n" in self._msg:
-            pos = self._msg.find("\n")
-            self._writer(self._msg[:pos])
-            self._msg = self._msg[pos + 1 :]
-
-    def flush(self):
-        if self._msg != "":
-            self._writer(self._msg)
-            self._msg = ""
-
 
 # Make sure we send all app output to logs as we have no console to view them on.
 sys.stdout = LoggerWriter(logging.debug)

--- a/platforms/desktop-app/src/kolibri_app/streams.py
+++ b/platforms/desktop-app/src/kolibri_app/streams.py
@@ -1,0 +1,51 @@
+import io
+import threading
+
+
+class _WriterState(threading.local):
+    """Per-thread buffer and reentrancy flag; the class attributes are the defaults."""
+
+    msg = ""
+    writing = False
+
+
+class LoggerWriter(io.IOBase):
+    """
+    File-like object that forwards each complete line it receives to a logging
+    callable.
+
+    Partial lines are buffered per thread, so two threads mid-line cannot
+    interleave into one message. Writes issued while this thread is already
+    inside the callable are dropped: logging reports handler failures on
+    sys.stderr, which the app points back here, so re-logging one failure
+    produces more of them without bound (learningequality/kolibri#15150).
+    """
+
+    def __init__(self, writer):
+        self._writer = writer
+        self._state = _WriterState()
+
+    def readable(self):
+        return False
+
+    def writable(self):
+        return True
+
+    def write(self, message):
+        if self._state.writing:
+            return
+        self._state.writing = True
+        try:
+            msg = self._state.msg + message
+            while "\n" in msg:
+                pos = msg.find("\n")
+                self._writer(msg[:pos])
+                msg = msg[pos + 1 :]
+            self._state.msg = msg
+        finally:
+            self._state.writing = False
+
+    def flush(self):
+        # Completing the buffered line through write() reuses its guard.
+        if self._state.msg:
+            self.write("\n")

--- a/platforms/desktop-app/src/kolibri_app/windows_utils.py
+++ b/platforms/desktop-app/src/kolibri_app/windows_utils.py
@@ -3,6 +3,7 @@ import sys
 import pywintypes
 import win32service
 
+from kolibri_app.constants import RUN_AS_SERVER
 from kolibri_app.constants import SERVICE_NAME
 from kolibri_app.logger import logging
 from kolibri_app.server_process_windows import WindowsKolibriProcess
@@ -86,7 +87,7 @@ def handle_windows_commands():
         sys.exit(exit_code)
 
     # This block is the entry point for the server subprocess
-    if "--run-as-server" in sys.argv:
+    if RUN_AS_SERVER:
         logging.info("Starting in server mode...")
         server = WindowsKolibriProcess()
         server.run()

--- a/platforms/desktop-app/tests/test_streams.py
+++ b/platforms/desktop-app/tests/test_streams.py
@@ -1,0 +1,76 @@
+"""Tests for LoggerWriter in streams.py."""
+
+import threading
+import unittest
+
+from kolibri_app.streams import LoggerWriter
+
+
+class TestLoggerWriter(unittest.TestCase):
+    def test_forwards_complete_lines(self):
+        written = []
+        stream = LoggerWriter(written.append)
+
+        stream.write("one\ntwo\n")
+
+        self.assertEqual(written, ["one", "two"])
+
+    def test_buffers_a_partial_line_until_flush(self):
+        written = []
+        stream = LoggerWriter(written.append)
+
+        stream.write("partial")
+        self.assertEqual(written, [])
+
+        stream.flush()
+        self.assertEqual(written, ["partial"])
+
+    def test_partial_lines_from_two_threads_do_not_interleave(self):
+        # A shared buffer would splice the other thread's line into this one.
+        written = []
+        stream = LoggerWriter(written.append)
+
+        stream.write("main")
+        thread = threading.Thread(target=stream.write, args=("other\n",))
+        thread.start()
+        thread.join()
+        stream.write("\n")
+
+        self.assertEqual(written, ["other", "main"])
+
+    def test_drops_writes_issued_from_within_the_writer(self):
+        # logging reports a handler failure on sys.stderr, which the app points
+        # back at logging; re-logging that report recurses without bound.
+        written = []
+
+        def writer(line):
+            written.append(line)
+            # Bounded so an unguarded writer fails the assertion below rather
+            # than recursing until the test runner gives up.
+            if len(written) < 100:
+                stream.write("--- Logging error ---\n")
+
+        stream = LoggerWriter(writer)
+        stream.write("original\n")
+
+        self.assertEqual(written, ["original"])
+
+    def test_suppression_does_not_leak_to_other_threads(self):
+        # Only the thread that is mid-write is suppressed; a plain instance flag
+        # would silence every other thread logging at the same moment.
+        written = []
+        spawned = threading.Event()
+
+        def writer(line):
+            written.append(line)
+            if spawned.is_set():
+                return
+            spawned.set()
+            thread = threading.Thread(target=stream.write, args=("inner\n",))
+            thread.start()
+            thread.join()
+
+        stream = LoggerWriter(writer)
+        stream.write("outer\n")
+
+        self.assertIn("inner", written)


### PR DESCRIPTION
## Summary

1. CPU and memory growth was being caused by errors when two processes tried to log to the same file on Windows
2. These errors in logging then triggered _another_ log attempt to report the error - so it cascaded
3. A similar issue happened when trying to rotate log files that were contended
4. This would grow without bound because the logging queue was unbounded

Fixed by:

1. Using a different log file for the server specific process on Windows - this avoids the log file contention
2. Because the app captures stdout/stderr, errors during logging were re-logged by the stream handler there - stops those reports being emitted at all, and stops reentrant writes being captured
3. Catches OSErrors during log file rotation and does a back off on the rotation
4. Adds a max size to the logging queue so that there's a limit to how many queued logs there can be

## References

Fixes https://github.com/learningequality/kolibri/issues/15150

## Reviewer guidance

1. Install Windows installer
2. Confirm `kolibri-app-server.txt` in `C:\ProgramData\kolibri\logs`
3. Launching the UI adds `kolibri-app.txt` alongside it
4. Confirm that CPU and memory do not increase when idle

Noting that the thing that seemed to set off the error in @pcenov's case was an error from a scheduled task - so running a background task might be sufficient to trigger this.

I have not tested on Windows.

## AI usage

Used Claude Code to write the fix and its tests, then to review the resulting diff — that pass caught the Windows smoke test still looking for the renamed log file, and two guards that only closed the in-thread half of the loop. Verified with the `kolibri/utils` and desktop-app test suites, prek, and a local review pass over the diff.
