### PR TITLE
feat(QTI): add Gap Match interaction viewer

### DIFF
--- a/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AnswerGuide.vue
@@ -53,6 +53,11 @@
       message: 'Short answer only:',
       context: 'Tells the learner to type their answer in a text entry interaction',
     },
+    gapMatch: {
+      message: 'Choose a response, then choose a gap.',
+      context:
+        'Tells the learner how to fill each blank in a gap match question: pick a response from the pool, then pick the gap in the passage to put it in',
+    },
   });
 
   export default {

--- a/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/AssessmentItem.vue
@@ -42,6 +42,10 @@
   import SimpleAssociableChoice from './interactions/SimpleAssociableChoice.vue';
   import MatchInteraction from './interactions/MatchInteraction.vue';
   import SimpleMatchSet from './interactions/SimpleMatchSet.vue';
+  import GapMatchInteraction from './interactions/GapMatchInteraction.vue';
+  import Gap from './interactions/Gap.vue';
+  import GapText from './interactions/GapText.vue';
+  import GapImg from './interactions/GapImg.vue';
 
   const $themeTokens = themeTokens();
 
@@ -58,6 +62,10 @@
     [SimpleAssociableChoice.tag]: SimpleAssociableChoice,
     [MatchInteraction.tag]: MatchInteraction,
     [SimpleMatchSet.tag]: SimpleMatchSet,
+    [GapMatchInteraction.tag]: GapMatchInteraction,
+    [Gap.tag]: Gap,
+    [GapText.tag]: GapText,
+    [GapImg.tag]: GapImg,
   });
 
   /** @typedef {import('../utils/qti/values.js').QTIValue} QTIValue */

--- a/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/items.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/items.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a48b182d2a9a5c03b820f3417c192aa078bbecffa7f17d2cf8726762fe40e3c
-size 877423
+oid sha256:e5040c2e7b3d35609607eb6b6f3be6fb6ee1d9bd0a4e3d9649a5de12a608fa47
+size 880432

--- a/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/structure.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/__fixtures__/structure.js
@@ -404,6 +404,10 @@ export default [
         identifier: 'q6-gap-match-interaction-sv-4',
         title: 'Gap Match - Gap Widths',
       },
+      {
+        identifier: 'gap-match-distractor-pools',
+        title: 'Gap Match - Answer Specific Pools',
+      },
     ],
   },
   {

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -156,6 +156,13 @@
     border-style: solid;
   }
 
+  // QTI shared vocabulary: qti-input-width-N sizes a gap to roughly N
+  @each $width in 1, 2, 3, 4, 6, 10, 15, 20, 72 {
+    .qti-gap.qti-input-width-#{$width} {
+      min-width: #{$width}ch;
+    }
+  }
+
   .qti-gap:focus {
     outline: 3px solid var(--qti-gap-match-color-primary, #4368f3);
     outline-offset: 1px;

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -1,0 +1,91 @@
+<script>
+
+  import { computed, h, inject } from 'vue';
+  import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { QTIIdentifierProp, StringProp } from '../../utils/props';
+
+  const $themeTokens = themeTokens();
+  const $themePalette = themePalette();
+
+  export default {
+    name: 'Gap',
+    tag: 'qti-gap',
+
+    // SafeHTML hands an authored attribute over in `attrs`, and Vue applies a
+    // component placeholder's attrs after the component itself has rendered —
+    // so an authored `class` would replace this one's own root class rather
+    // than joining it. Take the attrs over and merge the class in by hand.
+    inheritAttrs: false,
+
+    setup(props, { attrs }) {
+      // The interaction owns every gap's state, because a gap's limits are
+      // stated across the whole interaction rather than on the gap itself.
+      // A gap authored outside one has nothing to fill it, so it renders nothing.
+      const gapMatch = inject('qtiGapMatch', null);
+
+      const index = computed(() => gapMatch?.indexOf(props.identifier) ?? -1);
+      const identifier = computed(() =>
+        index.value === -1 ? null : gapMatch.currentValue(index.value),
+      );
+      const filled = computed(() => Boolean(identifier.value));
+
+      const styles = computed(() => ({
+        backgroundColor: filled.value ? $themePalette.grey.v_100 : 'transparent',
+        borderColor: $themeTokens.fineLine,
+      }));
+
+      return () => {
+        if (!gapMatch || index.value === -1) {
+          return null;
+        }
+        return h(
+          'span',
+          {
+            class: ['qti-gap', attrs.class || '', { 'qti-gap-filled': filled.value }],
+            style: styles.value,
+            attrs: { 'aria-label': gapMatch.gapLabel(index.value) },
+          },
+          filled.value ? [gapMatch.renderChip(identifier.value)] : [],
+        );
+      };
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      identifier: QTIIdentifierProp(true),
+      // A space-separated list of the identifiers this gap may be filled from.
+      // Empty means any choice may go in it.
+      matchGroup: StringProp(false),
+      /* eslint-enable */
+    },
+  };
+
+</script>
+
+
+<!-- Not scoped: the chip a gap holds wraps authored QTI content, whose vnodes
+     are created by the item body's SafeHTML render and so carry a different
+     scope id. -->
+<style lang="scss">
+
+  .qti-gap {
+    // Flow inline within the sentence, without stretching the line box.
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 6ch;
+    min-height: 2.25em;
+    padding: 2px 6px;
+    vertical-align: middle;
+    border-style: dashed;
+    border-width: 1px;
+    border-radius: 6px;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
+  }
+
+  .qti-gap-filled {
+    border-style: solid;
+  }
+
+</style>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -1,11 +1,12 @@
 <script>
 
   import { computed, h, inject } from 'vue';
-  import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { themeBrand, themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { QTIIdentifierProp, StringProp } from '../../utils/props';
 
   const $themeTokens = themeTokens();
   const $themePalette = themePalette();
+  const $themeBrand = themeBrand();
 
   export default {
     name: 'Gap',
@@ -28,11 +29,20 @@
         index.value === -1 ? null : gapMatch.currentValue(index.value),
       );
       const filled = computed(() => Boolean(identifier.value));
+      const active = computed(() => index.value !== -1 && gapMatch.isActive(index.value));
 
-      const styles = computed(() => ({
-        backgroundColor: filled.value ? $themePalette.grey.v_100 : 'transparent',
-        borderColor: $themeTokens.fineLine,
-      }));
+      const styles = computed(() => {
+        if (active.value) {
+          return {
+            backgroundColor: $themeBrand.primary.v_50,
+            borderColor: $themeTokens.primary,
+          };
+        }
+        return {
+          backgroundColor: filled.value ? $themePalette.grey.v_100 : 'transparent',
+          borderColor: $themeTokens.fineLine,
+        };
+      });
 
       return () => {
         if (!gapMatch || index.value === -1) {
@@ -41,9 +51,18 @@
         return h(
           'span',
           {
-            class: ['qti-gap', attrs.class || '', { 'qti-gap-filled': filled.value }],
+            class: [
+              'qti-gap',
+              attrs.class || '',
+              {
+                'qti-gap-filled': filled.value,
+                'qti-gap-active': active.value,
+                'qti-gap-readonly': !gapMatch.interactive.value,
+              },
+            ],
             style: styles.value,
             attrs: { 'aria-label': gapMatch.gapLabel(index.value) },
+            on: { click: () => gapMatch.selectGap(index.value) },
           },
           filled.value ? [gapMatch.renderChip(identifier.value)] : [],
         );
@@ -76,6 +95,7 @@
     min-height: 2.25em;
     padding: 2px 6px;
     vertical-align: middle;
+    cursor: pointer;
     border-style: dashed;
     border-width: 1px;
     border-radius: 6px;
@@ -86,6 +106,10 @@
 
   .qti-gap-filled {
     border-style: solid;
+  }
+
+  .qti-gap-readonly {
+    cursor: default;
   }
 
 </style>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -2,6 +2,8 @@
 
   import { computed, h, inject } from 'vue';
   import { themeBrand, themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import DraggableRegion from 'kolibri-common/components/draggable/DraggableRegion';
+  import DraggableItem from 'kolibri-common/components/draggable/DraggableItem';
   import { QTIIdentifierProp, StringProp } from '../../utils/props';
 
   const $themeTokens = themeTokens();
@@ -48,7 +50,8 @@
         if (!gapMatch || index.value === -1) {
           return null;
         }
-        return h(
+        const label = gapMatch.gapLabel(index.value);
+        const gap = h(
           'span',
           {
             class: [
@@ -61,10 +64,32 @@
               },
             ],
             style: styles.value,
-            attrs: { 'aria-label': gapMatch.gapLabel(index.value) },
+            attrs: { 'aria-label': label },
             on: { click: () => gapMatch.selectGap(index.value) },
           },
-          filled.value ? [gapMatch.renderChip(identifier.value)] : [],
+          filled.value
+            ? [
+              h(DraggableItem, { props: { disabled: !gapMatch.interactive.value } }, [
+                gapMatch.renderChip(identifier.value),
+              ]),
+            ]
+            : [],
+        );
+        return h(
+          DraggableRegion,
+          {
+            props: {
+              items: filled.value ? [{ identifier: identifier.value }] : [],
+              sortable: false,
+              disabled: !gapMatch.interactive.value,
+              label,
+            },
+            on: {
+              dragstart: () => gapMatch.noteDragOrigin(index.value),
+              'update:items': newItems => gapMatch.reconcileGap(index.value, newItems),
+            },
+          },
+          [gap],
         );
       };
     },

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -33,6 +33,7 @@
       const filled = computed(() => Boolean(identifier.value));
       const active = computed(() => index.value !== -1 && gapMatch.isActive(index.value));
       const refusing = computed(() => index.value !== -1 && gapMatch.isRefusingDrag(index.value));
+      const target = computed(() => index.value !== -1 && gapMatch.isOfferTarget(index.value));
 
       const styles = computed(() => {
         if (refusing.value) {
@@ -41,7 +42,7 @@
             borderColor: $themeTokens.fineLine,
           };
         }
-        if (active.value) {
+        if (active.value || target.value) {
           return {
             backgroundColor: $themeBrand.primary.v_50,
             borderColor: $themeTokens.primary,
@@ -68,6 +69,7 @@
               {
                 'qti-gap-filled': filled.value,
                 'qti-gap-active': active.value,
+                'qti-gap-target': target.value,
                 'qti-gap-refusing': refusing.value,
                 'qti-gap-readonly': !gapMatch.interactive.value,
               },

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -32,8 +32,15 @@
       );
       const filled = computed(() => Boolean(identifier.value));
       const active = computed(() => index.value !== -1 && gapMatch.isActive(index.value));
+      const refusing = computed(() => index.value !== -1 && gapMatch.isRefusingDrag(index.value));
 
       const styles = computed(() => {
+        if (refusing.value) {
+          return {
+            backgroundColor: 'transparent',
+            borderColor: $themeTokens.fineLine,
+          };
+        }
         if (active.value) {
           return {
             backgroundColor: $themeBrand.primary.v_50,
@@ -61,11 +68,16 @@
               {
                 'qti-gap-filled': filled.value,
                 'qti-gap-active': active.value,
+                'qti-gap-refusing': refusing.value,
                 'qti-gap-readonly': !gapMatch.interactive.value,
               },
             ],
             style: styles.value,
-            attrs: { 'aria-label': label, ...listbox.slotAttrs(index.value) },
+            attrs: {
+              'aria-label': label,
+              ...(refusing.value ? { 'aria-disabled': 'true' } : {}),
+              ...listbox.slotAttrs(index.value),
+            },
             on: {
               click: () => gapMatch.selectGap(index.value),
               ...listbox.handlers(index.value),
@@ -90,6 +102,7 @@
               items: filled.value ? [{ identifier: identifier.value }] : [],
               sortable: false,
               disabled: !gapMatch.interactive.value,
+              accepts: item => gapMatch.accepts(index.value, item),
               label,
             },
             on: {
@@ -144,6 +157,11 @@
   .qti-gap:focus {
     outline: 3px solid var(--qti-gap-match-color-primary, #4368f3);
     outline-offset: 1px;
+  }
+
+  .qti-gap-refusing {
+    cursor: default;
+    opacity: 0.55;
   }
 
   // Review mode has nothing to click

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -1,13 +1,12 @@
 <script>
 
   import { computed, h, inject } from 'vue';
-  import { themeBrand, themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { themeBrand, themeTokens } from 'kolibri-design-system/lib/styles/theme';
   import DraggableRegion from 'kolibri-common/components/draggable/DraggableRegion';
   import DraggableItem from 'kolibri-common/components/draggable/DraggableItem';
   import { QTIIdentifierProp, StringProp } from '../../utils/props';
 
   const $themeTokens = themeTokens();
-  const $themePalette = themePalette();
   const $themeBrand = themeBrand();
 
   export default {
@@ -36,6 +35,12 @@
       const target = computed(() => index.value !== -1 && gapMatch.isOfferTarget(index.value));
 
       const styles = computed(() => {
+        if (filled.value) {
+          return {
+            backgroundColor: 'transparent',
+            borderColor: 'transparent',
+          };
+        }
         if (refusing.value) {
           return {
             backgroundColor: 'transparent',
@@ -49,7 +54,7 @@
           };
         }
         return {
-          backgroundColor: filled.value ? $themePalette.grey.v_100 : 'transparent',
+          backgroundColor: 'transparent',
           borderColor: $themeTokens.fineLine,
         };
       });
@@ -152,15 +157,16 @@
       border-color 0.2s ease;
   }
 
-  .qti-gap-filled {
-    border-style: solid;
-  }
-
   // QTI shared vocabulary: qti-input-width-N sizes a gap to roughly N
   @each $width in 1, 2, 3, 4, 6, 10, 15, 20, 72 {
     .qti-gap.qti-input-width-#{$width} {
       min-width: #{$width}ch;
     }
+  }
+
+  .qti-gap.qti-gap-filled {
+    min-width: 0;
+    padding: 0;
   }
 
   .qti-gap:focus {

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/Gap.vue
@@ -51,6 +51,7 @@
           return null;
         }
         const label = gapMatch.gapLabel(index.value);
+        const { listbox } = gapMatch;
         const gap = h(
           'span',
           {
@@ -64,16 +65,23 @@
               },
             ],
             style: styles.value,
-            attrs: { 'aria-label': label },
-            on: { click: () => gapMatch.selectGap(index.value) },
+            attrs: { 'aria-label': label, ...listbox.slotAttrs(index.value) },
+            on: {
+              click: () => gapMatch.selectGap(index.value),
+              ...listbox.handlers(index.value),
+            },
           },
-          filled.value
-            ? [
-              h(DraggableItem, { props: { disabled: !gapMatch.interactive.value } }, [
+          [
+            // The visible value is the listbox's trigger: its content repeats
+            // the selected option, which the listbox already announces.
+            filled.value
+              ? h(DraggableItem, { props: { disabled: !gapMatch.interactive.value } }, [
                 gapMatch.renderChip(identifier.value),
-              ]),
-            ]
-            : [],
+              ])
+              : null,
+            listbox.renderStepper(),
+            gapMatch.interactive.value ? listbox.renderOptions(index.value) : null,
+          ].filter(Boolean),
         );
         return h(
           DraggableRegion,
@@ -133,6 +141,12 @@
     border-style: solid;
   }
 
+  .qti-gap:focus {
+    outline: 3px solid var(--qti-gap-match-color-primary, #4368f3);
+    outline-offset: 1px;
+  }
+
+  // Review mode has nothing to click
   .qti-gap-readonly {
     cursor: default;
   }

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapImg.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapImg.vue
@@ -1,0 +1,45 @@
+<template>
+
+  <!--
+    Rendered indirectly: GapMatchInteraction reads the gap choices out of its
+    slot and renders their content as chips in the response pool, so this
+    component is not mounted on its own. It still has to be a registered
+    component, or DOMPurify drops the element and the choice content with it.
+  -->
+  <span
+    class="qti-gap-img"
+    dir="auto"
+  ><slot></slot></span>
+
+</template>
+
+
+<script>
+
+  import {
+    BooleanProp,
+    NonNegativeIntProp,
+    QTIIdentifierProp,
+    StringProp,
+  } from '../../utils/props';
+
+  export default {
+    name: 'GapImg',
+    tag: 'qti-gap-img',
+    setup() {
+      return {};
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      identifier: QTIIdentifierProp(true),
+      fixed: BooleanProp(false, false),
+      matchMax: NonNegativeIntProp(false, 1),
+      matchMin: NonNegativeIntProp(false, 0),
+      // A space-separated list of the identifiers this choice may be matched
+      // with. Empty means it may go in any gap.
+      matchGroup: StringProp(false),
+      /* eslint-enable */
+    },
+  };
+
+</script>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -4,6 +4,10 @@
   import { computed, h, inject, provide, ref, watch } from 'vue';
   import { themeBrand, themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { createTranslator } from 'kolibri/utils/i18n';
+  import DraggableRegion from 'kolibri-common/components/draggable/DraggableRegion';
+  import DraggableItem from 'kolibri-common/components/draggable/DraggableItem';
+  import DraggableHandle from 'kolibri-common/components/draggable/DraggableHandle';
+  import useDraggableUniverse from 'kolibri-common/components/draggable/useDraggableUniverse';
   import AnswerGuide, { answerGuideStrings } from '../AnswerGuide.vue';
   import {
     choiceText,
@@ -107,14 +111,27 @@
       // Every gap is a row that holds one choice; the pool is the whole choice
       // set. A gap match pair names the choice first, which is the one thing
       // that differs from a match interaction's rows.
-      const { pool, pairs, currentValue, isPlaceable, place, clear, candidatesFor, hydrate } =
-        useMatchRows({
-          sourceIds: gapIds,
-          targetIds: choiceIds,
-          matchMaxOf,
-          maxAssociations: computed(() => typedProps.maxAssociations.value),
-          pairOrder: PAIR_ORDER.POOL_FIRST,
-        });
+      const {
+        pool,
+        pairs,
+        currentValue,
+        isPlaceable,
+        place,
+        clear,
+        remove,
+        candidatesFor,
+        hydrate,
+      } = useMatchRows({
+        sourceIds: gapIds,
+        targetIds: choiceIds,
+        matchMaxOf,
+        maxAssociations: computed(() => typedProps.maxAssociations.value),
+        pairOrder: PAIR_ORDER.POOL_FIRST,
+      });
+
+      useDraggableUniverse();
+
+      let dragOriginGap = null;
 
       const variable = computed(() => responses.value[typedProps.responseIdentifier.value]);
 
@@ -171,6 +188,29 @@
           return false;
         }
         return candidatesFor(activeGap.value, 0).includes(identifier);
+      }
+
+      // A drop is reported as a new item list rather than as a placement, so
+      // work out what changed rather than trusting the list.
+      function reconcileGap(gapIndex, newItems) {
+        if (!interactive.value) {
+          return;
+        }
+        const identifiers = newItems.map(item => item.identifier).filter(Boolean);
+        const current = currentValue(gapIndex, 0);
+
+        const arrived = identifiers.find(identifier => identifier !== current);
+        if (arrived) {
+          if (dragOriginGap !== null && dragOriginGap !== gapIndex) {
+            remove(arrived, dragOriginGap);
+          }
+          place(arrived, gapIndex, 0);
+          return;
+        }
+
+        if (!identifiers.length && current) {
+          remove(current, gapIndex);
+        }
       }
 
       // The variable is derived from the gaps, so ignore the change our own
@@ -234,11 +274,20 @@
         };
       }
 
+      // The whole chip is the drag handle, so DraggableHandle marks the chip
+      // itself rather than wrapping it in another element.
       function renderChip(
         identifier,
-        { exhausted = false, selected = false, candidate = false, ariaHidden = false, on } = {},
+        {
+          exhausted = false,
+          selected = false,
+          candidate = false,
+          ariaHidden = false,
+          draggable = false,
+          on,
+        } = {},
       ) {
-        return h(
+        const chip = h(
           'span',
           {
             class: [
@@ -258,6 +307,7 @@
           },
           [...contentByIdentifier[identifier]],
         );
+        return draggable && interactive.value ? h(DraggableHandle, [chip]) : chip;
       }
 
       function gapLabel(gapIndex) {
@@ -278,9 +328,13 @@
         gapLabel,
         // The chip a gap shows repeats a response the pool already names, so it
         // is hidden from a screen reader in favour of the gap's own label.
-        renderChip: identifier => renderChip(identifier, { ariaHidden: true }),
+        renderChip: identifier => renderChip(identifier, { ariaHidden: true, draggable: true }),
         isActive: gapIndex => activeGap.value === gapIndex,
         selectGap,
+        reconcileGap,
+        noteDragOrigin: gapIndex => {
+          dragOriginGap = gapIndex;
+        },
         interactive,
       });
 
@@ -296,21 +350,52 @@
             responsePoolLabel$(),
           ),
           h(
-            'ul',
+            DraggableRegion,
             {
-              class: 'qti-gap-match-pool-items',
-              attrs: { 'aria-label': responsePoolLabel$() },
+              props: {
+                // Exhausted chips stay visible but are not draggable, so they
+                // are left out of the region's items to keep its indexes
+                // aligned with the rendered children
+                items: pool.value
+                  .filter(identifier => isPlaceable(identifier))
+                  .map(identifier => ({ identifier })),
+                sortable: false,
+                disabled: !interactive.value,
+                label: responsePoolLabel$(),
+              },
+              on: {
+                dragstart: () => {
+                  dragOriginGap = null;
+                },
+              },
             },
-            pool.value.map(identifier =>
-              h('li', { key: identifier, class: 'qti-gap-match-pool-entry' }, [
-                renderChip(identifier, {
-                  exhausted: !isPlaceable(identifier),
-                  selected: selectedIdentifier.value === identifier,
-                  candidate: isCandidateForActiveGap(identifier),
-                  on: { click: () => selectResponse(identifier) },
+            [
+              h(
+                'ul',
+                {
+                  class: 'qti-gap-match-pool-items',
+                  attrs: { 'aria-label': responsePoolLabel$() },
+                },
+                pool.value.map(identifier => {
+                  const exhausted = !isPlaceable(identifier);
+                  const chip = renderChip(identifier, {
+                    exhausted,
+                    draggable: !exhausted,
+                    selected: selectedIdentifier.value === identifier,
+                    candidate: isCandidateForActiveGap(identifier),
+                    on: { click: () => selectResponse(identifier) },
+                  });
+                  if (exhausted) {
+                    return h('li', { key: identifier, class: 'qti-gap-match-pool-entry' }, [chip]);
+                  }
+                  return h(
+                    DraggableItem,
+                    { key: identifier, props: { disabled: !interactive.value } },
+                    [h('li', { class: 'qti-gap-match-pool-entry' }, [chip])],
+                  );
                 }),
-              ]),
-            ),
+              ),
+            ],
           ),
         ]);
       }

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -75,9 +75,8 @@
       // A gap sits wherever the author put it in the passage, so the gaps are
       // found by walking it. Document order is the order a learner reads them
       // in, which is what their numbering has to follow.
-      const gapIds = findVNodes(passageContent, [GAP_TAG]).map(
-        vnode => vnode.componentOptions.propsData.identifier,
-      );
+      const gapVNodes = findVNodes(passageContent, [GAP_TAG]);
+      const gapIds = gapVNodes.map(vnode => vnode.componentOptions.propsData.identifier);
 
       const choices = choiceVNodes.map(vnode => ({
         identifier: vnode.componentOptions.propsData.identifier,
@@ -87,12 +86,37 @@
       const contentByIdentifier = {};
       const textByIdentifier = {};
       const matchMaxByIdentifier = {};
+      // `match-group` is a list of the identifiers the element may be paired
+      // with, so an authored one is read as a set rather than as a name.
+      const matchGroupByIdentifier = {};
+      function readMatchGroup(vnode) {
+        const { identifier, matchGroup } = vnode.componentOptions.propsData;
+        matchGroupByIdentifier[identifier] = new Set(
+          String(matchGroup || '')
+            .split(/\s+/)
+            .filter(Boolean),
+        );
+      }
       choiceVNodes.forEach(vnode => {
         const { identifier, matchMax } = vnode.componentOptions.propsData;
         contentByIdentifier[identifier] = vnode.componentOptions.children || [];
         textByIdentifier[identifier] = choiceText(vnode);
         matchMaxByIdentifier[identifier] = matchMax === undefined ? 1 : Number(matchMax);
+        readMatchGroup(vnode);
       });
+      gapVNodes.forEach(readMatchGroup);
+
+      function isCompatible(gapId, choiceId) {
+        const gapGroup = matchGroupByIdentifier[gapId];
+        const choiceGroup = matchGroupByIdentifier[choiceId];
+        if (choiceGroup?.size && !choiceGroup.has(gapId)) {
+          return false;
+        }
+        if (gapGroup?.size && !gapGroup.has(choiceId)) {
+          return false;
+        }
+        return true;
+      }
       // A gap holds exactly one choice, which is the row capacity the rows
       // composable reads off its sources.
       gapIds.forEach(identifier => {
@@ -130,7 +154,7 @@
         pairOrder: PAIR_ORDER.POOL_FIRST,
       });
 
-      useDraggableUniverse();
+      const { isDragging, draggedItem } = useDraggableUniverse();
 
       let dragOriginGap = null;
 
@@ -146,12 +170,25 @@
         activeGap.value = null;
       }
 
+      function candidatesForGap(gapIndex) {
+        return candidatesFor(gapIndex, 0).filter(identifier =>
+          isCompatible(gapIds[gapIndex], identifier),
+        );
+      }
+
+      function placeInGap(identifier, gapIndex) {
+        if (!isCompatible(gapIds[gapIndex], identifier)) {
+          return;
+        }
+        place(identifier, gapIndex, 0);
+      }
+
       function selectResponse(identifier) {
         if (!interactive.value || !isPlaceable(identifier)) {
           return;
         }
         if (activeGap.value !== null) {
-          place(identifier, activeGap.value, 0);
+          placeInGap(identifier, activeGap.value);
           clearSelection();
           return;
         }
@@ -164,9 +201,9 @@
           return;
         }
         if (selectedIdentifier.value) {
-          // place() refuses anything the item's limits forbid, so a refusal
-          // just leaves the gap as it was
-          place(selectedIdentifier.value, gapIndex, 0);
+          // A refusal, by the item's limits or by match-group, just leaves the
+          // gap as it was
+          placeInGap(selectedIdentifier.value, gapIndex);
           clearSelection();
           return;
         }
@@ -189,16 +226,16 @@
         if (activeGap.value === null) {
           return false;
         }
-        return candidatesFor(activeGap.value, 0).includes(identifier);
+        return candidatesForGap(activeGap.value).includes(identifier);
       }
 
       // Keyboard navigation is for the gaps, not the pool. A gap is one slot
       // holding one response, so it is addressed by its position alone and the
       // row's single entry is filled in here.
       const listbox = useSlotListbox({
-        candidatesFor: gapIndex => candidatesFor(gapIndex, 0),
+        candidatesFor: candidatesForGap,
         currentValue: gapIndex => currentValue(gapIndex, 0),
-        commit: (identifier, gapIndex) => place(identifier, gapIndex, 0),
+        commit: placeInGap,
         clear: gapIndex => clear(gapIndex, 0),
         labelFor,
         disabled: computed(() => !interactive.value),
@@ -219,13 +256,22 @@
           if (dragOriginGap !== null && dragOriginGap !== gapIndex) {
             remove(arrived, dragOriginGap);
           }
-          place(arrived, gapIndex, 0);
+          placeInGap(arrived, gapIndex);
           return;
         }
 
         if (!identifiers.length && current) {
           remove(current, gapIndex);
         }
+      }
+
+      function admissible(value) {
+        if (!Array.isArray(value)) {
+          return value;
+        }
+        return value.filter(
+          pair => Array.isArray(pair) && pair.length === 2 && isCompatible(pair[1], pair[0]),
+        );
       }
 
       // The variable is derived from the gaps, so ignore the change our own
@@ -236,7 +282,7 @@
           if (isEqual(value, pairs.value)) {
             return;
           }
-          hydrate(value);
+          hydrate(admissible(value));
         },
         { immediate: true },
       );
@@ -345,6 +391,11 @@
         // is hidden from a screen reader in favour of the gap's own label.
         renderChip: identifier => renderChip(identifier, { ariaHidden: true, draggable: true }),
         isActive: gapIndex => activeGap.value === gapIndex,
+        accepts: (gapIndex, item) => isCompatible(gapIds[gapIndex], item?.identifier),
+        isRefusingDrag: gapIndex =>
+          isDragging.value &&
+          Boolean(draggedItem.value) &&
+          !isCompatible(gapIds[gapIndex], draggedItem.value.identifier),
         listbox,
         selectGap,
         reconcileGap,

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -1,0 +1,369 @@
+<script>
+
+  import isEqual from 'lodash/isEqual';
+  import { computed, h, inject, provide, watch } from 'vue';
+  import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { createTranslator } from 'kolibri/utils/i18n';
+  import AnswerGuide, { answerGuideStrings } from '../AnswerGuide.vue';
+  import {
+    choiceText,
+    findVNodes,
+    getComponentTag,
+    isFixed,
+    orderChoices,
+  } from '../../utils/choices';
+  import { BooleanProp, NonNegativeIntProp, QTIIdentifierProp } from '../../utils/props';
+  import useTypedProps from '../../composables/useTypedProps';
+  import useMatchRows, { PAIR_ORDER } from '../../composables/useMatchRows';
+
+  const PROMPT_TAG = 'qti-prompt';
+  const GAP_TAG = 'qti-gap';
+  const CHOICE_TAGS = ['qti-gap-text', 'qti-gap-img'];
+
+  export const gapMatchStrings = createTranslator('GapMatchInteractionStrings', {
+    responsePoolLabel: {
+      message: 'Response pool',
+      context:
+        'Label for the set of answers a learner drags or picks from when filling the blanks in a gap match question',
+    },
+    gapEmpty: {
+      message: 'Gap {number, number} of {total, number}: empty',
+      context:
+        'Accessible label for a blank a learner has not filled yet. {number} is its position in the passage, so a screen-reader user can tell the gaps apart.',
+    },
+    gapFilled: {
+      message: 'Gap {number, number} of {total, number}: {response}',
+      context:
+        'Accessible label for a blank a learner has filled. {number} is its position in the passage, and {response} the answer placed there.',
+    },
+  });
+
+  const { responsePoolLabel$, gapEmpty$, gapFilled$ } = gapMatchStrings;
+
+  const $themeTokens = themeTokens();
+  const $themePalette = themePalette();
+
+  export default {
+    name: 'QtiGapMatchInteraction',
+    tag: 'qti-gap-match-interaction',
+
+    setup(props, { slots, attrs }) {
+      const QTI_CONTEXT = inject('QTI_CONTEXT');
+      const responses = inject('responses');
+      const interactive = inject('interactive');
+      const typedProps = useTypedProps(props);
+
+      // The passage and the choices are static: parse the slot vnodes once
+      // rather than on every render.
+      const allContent = (slots.default && slots.default()) || [];
+      const isChoice = vnode => CHOICE_TAGS.includes(getComponentTag(vnode));
+      const promptContent = allContent.filter(vnode => getComponentTag(vnode) === PROMPT_TAG);
+      const choiceVNodes = allContent.filter(isChoice);
+      const passageContent = allContent.filter(
+        vnode => getComponentTag(vnode) !== PROMPT_TAG && !isChoice(vnode),
+      );
+
+      // A gap sits wherever the author put it in the passage, so the gaps are
+      // found by walking it. Document order is the order a learner reads them
+      // in, which is what their numbering has to follow.
+      const gapIds = findVNodes(passageContent, [GAP_TAG]).map(
+        vnode => vnode.componentOptions.propsData.identifier,
+      );
+
+      const choices = choiceVNodes.map(vnode => ({
+        identifier: vnode.componentOptions.propsData.identifier,
+        fixed: isFixed(vnode),
+      }));
+
+      const contentByIdentifier = {};
+      const textByIdentifier = {};
+      const matchMaxByIdentifier = {};
+      choiceVNodes.forEach(vnode => {
+        const { identifier, matchMax } = vnode.componentOptions.propsData;
+        contentByIdentifier[identifier] = vnode.componentOptions.children || [];
+        textByIdentifier[identifier] = choiceText(vnode);
+        matchMaxByIdentifier[identifier] = matchMax === undefined ? 1 : Number(matchMax);
+      });
+      // A gap holds exactly one choice, which is the row capacity the rows
+      // composable reads off its sources.
+      gapIds.forEach(identifier => {
+        matchMaxByIdentifier[identifier] = 1;
+      });
+
+      const matchMaxOf = identifier => matchMaxByIdentifier[identifier] ?? 1;
+      const labelFor = identifier => textByIdentifier[identifier] || identifier;
+
+      const choiceIds = computed(() =>
+        orderChoices(choices, {
+          shuffle: typedProps.shuffle.value,
+          seed: QTI_CONTEXT.value.candidateIdentifier,
+        }).map(choice => choice.identifier),
+      );
+
+      // Every gap is a row that holds one choice; the pool is the whole choice
+      // set. A gap match pair names the choice first, which is the one thing
+      // that differs from a match interaction's rows.
+      const { pool, pairs, currentValue, isPlaceable, hydrate } = useMatchRows({
+        sourceIds: gapIds,
+        targetIds: choiceIds,
+        matchMaxOf,
+        maxAssociations: computed(() => typedProps.maxAssociations.value),
+        pairOrder: PAIR_ORDER.POOL_FIRST,
+      });
+
+      const variable = computed(() => responses.value[typedProps.responseIdentifier.value]);
+
+      // The variable is derived from the gaps, so ignore the change our own
+      // write causes and only rebuild from a value that came from elsewhere.
+      watch(
+        () => variable.value?.value,
+        value => {
+          if (isEqual(value, pairs.value)) {
+            return;
+          }
+          hydrate(value);
+        },
+        { immediate: true },
+      );
+
+      watch(pairs, value => {
+        if (!interactive.value || !variable.value) {
+          return;
+        }
+        variable.value.value = value.map(pair => [...pair]);
+      });
+
+      const poolStyles = computed(() => ({
+        backgroundColor: $themePalette.grey.v_100,
+        borderColor: $themeTokens.fineLine,
+      }));
+      const poolLabelStyles = computed(() => ({ color: $themeTokens.annotation }));
+      const passageStyles = computed(() => ({
+        borderColor: $themeTokens.fineLine,
+        color: $themeTokens.text,
+      }));
+
+      function chipStyles({ exhausted }) {
+        if (exhausted) {
+          return {
+            backgroundColor: $themeTokens.surface,
+            borderColor: $themeTokens.fineLine,
+            color: $themeTokens.annotation,
+          };
+        }
+        return {
+          backgroundColor: $themeTokens.surface,
+          borderColor: $themeTokens.fineLine,
+          color: $themeTokens.text,
+        };
+      }
+
+      function renderChip(identifier, { exhausted = false } = {}) {
+        return h(
+          'span',
+          {
+            class: ['qti-gap-match-chip', { 'qti-gap-match-chip-exhausted': exhausted }],
+            style: chipStyles({ exhausted }),
+            attrs: exhausted ? { 'aria-disabled': 'true' } : {},
+          },
+          [...contentByIdentifier[identifier]],
+        );
+      }
+
+      function gapLabel(gapIndex) {
+        const number = gapIndex + 1;
+        const total = gapIds.length;
+        const identifier = currentValue(gapIndex, 0);
+        return identifier
+          ? gapFilled$({ number, total, response: labelFor(identifier) })
+          : gapEmpty$({ number, total });
+      }
+
+      // What a gap needs from the interaction. A gap's limits are stated across
+      // the whole interaction rather than on the gap itself, so the state stays
+      // here and the gap reads from it.
+      provide('qtiGapMatch', {
+        indexOf: identifier => gapIds.indexOf(identifier),
+        currentValue: gapIndex => currentValue(gapIndex, 0),
+        gapLabel,
+        renderChip,
+      });
+
+      function renderPool() {
+        return h('div', { class: 'qti-gap-match-pool', style: poolStyles.value }, [
+          h(
+            'p',
+            {
+              class: 'qti-gap-match-pool-label',
+              style: poolLabelStyles.value,
+              attrs: { 'aria-hidden': 'true' },
+            },
+            responsePoolLabel$(),
+          ),
+          h(
+            'ul',
+            {
+              class: 'qti-gap-match-pool-items',
+              attrs: { 'aria-label': responsePoolLabel$() },
+            },
+            pool.value.map(identifier =>
+              h('li', { key: identifier, class: 'qti-gap-match-pool-entry' }, [
+                renderChip(identifier, { exhausted: !isPlaceable(identifier) }),
+              ]),
+            ),
+          ),
+        ]);
+      }
+
+      return () => {
+        if (!choices.length || !gapIds.length) {
+          return;
+        }
+
+        return h('div', [
+          ...promptContent,
+          h(AnswerGuide, { props: { text: answerGuideStrings.gapMatch$() } }),
+          h(
+            'div',
+            {
+              class: [
+                attrs.class || '',
+                'qti-gap-match-interaction',
+                { 'qti-gap-match-readonly': !interactive.value },
+              ],
+            },
+            [
+              renderPool(),
+              h(
+                'div',
+                { class: 'qti-gap-match-passage', style: passageStyles.value },
+                passageContent,
+              ),
+            ],
+          ),
+        ]);
+      };
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      responseIdentifier: QTIIdentifierProp(true),
+      shuffle: BooleanProp(false, false),
+      // QTI's default for gap match is 1, unlike match, where it is unlimited
+      maxAssociations: NonNegativeIntProp(false, 1),
+      minAssociations: NonNegativeIntProp(false, 0),
+      /* eslint-enable */
+    },
+  };
+
+</script>
+
+
+<!-- Not scoped: the chips wrap authored QTI content, whose vnodes are created by
+     the item body's SafeHTML render and so carry a different scope id. -->
+<style lang="scss">
+
+  $chip-max-size: 150px;
+  $chip-padding-block: 8px;
+  $chip-padding-inline: 12px;
+  $chip-border-width: 1px;
+  $chip-content-max-size: $chip-max-size - 2 * ($chip-padding-inline + $chip-border-width);
+
+  .qti-gap-match-pool {
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 8px;
+  }
+
+  .qti-gap-match-pool-label {
+    margin: 0 0 0.5rem;
+    font-size: 12px;
+  }
+
+  .qti-gap-match-pool-items {
+    display: flex;
+    // Not the default `stretch`: an entry taller than the chip it holds shows up
+    // as empty space the moment a drag puts a shadow on it.
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .qti-gap-match-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-width: $chip-max-size;
+    padding-block: $chip-padding-block;
+    padding-inline: $chip-padding-inline;
+    overflow: hidden;
+    cursor: pointer;
+    user-select: none;
+    border-style: solid;
+    border-width: $chip-border-width;
+    border-radius: 8px;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+
+    // Authored content is scaled down to the response size rather than the chip
+    // growing to the content. SafeHTML styles images for page-level display,
+    // which is furniture a chip has no room for.
+    .image-container,
+    .img-wrapper,
+    .img-button {
+      width: $chip-content-max-size;
+      min-width: 0;
+      max-width: none;
+      height: $chip-content-max-size;
+      margin: 0;
+    }
+
+    .img-wrapper {
+      box-shadow: none;
+    }
+
+    .img-button {
+      pointer-events: none;
+    }
+
+    .expand-btn {
+      display: none;
+    }
+
+    img {
+      width: 100%;
+      max-width: none;
+      height: 100%;
+      max-height: none;
+      object-fit: scale-down;
+    }
+  }
+
+  // Every use spent, so it can no longer fill a gap
+  .qti-gap-match-chip-exhausted {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  // Review mode has nothing to click
+  .qti-gap-match-readonly {
+    .qti-gap-match-chip {
+      cursor: default;
+    }
+  }
+
+  .qti-gap-match-passage {
+    padding: 1rem 1.125rem;
+    line-height: 2.25;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -141,6 +141,7 @@
         pairs,
         currentValue,
         isPlaceable,
+        canPlace,
         place,
         clear,
         remove,
@@ -156,7 +157,7 @@
 
       const { isDragging, draggedItem } = useDraggableUniverse();
 
-      let dragOriginGap = null;
+      const dragOriginGap = ref(null);
 
       const variable = computed(() => responses.value[typedProps.responseIdentifier.value]);
 
@@ -242,6 +243,33 @@
         onKeyboardFocus: clearSelection,
       });
 
+      // What the learner is holding out to the gaps, however they picked it up
+      function offeredIdentifier() {
+        if (selectedIdentifier.value) {
+          return selectedIdentifier.value;
+        }
+        return isDragging.value ? draggedItem.value?.identifier : null;
+      }
+
+      function isOfferTarget(gapIndex) {
+        const offered = offeredIdentifier();
+        if (!offered || !isCompatible(gapIds[gapIndex], offered)) {
+          return false;
+        }
+        if (currentValue(gapIndex, 0)) {
+          return false;
+        }
+        const fromRow = isDragging.value ? dragOriginGap.value : null;
+        return canPlace(offered, gapIndex, 0, { fromRow });
+      }
+
+      function isRefusingDrag(gapIndex) {
+        if (!isDragging.value || !draggedItem.value) {
+          return false;
+        }
+        return !isCompatible(gapIds[gapIndex], draggedItem.value.identifier);
+      }
+
       // A drop is reported as a new item list rather than as a placement, so
       // work out what changed rather than trusting the list.
       function reconcileGap(gapIndex, newItems) {
@@ -253,8 +281,8 @@
 
         const arrived = identifiers.find(identifier => identifier !== current);
         if (arrived) {
-          if (dragOriginGap !== null && dragOriginGap !== gapIndex) {
-            remove(arrived, dragOriginGap);
+          if (dragOriginGap.value !== null && dragOriginGap.value !== gapIndex) {
+            remove(arrived, dragOriginGap.value);
           }
           placeInGap(arrived, gapIndex);
           return;
@@ -392,15 +420,13 @@
         renderChip: identifier => renderChip(identifier, { ariaHidden: true, draggable: true }),
         isActive: gapIndex => activeGap.value === gapIndex,
         accepts: (gapIndex, item) => isCompatible(gapIds[gapIndex], item?.identifier),
-        isRefusingDrag: gapIndex =>
-          isDragging.value &&
-          Boolean(draggedItem.value) &&
-          !isCompatible(gapIds[gapIndex], draggedItem.value.identifier),
+        isOfferTarget,
+        isRefusingDrag,
         listbox,
         selectGap,
         reconcileGap,
         noteDragOrigin: gapIndex => {
-          dragOriginGap = gapIndex;
+          dragOriginGap.value = gapIndex;
         },
         interactive,
       });
@@ -432,7 +458,7 @@
               },
               on: {
                 dragstart: () => {
-                  dragOriginGap = null;
+                  dragOriginGap.value = null;
                 },
               },
             },

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -1,8 +1,8 @@
 <script>
 
   import isEqual from 'lodash/isEqual';
-  import { computed, h, inject, provide, watch } from 'vue';
-  import { themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
+  import { computed, h, inject, provide, ref, watch } from 'vue';
+  import { themeBrand, themeTokens, themePalette } from 'kolibri-design-system/lib/styles/theme';
   import { createTranslator } from 'kolibri/utils/i18n';
   import AnswerGuide, { answerGuideStrings } from '../AnswerGuide.vue';
   import {
@@ -42,6 +42,10 @@
 
   const $themeTokens = themeTokens();
   const $themePalette = themePalette();
+  const $themeBrand = themeBrand();
+
+  // Exposed as a custom property so the :focus rule below can use a theme colour
+  const interactionCSSVars = { '--qti-gap-match-color-primary': $themeTokens.primary };
 
   export default {
     name: 'QtiGapMatchInteraction',
@@ -103,15 +107,71 @@
       // Every gap is a row that holds one choice; the pool is the whole choice
       // set. A gap match pair names the choice first, which is the one thing
       // that differs from a match interaction's rows.
-      const { pool, pairs, currentValue, isPlaceable, hydrate } = useMatchRows({
-        sourceIds: gapIds,
-        targetIds: choiceIds,
-        matchMaxOf,
-        maxAssociations: computed(() => typedProps.maxAssociations.value),
-        pairOrder: PAIR_ORDER.POOL_FIRST,
-      });
+      const { pool, pairs, currentValue, isPlaceable, place, clear, candidatesFor, hydrate } =
+        useMatchRows({
+          sourceIds: gapIds,
+          targetIds: choiceIds,
+          matchMaxOf,
+          maxAssociations: computed(() => typedProps.maxAssociations.value),
+          pairOrder: PAIR_ORDER.POOL_FIRST,
+        });
 
       const variable = computed(() => responses.value[typedProps.responseIdentifier.value]);
+
+      // Only one of these is ever set: the learner either picks a response and
+      // then a gap, or picks a gap and then a response.
+      const selectedIdentifier = ref(null);
+      const activeGap = ref(null);
+
+      function clearSelection() {
+        selectedIdentifier.value = null;
+        activeGap.value = null;
+      }
+
+      function selectResponse(identifier) {
+        if (!interactive.value || !isPlaceable(identifier)) {
+          return;
+        }
+        if (activeGap.value !== null) {
+          place(identifier, activeGap.value, 0);
+          clearSelection();
+          return;
+        }
+        selectedIdentifier.value = selectedIdentifier.value === identifier ? null : identifier;
+      }
+
+      function selectGap(gapIndex) {
+        if (!interactive.value) {
+          return;
+        }
+        if (selectedIdentifier.value) {
+          // place() refuses anything the item's limits forbid, so a refusal
+          // just leaves the gap as it was
+          place(selectedIdentifier.value, gapIndex, 0);
+          clearSelection();
+          return;
+        }
+        if (activeGap.value === gapIndex) {
+          clearSelection();
+          return;
+        }
+        // A choice can be reusable, so there is nothing to pick up and carry
+        // from a filled gap: clicking it takes the response back out instead.
+        if (currentValue(gapIndex, 0)) {
+          clear(gapIndex, 0);
+          clearSelection();
+          return;
+        }
+        activeGap.value = gapIndex;
+      }
+
+      // Whether the pool should offer this choice for the gap awaiting one
+      function isCandidateForActiveGap(identifier) {
+        if (activeGap.value === null) {
+          return false;
+        }
+        return candidatesFor(activeGap.value, 0).includes(identifier);
+      }
 
       // The variable is derived from the gaps, so ignore the change our own
       // write causes and only rebuild from a value that came from elsewhere.
@@ -133,6 +193,8 @@
         variable.value.value = value.map(pair => [...pair]);
       });
 
+      watch(interactive, clearSelection);
+
       const poolStyles = computed(() => ({
         backgroundColor: $themePalette.grey.v_100,
         borderColor: $themeTokens.fineLine,
@@ -143,12 +205,26 @@
         color: $themeTokens.text,
       }));
 
-      function chipStyles({ exhausted }) {
+      function chipStyles({ exhausted, selected, candidate }) {
         if (exhausted) {
           return {
             backgroundColor: $themeTokens.surface,
             borderColor: $themeTokens.fineLine,
             color: $themeTokens.annotation,
+          };
+        }
+        if (selected) {
+          return {
+            backgroundColor: $themeBrand.primary.v_50,
+            borderColor: $themeTokens.primary,
+            color: $themeTokens.primary,
+          };
+        }
+        if (candidate) {
+          return {
+            backgroundColor: $themeTokens.surface,
+            borderColor: $themeTokens.primary,
+            color: $themeTokens.primary,
           };
         }
         return {
@@ -158,13 +234,27 @@
         };
       }
 
-      function renderChip(identifier, { exhausted = false } = {}) {
+      function renderChip(
+        identifier,
+        { exhausted = false, selected = false, candidate = false, ariaHidden = false, on } = {},
+      ) {
         return h(
           'span',
           {
-            class: ['qti-gap-match-chip', { 'qti-gap-match-chip-exhausted': exhausted }],
-            style: chipStyles({ exhausted }),
-            attrs: exhausted ? { 'aria-disabled': 'true' } : {},
+            class: [
+              'qti-gap-match-chip',
+              {
+                'qti-gap-match-chip-exhausted': exhausted,
+                'qti-gap-match-chip-selected': selected,
+                'qti-gap-match-chip-candidate': candidate && !selected,
+              },
+            ],
+            style: chipStyles({ exhausted, selected, candidate }),
+            attrs: {
+              ...(exhausted ? { 'aria-disabled': 'true' } : {}),
+              ...(ariaHidden ? { 'aria-hidden': 'true' } : {}),
+            },
+            on,
           },
           [...contentByIdentifier[identifier]],
         );
@@ -186,7 +276,12 @@
         indexOf: identifier => gapIds.indexOf(identifier),
         currentValue: gapIndex => currentValue(gapIndex, 0),
         gapLabel,
-        renderChip,
+        // The chip a gap shows repeats a response the pool already names, so it
+        // is hidden from a screen reader in favour of the gap's own label.
+        renderChip: identifier => renderChip(identifier, { ariaHidden: true }),
+        isActive: gapIndex => activeGap.value === gapIndex,
+        selectGap,
+        interactive,
       });
 
       function renderPool() {
@@ -208,7 +303,12 @@
             },
             pool.value.map(identifier =>
               h('li', { key: identifier, class: 'qti-gap-match-pool-entry' }, [
-                renderChip(identifier, { exhausted: !isPlaceable(identifier) }),
+                renderChip(identifier, {
+                  exhausted: !isPlaceable(identifier),
+                  selected: selectedIdentifier.value === identifier,
+                  candidate: isCandidateForActiveGap(identifier),
+                  on: { click: () => selectResponse(identifier) },
+                }),
               ]),
             ),
           ),
@@ -231,6 +331,7 @@
                 'qti-gap-match-interaction',
                 { 'qti-gap-match-readonly': !interactive.value },
               ],
+              style: interactionCSSVars,
             },
             [
               renderPool(),
@@ -343,6 +444,10 @@
       max-height: none;
       object-fit: scale-down;
     }
+  }
+
+  .qti-gap-match-chip-selected {
+    font-weight: 600;
   }
 
   // Every use spent, so it can no longer fill a gap

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapMatchInteraction.vue
@@ -19,6 +19,7 @@
   import { BooleanProp, NonNegativeIntProp, QTIIdentifierProp } from '../../utils/props';
   import useTypedProps from '../../composables/useTypedProps';
   import useMatchRows, { PAIR_ORDER } from '../../composables/useMatchRows';
+  import useSlotListbox from '../../composables/useSlotListbox';
 
   const PROMPT_TAG = 'qti-prompt';
   const GAP_TAG = 'qti-gap';
@@ -158,6 +159,7 @@
       }
 
       function selectGap(gapIndex) {
+        listbox.forgetPointer();
         if (!interactive.value) {
           return;
         }
@@ -189,6 +191,19 @@
         }
         return candidatesFor(activeGap.value, 0).includes(identifier);
       }
+
+      // Keyboard navigation is for the gaps, not the pool. A gap is one slot
+      // holding one response, so it is addressed by its position alone and the
+      // row's single entry is filled in here.
+      const listbox = useSlotListbox({
+        candidatesFor: gapIndex => candidatesFor(gapIndex, 0),
+        currentValue: gapIndex => currentValue(gapIndex, 0),
+        commit: (identifier, gapIndex) => place(identifier, gapIndex, 0),
+        clear: gapIndex => clear(gapIndex, 0),
+        labelFor,
+        disabled: computed(() => !interactive.value),
+        onKeyboardFocus: clearSelection,
+      });
 
       // A drop is reported as a new item list rather than as a placement, so
       // work out what changed rather than trusting the list.
@@ -330,6 +345,7 @@
         // is hidden from a screen reader in favour of the gap's own label.
         renderChip: identifier => renderChip(identifier, { ariaHidden: true, draggable: true }),
         isActive: gapIndex => activeGap.value === gapIndex,
+        listbox,
         selectGap,
         reconcileGap,
         noteDragOrigin: gapIndex => {

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/GapText.vue
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/GapText.vue
@@ -1,0 +1,45 @@
+<template>
+
+  <!--
+    Rendered indirectly: GapMatchInteraction reads the gap choices out of its
+    slot and renders their content as chips in the response pool, so this
+    component is not mounted on its own. It still has to be a registered
+    component, or DOMPurify drops the element and the choice content with it.
+  -->
+  <span
+    class="qti-gap-text"
+    dir="auto"
+  ><slot></slot></span>
+
+</template>
+
+
+<script>
+
+  import {
+    BooleanProp,
+    NonNegativeIntProp,
+    QTIIdentifierProp,
+    StringProp,
+  } from '../../utils/props';
+
+  export default {
+    name: 'GapText',
+    tag: 'qti-gap-text',
+    setup() {
+      return {};
+    },
+    props: {
+      /* eslint-disable vue/no-unused-properties */
+      identifier: QTIIdentifierProp(true),
+      fixed: BooleanProp(false, false),
+      matchMax: NonNegativeIntProp(false, 1),
+      matchMin: NonNegativeIntProp(false, 0),
+      // A space-separated list of the identifiers this choice may be matched
+      // with. Empty means it may go in any gap.
+      matchGroup: StringProp(false),
+      /* eslint-enable */
+    },
+  };
+
+</script>

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -114,6 +114,30 @@ describe('Gaps in authored content', () => {
   });
 });
 
+describe('Gap widths', () => {
+  // The styling itself is CSS, so what is worth pinning here is that the
+  // authored class survives to the gap alongside the component's own — the
+  // width rule needs both, and an inherited attribute would have replaced one.
+  it('keeps the authored width class on the gap', () => {
+    const { container } = renderAssessmentItem(items['q6-gap-match-interaction-sv-4'].xml);
+    const widths = gaps(container);
+
+    expect(widths).toHaveLength(9);
+    expect(widths[0]).toHaveClass('qti-gap', 'qti-input-width-1');
+    expect(widths[2]).toHaveClass('qti-gap', 'qti-input-width-3');
+    expect(widths[8]).toHaveClass('qti-gap', 'qti-input-width-72');
+  });
+
+  it('still renders a gap the author gave no width', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    gaps(container).forEach(gap => {
+      expect(gap).toHaveClass('qti-gap');
+      expect(gap.className).not.toMatch(/qti-input-width/);
+    });
+  });
+});
+
 describe('Restoring an answer', () => {
   it('shows a restored response in its gap', () => {
     const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -1,10 +1,12 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/vue';
+import { slotListboxStrings } from '../../../composables/useSlotListbox';
 import items from '../../__fixtures__/items';
 import { renderAssessmentItem } from '../../__tests__/helpers';
 import { answerGuideStrings } from '../../AnswerGuide.vue';
 import { gapMatchStrings } from '../GapMatchInteraction.vue';
 
 const { responsePoolLabel$, gapEmpty$, gapFilled$ } = gapMatchStrings;
+const { emptyOption$ } = slotListboxStrings;
 
 // Choice content comes from the fixture XML rather than a translation, so it is
 // matched on the rendered chip instead of through a *ByText query.
@@ -24,7 +26,14 @@ function poolChip(container, text) {
   ).find(chip => chip.textContent.trim() === text);
 }
 
-const gapTexts = container => gaps(container).map(gap => gap.textContent.trim());
+// A gap owns a visually hidden option list for its listbox, so what it holds is
+// read off the chip rather than the gap's own text.
+function gapText(gap) {
+  const chip = gap.querySelector('.qti-gap-match-chip');
+  return chip ? chip.textContent.trim() : '';
+}
+
+const gapTexts = container => gaps(container).map(gapText);
 
 describe('Smoke', () => {
   it('renders the prompt', () => {
@@ -111,7 +120,7 @@ describe('Restoring an answer', () => {
       answerState: { RESPONSE: [['W', 'G1']] },
     });
     const [first] = gaps(container);
-    expect(first.textContent.trim()).toBe('winter');
+    expect(gapText(first)).toBe('winter');
   });
 
   it('names the filled gap for a screen reader', () => {
@@ -128,7 +137,7 @@ describe('Restoring an answer', () => {
     const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
       answerState: { RESPONSE: [['Su', 'G2']] },
     });
-    expect(gaps(container)[1].textContent.trim()).toBe('summer');
+    expect(gapText(gaps(container)[1])).toBe('summer');
   });
 
   it('spends the use of a restored response', () => {
@@ -163,7 +172,7 @@ describe('Restoring an answer', () => {
     const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
       answerState: { RESPONSE: [['W', 'nope']] },
     });
-    expect(gaps(container).map(gap => gap.textContent.trim())).toEqual(['', '']);
+    expect(gapTexts(container)).toEqual(['', '']);
   });
 
   it('ignores a pair written the wrong way round', () => {
@@ -171,7 +180,7 @@ describe('Restoring an answer', () => {
     const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
       answerState: { RESPONSE: [['G1', 'W']] },
     });
-    expect(gaps(container).map(gap => gap.textContent.trim())).toEqual(['', '']);
+    expect(gapTexts(container)).toEqual(['', '']);
   });
 });
 
@@ -519,5 +528,180 @@ describe('Placing by drag', () => {
     await drag(poolRegion(container), gapRegion(container, 0), 'W');
 
     expect(gapTexts(container)).toEqual(['', '']);
+  });
+});
+
+describe('Keyboard', () => {
+  function optionsOf(gap) {
+    return Array.from(gap.querySelectorAll('[role="option"]')).map(option => ({
+      text: option.textContent.trim(),
+      selected: option.getAttribute('aria-selected'),
+    }));
+  }
+
+  // The responses alone, without the empty option that leads them
+  const responsesOf = gap => optionsOf(gap).slice(1);
+
+  function activeOptionText(gap) {
+    const id = gap.getAttribute('aria-activedescendant');
+    return gap.querySelector(`#${id}`).textContent.trim();
+  }
+
+  it('exposes every gap as a listbox that tab can reach', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    gaps(container).forEach(gap => {
+      expect(gap).toHaveAttribute('role', 'listbox');
+      expect(gap).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  it('keeps the response pool out of the tab order', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const pool = container.querySelector('.qti-gap-match-pool');
+
+    expect(pool.querySelectorAll('[tabindex="0"]')).toHaveLength(0);
+  });
+
+  it('leads the options with an empty one, so an answer can be taken back out', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    expect(optionsOf(gaps(container)[0])[0].text).toBe(emptyOption$());
+  });
+
+  it('offers every response a gap could take', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    expect(responsesOf(gaps(container)[0]).map(option => option.text)).toEqual([
+      'winter',
+      'spring',
+      'summer',
+      'autumn',
+    ]);
+  });
+
+  it('leaves out a response that has no use left', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    // W is match-max="1" and spent, so the other gap cannot take it
+    expect(responsesOf(gaps(container)[1]).map(option => option.text)).toEqual([
+      'spring',
+      'summer',
+      'autumn',
+    ]);
+  });
+
+  it("keeps a gap's own response among its options", () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    const options = optionsOf(gaps(container)[0]);
+    expect(options.map(option => option.text)).toContain('winter');
+    expect(options.filter(option => option.selected === 'true')).toHaveLength(1);
+  });
+
+  it('answers a gap when it is tabbed to', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.focus(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+
+  it('does not answer a gap a pointer press moved focus to', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const gap = gaps(container)[0];
+
+    await fireEvent.mouseDown(gap);
+    await fireEvent.focus(gap);
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('puts down a carried response when the keyboard takes over', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'spring'));
+    await fireEvent.focus(gaps(container)[0]);
+
+    // The gap answers itself on focus, so a response still held from a pointer
+    // click would leave the learner carrying something they never placed
+    expect(poolChip(container, 'spring')).not.toHaveClass('qti-gap-match-chip-selected');
+  });
+
+  it('steps to the next response with the down arrow', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const gap = gaps(container)[0];
+
+    await fireEvent.focus(gap);
+    await fireEvent.keyDown(gap, { key: 'ArrowDown' });
+
+    expect(gapTexts(container)).toEqual(['spring', '']);
+  });
+
+  it('steps back to the empty option with the up arrow', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const gap = gaps(container)[0];
+
+    await fireEvent.focus(gap);
+    await fireEvent.keyDown(gap, { key: 'ArrowUp' });
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('jumps to the last response with End', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const gap = gaps(container)[0];
+
+    await fireEvent.focus(gap);
+    await fireEvent.keyDown(gap, { key: 'End' });
+
+    expect(gapTexts(container)).toEqual(['autumn', '']);
+  });
+
+  it('empties the gap with Escape', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    const gap = gaps(container)[0];
+
+    await fireEvent.keyDown(gap, { key: 'Escape' });
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('names the option a gap is resting on', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    const gap = gaps(container)[0];
+
+    await fireEvent.focus(gap);
+
+    expect(activeOptionText(gaps(container)[0])).toBe('winter');
+  });
+
+  it('fills nothing on focus once max-associations is reached', async () => {
+    // sv-3's second interaction takes QTI's default of one association
+    const { container } = renderAssessmentItem(items['q6-gap-match-interaction-sv-3'].xml);
+    const second = container.querySelectorAll('.qti-gap-match-interaction')[1];
+
+    await fireEvent.focus(gaps(second)[0]);
+    await fireEvent.focus(gaps(second)[1]);
+
+    // Tabbing through must not raise a refusal on every gap it passes
+    expect(gapTexts(second)).toEqual(['winter', '']);
+  });
+
+  it('is not a listbox in review mode', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+    });
+
+    gaps(container).forEach(gap => {
+      expect(gap).not.toHaveAttribute('role');
+      expect(gap).not.toHaveAttribute('tabindex');
+    });
   });
 });

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/vue';
+import { fireEvent, screen, waitFor, within } from '@testing-library/vue';
 import items from '../../__fixtures__/items';
 import { renderAssessmentItem } from '../../__tests__/helpers';
 import { answerGuideStrings } from '../../AnswerGuide.vue';
@@ -17,6 +17,14 @@ function poolChips(container) {
 function gaps(container) {
   return Array.from(container.querySelectorAll('.qti-gap'));
 }
+
+function poolChip(container, text) {
+  return Array.from(
+    container.querySelectorAll('.qti-gap-match-pool-entry .qti-gap-match-chip'),
+  ).find(chip => chip.textContent.trim() === text);
+}
+
+const gapTexts = container => gaps(container).map(gap => gap.textContent.trim());
 
 describe('Smoke', () => {
   it('renders the prompt', () => {
@@ -143,9 +151,7 @@ describe('Restoring an answer', () => {
     ).find(candidate => candidate.textContent.trim() === 'Earth');
     expect(chip).not.toHaveClass('qti-gap-match-chip-exhausted');
   });
-});
 
-describe('Response variable', () => {
   it('reports a restored answer back choice first', () => {
     const { checkAnswer } = renderAssessmentItem(items['gap-match-example-1'].xml, {
       answerState: { RESPONSE: [['W', 'G1']] },
@@ -166,5 +172,221 @@ describe('Response variable', () => {
       answerState: { RESPONSE: [['G1', 'W']] },
     });
     expect(gaps(container).map(gap => gap.textContent.trim())).toEqual(['', '']);
+  });
+});
+
+describe('Placing by click', () => {
+  it('puts a chosen response in the gap chosen next', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+
+  it('takes the response the other way round too', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(gaps(container)[1]);
+    await fireEvent.click(poolChip(container, 'summer'));
+
+    expect(gapTexts(container)).toEqual(['', 'summer']);
+  });
+
+  it('marks the chosen response as selected', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+
+    expect(poolChip(container, 'winter')).toHaveClass('qti-gap-match-chip-selected');
+  });
+
+  it('unselects a response chosen twice', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(poolChip(container, 'winter'));
+
+    expect(poolChip(container, 'winter')).not.toHaveClass('qti-gap-match-chip-selected');
+  });
+
+  it('marks a gap awaiting a response as active', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gaps(container)[0]).toHaveClass('qti-gap-active');
+  });
+
+  it('offers the responses that could fill the active gap', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(poolChip(container, 'winter')).toHaveClass('qti-gap-match-chip-candidate');
+  });
+
+  it('stops waiting when the active gap is chosen again', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(gaps(container)[0]);
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gaps(container)[0]).not.toHaveClass('qti-gap-active');
+  });
+
+  it('takes a response back out of a filled gap', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('returns a response to the pool when its gap is emptied', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    expect(poolChip(container, 'winter')).toHaveClass('qti-gap-match-chip-exhausted');
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(poolChip(container, 'winter')).not.toHaveClass('qti-gap-match-chip-exhausted');
+  });
+
+  it('replaces what a filled gap holds when a response is carried to it', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await fireEvent.click(poolChip(container, 'summer'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['summer', '']);
+  });
+
+  it('does not pick up a response that has no use left', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await fireEvent.click(poolChip(container, 'winter'));
+
+    // Selecting it would leave the learner carrying something no gap can take
+    expect(poolChip(container, 'winter')).not.toHaveClass('qti-gap-match-chip-selected');
+  });
+
+  it('refuses a response that has no use left', async () => {
+    // Every choice in example-1 is match-max="1"
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[1]);
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+
+  it('lets an unlimited response fill more than one gap', async () => {
+    // gap-match-example-3's choices are all match-max="0"
+    const { container } = renderAssessmentItem(items['gap-match-example-3'].xml);
+
+    await fireEvent.click(poolChip(container, 'Earth'));
+    await fireEvent.click(gaps(container)[0]);
+    await fireEvent.click(poolChip(container, 'Earth'));
+    await fireEvent.click(gaps(container)[1]);
+
+    expect(gapTexts(container).slice(0, 2)).toEqual(['Earth', 'Earth']);
+  });
+
+  it('refuses a placement past max-associations', async () => {
+    // sv-3's second interaction declares no max-associations, so QTI's default
+    // of 1 applies
+    const { container } = renderAssessmentItem(items['q6-gap-match-interaction-sv-3'].xml);
+    const second = container.querySelectorAll('.qti-gap-match-interaction')[1];
+
+    await fireEvent.click(poolChip(second, 'winter'));
+    await fireEvent.click(gaps(second)[0]);
+    await fireEvent.click(poolChip(second, 'summer'));
+    await fireEvent.click(gaps(second)[1]);
+
+    expect(gapTexts(second)).toEqual(['winter', '']);
+  });
+});
+
+describe('Review mode', () => {
+  it('does not place anything', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+    });
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('still shows the answer that was given', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+
+  it('does not empty a filled gap', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+});
+
+describe('Response variable', () => {
+  it('reports each pairing choice first', async () => {
+    const { container, checkAnswer } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[0]);
+
+    await waitFor(() => {
+      expect(checkAnswer().answerState.RESPONSE).toEqual([['W', 'G1']]);
+    });
+  });
+
+  it('scores through the mapping when the answer is correct', async () => {
+    const { container, checkAnswer } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[0]);
+    await fireEvent.click(poolChip(container, 'summer'));
+    await fireEvent.click(gaps(container)[1]);
+
+    // 1 + 2 from the fixture's qti-mapping, whose keys are 'W G1' and 'Su G2'.
+    // A transposition would miss every map key and score the -1 default, so
+    // this is the check that the directed pairs come out the right way round.
+    await waitFor(() => {
+      expect(checkAnswer().outcomes.SCORE).toBe(3);
+    });
+  });
+
+  it('tells the host the learner has interacted', async () => {
+    const { container, interactionFn } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await fireEvent.click(poolChip(container, 'winter'));
+    await fireEvent.click(gaps(container)[0]);
+
+    await waitFor(() => {
+      expect(interactionFn).toHaveBeenCalled();
+    });
   });
 });

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -390,3 +390,134 @@ describe('Response variable', () => {
     });
   });
 });
+
+// SortableJS cannot be driven in jsdom, so a drag is exercised the way the
+// abstraction reports it: handleStart announces the source region, then
+// handleEnd inserts into the destination region and emits the source's
+// remaining items.
+function findRegions() {
+  const mounted = Array.from(document.body.querySelectorAll('*')).find(el => el.__vue__);
+  const regions = [];
+  const walk = vm => {
+    if (!vm) {
+      return;
+    }
+    if (vm.$options.name === 'DraggableRegion') {
+      regions.push(vm);
+    }
+    (vm.$children || []).forEach(walk);
+  };
+  walk(mounted && mounted.__vue__.$root);
+  return regions;
+}
+
+// A gap's label changes as it fills, so regions are found by the element they
+// render rather than by their label.
+function regionOfEl(el) {
+  return findRegions().find(region => region.$el === el);
+}
+
+const gapRegion = (container, index) => regionOfEl(gaps(container)[index]);
+const poolRegion = container => regionOfEl(container.querySelector('.qti-gap-match-pool-items'));
+
+async function drag(source, target, identifier) {
+  const sourceItemsBeforeDrag = source.items;
+  source.$emit('dragstart');
+  target.$emit('update:items', [...target.items, { identifier }]);
+  source.$emit(
+    'update:items',
+    sourceItemsBeforeDrag.filter(item => item.identifier !== identifier),
+  );
+  await target.$nextTick();
+}
+
+describe('Placing by drag', () => {
+  it('fills a gap dragged onto from the pool', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await drag(poolRegion(container), gapRegion(container, 0), 'W');
+
+    expect(gapTexts(container)).toEqual(['winter', '']);
+  });
+
+  it('leaves out a response with no uses left', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    // An exhausted chip is still shown, but it is not something to pick up
+    expect(poolRegion(container).items.map(item => item.identifier)).not.toContain('W');
+  });
+
+  it('empties the gap a response is dragged out of', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await drag(gapRegion(container, 0), poolRegion(container), 'W');
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('moves a response from one gap to another', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-3'].xml, {
+      answerState: { RESPONSE: [['s1', 't1']] },
+    });
+
+    await drag(gapRegion(container, 0), gapRegion(container, 1), 's1');
+
+    expect(gapTexts(container).slice(0, 2)).toEqual(['', 'Earth']);
+  });
+
+  it('moves a response on its last use to another gap', async () => {
+    // Every choice in example-1 is match-max="1", so the destination can only
+    // take it once the origin has given it up
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await drag(gapRegion(container, 0), gapRegion(container, 1), 'W');
+
+    expect(gapTexts(container)).toEqual(['', 'winter']);
+  });
+
+  it('replaces what a filled gap holds', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    await drag(poolRegion(container), gapRegion(container, 0), 'Su');
+
+    expect(gapTexts(container)).toEqual(['summer', '']);
+  });
+
+  it('reports a dragged placement on the response variable', async () => {
+    const { container, checkAnswer } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await drag(poolRegion(container), gapRegion(container, 0), 'W');
+
+    await waitFor(() => {
+      expect(checkAnswer().answerState.RESPONSE).toEqual([['W', 'G1']]);
+    });
+  });
+
+  it('disables every region in review mode', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+
+    expect(poolRegion(container).disabled).toBe(true);
+    expect(gapRegion(container, 0).disabled).toBe(true);
+  });
+
+  it('places nothing dropped in review mode', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      interactive: false,
+    });
+
+    await drag(poolRegion(container), gapRegion(container, 0), 'W');
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -705,3 +705,204 @@ describe('Keyboard', () => {
     });
   });
 });
+
+// The second mode from the design board: a gap is fed by the responses its
+// match-group admits rather than by the whole pool. The fixture groups two
+// gaps from the choice side and one from the gap side, and holds one choice
+// that names no group at all.
+describe('Answer-specific distractor pools', () => {
+  const FIXTURE = 'gap-match-distractor-pools';
+
+  function optionTexts(gap) {
+    return Array.from(gap.querySelectorAll('[role="option"]'))
+      .map(option => option.textContent.trim())
+      .slice(1);
+  }
+
+  it('offers a gap only the responses grouped to it', () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    // kitten, lamb and kid name G1; cub names no group, so it is open to any
+    // gap that does not name a list of its own
+    expect(optionTexts(gaps(container)[0])).toEqual(['kitten', 'lamb', 'kid', 'cub']);
+  });
+
+  it("keeps another gap's responses out", () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    expect(optionTexts(gaps(container)[1])).toEqual(['puppy', 'foal', 'calf', 'cub']);
+  });
+
+  it('narrows a gap that names its own responses', () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    // The bird words name G3 themselves; what G3's own list adds is keeping out
+    // cub, the one choice that names no group and is otherwise open to any gap
+    expect(optionTexts(gaps(container)[2])).toEqual(['cygnet', 'duckling', 'gosling']);
+  });
+
+  it('highlights only the responses the chosen gap would take', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(poolChip(container, 'kitten')).toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'cub')).toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'puppy')).not.toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'cygnet')).not.toHaveClass('qti-gap-match-chip-candidate');
+  });
+
+  it('refuses a response carried to a gap that excludes it', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(poolChip(container, 'puppy'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['', '', '']);
+  });
+
+  it('refuses a gap chosen first and then an excluded response', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(gaps(container)[0]);
+    await fireEvent.click(poolChip(container, 'puppy'));
+
+    expect(gapTexts(container)).toEqual(['', '', '']);
+  });
+
+  it('still takes a response the gap admits', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(poolChip(container, 'kitten'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['kitten', '', '']);
+  });
+
+  it('takes the ungrouped response in a gap that names no list', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(poolChip(container, 'cub'));
+    await fireEvent.click(gaps(container)[1]);
+
+    expect(gapTexts(container)).toEqual(['', 'cub', '']);
+  });
+
+  it('keeps the ungrouped response out of a gap whose list omits it', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(poolChip(container, 'cub'));
+    await fireEvent.click(gaps(container)[2]);
+
+    expect(gapTexts(container)).toEqual(['', '', '']);
+  });
+
+  it('refuses a drop from an excluded response', () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    expect(gapRegion(container, 0).accepts({ identifier: 'puppy' })).toBe(false);
+    expect(gapRegion(container, 0).accepts({ identifier: 'cygnet' })).toBe(false);
+    expect(gapRegion(container, 0).accepts({ identifier: 'kitten' })).toBe(true);
+    expect(gapRegion(container, 0).accepts({ identifier: 'cub' })).toBe(true);
+    // G3 names its own list, which omits the otherwise open cub
+    expect(gapRegion(container, 2).accepts({ identifier: 'cub' })).toBe(false);
+    expect(gapRegion(container, 2).accepts({ identifier: 'cygnet' })).toBe(true);
+  });
+
+  it('ignores an excluded pair restored from an answer', () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml, {
+      answerState: { RESPONSE: [['puppy', 'G1']] },
+    });
+
+    expect(gapTexts(container)).toEqual(['', '', '']);
+  });
+
+  it('scores through the mapping when each gap takes its own answer', async () => {
+    const { container, checkAnswer } = renderAssessmentItem(items[FIXTURE].xml);
+
+    const answers = [
+      ['kitten', 0],
+      ['puppy', 1],
+      ['cygnet', 2],
+    ];
+    for (const [text, index] of answers) {
+      await fireEvent.click(poolChip(container, text));
+      await fireEvent.click(gaps(container)[index]);
+    }
+
+    await waitFor(() => {
+      expect(checkAnswer().outcomes.SCORE).toBe(3);
+    });
+  });
+});
+
+describe('Refusing a drag', () => {
+  // The regions share a drag universe provided by the interaction. A drag in
+  // flight is simulated by putting that universe into the state handleStart
+  // would, since SortableJS itself cannot be driven in jsdom.
+  function draggableUniverse() {
+    let vm = findRegions()[0];
+    while (vm) {
+      const provided = vm._provided || {};
+      const found = Object.getOwnPropertySymbols(provided)
+        .map(symbol => provided[symbol])
+        .find(value => value && value.isDragging && value.draggedItem);
+      if (found) {
+        return found;
+      }
+      vm = vm.$parent;
+    }
+    return null;
+  }
+
+  async function carry(container, identifier) {
+    const universe = draggableUniverse();
+    universe.isDragging.value = true;
+    universe.draggedItem.value = { identifier };
+    await poolRegion(container).$nextTick();
+  }
+
+  it('marks the gaps that would refuse what is being carried', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
+
+    await carry(container, 'puppy');
+
+    expect(gaps(container)[0]).toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-refusing');
+  });
+
+  it('leaves the gaps that would take it alone', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
+
+    await carry(container, 'puppy');
+
+    expect(gaps(container)[1]).not.toHaveClass('qti-gap-refusing');
+  });
+
+  it('tells a screen reader a refusing gap is unavailable', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
+
+    await carry(container, 'puppy');
+
+    expect(gaps(container)[0]).toHaveAttribute('aria-disabled', 'true');
+    expect(gaps(container)[1]).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('marks only the gap whose list omits an otherwise open response', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
+
+    await carry(container, 'cub');
+
+    expect(gaps(container)[0]).not.toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[1]).not.toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-refusing');
+  });
+
+  it('marks nothing in an item body with no match-group at all', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+
+    await carry(container, 'W');
+
+    gaps(container).forEach(gap => expect(gap).not.toHaveClass('qti-gap-refusing'));
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -707,9 +707,9 @@ describe('Keyboard', () => {
 });
 
 // The second mode from the design board: a gap is fed by the responses its
-// match-group admits rather than by the whole pool. The fixture groups two
-// gaps from the choice side and one from the gap side, and holds one choice
-// that names no group at all.
+// match-group admits rather than by the whole pool. The fixture groups by word
+// class, so each group spans several gaps — a group that mapped onto one gap
+// would make the highlight itself an answer key.
 describe('Answer-specific distractor pools', () => {
   const FIXTURE = 'gap-match-distractor-pools';
 
@@ -722,23 +722,59 @@ describe('Answer-specific distractor pools', () => {
   it('offers a gap only the responses grouped to it', () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    // kitten, lamb and kid name G1; cub names no group, so it is open to any
-    // gap that does not name a list of its own
-    expect(optionTexts(gaps(container)[0])).toEqual(['kitten', 'lamb', 'kid', 'cub']);
+    expect(optionTexts(gaps(container)[0])).toEqual(['sat', 'slept', 'barked', 'ran', 'jumped']);
   });
 
-  it("keeps another gap's responses out", () => {
+  it("keeps another group's responses out", () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    expect(optionTexts(gaps(container)[1])).toEqual(['puppy', 'foal', 'calf', 'cub']);
+    expect(optionTexts(gaps(container)[1])).toEqual(['mat', 'door', 'tree', 'roof']);
   });
 
-  it('narrows a gap that names its own responses', () => {
+  it('offers the same group to every gap that shares it', () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    // The bird words name G3 themselves; what G3's own list adds is keeping out
-    // cub, the one choice that names no group and is otherwise open to any gap
-    expect(optionTexts(gaps(container)[2])).toEqual(['cygnet', 'duckling', 'gosling']);
+    // G1, G3 and G4 all take a verb; G2 and G5 both take a noun
+    expect(optionTexts(gaps(container)[2])).toEqual(optionTexts(gaps(container)[0]));
+    expect(optionTexts(gaps(container)[3])).toEqual(optionTexts(gaps(container)[0]));
+    expect(optionTexts(gaps(container)[4])).toEqual(optionTexts(gaps(container)[1]));
+  });
+
+  it('highlights every gap a chosen response could go in', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml);
+
+    await fireEvent.click(poolChip(container, 'sat'));
+
+    // Every verb slot, so choosing a response never says which gap it answers
+    expect(gaps(container)[0]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[3]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[1]).not.toHaveClass('qti-gap-target');
+    expect(gaps(container)[4]).not.toHaveClass('qti-gap-target');
+  });
+
+  it('leaves a gap that is already filled out of the highlight', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml, {
+      answerState: { RESPONSE: [['sat', 'G1']] },
+    });
+
+    await fireEvent.click(poolChip(container, 'ran'));
+
+    // G1 holds a response already, so it is not somewhere free to put this one
+    expect(gaps(container)[0]).not.toHaveClass('qti-gap-target');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[3]).toHaveClass('qti-gap-target');
+  });
+
+  it('still lets a filled gap be replaced, unhighlighted', async () => {
+    const { container } = renderAssessmentItem(items[FIXTURE].xml, {
+      answerState: { RESPONSE: [['sat', 'G1']] },
+    });
+
+    await fireEvent.click(poolChip(container, 'ran'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['ran', '', '', '', '']);
   });
 
   it('highlights only the responses the chosen gap would take', async () => {
@@ -746,84 +782,86 @@ describe('Answer-specific distractor pools', () => {
 
     await fireEvent.click(gaps(container)[0]);
 
-    expect(poolChip(container, 'kitten')).toHaveClass('qti-gap-match-chip-candidate');
-    expect(poolChip(container, 'cub')).toHaveClass('qti-gap-match-chip-candidate');
-    expect(poolChip(container, 'puppy')).not.toHaveClass('qti-gap-match-chip-candidate');
-    expect(poolChip(container, 'cygnet')).not.toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'sat')).toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'ran')).toHaveClass('qti-gap-match-chip-candidate');
+    expect(poolChip(container, 'mat')).not.toHaveClass('qti-gap-match-chip-candidate');
   });
 
   it('refuses a response carried to a gap that excludes it', async () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    await fireEvent.click(poolChip(container, 'puppy'));
+    await fireEvent.click(poolChip(container, 'mat'));
     await fireEvent.click(gaps(container)[0]);
 
-    expect(gapTexts(container)).toEqual(['', '', '']);
+    expect(gapTexts(container)).toEqual(['', '', '', '', '']);
   });
 
   it('refuses a gap chosen first and then an excluded response', async () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
     await fireEvent.click(gaps(container)[0]);
-    await fireEvent.click(poolChip(container, 'puppy'));
+    await fireEvent.click(poolChip(container, 'mat'));
 
-    expect(gapTexts(container)).toEqual(['', '', '']);
+    expect(gapTexts(container)).toEqual(['', '', '', '', '']);
   });
 
   it('still takes a response the gap admits', async () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    await fireEvent.click(poolChip(container, 'kitten'));
+    await fireEvent.click(poolChip(container, 'sat'));
     await fireEvent.click(gaps(container)[0]);
 
-    expect(gapTexts(container)).toEqual(['kitten', '', '']);
+    expect(gapTexts(container)).toEqual(['sat', '', '', '', '']);
   });
 
-  it('takes the ungrouped response in a gap that names no list', async () => {
+  it('takes a response in any gap of its group', async () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    await fireEvent.click(poolChip(container, 'cub'));
-    await fireEvent.click(gaps(container)[1]);
+    await fireEvent.click(poolChip(container, 'barked'));
+    await fireEvent.click(gaps(container)[3]);
 
-    expect(gapTexts(container)).toEqual(['', 'cub', '']);
+    expect(gapTexts(container)).toEqual(['', '', '', 'barked', '']);
   });
 
-  it('keeps the ungrouped response out of a gap whose list omits it', async () => {
+  it('lets one sentence take two responses from the same group', async () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    await fireEvent.click(poolChip(container, 'cub'));
+    await fireEvent.click(poolChip(container, 'sat'));
+    await fireEvent.click(gaps(container)[0]);
+    await fireEvent.click(poolChip(container, 'ran'));
     await fireEvent.click(gaps(container)[2]);
 
-    expect(gapTexts(container)).toEqual(['', '', '']);
+    expect(gapTexts(container)).toEqual(['sat', '', 'ran', '', '']);
   });
 
   it('refuses a drop from an excluded response', () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml);
 
-    expect(gapRegion(container, 0).accepts({ identifier: 'puppy' })).toBe(false);
-    expect(gapRegion(container, 0).accepts({ identifier: 'cygnet' })).toBe(false);
-    expect(gapRegion(container, 0).accepts({ identifier: 'kitten' })).toBe(true);
-    expect(gapRegion(container, 0).accepts({ identifier: 'cub' })).toBe(true);
-    // G3 names its own list, which omits the otherwise open cub
-    expect(gapRegion(container, 2).accepts({ identifier: 'cub' })).toBe(false);
-    expect(gapRegion(container, 2).accepts({ identifier: 'cygnet' })).toBe(true);
+    expect(gapRegion(container, 0).accepts({ identifier: 'mat' })).toBe(false);
+    expect(gapRegion(container, 0).accepts({ identifier: 'sat' })).toBe(true);
+    expect(gapRegion(container, 2).accepts({ identifier: 'sat' })).toBe(true);
+    expect(gapRegion(container, 3).accepts({ identifier: 'sat' })).toBe(true);
+    expect(gapRegion(container, 1).accepts({ identifier: 'mat' })).toBe(true);
+    expect(gapRegion(container, 4).accepts({ identifier: 'mat' })).toBe(true);
   });
 
   it('ignores an excluded pair restored from an answer', () => {
     const { container } = renderAssessmentItem(items[FIXTURE].xml, {
-      answerState: { RESPONSE: [['puppy', 'G1']] },
+      answerState: { RESPONSE: [['mat', 'G1']] },
     });
 
-    expect(gapTexts(container)).toEqual(['', '', '']);
+    expect(gapTexts(container)).toEqual(['', '', '', '', '']);
   });
 
   it('scores through the mapping when each gap takes its own answer', async () => {
     const { container, checkAnswer } = renderAssessmentItem(items[FIXTURE].xml);
 
     const answers = [
-      ['kitten', 0],
-      ['puppy', 1],
-      ['cygnet', 2],
+      ['sat', 0],
+      ['mat', 1],
+      ['ran', 2],
+      ['barked', 3],
+      ['door', 4],
     ];
     for (const [text, index] of answers) {
       await fireEvent.click(poolChip(container, text));
@@ -831,17 +869,75 @@ describe('Answer-specific distractor pools', () => {
     }
 
     await waitFor(() => {
-      expect(checkAnswer().outcomes.SCORE).toBe(3);
+      expect(checkAnswer().outcomes.SCORE).toBe(5);
     });
   });
 });
 
+// The rule is symmetric, and an author can write it from either end. The
+// fixture above has each choice name the gaps it belongs to; this names the
+// same relationship the other way round, from the gaps.
+const GAP_SIDE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="gap-side-groups" title="Gap-side groups"
+  adaptive="false" time-dependent="false">
+  <qti-response-declaration identifier="RESPONSE" cardinality="multiple" base-type="directedPair"/>
+  <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float"/>
+  <qti-item-body>
+    <qti-gap-match-interaction max-associations="0" response-identifier="RESPONSE">
+      <qti-gap-text identifier="red" match-max="1">red</qti-gap-text>
+      <qti-gap-text identifier="green" match-max="1">green</qti-gap-text>
+      <qti-gap-text identifier="blue" match-max="1">blue</qti-gap-text>
+      <qti-gap-text identifier="one" match-max="1">one</qti-gap-text>
+      <qti-gap-text identifier="two" match-max="1">two</qti-gap-text>
+      <qti-gap-text identifier="three" match-max="1">three</qti-gap-text>
+      <p>A colour: <qti-gap identifier="C" match-group="red green blue"/>.</p>
+      <p>A number: <qti-gap identifier="N" match-group="one two three"/>.</p>
+    </qti-gap-match-interaction>
+  </qti-item-body>
+</qti-assessment-item>`;
+
+describe('Groups named by the gap', () => {
+  function optionTexts(gap) {
+    return Array.from(gap.querySelectorAll('[role="option"]'))
+      .map(option => option.textContent.trim())
+      .slice(1);
+  }
+
+  it('offers a gap only the responses it names', () => {
+    const { container } = renderAssessmentItem(GAP_SIDE_XML);
+
+    expect(optionTexts(gaps(container)[0])).toEqual(['red', 'green', 'blue']);
+    expect(optionTexts(gaps(container)[1])).toEqual(['one', 'two', 'three']);
+  });
+
+  it('refuses a response it does not name', async () => {
+    const { container } = renderAssessmentItem(GAP_SIDE_XML);
+
+    await fireEvent.click(poolChip(container, 'one'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['', '']);
+  });
+
+  it('takes a response it does name', async () => {
+    const { container } = renderAssessmentItem(GAP_SIDE_XML);
+
+    await fireEvent.click(poolChip(container, 'green'));
+    await fireEvent.click(gaps(container)[0]);
+
+    expect(gapTexts(container)).toEqual(['green', '']);
+  });
+});
+
 describe('Refusing a drag', () => {
-  // The regions share a drag universe provided by the interaction. A drag in
+  // Each interaction provides its own drag universe, so an item body holding
+  // two has two of them and the one under test has to be named. A drag in
   // flight is simulated by putting that universe into the state handleStart
   // would, since SortableJS itself cannot be driven in jsdom.
-  function draggableUniverse() {
-    let vm = findRegions()[0];
+  function draggableUniverse(scope) {
+    let vm = findRegions().find(region => !scope || scope.contains(region.$el));
     while (vm) {
       const provided = vm._provided || {};
       const found = Object.getOwnPropertySymbols(provided)
@@ -855,54 +951,93 @@ describe('Refusing a drag', () => {
     return null;
   }
 
-  async function carry(container, identifier) {
-    const universe = draggableUniverse();
+  async function carry(container, identifier, scope) {
+    const universe = draggableUniverse(scope);
     universe.isDragging.value = true;
     universe.draggedItem.value = { identifier };
     await poolRegion(container).$nextTick();
   }
 
-  it('marks the gaps that would refuse what is being carried', async () => {
+  it('marks every gap that would take what is being carried', async () => {
     const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
 
-    await carry(container, 'puppy');
+    await carry(container, 'sat');
 
-    expect(gaps(container)[0]).toHaveClass('qti-gap-refusing');
-    expect(gaps(container)[2]).toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[0]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-target');
+    expect(gaps(container)[3]).toHaveClass('qti-gap-target');
   });
 
-  it('leaves the gaps that would take it alone', async () => {
+  it('does not mark a gap that is already filled', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml, {
+      answerState: { RESPONSE: [['sat', 'G1']] },
+    });
+
+    await carry(container, 'ran');
+
+    expect(gaps(container)[0]).not.toHaveClass('qti-gap-target');
+    expect(gaps(container)[2]).toHaveClass('qti-gap-target');
+  });
+
+  it('marks the gaps that would refuse it', async () => {
     const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
 
-    await carry(container, 'puppy');
+    await carry(container, 'sat');
 
-    expect(gaps(container)[1]).not.toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[1]).toHaveClass('qti-gap-refusing');
+    expect(gaps(container)[4]).toHaveClass('qti-gap-refusing');
   });
 
   it('tells a screen reader a refusing gap is unavailable', async () => {
     const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
 
-    await carry(container, 'puppy');
+    await carry(container, 'sat');
 
-    expect(gaps(container)[0]).toHaveAttribute('aria-disabled', 'true');
-    expect(gaps(container)[1]).not.toHaveAttribute('aria-disabled');
+    expect(gaps(container)[1]).toHaveAttribute('aria-disabled', 'true');
+    expect(gaps(container)[0]).not.toHaveAttribute('aria-disabled');
   });
 
-  it('marks only the gap whose list omits an otherwise open response', async () => {
-    const { container } = renderAssessmentItem(items['gap-match-distractor-pools'].xml);
+  it('marks every gap for a response with no group of its own', async () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
 
-    await carry(container, 'cub');
+    await carry(container, 'W');
 
-    expect(gaps(container)[0]).not.toHaveClass('qti-gap-refusing');
-    expect(gaps(container)[1]).not.toHaveClass('qti-gap-refusing');
-    expect(gaps(container)[2]).toHaveClass('qti-gap-refusing');
+    gaps(container).forEach(gap => expect(gap).toHaveClass('qti-gap-target'));
   });
 
-  it('marks nothing in an item body with no match-group at all', async () => {
+  it('marks nothing refusing in an item body with no match-group at all', async () => {
     const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
 
     await carry(container, 'W');
 
     gaps(container).forEach(gap => expect(gap).not.toHaveClass('qti-gap-refusing'));
+  });
+
+  it('marks the gap a response is being carried out of as a place to put it back', async () => {
+    // W is match-max="1" and already spent on G1, so without discounting the
+    // gap it is leaving it would report that there is nowhere left to put it
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    const universe = draggableUniverse();
+    universe.isDragging.value = true;
+    universe.draggedItem.value = { identifier: 'W' };
+    gapRegion(container, 0).$emit('dragstart');
+    await poolRegion(container).$nextTick();
+
+    expect(gaps(container)[1]).toHaveClass('qti-gap-target');
+  });
+
+  it('marks nothing once max-associations is reached', async () => {
+    // sv-3's second interaction takes QTI's default of one association
+    const { container } = renderAssessmentItem(items['q6-gap-match-interaction-sv-3'].xml, {
+      answerState: { RESPONSE1: [], RESPONSE2: [['W', 'G1']] },
+    });
+    const second = container.querySelectorAll('.qti-gap-match-interaction')[1];
+
+    await carry(container, 'Sp', second);
+
+    // G1 already holds the one association the interaction allows
+    expect(gaps(second)[1]).not.toHaveClass('qti-gap-target');
   });
 });

--- a/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/components/interactions/__tests__/GapMatchInteraction.spec.js
@@ -1,0 +1,170 @@
+import { screen, within } from '@testing-library/vue';
+import items from '../../__fixtures__/items';
+import { renderAssessmentItem } from '../../__tests__/helpers';
+import { answerGuideStrings } from '../../AnswerGuide.vue';
+import { gapMatchStrings } from '../GapMatchInteraction.vue';
+
+const { responsePoolLabel$, gapEmpty$, gapFilled$ } = gapMatchStrings;
+
+// Choice content comes from the fixture XML rather than a translation, so it is
+// matched on the rendered chip instead of through a *ByText query.
+function poolChips(container) {
+  return Array.from(
+    container.querySelectorAll('.qti-gap-match-pool-entry .qti-gap-match-chip'),
+  ).map(chip => chip.textContent.trim());
+}
+
+function gaps(container) {
+  return Array.from(container.querySelectorAll('.qti-gap'));
+}
+
+describe('Smoke', () => {
+  it('renders the prompt', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(container).toHaveTextContent(
+      /Identify the missing words in this famous quote from Shakespeare's Richard III/,
+    );
+  });
+
+  it('renders the gap match guide', () => {
+    renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(
+      screen.getByText(answerGuideStrings.gapMatch$(), {
+        selector: 'p.qti-selection-instructions',
+      }),
+    ).toBeVisible();
+  });
+
+  it('puts the gap choices in the pool', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(poolChips(container).sort()).toEqual(['autumn', 'spring', 'summer', 'winter']);
+  });
+
+  it('labels the pool', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(within(container).getByLabelText(responsePoolLabel$())).toBeVisible();
+  });
+
+  it('renders a gap for each qti-gap in the passage', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(gaps(container)).toHaveLength(2);
+  });
+
+  it('keeps the passage around the gaps intact', () => {
+    // The item body is parsed as XML, where <qti-gap/> is self-closing. Read
+    // back by the HTML parser that is a start tag with no end, which would
+    // swallow the rest of the quotation into the first gap.
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(container).toHaveTextContent(/Now is the/);
+    expect(container).toHaveTextContent(/of our discontent/);
+    expect(container).toHaveTextContent(/In the deep bosom of the ocean buried/);
+  });
+
+  it('numbers each gap for a screen reader', () => {
+    renderAssessmentItem(items['gap-match-example-1'].xml);
+    expect(screen.getByLabelText(gapEmpty$({ number: 1, total: 2 }))).toBeVisible();
+    expect(screen.getByLabelText(gapEmpty$({ number: 2, total: 2 }))).toBeVisible();
+  });
+});
+
+describe('Gaps in authored content', () => {
+  it('finds gaps nested in a table', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-2'].xml);
+    expect(gaps(container)).toHaveLength(8);
+  });
+
+  it('finds gaps inline in a paragraph', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-3'].xml);
+    expect(gaps(container)).toHaveLength(4);
+  });
+
+  it('keeps its own class when the author puts one on a gap', () => {
+    // example-3's last gap carries class="ets-target"
+    const { container } = renderAssessmentItem(items['gap-match-example-3'].xml);
+    const last = gaps(container)[3];
+    expect(last).toHaveClass('qti-gap');
+    expect(last).toHaveClass('ets-target');
+  });
+
+  it('gives each interaction in an item body only its own gaps', () => {
+    // sv-3 holds two interactions, both of which name their gaps G1 and G2
+    const { container } = renderAssessmentItem(items['q6-gap-match-interaction-sv-3'].xml);
+    const interactions = container.querySelectorAll('.qti-gap-match-interaction');
+    expect(interactions).toHaveLength(2);
+    interactions.forEach(interaction => {
+      expect(interaction.querySelectorAll('.qti-gap')).toHaveLength(2);
+    });
+  });
+});
+
+describe('Restoring an answer', () => {
+  it('shows a restored response in its gap', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    const [first] = gaps(container);
+    expect(first.textContent.trim()).toBe('winter');
+  });
+
+  it('names the filled gap for a screen reader', () => {
+    renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    expect(
+      screen.getByLabelText(gapFilled$({ number: 1, total: 2, response: 'winter' })),
+    ).toBeVisible();
+  });
+
+  it('reads a pair as choice first', () => {
+    // 'Su G2' is summer in the second gap, not a gap called Su
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['Su', 'G2']] },
+    });
+    expect(gaps(container)[1].textContent.trim()).toBe('summer');
+  });
+
+  it('spends the use of a restored response', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    const chip = Array.from(
+      container.querySelectorAll('.qti-gap-match-pool-entry .qti-gap-match-chip'),
+    ).find(candidate => candidate.textContent.trim() === 'winter');
+    expect(chip).toHaveClass('qti-gap-match-chip-exhausted');
+  });
+
+  it('keeps an unlimited response available once used', () => {
+    // gap-match-example-3's choices are all match-max="0"
+    const { container } = renderAssessmentItem(items['gap-match-example-3'].xml, {
+      answerState: { RESPONSE: [['s1', 't1']] },
+    });
+    const chip = Array.from(
+      container.querySelectorAll('.qti-gap-match-pool-entry .qti-gap-match-chip'),
+    ).find(candidate => candidate.textContent.trim() === 'Earth');
+    expect(chip).not.toHaveClass('qti-gap-match-chip-exhausted');
+  });
+});
+
+describe('Response variable', () => {
+  it('reports a restored answer back choice first', () => {
+    const { checkAnswer } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'G1']] },
+    });
+    expect(checkAnswer().answerState.RESPONSE).toEqual([['W', 'G1']]);
+  });
+
+  it('ignores a pair naming a gap that is not in the passage', () => {
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['W', 'nope']] },
+    });
+    expect(gaps(container).map(gap => gap.textContent.trim())).toEqual(['', '']);
+  });
+
+  it('ignores a pair written the wrong way round', () => {
+    // Gap first rather than choice first: 'G1' is not a choice, so nothing fills
+    const { container } = renderAssessmentItem(items['gap-match-example-1'].xml, {
+      answerState: { RESPONSE: [['G1', 'W']] },
+    });
+    expect(gaps(container).map(gap => gap.textContent.trim())).toEqual(['', '']);
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/composables/__tests__/useMatchRows.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/composables/__tests__/useMatchRows.spec.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import useMatchRows from '../useMatchRows.js';
+import useMatchRows, { PAIR_ORDER } from '../useMatchRows.js';
 
 // Shaped after match-example-1: four sources used once each, three targets
 // reusable up to four times.
@@ -12,12 +12,14 @@ function setup({
   targetIds = TARGETS,
   matchMax = MATCH_MAX,
   maxAssociations = 0,
+  pairOrder = undefined,
 } = {}) {
   return useMatchRows({
     sourceIds,
     targetIds,
     matchMaxOf: identifier => matchMax[identifier] ?? 1,
     maxAssociations,
+    ...(pairOrder ? { pairOrder } : {}),
   });
 }
 
@@ -395,5 +397,67 @@ describe('reactive choices', () => {
     targetIds.value = ['T', 'R', 'M'];
 
     expect(pool.value).toEqual(['T', 'R', 'M']);
+  });
+});
+
+// `qti-match-interaction` authors a pair source-first, `qti-gap-match-interaction`
+// pool-choice-first. The rows are the same either way; only the value the
+// interaction reads and writes is turned around.
+describe('pair order', () => {
+  it('names the source first by default', () => {
+    const { pairs, place } = setup();
+    place('M', 0, 0);
+
+    expect(pairs.value).toEqual([['C', 'M']]);
+  });
+
+  it('names the pool choice first when asked to', () => {
+    const { pairs, place } = setup({ pairOrder: PAIR_ORDER.POOL_FIRST });
+    place('M', 0, 0);
+
+    expect(pairs.value).toEqual([['M', 'C']]);
+  });
+
+  it('reads a pool-first value back into the row it came from', () => {
+    const { rows, hydrate } = setup({ pairOrder: PAIR_ORDER.POOL_FIRST });
+    hydrate([
+      ['M', 'C'],
+      ['R', 'L'],
+    ]);
+
+    expect(rows.value).toEqual([['M'], [], ['R'], []]);
+  });
+
+  it('round-trips its own pairs', () => {
+    const { pairs, rows, place, hydrate } = setup({ pairOrder: PAIR_ORDER.POOL_FIRST });
+    place('M', 0, 0);
+    place('T', 3, 0);
+    const written = pairs.value;
+
+    hydrate(written);
+
+    expect(pairs.value).toEqual(written);
+    expect(rows.value).toEqual([['M'], [], [], ['T']]);
+  });
+
+  it('still applies every limit to a pool-first value', () => {
+    const { pairs, hydrate } = setup({
+      maxAssociations: 1,
+      pairOrder: PAIR_ORDER.POOL_FIRST,
+    });
+    hydrate([
+      ['R', 'C'],
+      ['M', 'D'],
+    ]);
+
+    expect(pairs.value).toEqual([['R', 'C']]);
+  });
+
+  it('drops a pool-first pair naming an unknown source', () => {
+    const { rows, hydrate } = setup({ pairOrder: PAIR_ORDER.POOL_FIRST });
+    // Source-first order, so 'C' lands where a target belongs and is refused
+    hydrate([['C', 'M']]);
+
+    expect(rows.value).toEqual([[], [], [], []]);
   });
 });

--- a/kolibri/plugins/qti_viewer/frontend/composables/useMatchRows.js
+++ b/kolibri/plugins/qti_viewer/frontend/composables/useMatchRows.js
@@ -22,6 +22,17 @@ export const PROBLEM = Object.freeze({
 });
 
 /**
+ * Which end of a directed pair the row's source is. A pair is ordered, so an
+ * interaction has to say which of its two sets the base type names first:
+ * `qti-match-interaction` authors its pairs source-first, `qti-gap-match-interaction`
+ * authors them pool-choice-first.
+ */
+export const PAIR_ORDER = Object.freeze({
+  ROW_FIRST: 'rowFirst',
+  POOL_FIRST: 'poolFirst',
+});
+
+/**
  * Track which targets are paired with each source, and the limits on doing so.
  * @param {object} options - The interaction's choices and limits
  * @param {import('vue').Ref<string[]>|string[]} options.sourceIds - First set,
@@ -32,13 +43,27 @@ export const PROBLEM = Object.freeze({
  * own `match-max`, where 0 means no limit
  * @param {import('vue').Ref<number>|number} [options.maxAssociations] - Cap on
  * the total number of pairs, where 0 means no limit
+ * @param {string} [options.pairOrder] - Which end of each directed pair the row's
+ * source is, see {@link PAIR_ORDER}. Fixed for an interaction, so not a ref.
  * @returns {object} The row state and the operations over it
  */
-export default function useMatchRows({ sourceIds, targetIds, matchMaxOf, maxAssociations = 0 }) {
+export default function useMatchRows({
+  sourceIds,
+  targetIds,
+  matchMaxOf,
+  maxAssociations = 0,
+  pairOrder = PAIR_ORDER.ROW_FIRST,
+}) {
   const stored = ref([]);
 
   const sources = () => unref(sourceIds);
   const targets = () => unref(targetIds);
+
+  // Reading and writing a pair go through these two, so the order can never be
+  // applied in one direction and forgotten in the other.
+  const poolFirst = pairOrder === PAIR_ORDER.POOL_FIRST;
+  const toPair = (source, target) => (poolFirst ? [target, source] : [source, target]);
+  const fromPair = pair => (poolFirst ? [pair[1], pair[0]] : [pair[0], pair[1]]);
 
   // Normalise on read, so a change to the choices cannot leave stale rows
   const rows = computed(() =>
@@ -202,9 +227,9 @@ export default function useMatchRows({ sourceIds, targetIds, matchMaxOf, maxAsso
     );
   }
 
-  /** One directed pair per entry, source first, as the base type requires. */
+  /** One directed pair per entry, ordered as the interaction's base type requires. */
   const pairs = computed(() =>
-    rows.value.flatMap((row, index) => row.map(identifier => [sources()[index], identifier])),
+    rows.value.flatMap((row, index) => row.map(identifier => toPair(sources()[index], identifier))),
   );
 
   function hydrate(value) {
@@ -216,7 +241,7 @@ export default function useMatchRows({ sourceIds, targetIds, matchMaxOf, maxAsso
       if (!Array.isArray(pair) || pair.length !== 2) {
         continue;
       }
-      const [source, target] = pair;
+      const [source, target] = fromPair(pair);
       const rowIndex = rowOf.get(source);
       // Drop anything a learner could not have produced, so a malformed value
       // cannot push the rows past the limits the item declares

--- a/kolibri/plugins/qti_viewer/frontend/utils/__tests__/choices.spec.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/__tests__/choices.spec.js
@@ -1,0 +1,117 @@
+import { render } from '@testing-library/vue';
+import { findVNodes, getComponentTag } from '../choices';
+
+// Stand-ins for the QTI elements SafeHTML registers. What matters is that they
+// are real components carrying a `tag`, so the vnodes below are the same shape
+// an interaction is handed at runtime rather than hand-built lookalikes.
+function qtiElement(tag) {
+  return {
+    name: tag,
+    tag,
+    props: { identifier: { type: String, default: null } },
+    render(h) {
+      return h('span', this.$slots.default);
+    },
+  };
+}
+
+const Gap = qtiElement('qti-gap');
+const GapText = qtiElement('qti-gap-text');
+
+// Render `buildContent(h)` as the default slot of an interaction-like component
+// and return what findVNodes picks out of it.
+function search(buildContent, tags) {
+  let found = null;
+  const Interaction = {
+    name: 'interaction',
+    render(h) {
+      found = findVNodes(this.$slots.default, tags);
+      return h('div', this.$slots.default);
+    },
+  };
+  render({
+    render(h) {
+      return h(Interaction, buildContent(h));
+    },
+  });
+  return found;
+}
+
+const identifiersOf = vnodes => vnodes.map(vnode => vnode.componentOptions.propsData.identifier);
+
+describe('findVNodes', () => {
+  it('finds a gap nested inside authored markup', () => {
+    const found = search(
+      h => [h('blockquote', [h('p', ['Now is the ', h(Gap, { props: { identifier: 'G1' } })])])],
+      ['qti-gap'],
+    );
+
+    expect(identifiersOf(found)).toEqual(['G1']);
+  });
+
+  it('returns matches in document order, whatever depth they sit at', () => {
+    // Shaped after gap-match-example-2, whose gaps live in table cells
+    const found = search(
+      h => [
+        h(GapText, { props: { identifier: 's1' } }, ['Earth']),
+        h('table', [
+          h('tbody', [
+            h('tr', [
+              h('td', [h('p', [h(Gap, { props: { identifier: 't1' } })])]),
+              h('td', [h('p', [h(Gap, { props: { identifier: 't2' } })])]),
+            ]),
+            h('tr', [h('td', [h(Gap, { props: { identifier: 't3' } })])]),
+          ]),
+        ]),
+        h('p', ['trailing ', h(Gap, { props: { identifier: 't4' } })]),
+      ],
+      ['qti-gap'],
+    );
+
+    expect(identifiersOf(found)).toEqual(['t1', 't2', 't3', 't4']);
+  });
+
+  it('matches any of the tags it is given', () => {
+    const found = search(
+      h => [
+        h(GapText, { props: { identifier: 'W' } }, ['winter']),
+        h('p', [h(Gap, { props: { identifier: 'G1' } })]),
+      ],
+      ['qti-gap-text', 'qti-gap'],
+    );
+
+    expect(identifiersOf(found)).toEqual(['W', 'G1']);
+  });
+
+  it('leaves content that matches nothing alone', () => {
+    const found = search(h => [h('p', ['just a passage'])], ['qti-gap']);
+
+    expect(found).toEqual([]);
+  });
+
+  it('does not descend into a match', () => {
+    // A gap-text holding a gap is not valid QTI, but it pins the contract: the
+    // caller gets the outer element, not something buried inside it.
+    const found = search(
+      h => [h(GapText, { props: { identifier: 'W' } }, [h(Gap, { props: { identifier: 'G1' } })])],
+      ['qti-gap-text', 'qti-gap'],
+    );
+
+    expect(identifiersOf(found)).toEqual(['W']);
+  });
+
+  it('walks text and empty content without tripping over it', () => {
+    const found = search(
+      h => ['bare text', h('p', []), h('div', [h(Gap, { props: { identifier: 'G1' } })])],
+      ['qti-gap'],
+    );
+
+    expect(identifiersOf(found)).toEqual(['G1']);
+  });
+
+  it('reads the tags the same way getComponentTag does', () => {
+    const found = search(h => [h('p', [h(Gap, { props: { identifier: 'G1' } })])], ['qti-gap']);
+
+    expect(getComponentTag(found[0])).toBe('qti-gap');
+  });
+});

--- a/kolibri/plugins/qti_viewer/frontend/utils/choices.js
+++ b/kolibri/plugins/qti_viewer/frontend/utils/choices.js
@@ -20,6 +20,44 @@ export function getComponentTag(vnode) {
 }
 
 /**
+ * Every vnode in a tree that was rendered from one of the given QTI tags, in
+ * document order.
+ *
+ * Most interactions pick their choices out of the default slot with a flat
+ * filter, because that is where the author has to put them. An interaction
+ * whose answer slots are embedded in its own flow content cannot: a `qti-gap`
+ * sits wherever the passage puts it — inside a blockquote, a table cell, a
+ * paragraph — so finding them means walking the tree.
+ *
+ * A match is not descended into: the QTI elements this looks for do not nest
+ * inside one another.
+ * @param {Array} vnodes - The vnodes to search, e.g. an interaction's slot content
+ * @param {string[]} tags - The QTI tags to match, e.g. `['qti-gap']`
+ * @returns {Array} The matching vnodes, in the order they appear in the item body
+ */
+export function findVNodes(vnodes, tags) {
+  const found = [];
+
+  function visit(nodes) {
+    for (const vnode of nodes || []) {
+      if (!vnode) {
+        continue;
+      }
+      if (tags.includes(getComponentTag(vnode))) {
+        found.push(vnode);
+        continue;
+      }
+      // A component keeps the children it was given under componentOptions;
+      // a plain element keeps them directly. Text vnodes have neither.
+      visit(vnode.componentOptions ? vnode.componentOptions.children : vnode.children);
+    }
+  }
+
+  visit(vnodes);
+  return found;
+}
+
+/**
  * Whether a choice is marked `fixed`, and so keeps its authored position when
  * the rest are shuffled.
  * @param {object} vnode - A choice vnode


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->

This PR adds the QTI Gap Match interaction.
Gap match asks a learner to fill blanks in a passage from a pool of words. The fixtures for it already existed but I added extra examples for the answer specific pools.

### What it does
- Renders `qti-gap-match-interaction` with a response pool above the passage and inline blanks in the text
- Fill a gap by clicking a word then a gap, or a gap then a word
- Drag a word into a gap, between gaps, or back to the pool
- Tab reaches each gap and the arrow keys step through its options, so nothing needs a mouse
- Clicking a filled gap empties it; dropping onto one replaces what's there
- Restores a saved answer and reports it back for scoring

### Answer-specific distractor pools
A gap can be fed by its own set of words instead of the whole pool. Picking up a word highlights the gaps that would take it
**Behavior description:**
- While dragging, gaps that would reject the word are dimmed
- Gaps that already hold a word aren't highlighted, though they can still be replaced
- An item with no match-group behaves exactly as before, one pool feeding every gap

[qti-answer-specific-pools.webm](https://github.com/user-attachments/assets/574dbd7a-badb-4e2b-a850-e92447abd1b9)

### Notable details
- Gaps are found by walking the passage, since a gap can sit anywhere the author puts it, inside a paragraph, a table cell, a quotation
- Gap match writes its pairs word-first, the opposite of match interaction, so useMatchRows gained an option for which end comes first. Match interaction is unaffected.
- `Gap.vue` takes its attributes over rather than inheriting them. An inherited class replaces the component's own root class instead of joining it, which would break both the gap styling and the width classes.
- `qti-input-width-N` sizes a blank to roughly N characters

### $\color{rgba(0, 128, 0)}{\textsf{Gap match inside a table example:}}$

<img width="656" height="779" alt="image" src="https://github.com/user-attachments/assets/f7bd01a2-1c25-4dc0-a99e-dd4e1503594c" />


---

## References
- fixes #15213
- based on #15151

---

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
1. Navigate to `http://localhost:8000/en/learn/#/qti_sandbox`
2. All of the gap match examples in the sandbox are supported and render
but these examples don't do all what the name implies, some of these were dropped:
	- Positioning: qti-choices-top/bottom/left/right are ignored, so all four pools sit above their passage instead of beside it.
	- Container Width: data-choices-container-width is ignored. The apparent width difference comes from the fixture's own qti-layout-col5 / qti-layout-col9 wrappers.
	- Custom Messages: data-max-selections-message and data-min-selections-message are ignored, and there's no notice yet at all, so nothing is shown when a limit is hit.


---

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
All unit tests are written by Claude in addition to the extra fixture I added