### PR TITLE
Stop PR comment workflows matching a PR on pushes to develop

### DIFF
--- a/.github/__tests__/githubUtils.spec.js
+++ b/.github/__tests__/githubUtils.spec.js
@@ -2,9 +2,67 @@
 'use strict';
 
 const {
+  findPrByHeadSha,
   validateNpmVersionData,
   renderNpmVersionMarkdown,
 } = require('../githubUtils.js');
+
+// ---- findPrByHeadSha ----
+
+describe('findPrByHeadSha', () => {
+  function makeContext({ event = 'pull_request', branch = 'my-feature', sha = 'abc123' } = {}) {
+    return {
+      repo: { owner: 'learningequality', repo: 'kolibri' },
+      payload: {
+        workflow_run: {
+          event,
+          head_branch: branch,
+          head_sha: sha,
+          head_repository: { owner: { login: 'contributor' } },
+        },
+      },
+    };
+  }
+
+  function makeGithub(prs) {
+    const list = jest.fn().mockResolvedValue({ data: prs });
+    return { github: { rest: { pulls: { list } } }, list };
+  }
+
+  it('returns the PR whose head SHA matches', async () => {
+    const { github } = makeGithub([
+      { number: 10, head: { sha: 'other' } },
+      { number: 11, head: { sha: 'abc123' } },
+    ]);
+    expect(await findPrByHeadSha(github, makeContext())).toBe(11);
+  });
+
+  it('falls back to the most recently updated PR for the head branch', async () => {
+    const { github } = makeGithub([
+      { number: 12, head: { sha: 'rebased' } },
+      { number: 9, head: { sha: 'older' } },
+    ]);
+    expect(await findPrByHeadSha(github, makeContext())).toBe(12);
+  });
+
+  it('returns null for a push run rather than matching a same-named branch', async () => {
+    const { github, list } = makeGithub([{ number: 8496, head: { sha: 'ancient' } }]);
+    const context = makeContext({ event: 'push', branch: 'develop', sha: 'deadbeef' });
+    expect(await findPrByHeadSha(github, context)).toBeNull();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('only considers open PRs', async () => {
+    const { github, list } = makeGithub([]);
+    await findPrByHeadSha(github, makeContext());
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ state: 'open' }));
+  });
+
+  it('returns null when there are no matching PRs', async () => {
+    const { github } = makeGithub([]);
+    expect(await findPrByHeadSha(github, makeContext())).toBeNull();
+  });
+});
 
 // ---- validateNpmVersionData ----
 

--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -311,11 +311,15 @@ async function postNpmVersionComment(github, context, prNumber, body) {
  * (fork) repo for pull_request-triggered workflows, which is what we
  * need here.
  *
+ * The upstream workflows also run on push to develop, where head_branch is
+ * `develop` and the head filter matches long-merged develop -> release-*
+ * PRs, so restrict to pull_request runs and open PRs.
+ *
  * Returns the PR number, or null if no PR is found.
  */
 async function findPrByHeadSha(github, context) {
   const wr = context.payload.workflow_run;
-  if (!wr || !wr.head_repository || !wr.head_branch) {
+  if (!wr || wr.event !== 'pull_request' || !wr.head_repository || !wr.head_branch) {
     return null;
   }
 
@@ -327,7 +331,7 @@ async function findPrByHeadSha(github, context) {
     owner: context.repo.owner,
     repo: context.repo.repo,
     head: `${headOwner}:${headBranch}`,
-    state: 'all',
+    state: 'open',
     per_page: 100,
     sort: 'updated',
     direction: 'desc',


### PR DESCRIPTION
## Summary

* Properly checks action completion events come from PRs before trying to make a comment

## References

First seen: https://github.com/learningequality/kolibri/pull/8496#issuecomment-5361044859

## Reviewer guidance

JS tests pass on CI.

## AI usage

Used Claude Code to trace the mis-targeted comment back to the head-branch lookup and to write the fix and its tests. Verified with the JS test suite and prek.
