### PR TITLE
Tolerate a missing helpNeeded count in status tallies

### DIFF
--- a/kolibri/plugins/coach/frontend/views/common/status/tallyMixin.js
+++ b/kolibri/plugins/coach/frontend/views/common/status/tallyMixin.js
@@ -9,7 +9,7 @@ export default {
           Number.isInteger(value.started) &&
           Number.isInteger(value.notStarted) &&
           Number.isInteger(value.completed) &&
-          Number.isInteger(value.helpNeeded)
+          (value.helpNeeded === undefined || Number.isInteger(value.helpNeeded))
         );
       },
     },
@@ -22,7 +22,7 @@ export default {
       return this.tally.completed;
     },
     helpNeeded() {
-      return this.tally.helpNeeded;
+      return this.tally.helpNeeded || 0;
     },
     notStarted() {
       return this.tally.notStarted;

--- a/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
+++ b/kolibri/plugins/coach/frontend/views/courses/__tests__/CoursesRootPage.spec.js
@@ -12,6 +12,7 @@ import useCourses, { useCoursesMock } from '../../../composables/useCourses';
 // eslint-disable-next-line import-x/named
 import useClassSummary, { useClassSummaryMock } from '../../../composables/useClassSummary';
 import { coachStrings } from '../../common/commonCoachStrings';
+import { learnerProgressTranslators } from '../../common/status/statusStrings';
 
 const { courseDetailsAction$, editRecipientsAction$, preTestRunningLabel$, unitInProgressLabel$ } =
   coursesStrings;
@@ -200,12 +201,19 @@ describe('CoursesRootPage', () => {
       expect(screen.getByText('—')).toBeInTheDocument();
     });
 
-    it('shows learner progress data when test_learner_progress is provided', () => {
+    // The API omits helpNeeded, which tests have no signal for; the ratio
+    // denominator must not become NaN.
+    it('shows learner progress ratios when test_learner_progress is provided', () => {
       renderWithCourse({
         unit_phase: UnitPhase.PRE_TEST_ACTIVE,
         test_learner_progress: { completed: 1, started: 2, notStarted: 3, total: 6 },
       });
       expect(screen.queryByText('—')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          learnerProgressTranslators.completed.$tr('ratioShort', { count: 1, total: 6 }),
+        ),
+      ).toBeInTheDocument();
     });
 
     it('shows entire class label in recipients column when course has group assignments', () => {


### PR DESCRIPTION
## Summary

* Course test progress doesn't return a help wanted value
* Make it optional in the StatusTally to allow the total to still be calculated even if it is missing

## References

Fixes #15159.

## Reviewer guidance

1. Coach > Courses for a class with a course whose pre- or post-test is running and has at least one learner attempt — the Learner Progress column reads "Completed by N of M", not "of NaN".
2. Coach > Lessons and Quizzes — tallies that do carry `helpNeeded` still count it in their totals.

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/ytVGxWs.png) | ![After](https://i.imgur.com/IY83R0Y.png) |

axe audit on the page: one serious `color-contrast` violation, pre-existing on the disabled "have not started" text.

## AI usage

Used Claude Code to reproduce the NaN in a browser against seeded course data, write the failing test, and apply the fix. Verified with the coach Jest suite and manual QA in a browser.
