### PR TITLE
Make FrozenRow survive a pickle round trip

### DIFF
--- a/kolibri/core/test/test_api.py
+++ b/kolibri/core/test/test_api.py
@@ -1,4 +1,5 @@
 import datetime
+import pickle
 import uuid
 from typing import Type
 from unittest.mock import MagicMock
@@ -2501,6 +2502,23 @@ class TestDevModeSafeguards(TestCase):
         # Replacing the field, rather than mutating it, stays allowed.
         items[0]["publisher"] = dict(items[0]["publisher"], name="Mutated")
         self.assertEqual(items[1]["publisher"]["name"], "Shared")
+
+    @override_settings(DEBUG=True)
+    def test_frozen_children_survive_a_pickle_round_trip(self):
+        """Cached API responses are pickled, and the guard must not break that."""
+        publisher = Publisher.objects.create(name="Shared")
+        Author.objects.create(name="A", email="a@e.com", publisher=publisher)
+        viewset = make_viewset(
+            queryset=Author.objects.all(),
+            id=serializers.UUIDField(),
+            publisher=PublisherSerializer(),
+        )
+
+        items = pickle.loads(pickle.dumps(viewset.serialize(viewset.get_queryset())))
+
+        self.assertEqual(items[0]["publisher"]["name"], "Shared")
+        with self.assertRaises(TypeError):
+            items[0]["publisher"]["name"] = "Mutated"
 
     @override_settings(DEBUG=False)
     def test_fetched_children_are_plain_dicts_when_debug_false(self):

--- a/kolibri/core/utils/values_viewset/field_map.py
+++ b/kolibri/core/utils/values_viewset/field_map.py
@@ -52,6 +52,11 @@ class FrozenRow(dict):
     setdefault = _frozen
     update = _frozen
 
+    def __reduce__(self) -> Tuple[Any, ...]:
+        # pickle rebuilds a dict subclass by replaying its items through
+        # ``__setitem__``, which the guard refuses.
+        return (self.__class__, (dict(self),))
+
 
 class FieldMapEntry(ABC):
     """


### PR DESCRIPTION
## Summary

* FrozenRow was added to prevent modifications of data that was used in two different parts of a response.
* When unpickling from Django cache it uses the same methods that FrozenRow freezes, so it triggered the error because it looks like an edit
* Add a `__reduce__` dunder method to allow restoring from the pickle without triggering the guard

## References

Introduced in: #15085.

## Reviewer guidance

1. With `DEBUG=True`, request `/api/content/contentnode/?available=true&max_results=25&modality=COURSE&keywords=` twice on a device with course content — both respond 200. Use curl or a `cache: 'no-store'` fetch; a browser reload serves its own cached copy and never re-hits the server - prior to this change the second request would be a 500 (in DEBUG=True only)
2. Python tests pass on CI.

## AI usage

Used Claude Code to trace the 500 to the guard, write the failing test, and add `__reduce__`. Verified with the values viewset test module and manual QA against a local dev server.
