### PR TITLE
Hide courses from learners on learn-only devices

### DIFF
--- a/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/frontend/views/TopicsPage/index.vue
@@ -376,7 +376,7 @@
       const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       const { channelsMap, fetchChannels } = useChannels();
       const { fetchContentNodeProgress, fetchContentNodeTreeProgress } = useContentNodeProgress();
-      const { isUserLoggedIn, hasRole } = useUser();
+      const { isUserLoggedIn, hasRole, isLearnerOnlyImport } = useUser();
       const { fetchUserDownloadRequests } = useDownloadRequests(store);
 
       const isRoot = ref(false);
@@ -433,8 +433,10 @@
         const skip = route.query && route.query.skip === 'true';
         const params = {
           include_coach_content: get(hasRole),
-          // Only hide COURSE from Learners in the library view
-          exclude_modalities: get(hasRole) ? null : Modalities.COURSE,
+          // Only hide COURSE from Learners in the library view. On a learn-only
+          // device the learner is also the admin of their own device, so a role
+          // there does not mean courses should be surfaced to them.
+          exclude_modalities: get(hasRole) && !get(isLearnerOnlyImport) ? null : Modalities.COURSE,
           baseurl,
         };
         if (get(isUserLoggedIn) && !baseurl) {

--- a/kolibri/plugins/learn/frontend/views/__tests__/TopicsPage.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/TopicsPage.spec.js
@@ -17,6 +17,9 @@ import useBaseSearch, {
 /* eslint-enable import-x/named */
 // eslint-disable-next-line import-x/named
 import useChannels, { useChannelsMock } from 'kolibri-common/composables/useChannels';
+// eslint-disable-next-line import-x/named
+import useUser, { useUserMock } from 'kolibri/composables/useUser';
+import Modalities from 'kolibri-constants/Modalities';
 import makeStore from '../../__tests__/utils/makeStore';
 import CustomContentRenderer from '../ChannelRenderer/CustomContentRenderer';
 import { PageNames } from '../../constants';
@@ -138,7 +141,17 @@ describe('TopicsPage', () => {
       }),
     );
 
+    ContentNodeResource.fetchTree_v2.mockClear();
     ContentNodeResource.fetchTree_v2.mockResolvedValue(DEFAULT_TOPIC);
+
+    useUser.mockImplementation(() => useUserMock());
+
+    // Large-screen default; the small-screen tests override this.
+    useKResponsiveWindow.mockImplementation(() => ({
+      windowIsSmall: false,
+      windowIsLarge: true,
+      windowBreakpoint: ref(4),
+    }));
 
     store = makeStore({});
     useDevicesWithFilter.mockReturnValue({
@@ -151,17 +164,36 @@ describe('TopicsPage', () => {
     });
   });
 
+  describe('excluding courses when fetching the topic tree', () => {
+    async function fetchedParams() {
+      shallowMount(TopicsPage, { store, localVue, router, propsData: { id: 'topic-id' } });
+      await flushPromises();
+      return ContentNodeResource.fetchTree_v2.mock.calls[0][0].params;
+    }
+
+    it('excludes courses for a user without a role', async () => {
+      expect((await fetchedParams()).exclude_modalities).toEqual(Modalities.COURSE);
+    });
+
+    it('includes courses for a user with a role', async () => {
+      useUser.mockImplementation(() => useUserMock({ hasRole: true }));
+      expect((await fetchedParams()).exclude_modalities).toBeNull();
+    });
+
+    it('excludes courses on a learn-only device, even for a user with a role', async () => {
+      useUser.mockImplementation(() => useUserMock({ hasRole: true, isLearnerOnlyImport: true }));
+      const params = await fetchedParams();
+      expect(params.exclude_modalities).toEqual(Modalities.COURSE);
+      // Coach content is not gated on the device being a learn-only device.
+      expect(params.include_coach_content).toBe(true);
+    });
+  });
+
   describe('When current topic modality is CUSTOM_NAVIGATION and custom channel nav is enabled', () => {
     it('renders a CustomContentRenderer', async () => {
       plugin_data.enableCustomChannelNav.mockImplementation(() => true);
 
       useBaseSearch.mockImplementation(() => useBaseSearchMock());
-
-      useKResponsiveWindow.mockImplementation(() => ({
-        windowIsSmall: false,
-        windowIsLarge: true,
-        windowBreakpoint: ref(4),
-      }));
 
       ContentNodeResource.fetchTree_v2.mockResolvedValue({
         ...DEFAULT_TOPIC,
@@ -180,11 +212,6 @@ describe('TopicsPage', () => {
 
   describe('Displaying the header', () => {
     it('displays breadcrumbs when not on a small screen', async () => {
-      useKResponsiveWindow.mockImplementation(() => ({
-        windowIsSmall: false,
-        windowIsLarge: true,
-        windowBreakpoint: ref(4),
-      }));
       const wrapper = shallowMount(TopicsPage, {
         store: store,
         localVue,
@@ -196,11 +223,6 @@ describe('TopicsPage', () => {
   });
 
   it('displays the header with tabs when not on a small screen', async () => {
-    useKResponsiveWindow.mockImplementation(() => ({
-      windowIsSmall: false,
-      windowIsLarge: true,
-      windowBreakpoint: ref(4),
-    }));
     const wrapper = shallowMount(TopicsPage, {
       store: store,
       localVue,
@@ -211,11 +233,6 @@ describe('TopicsPage', () => {
   });
 
   it('displays the topic title when page is not small', async () => {
-    useKResponsiveWindow.mockImplementation(() => ({
-      windowIsSmall: false,
-      windowIsLarge: true,
-      windowBreakpoint: ref(4),
-    }));
     const wrapper = mount(TopicsPage, {
       store: store,
       localVue,

--- a/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
@@ -212,6 +212,33 @@ describe(`useBaseSearch`, () => {
       expect(get(displayingSearchResults)).toBe(true);
     });
   });
+  describe('course search params', () => {
+    async function searchParams() {
+      const { mockRoute } = prep();
+      mockRoute.query = { categories: 'test1' };
+      await nextTick();
+      const call = ContentNodeResource.fetchCollection.mock.calls.find(
+        ([{ getParams }]) => getParams.categories,
+      );
+      return call[0].getParams;
+    }
+
+    it('includes courses for a user with a role', async () => {
+      useUser.mockImplementation(() => useUserMock({ hasRole: true }));
+      const params = await searchParams();
+      expect(params.exclude_modalities).toBeNull();
+      expect(params.exclude_course_ancestry).toBe(false);
+    });
+
+    it('excludes courses on a learn-only device, even for a user with a role', async () => {
+      useUser.mockImplementation(() => useUserMock({ hasRole: true, isLearnerOnlyImport: true }));
+      const params = await searchParams();
+      expect(params.exclude_modalities).toEqual(Modalities.COURSE);
+      expect(params.exclude_course_ancestry).toBe(true);
+      // Coach content is not gated on the device being a learn-only device.
+      expect(params.include_coach_content).toBe(true);
+    });
+  });
   describe('search method', () => {
     it('should call ContentNodeResource.fetchCollection when searchTerms changes', async () => {
       const { mockRoute } = prep();

--- a/packages/kolibri-common/composables/useBaseSearch.js
+++ b/packages/kolibri-common/composables/useBaseSearch.js
@@ -204,7 +204,11 @@ export default function useBaseSearch({
   const labels = ref(null);
   const autoCompleteSuggestions = ref([]);
 
-  const { hasRole, isUserLoggedIn } = useUser();
+  const { hasRole, isLearnerOnlyImport, isUserLoggedIn } = useUser();
+
+  // On a learn-only device the learner is also the admin of their own device,
+  // so a role there does not mean courses should be surfaced to them.
+  const showCourses = computed(() => get(hasRole) && !get(isLearnerOnlyImport));
 
   const searchTerms = computed({
     get() {
@@ -269,9 +273,10 @@ export default function useBaseSearch({
 
   function createBaseSearchGetParams() {
     const role = get(hasRole);
+    const courses = get(showCourses);
     const getParams = {
-      exclude_modalities: role ? null : Modalities.COURSE,
-      exclude_course_ancestry: !role,
+      exclude_modalities: courses ? null : Modalities.COURSE,
+      exclude_course_ancestry: !courses,
       include_coach_content: role,
       baseurl: get(baseurl),
     };


### PR DESCRIPTION
## Summary

Courses were hidden from learners in the library based on the user's role alone. On a learn-only device the learner is also the admin of their own device, so they have a role and the course — and its resources — showed up in the library.

Both the library search params and the topic tree fetch now also require the device not to be a learn-only device before surfacing courses. `include_coach_content` is deliberately left keyed on role alone, since it is not affected by the device being learn-only.

## References

Fixes #15188

## Reviewer guidance

Automated coverage: three cases in each of `useBaseSearch.spec.js` and `TopicsPage.spec.js` — no role (courses excluded), role on a full-facility device (courses included), role on a LOD (courses excluded, `include_coach_content` still true). I verified each LOD case fails when the fix is reverted.

Manual reproduction follows the steps in #15188: assign a course to a learner on a LOD, sync, then check the Library page and the channel/folder browsing view — the course and its resources should no longer appear.

Worth a careful look: `include_coach_content` is intentionally *not* gated on `isLearnerOnlyImport` — if courses and coach content should be gated together, that's a different fix.

## AI usage

I identified the bug and asked Claude Code to fix it and update the tests. I reviewed the result.