### PR TITLE
Replace 'Start' with 'Resume' course after pre-test completion

### DIFF
--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -121,7 +121,7 @@ class CourseSession(AbstractFacilityDataModel):
         :param user: A FacilityUser instance
         :return: dict with keys:
             - started (bool)
-            - active_test (dict with unit_id, test_type and submitted, or None)
+            - active_test (dict with unit_id, test_type and opened, or None)
             - resume_position (dict with unit_id, lesson_id, resource_id, or None)
             - completed (bool)
         """
@@ -141,9 +141,9 @@ class CourseSession(AbstractFacilityDataModel):
             result["active_test"] = {
                 "unit_id": unit_test_active.unit_contentnode_id,
                 "test_type": unit_test_active.test_type,
-                # A test stays open until a coach closes it, regardless
-                # of whether it was not started or has been submitted.
-                "submitted": self._test_submitted(user, unit_test_active),
+                # A test stays open until a coach closes it, regardless of
+                # whether the learner has opened it yet.
+                "opened": self._test_opened(user, unit_test_active),
             }
             result["started"] = True
             return result
@@ -209,11 +209,12 @@ class CourseSession(AbstractFacilityDataModel):
 
         return result
 
-    def _test_submitted(self, user, unit_test_assignment):
+    def _test_opened(self, user, unit_test_assignment):
         """
-        Whether the learner has submitted the given unit test. Test attempts are
-        logged against a synthetic content_id shared by the whole class, so this
-        must be filtered by user.
+        Whether the learner has opened the given unit test - a summary log is
+        created when the learner first opens it, whether or not they go on to
+        submit it. Test sessions are logged against a synthetic content_id
+        shared by the whole class, so this must be filtered by user.
         """
         content_id = get_synthetic_content_id(
             str(self.id),
@@ -223,7 +224,6 @@ class CourseSession(AbstractFacilityDataModel):
         return ContentSummaryLog.objects.filter(
             user=user,
             content_id=content_id,
-            progress__gte=1,
         ).exists()
 
     def _is_completed(self, unit_test_assignments_qs):

--- a/kolibri/core/courses/models.py
+++ b/kolibri/core/courses/models.py
@@ -19,6 +19,7 @@ from kolibri.core.content.models import ContentRequestPriority
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.fields import DateTimeTzField
 from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.utils.pre_post_test import get_synthetic_content_id
 from kolibri.core.utils.cache import process_cache
 from kolibri.utils.data import ChoicesEnum
 from kolibri.utils.time_utils import local_now
@@ -120,7 +121,7 @@ class CourseSession(AbstractFacilityDataModel):
         :param user: A FacilityUser instance
         :return: dict with keys:
             - started (bool)
-            - active_test (dict with unit_id and test_type, or None)
+            - active_test (dict with unit_id, test_type and submitted, or None)
             - resume_position (dict with unit_id, lesson_id, resource_id, or None)
             - completed (bool)
         """
@@ -140,6 +141,9 @@ class CourseSession(AbstractFacilityDataModel):
             result["active_test"] = {
                 "unit_id": unit_test_active.unit_contentnode_id,
                 "test_type": unit_test_active.test_type,
+                # A test stays open until a coach closes it, regardless
+                # of whether it was not started or has been submitted.
+                "submitted": self._test_submitted(user, unit_test_active),
             }
             result["started"] = True
             return result
@@ -204,6 +208,23 @@ class CourseSession(AbstractFacilityDataModel):
         result["completed"] = self._is_completed(unit_test_assignments_qs)
 
         return result
+
+    def _test_submitted(self, user, unit_test_assignment):
+        """
+        Whether the learner has submitted the given unit test. Test attempts are
+        logged against a synthetic content_id shared by the whole class, so this
+        must be filtered by user.
+        """
+        content_id = get_synthetic_content_id(
+            str(self.id),
+            str(unit_test_assignment.unit_contentnode_id),
+            unit_test_assignment.test_type,
+        )
+        return ContentSummaryLog.objects.filter(
+            user=user,
+            content_id=content_id,
+            progress__gte=1,
+        ).exists()
 
     def _is_completed(self, unit_test_assignments_qs):
         """

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -116,13 +116,13 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertTrue(result["started"])
         self.assertEqual(result["active_test"]["unit_id"], self.unit_node.id)
         self.assertEqual(result["active_test"]["test_type"], TestType.Pre)
-        self.assertFalse(result["active_test"]["submitted"])
+        self.assertFalse(result["active_test"]["opened"])
         self.assertIsNone(result["resume_position"])
         self.assertFalse(result["completed"])
 
-    def test_active_test_submitted_by_learner(self):
-        """A test stays open until a coach closes it, so a learner can have
-        submitted the test that is still active."""
+    def test_active_test_opened_but_not_submitted_by_learner(self):
+        """Opening a test creates its summary log, so a learner who has yet to
+        submit the still active test has nonetheless opened it."""
         UnitTestAssignment.objects.create(
             course_session=self.course_session,
             unit_contentnode_id=self.unit_node.id,
@@ -138,19 +138,19 @@ class CourseSessionGetResumeDataTestCase(TestCase):
             ),
             channel_id=None,
             kind=content_kinds.QUIZ,
-            progress=1.0,
+            progress=0,
             start_timestamp=timezone.now(),
         )
 
         result = self.course_session.get_resume_data(self.learner)
 
-        self.assertTrue(result["active_test"]["submitted"])
+        self.assertTrue(result["active_test"]["opened"])
 
-    def test_active_test_submitted_is_per_learner(self):
-        """Another learner's submission should not mark this learner's test
-        submitted, the synthetic content_id is shared across the class."""
+    def test_active_test_opened_is_per_learner(self):
+        """Another learner opening the test should not mark this learner's
+        test opened, the synthetic content_id is shared across the class."""
         other_learner = FacilityUser.objects.create(
-            username="other_submitter", facility=self.facility
+            username="other_opener", facility=self.facility
         )
         self.classroom.add_member(other_learner)
         UnitTestAssignment.objects.create(
@@ -174,7 +174,7 @@ class CourseSessionGetResumeDataTestCase(TestCase):
 
         result = self.course_session.get_resume_data(self.learner)
 
-        self.assertFalse(result["active_test"]["submitted"])
+        self.assertFalse(result["active_test"]["opened"])
 
     def test_completed_pre_test_marks_started(self):
         UnitTestAssignment.objects.create(

--- a/kolibri/core/courses/test/test_models.py
+++ b/kolibri/core/courses/test/test_models.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.test import TestCase
 from django.utils import timezone
+from le_utils.constants import content_kinds
 from le_utils.constants import modalities
 
 from kolibri.core.auth.models import Classroom
@@ -15,6 +16,7 @@ from kolibri.core.courses.models import CourseSessionAssignment
 from kolibri.core.courses.models import TestType
 from kolibri.core.courses.models import UnitTestAssignment
 from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.utils.pre_post_test import get_synthetic_content_id
 
 DUMMY_PASSWORD = "password"
 
@@ -114,8 +116,65 @@ class CourseSessionGetResumeDataTestCase(TestCase):
         self.assertTrue(result["started"])
         self.assertEqual(result["active_test"]["unit_id"], self.unit_node.id)
         self.assertEqual(result["active_test"]["test_type"], TestType.Pre)
+        self.assertFalse(result["active_test"]["submitted"])
         self.assertIsNone(result["resume_position"])
         self.assertFalse(result["completed"])
+
+    def test_active_test_submitted_by_learner(self):
+        """A test stays open until a coach closes it, so a learner can have
+        submitted the test that is still active."""
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=False,
+            activated_by=self.coach,
+        )
+        ContentSummaryLog.objects.create(
+            user=self.learner,
+            content_id=get_synthetic_content_id(
+                self.course_session.id, self.unit_node.id, TestType.Pre
+            ),
+            channel_id=None,
+            kind=content_kinds.QUIZ,
+            progress=1.0,
+            start_timestamp=timezone.now(),
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertTrue(result["active_test"]["submitted"])
+
+    def test_active_test_submitted_is_per_learner(self):
+        """Another learner's submission should not mark this learner's test
+        submitted, the synthetic content_id is shared across the class."""
+        other_learner = FacilityUser.objects.create(
+            username="other_submitter", facility=self.facility
+        )
+        self.classroom.add_member(other_learner)
+        UnitTestAssignment.objects.create(
+            course_session=self.course_session,
+            unit_contentnode_id=self.unit_node.id,
+            collection=self.classroom,
+            test_type=TestType.Pre,
+            closed=False,
+            activated_by=self.coach,
+        )
+        ContentSummaryLog.objects.create(
+            user=other_learner,
+            content_id=get_synthetic_content_id(
+                self.course_session.id, self.unit_node.id, TestType.Pre
+            ),
+            channel_id=None,
+            kind=content_kinds.QUIZ,
+            progress=1.0,
+            start_timestamp=timezone.now(),
+        )
+
+        result = self.course_session.get_resume_data(self.learner)
+
+        self.assertFalse(result["active_test"]["submitted"])
 
     def test_completed_pre_test_marks_started(self):
         UnitTestAssignment.objects.create(

--- a/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
@@ -354,20 +354,20 @@
         }
         // `started` flips true as soon as the first pre-test becomes active,
         // so it alone mislabels the very first pre-test as "Resume". A test
-        // stays active until a coach closes it, so only an unsubmitted
+        // stays active until a coach closes it, so only an unopened
         // first-unit pre-test means the course has not been started by the learner.
         // When a later-unit pre-test is active, the backend wipes resume_position —
-        // so the only remaining signal that an earlier pre-test was submitted
-        // is an active test belonging to a non-first unit.
+        // so the only remaining signal that the learner has worked through an earlier
+        // unit is an active test belonging to a non-first unit.
         const firstUnitId = units.value?.[0]?.id;
         const activeTest = progress.active_test;
-        const onUnsubmittedFirstPreTest =
+        const onUnopenedFirstPreTest =
           activeTest?.test_type === TestType.PRE &&
           activeTest?.unit_id === firstUnitId &&
-          !activeTest?.submitted &&
+          !activeTest?.opened &&
           !progress.resume_position;
 
-        if (onUnsubmittedFirstPreTest) {
+        if (onUnopenedFirstPreTest) {
           return startCourseAction$();
         }
         if (progress.completed) {

--- a/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
+++ b/kolibri/plugins/learn/frontend/views/CourseWelcomePage.vue
@@ -353,17 +353,21 @@
           return startCourseAction$();
         }
         // `started` flips true as soon as the first pre-test becomes active,
-        // so it alone mislabels the very first pre-test as "Resume". When a
-        // later-unit pre-test is active, the backend wipes resume_position —
+        // so it alone mislabels the very first pre-test as "Resume". A test
+        // stays active until a coach closes it, so only an unsubmitted
+        // first-unit pre-test means the course has not been started by the learner.
+        // When a later-unit pre-test is active, the backend wipes resume_position —
         // so the only remaining signal that an earlier pre-test was submitted
         // is an active test belonging to a non-first unit.
         const firstUnitId = units.value?.[0]?.id;
-        const onFirstPreTest =
-          progress.active_test?.test_type === TestType.PRE &&
-          progress.active_test?.unit_id === firstUnitId &&
+        const activeTest = progress.active_test;
+        const onUnsubmittedFirstPreTest =
+          activeTest?.test_type === TestType.PRE &&
+          activeTest?.unit_id === firstUnitId &&
+          !activeTest?.submitted &&
           !progress.resume_position;
 
-        if (onFirstPreTest) {
+        if (onUnsubmittedFirstPreTest) {
           return startCourseAction$();
         }
         if (progress.completed) {

--- a/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
@@ -267,7 +267,7 @@ describe('CourseWelcomePage', () => {
   it('navigates to the pre-test when the Start link is clicked during an active test', async () => {
     useResources({
       started: true,
-      active_test: { unit_id: 'unit-1', test_type: 'pre', submitted: false },
+      active_test: { unit_id: 'unit-1', test_type: 'pre', opened: false },
       resume_position: null,
     });
     const wrapper = renderComponent();
@@ -285,12 +285,12 @@ describe('CourseWelcomePage', () => {
     });
   });
 
-  it('labels the action Resume when the first pre-test is submitted but still open', async () => {
-    // A test is only closed by a coach, so the learner can complete
+  it('labels the action Resume once the learner has opened the first pre-test', async () => {
+    // A test is only closed by a coach, so the learner can start or submit
     // the first pre-test while it is still the active test.
     useResources({
       started: true,
-      active_test: { unit_id: 'unit-1', test_type: 'pre', submitted: true },
+      active_test: { unit_id: 'unit-1', test_type: 'pre', opened: true },
       resume_position: null,
     });
     const wrapper = renderComponent();

--- a/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
+++ b/kolibri/plugins/learn/frontend/views/__tests__/CourseWelcomePage.spec.js
@@ -267,7 +267,7 @@ describe('CourseWelcomePage', () => {
   it('navigates to the pre-test when the Start link is clicked during an active test', async () => {
     useResources({
       started: true,
-      active_test: { unit_id: 'unit-1', test_type: 'pre' },
+      active_test: { unit_id: 'unit-1', test_type: 'pre', submitted: false },
       resume_position: null,
     });
     const wrapper = renderComponent();
@@ -283,6 +283,20 @@ describe('CourseWelcomePage', () => {
         }),
       );
     });
+  });
+
+  it('labels the action Resume when the first pre-test is submitted but still open', async () => {
+    // A test is only closed by a coach, so the learner can complete
+    // the first pre-test while it is still the active test.
+    useResources({
+      started: true,
+      active_test: { unit_id: 'unit-1', test_type: 'pre', submitted: true },
+      resume_position: null,
+    });
+    const wrapper = renderComponent();
+
+    await wrapper.findByRole('link', { name: resumeCourseAction$() });
+    expect(wrapper.queryByRole('link', { name: startCourseAction$() })).not.toBeInTheDocument();
   });
 
   it('locks lessons past the resume position within the resume unit', async () => {


### PR DESCRIPTION

<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
This pull requests updates the action button label that opens a course for a learner, based on if the learner has completed the first pre-test.

Previously, if a learner had completed the 1st unit’s pre-test, the label for the open course button was “Start Course”, which was incorrect because the course had technically already been started.

Now, if the course’s first pre-test has been completed, the button label is “Resume Course”.

Because a test is closed by a coach, an active pre-test in the first unit could mean it hadn’t been taken by the learner yet, or was submitted and waiting to be closed by the coach, but the resume payload did not differentiate between the two.


`get_resume_data` has been updated to include “submitted” on `active_test`, using `_test_submitted()`, which checks the learner's `ContentSummaryLog` (progress >= 1) for the test's synthetic content id,  the same id the progress-tracking API logs attempts against.

## References
<!--
 * references to related issues and PRs
-->

Fixes #15193 

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
1. Assign a course to a learner and complete the first pre-test
2. Go to the course home page


https://github.com/user-attachments/assets/98b0c586-fd21-466f-8020-d4d5431dca32


<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude Code to update the backend & frontend tests, and to review the code changes.