### PR TITLE
Fix failing tests

### DIFF
--- a/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
+++ b/packages/kolibri-common/composables/__tests__/useBaseSearch.spec.js
@@ -217,10 +217,8 @@ describe(`useBaseSearch`, () => {
       const { mockRoute } = prep();
       mockRoute.query = { categories: 'test1' };
       await nextTick();
-      const call = ContentNodeResource.fetchCollection.mock.calls.find(
-        ([{ getParams }]) => getParams.categories,
-      );
-      return call[0].getParams;
+      const call = ContentNodeResource.list.mock.calls.find(([params]) => params.categories);
+      return call[0];
     }
 
     it('includes courses for a user with a role', async () => {


### PR DESCRIPTION
## Summary

I forgot to rebase https://github.com/learningequality/kolibri/pull/15226 after https://github.com/learningequality/kolibri/pull/15163 was merged, and it included tests asserting the old API Resource methods. This PR adapts these tests to the new API.

## References

JS tests are failing on `develop`.

## Reviewer guidance
Check that the tests are succeeding.
