### PR TITLE
Miscelaneous style fixes on SectionOrder component

### DIFF
--- a/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
+++ b/kolibri/plugins/coach/frontend/views/quizzes/CreateExamPage/sidePanels/SectionSidePanel/SectionOrder.vue
@@ -25,7 +25,6 @@
                 class="section-order-list"
               >
                 <DragSortWidget
-                  class="drag-title"
                   :isFirst="index === 0"
                   :isLast="index === sectionOrderList.length - 1"
                   :itemLabel="sectionOrderingTitle(section)"
@@ -34,10 +33,7 @@
                   @moveUp="() => handleKeyboardDragUp(index, sectionOrderList)"
                   @moveDown="() => handleKeyboardDragDown(index, sectionOrderList)"
                 />
-                <span
-                  class="drag-title"
-                  style="flex: 1"
-                >
+                <span style="flex: 1">
                   {{ sectionOrderingTitle(section) }}
                 </span>
                 <span
@@ -60,7 +56,13 @@
       </div>
     </DraggableRegion>
 
-    <div class="bottom-buttons-style">
+    <div
+      class="bottom-buttons-style"
+      :style="{
+        backgroundColor: $themeTokens.surface,
+        borderTop: `1px solid ${$themeTokens.fineLine}`,
+      }"
+    >
       <KButton
         :primary="true"
         :text="applySettings$()"
@@ -263,44 +265,20 @@
     margin-bottom: 7em;
   }
 
-  .section-settings-heading {
-    margin-bottom: 0.5em;
-    font-weight: 600;
-  }
-
-  .section-settings-top-heading {
-    margin-top: 0;
-    margin-bottom: 1.125em;
-    font-size: 2em;
-    font-weight: 600;
-  }
-
   .section-order-list {
     display: flex;
     flex-wrap: nowrap;
+    gap: 1em;
     align-items: center;
-    height: 2.5em;
+    min-height: 2.5em;
+    padding: 0.5em;
     margin-top: 0.5em;
     border: 1px solid;
     border-radius: 2px;
   }
 
-  .space-content {
-    margin: 0.5em;
-    font-size: 1em;
-  }
-
-  .section-order-style {
-    font-size: 1em;
-  }
-
   .current-section-style {
     font-size: 1em;
-  }
-
-  .drag-title {
-    display: inline-block;
-    padding: 8px;
   }
 
   .bottom-buttons-style {
@@ -311,20 +289,10 @@
     padding: 1em;
     margin-top: 1em;
     text-align: right;
-    background-color: #ffffff;
-    border-top: 1px solid black;
 
     > div {
       padding-right: 1em;
     }
-  }
-
-  /deep/ .textbox {
-    max-width: 100% !important;
-  }
-
-  .description-ktextbox-style /deep/ .ui-textbox-label {
-    width: 100%;
   }
 
   .current-section-text {


### PR DESCRIPTION
## Summary

Found a wonky drag handler on the SectionOrder component while reviewing https://github.com/learningequality/kolibri/pull/15256, and then just kept finding wonky and unused styles on the SectionOrder component and I couldn't resist fixing them (and prevented myself from doing further refactors 😅 ).

Before:

<img width="768" height="1005" alt="image" src="https://github.com/user-attachments/assets/a9f12eba-fbf9-440a-baa0-558448df3744" />

After:

<img width="763" height="999" alt="image" src="https://github.com/user-attachments/assets/e22da35b-2428-42bd-84bb-0b0ca43d363b" />

## Reviewer guidance

* Go to add new quiz.
* Add multiple sections.
* Go to "edit section order"
* Check that styles are working properly.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
None