### PR TITLE
Remove accidentally doubled words in comments, docstrings and tests

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -279,7 +279,7 @@ However, this should be avoided whenever possible. Consider whether your use cas
 Behavior
 ~~~~~~~~
 
-Occasionally it is necessary to perform different logic depending on the directionalty of the the currently-selected language. For example, the handling of a button that changes horizontal scroll position would need to flip direction.
+Occasionally it is necessary to perform different logic depending on the directionality of the currently-selected language. For example, the handling of a button that changes horizontal scroll position would need to flip direction.
 
 In the frontend, we provide a ``isRtl`` property attached to every Vue instance. For example, you could write Vue methods like:
 

--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -1,5 +1,5 @@
 """
-CAUTION! Keep everything here at at minimum. Do not import stuff.
+CAUTION! Keep everything here at minimum. Do not import stuff.
 Do not import dependencies here.
 """
 

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -233,7 +233,7 @@ class CollectionRoleMembershipDeletionTestCase(TestCase):
             self.cr.remove_coach(self.learner)
 
     def test_remove_indirect_admin_role(self):
-        """Trying to remove the admin role for a a Facility admin from a descendant classroom doesn't actually remove anything."""
+        """Trying to remove the admin role for a Facility admin from a descendant classroom doesn't actually remove anything."""
         with self.assertRaises(UserDoesNotHaveRoleError):
             self.cr.remove_admin(self.facility_admin)
 

--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -213,7 +213,7 @@ class DynamicNetworkLocation(NetworkLocation):
         else:
             raise ValidationError(
                 {
-                    "instance_id": "DynamicNetworkLocations must be be created with an instance ID!"
+                    "instance_id": "DynamicNetworkLocations must be created with an instance ID!"
                 }
             )
 

--- a/kolibri/core/logger/upgrade.py
+++ b/kolibri/core/logger/upgrade.py
@@ -77,7 +77,7 @@ def fix_masterylog_end_timestamps():
     Fix any MasteryLogs that have an end_timestamp that was not updated after creation due to a bug in the
     integrated logging API endpoint.
     """
-    # Fix the MasteryLogs that that have attempts - infer from the end_timestamp of the last attempt.
+    # Fix the MasteryLogs that have attempts - infer from the end_timestamp of the last attempt.
     attempt_subquery = (
         AttemptLog.objects.filter(masterylog=OuterRef("pk"))
         .values("masterylog")

--- a/kolibri/core/tasks/viewsets/tasks.py
+++ b/kolibri/core/tasks/viewsets/tasks.py
@@ -139,13 +139,13 @@ class TasksViewSet(viewsets.GenericViewSet):
                 jobs_response.append(self._job_to_response(job))
             except KeyError:
                 # Note: Temporarily including unregistered tasks until we complete
-                # our transition to to the new tasks API.
+                # our transition to the new tasks API.
                 # After completing transition to the new tasks API, we won't be
                 # including unregistered tasks to the response list.
                 jobs_response.append(self._job_to_response(job))
             except PermissionDenied:
                 # `request.user` do not have permission for this job hence
-                # we we will NOT append this job to the list.
+                # we will NOT append this job to the list.
                 pass
 
         return Response(jobs_response)

--- a/kolibri/plugins/coach/frontend/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
+++ b/kolibri/plugins/coach/frontend/views/common/assignments/IndividualLearnerSelector/IndividualLearnerSelectorTable.vue
@@ -117,7 +117,7 @@
     computed: {
       ...mapState('classSummary', ['groupMap']),
       allLearners() {
-        // If we get a class ID different that that in Vuex state,
+        // If we get a class ID different from that in Vuex state,
         // then we're going to need to fetch that class's learners
         if (this.targetClassId != this.classId) {
           // This is init to null so we've not fetched it yet.

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/AssignCoachesSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/AssignCoachesSidePanel.vue
@@ -334,7 +334,7 @@
       // have selected any users if we load into this page, so go to the users table.
       if (from.name === null) {
         next(
-          // Override to to keep params like facility_id in place
+          // Override to keep params like facility_id in place
           overrideRoute(to, {
             name: PageNames.USER_MGMT_PAGE,
           }),

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/EnrollLearnersSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/EnrollLearnersSidePanel.vue
@@ -335,7 +335,7 @@
       // have selected any users if we load into this page, so go to the users table.
       if (from.name === null) {
         next(
-          // Override to to keep params like facility_id in place
+          // Override to keep params like facility_id in place
           overrideRoute(to, {
             name: PageNames.USER_MGMT_PAGE,
           }),

--- a/kolibri/plugins/facility/frontend/views/users/sidePanels/RemoveFromClassSidePanel.vue
+++ b/kolibri/plugins/facility/frontend/views/users/sidePanels/RemoveFromClassSidePanel.vue
@@ -353,7 +353,7 @@
       // have selected any users if we load into this page, so go to the users table.
       if (from.name === null) {
         next(
-          // Override to to keep params like facility_id in place
+          // Override to keep params like facility_id in place
           overrideRoute(to, {
             name: PageNames.USER_MGMT_PAGE,
           }),

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -76,7 +76,7 @@ def retry_import(e):
     When an exception occurs during channel/content import, if
         * there is an Internet connection error or timeout error,
           or HTTPError where the error code is one of the RETRY_STATUS_CODE,
-          return return True to retry the file transfer
+          return True to retry the file transfer
     return value:
         * True - needs retry.
         * False - Does not need retry.

--- a/packages/kolibri/__tests__/api-resource.spec.js
+++ b/packages/kolibri/__tests__/api-resource.spec.js
@@ -1035,7 +1035,7 @@ describe('Model', function () {
       });
     });
     describe('if called when Model.synced = true and attrs are different', function () {
-      it('should should call the client once', function (done) {
+      it('should call the client once', function (done) {
         model.synced = true;
         const payload = { somethingNew: 'new' };
         const data = {};
@@ -1049,7 +1049,7 @@ describe('Model', function () {
           done();
         });
       });
-      it('should should call set once with the changed attributes', function (done) {
+      it('should call set once with the changed attributes', function (done) {
         model.synced = true;
         const payload = { somethingNew: 'new' };
         const data = {};

--- a/packages/kolibri/components/pages/ScrollingHeader.vue
+++ b/packages/kolibri/components/pages/ScrollingHeader.vue
@@ -80,7 +80,7 @@
         // Also, to mitigate overscroll rebound and other reasons,
         // the upward threshold is set higher than the downward one.
         // Capped at 240 px, which is half the height of a iPhone 4,
-        // the page would need to be be at least 4800px high to reach this cap.
+        // the page would need to be at least 4800px high to reach this cap.
         const downThresh = Math.min(Math.round(this.mainWrapperScrollHeight * 0.05), 240);
         return {
           up: downThresh * 2,

--- a/packages/kolibri/components/pages/__tests__/NotificationsRoot.spec.js
+++ b/packages/kolibri/components/pages/__tests__/NotificationsRoot.spec.js
@@ -55,7 +55,7 @@ describe('NotificationsRoot', function () {
       expect(wrapper.findComponent({ name: 'AppError' }).exists()).toBeFalsy();
     });
 
-    it('if user is not authorized, authorization component in the base page page should be rendered', async () => {
+    it('if user is not authorized, authorization component in the base page should be rendered', async () => {
       error.value = { response: { status: 403 } };
       const { wrapper } = makeWrapper();
 


### PR DESCRIPTION
A pass for accidentally repeated words in comments, docstrings and test
titles - sixteen of them across Python, Vue and one docs page: "at at",
"a a", "be be", "that that", "to to", "we we", "return return", "should
should", "page page" and several "the the". `docs/i18n.rst` also had
"directionalty" in the same sentence as one of them.

One is slightly more than a de-duplication: a comment read "If we get a
class ID different that that in Vuex state", which now reads "different
from that in Vuex state".

The only non-comment string touched is a `ValidationError` message in
`core/discovery/models.py` ("must be be created with an instance ID"),
which is not asserted on in the tests and is not a translated string. Two
Jest test titles change; there are no snapshot files for them.

## AI usage

I used AI for support on this one and it is worth being precise about
how, since the change is a sweep rather than a single edit.

- **Disclose:** I used Claude Code to search the codebase for repeated
  words in comments, docstrings and test titles, and to apply the
  one-word edits it found.
- **Engage critically:** I went through every hit before accepting it.
  Several were rejected - "many many objects" in
  `packages/kolibri-format/index.js` reads as deliberate emphasis rather
  than a slip, so I left it alone, and I checked that the one non-comment
  string (the `ValidationError` in `core/discovery/models.py`) is neither
  asserted on in the tests nor a translated `msgid`.
- **Edit:** One suggestion was a plain de-duplication that would have
  left the sentence broken - "a class ID different that that in Vuex
  state" - so I rewrote it as "different from that in Vuex state"
  instead.
- **Process sharing:** the useful part was treating the search as
  candidates rather than fixes. A doubled-word search finds intentional
  repetition and missing words as well as real duplicates, so each hit
  needed reading in context; roughly one in five was not a simple
  duplicate.

Two Jest test titles change; there are no snapshot files under
`packages/kolibri` for them, so nothing needed regenerating. I have not
run pre-commit here - the change is text inside existing lines, so no
formatting or lint rule is affected.
