### PR TITLE
fix: normalize dev versions to valid SemVer strings

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -200,6 +200,22 @@ class TestKolibriVersion(unittest.TestCase):
             "0.16-b.1",
         )
 
+    def test_normalize_version_to_semver_scm_dev(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.1.2.dev6+gdef09150",
+            ),
+            "0.1.2-dev6.gdef09150",
+        )
+
+    def test_normalize_version_to_semver_bipartite_dev(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.1.dev38363+g356cfe2f5",
+            ),
+            "0.1.0-dev38363.g356cfe2f5",
+        )
+
     @parameterized.expand(
         [
             ("0.15.8", ">=0.15.8", True),

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -50,16 +50,22 @@ def version_matches_range(version, version_range):
 
 
 def normalize_version_to_semver(version):
-    # dev = re.match(r"(.*?)(\.dev.*)?$", version).group()
     dev_match = re.match(r"(.*?)(\.dev.*)?$", version)
-
+    pre_dev = dev_match.group(1)
     dev = dev_match.group(2)
 
-    # extract the numeric semver component and the stuff that comes after
+    # extract numeric and prerelease from pre_dev
+    m = re.match(r"(^\d+\.\d+(?:\.\d+)?)([a-z0-9.+]*)", pre_dev)
+    if m:
+        numeric, after = m.groups()
+    else:
+        numeric, after = re.match(
+            r"(^\d+\.\d+[0-9]*\.?[0-9]*)([a-z0-9.+]*)", version
+        ).groups()
 
-    numeric, after = re.match(
-        r"(^\d+\.\d+[0-9]*\.?[0-9]*)([a-z0-9.+]*)", version
-    ).groups()
+    # If bipartite and followed by dev, ensure a patch segment exists for semver
+    if numeric.count(".") == 1 and dev:
+        numeric = numeric + ".0"
 
     # clean up the different variations of the post-numeric component to ease checking
     after = (after or "").strip("-").strip("+").strip(".").split("+")[0]
@@ -72,7 +78,16 @@ def normalize_version_to_semver(version):
     # make sure dev versions are sorted nicely relative to one another
     dev = (dev or "").replace("+", ".").replace("-", ".")
 
-    return "{}-{}{}".format(numeric, after, dev).strip("-")
+    if after and dev:
+        suffix = after + dev
+    elif after:
+        suffix = after
+    elif dev:
+        suffix = dev.lstrip(".")
+    else:
+        suffix = ""
+
+    return "{}-{}".format(numeric, suffix) if suffix else numeric
 
 
 def truncate_version(version, truncation_level=PATCH_VERSION):


### PR DESCRIPTION
## Summary

* **Headline:** Normalize development and fallback build version strings to valid SemVer 2.0 identifiers.
* **Motivation:** When running tests or starting Kolibri in environments without release tags (e.g. fresh clones, forks, or shallow checkouts), `setuptools-scm` emits fallback development versions such as `0.1.dev38363+g356cfe2f5`. During module initialization, `kolibri.core.upgrade` passes `kolibri.__version__` through `normalize_version_to_semver()` before parsing it with `semver.VersionInfo.parse()`. Due to a regex flaw in `normalize_version_to_semver()`, the preceding dot before `.dev` was captured into the numeric prefix and `.dev` was duplicated into both `after` and `dev`, producing `0.1.-dev38363.dev38363.g356cfe2f5`. This causes `semver.VersionInfo.parse()` to raise an unhandled `ValueError: ... is not valid SemVer string`, breaking pytest and Django startup entirely. Similarly, standard post-release dev strings like `0.1.2.dev6+gdef09150` resulted in `0.1.2-dev6.dev6.gdef09150`.
* **Approach:**
  1. Deconstruct the version string into its pre-dev base and `.dev` suffix separately so the dev fragment is never matched twice.
  2. Parse the base version using `^\d+\.\d+(?:\.\d+)?` to prevent trailing dot leakage into the numeric prefix.
  3. Ensure bipartite numeric versions followed by a dev suffix (e.g., `0.1.dev...`) receive a `.0` patch segment so they comply with SemVer's `MAJOR.MINOR.PATCH` specification.
  4. Preserve existing behavior for standard release and prerelease tags (`0.15.0`, `1.10`, `0.14a1`, `0.16b1`).
  5. Add unit test coverage in `kolibri/utils/tests/test_version.py` for both `setuptools-scm` dev and bipartite fallback versions.

## References

* Fixes #15269 

## Reviewer guidance

* Run unit tests for version normalization:
  ```bash
  uv run pytest kolibri/utils/tests/test_version.py
  ```
  All 76 tests should pass.
* Verify Django test settings load and execute properly on dev builds:
  ```bash
  uv run pytest kolibri/core/courses/test/test_models.py
  ```
  Verify that `kolibri.core.upgrade` imports cleanly without `ValueError`.
* Verify code formatting and linting:
  ```bash
  uv run ruff check kolibri/utils/version.py kolibri/utils/tests/test_version.py
  uv run ruff format --check kolibri/utils/version.py kolibri/utils/tests/test_version.py
  ```

## AI usage

I used Antigravity / Gemini to locate where `kolibri.core.upgrade` fails during pytest startup and identify the regex mismatch in `normalize_version_to_semver()`. I reviewed the SemVer 2.0 specification and `semver` library constraints, implemented the fix to prevent trailing dot leakage and duplicate `.dev` fragments, wrote regression tests in `kolibri/utils/tests/test_version.py`, and verified the entire test suite runs without errors.
