### PR TITLE
Bound CI job runtimes so stalled jobs fail fast

### DIFF
--- a/.github/scripts/apt-install.sh
+++ b/.github/scripts/apt-install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# apt-get update + install with bounded connections and an overall ceiling.
+#
+# Usage: apt-install.sh PACKAGE [PACKAGE ...]  (apt-get flags may be passed too)
+#
+# apt has no total-runtime ceiling of its own: Acquire::*::Timeout bounds a
+# single stalled connection and Acquire::Retries multiplies it, so an
+# unresponsive archive mirror holds a CI job open for hours rather than failing
+# it. The per-connection caps make one bad mirror fail fast enough for the
+# retries to reach a working one; `timeout` supplies the ceiling apt lacks.
+# Hosted runners hit this often enough to be the single largest source of
+# stalled builds.
+set -euo pipefail
+
+SUDO=""
+if [ "$(id -u)" != "0" ]; then
+  SUDO="sudo"
+fi
+
+APT_OPTS=(
+  -o Acquire::Retries=3
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+)
+
+# sudo drops DEBIAN_FRONTEND from the caller's environment, so set it here:
+# a package that asks debconf a question waits on the prompt forever otherwise.
+APT=(timeout 600 $SUDO env DEBIAN_FRONTEND=noninteractive apt-get "${APT_OPTS[@]}")
+
+"${APT[@]}" update
+"${APT[@]}" install -y "$@"

--- a/.github/workflows/build_pex.yml
+++ b/.github/workflows/build_pex.yml
@@ -15,6 +15,7 @@ jobs:
   build_pex:
     name: Build PEX
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       pex-file-name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
     steps:

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -21,14 +21,13 @@ jobs:
       whl-file-name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
       tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
     steps:
-      - name: Install Ubuntu dependencies
-        run: |
-          sudo apt-get -y -qq update
-          sudo apt-get install -y gettext sqlite3 binutils-aarch64-linux-gnu binutils-arm-linux-gnueabihf
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           lfs: true
+      - name: Install Ubuntu dependencies
+        run: >-
+          .github/scripts/apt-install.sh gettext sqlite3 binutils-aarch64-linux-gnu binutils-arm-linux-gnueabihf
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0
         with:

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -17,6 +17,7 @@ jobs:
   build_whl:
     name: Build WHL
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       whl-file-name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
       tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -21,6 +21,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -35,6 +36,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -18,6 +18,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -32,6 +33,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Install pnpm

--- a/.github/workflows/container_image_cleanup.yml
+++ b/.github/workflows/container_image_cleanup.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       packages: write
     steps:

--- a/.github/workflows/container_image_publish.yml
+++ b/.github/workflows/container_image_publish.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dependency_updates.yml
+++ b/.github/workflows/dependency_updates.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   update-h5p:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -113,6 +114,7 @@ jobs:
           base: develop
   update-precommit-hooks:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,6 +18,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -32,6 +33,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -7,6 +7,7 @@ jobs:
   download:
     name: Download translations and regenerate fonts
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       UV_PYTHON: "3.9"
     steps:

--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Install gettext
-        run: sudo apt-get update && sudo apt-get install -y gettext
+        run: .github/scripts/apt-install.sh gettext
       - name: Install Python dependencies
         # --all-packages installs the python_packages/* members; without them the
         # Makefile's importability guard skips their message-file generation and

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Install gettext
-        run: sudo apt-get update && sudo apt-get install -y gettext
+        run: .github/scripts/apt-install.sh gettext
       - name: Install Python dependencies
         # --all-packages installs the python_packages/* members; without them the
         # Makefile's importability guard skips their message extraction and their

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -7,6 +7,7 @@ jobs:
   upload:
     name: Extract and upload strings to Crowdin
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       UV_PYTHON: "3.9"
     steps:

--- a/.github/workflows/morango_integration.yml
+++ b/.github/workflows/morango_integration.yml
@@ -75,9 +75,17 @@ jobs:
         run: |
           echo "deb http://archive.debian.org/debian-archive/debian/ buster main" > /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
-          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
-          apt-get -y -qq update
-          apt-get install -y git git-lfs
+          # archive.debian.org regularly stalls mid-transfer, and apt bounds a
+          # single stalled connection but never its own total runtime — long
+          # enough to hold the job open for hours rather than failing it.
+          cat > /etc/apt/apt.conf.d/99archive <<'EOF'
+          Acquire::Check-Valid-Until "false";
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+          timeout 300 apt-get -y -qq update
+          timeout 300 apt-get install -y git git-lfs
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/morango_integration.yml
+++ b/.github/workflows/morango_integration.yml
@@ -19,6 +19,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -32,6 +33,7 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     env:
       INTEGRATION_TEST: 'true'
     strategy:
@@ -58,6 +60,7 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     env:
       INTEGRATION_TEST: 'true'
       PYTHONPATH: /home/runner/work/kolibri/kolibri
@@ -115,6 +118,7 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     env:
       INTEGRATION_TEST: 'true'
     services:

--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -21,6 +21,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -35,6 +36,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -45,6 +45,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read # Required for npm provenance attestation
       id-token: write # Required for npm OIDC trusted publishing

--- a/.github/workflows/npm_version_check.yml
+++ b/.github/workflows/npm_version_check.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/npm_version_comment.yml
+++ b/.github/workflows/npm_version_comment.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/platform-android-build_apk.yml
+++ b/.github/workflows/platform-android-build_apk.yml
@@ -69,6 +69,7 @@ jobs:
   build_apk:
     name: Build Android App
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: platforms/android

--- a/.github/workflows/platform-android-release_apk.yml
+++ b/.github/workflows/platform-android-release_apk.yml
@@ -20,6 +20,7 @@ jobs:
   release_apk:
     name: Release Android App
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: platforms/android

--- a/.github/workflows/platform-apt-repo-publish.yml
+++ b/.github/workflows/platform-apt-repo-publish.yml
@@ -45,9 +45,7 @@ jobs:
           DEB_URL: ${{ inputs.deb-url }}
         run: curl -fsSL --create-dirs --output-dir dist --remote-name "$DEB_URL"
       - name: Install reprepro and Debian packaging tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y reprepro dpkg-dev debhelper build-essential
+        run: .github/scripts/apt-install.sh reprepro dpkg-dev debhelper build-essential
       - name: Import the Debian repo signing key
         id: gpg
         run: |

--- a/.github/workflows/platform-apt-repo-publish.yml
+++ b/.github/workflows/platform-apt-repo-publish.yml
@@ -24,6 +24,7 @@ jobs:
   publish:
     name: Read-modify-write the reprepro repo on the release bucket
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # A publish is a read-modify-write against shared bucket state, so it must
     # never run concurrently with another publish nor be cancelled mid-write.
     concurrency:

--- a/.github/workflows/platform-apt-repo-test.yml
+++ b/.github/workflows/platform-apt-repo-test.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Install repo tooling
         # APT_REPO_TESTS_STRICT below turns a missing-tool SKIP into a failure,
         # so install everything the tests need (docker is preinstalled).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends reprepro gnupg dpkg-dev rsync
+        run: >-
+          .github/scripts/apt-install.sh --no-install-recommends reprepro gnupg dpkg-dev rsync
       - name: Run the apt-repo tests
         env:
           APT_REPO_TESTS_STRICT: "1"

--- a/.github/workflows/platform-apt-repo-test.yml
+++ b/.github/workflows/platform-apt-repo-test.yml
@@ -22,6 +22,7 @@ jobs:
   test:
     name: Run the apt-repo shell tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Install repo tooling

--- a/.github/workflows/platform-debian-server-build_deb.yml
+++ b/.github/workflows/platform-debian-server-build_deb.yml
@@ -14,6 +14,7 @@ jobs:
   build_deb:
     name: Build kolibri-server DEB file
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     outputs:
       deb-file-name: ${{ steps.get-deb-filename.outputs.deb-file-name }}
     steps:

--- a/.github/workflows/platform-debian-server-release.yml
+++ b/.github/workflows/platform-debian-server-release.yml
@@ -139,9 +139,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-launchpadlib
+        run: .github/scripts/apt-install.sh python3-launchpadlib
       - name: Write Launchpad credentials
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
@@ -167,9 +165,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-launchpadlib
+        run: .github/scripts/apt-install.sh python3-launchpadlib
       - name: Write Launchpad credentials
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
@@ -193,9 +189,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-launchpadlib
+        run: .github/scripts/apt-install.sh python3-launchpadlib
       - name: Write Launchpad credentials
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
@@ -230,9 +224,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-launchpadlib
+        run: .github/scripts/apt-install.sh python3-launchpadlib
       - name: Write Launchpad credentials
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}

--- a/.github/workflows/platform-debian-server-release.yml
+++ b/.github/workflows/platform-debian-server-release.yml
@@ -26,6 +26,7 @@ jobs:
   check_version:
     name: Resolve and validate the release version
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
@@ -68,6 +69,7 @@ jobs:
           echo "Debian version: ${VERSION}"
   build_package:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: check_version
     steps:
       - name: Checkout codebase
@@ -135,6 +137,8 @@ jobs:
       - check_version
       - build_package
     runs-on: ubuntu-latest
+    # launchpad_copy.py wait-for-published gives up after 30 minutes of its own.
+    timeout-minutes: 45
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
@@ -161,6 +165,7 @@ jobs:
   copy_to_other_distributions:
     needs: wait_for_source_published
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
@@ -185,6 +190,8 @@ jobs:
       - check_version
       - copy_to_other_distributions
     runs-on: ubuntu-latest
+    # launchpad_copy.py wait-for-published gives up after 30 minutes of its own.
+    timeout-minutes: 45
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1
@@ -211,6 +218,9 @@ jobs:
     needs:
       - wait_for_copies_published
     runs-on: ubuntu-latest
+    # Only bounds the job once approval is granted; the approval wait itself
+    # happens before the job starts and is not subject to this timeout.
+    timeout-minutes: 10
     environment: release
     steps:
       - run: echo "Release approved — proceeding to promote to kolibri PPA."
@@ -220,6 +230,8 @@ jobs:
       - check_version
       - block_release_step
     runs-on: ubuntu-latest
+    # launchpad_copy.py wait-for-published gives up after 30 minutes of its own.
+    timeout-minutes: 45
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/platform-macos-app-build_dmg.yml
+++ b/.github/workflows/platform-macos-app-build_dmg.yml
@@ -47,6 +47,7 @@ jobs:
   build_dmg:
     # This seems to be the only way to specify an intel based runner
     runs-on: macos-15-intel
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: platforms/desktop-app

--- a/.github/workflows/platform-pi-build_img.yml
+++ b/.github/workflows/platform-pi-build_img.yml
@@ -28,6 +28,7 @@ jobs:
   build_zip:
     name: Build Pi image
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
     env:
       CACHE_VERSION: v3
     outputs:

--- a/.github/workflows/platform-windows-app-build_exe.yml
+++ b/.github/workflows/platform-windows-app-build_exe.yml
@@ -41,6 +41,7 @@ jobs:
   build_exe:
     name: Build EXE file
     runs-on: windows-latest
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: platforms/desktop-app

--- a/.github/workflows/platform-windows-app-build_exe.yml
+++ b/.github/workflows/platform-windows-app-build_exe.yml
@@ -71,7 +71,21 @@ jobs:
       - name: Install build dependencies
         run: make dependencies
       - name: Install wget and Inno Setup
-        run: choco install wget --no-progress && choco install innosetup --version=6.6.1 --allow-downgrade --no-progress
+        shell: pwsh
+        run: |
+          # community.chocolatey.org serves 504s from its V2 feed often enough to
+          # be a leading cause of failed Windows builds; retry rather than fail.
+          function Install-ChocoPackage {
+            param([string[]]$ChocoArgs)
+            for ($attempt = 1; $attempt -le 3; $attempt++) {
+              choco install @ChocoArgs --no-progress
+              if ($LASTEXITCODE -eq 0) { return }
+              if ($attempt -lt 3) { Start-Sleep -Seconds (15 * $attempt) }
+            }
+            throw "choco install $ChocoArgs failed after 3 attempts"
+          }
+          Install-ChocoPackage @('wget')
+          Install-ChocoPackage @('innosetup', '--version=6.6.1', '--allow-downgrade')
       - name: Download and install the whl from URL
         if: ${{ inputs.whl-url }}
         shell: pwsh

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -11,6 +11,7 @@ jobs:
   postgres:
     name: Python postgres unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       max-parallel: 5
       matrix:

--- a/.github/workflows/pr_build_comment.yml
+++ b/.github/workflows/pr_build_comment.yml
@@ -14,6 +14,7 @@ jobs:
   post:
     name: Add build artifact PR comment
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -115,6 +115,7 @@ jobs:
     name: Android smoke test (API ${{ matrix.api-level }})
     needs: apk
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -268,6 +269,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         cext: [true, false]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0
@@ -299,6 +301,7 @@ jobs:
         python-version: [3.6, 3.7]
         cext: [true, false]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: python:${{ matrix.python-version }}-buster
     steps:
@@ -324,6 +327,7 @@ jobs:
       - test_whl_file_no_uv
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Fail if any needed job failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -175,13 +175,16 @@ jobs:
           # or a script file, not here, and directory changes do not persist between
           # lines — reference platforms/android explicitly.
           script: |
-            adb install -r platforms/android/dist/*.apk
-            adb shell am set-debug-app --persistent org.learningequality.Kolibri
-            adb wait-for-device
-            until adb shell pm path org.learningequality.Kolibri >/dev/null 2>&1; do sleep 1; done
+            # An emulator that goes offline mid-command leaves adb blocked with no
+            # ceiling of its own, so cap every call: observed as a 29 minute
+            # `adb install` on API 24 that ended only when the job timed out.
+            timeout 300 adb install -r platforms/android/dist/*.apk
+            timeout 60 adb shell am set-debug-app --persistent org.learningequality.Kolibri
+            timeout 120 adb wait-for-device
+            timeout 300 sh -c 'until adb shell pm path org.learningequality.Kolibri >/dev/null 2>&1; do sleep 1; done'
             # Pre-grant so the WRITE_EXTERNAL_STORAGE dialog (API 24-28) never appears.
             # `|| true`: the permission doesn't exist on API 29+.
-            adb shell pm grant org.learningequality.Kolibri android.permission.WRITE_EXTERNAL_STORAGE || true
+            timeout 60 adb shell pm grant org.learningequality.Kolibri android.permission.WRITE_EXTERNAL_STORAGE || true
             # Let the launcher settle before app launch, to avoid the "Pixel Launcher
             # isn't responding" ANR seen on the API 35 runner under cold-boot contention.
             sleep 15

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -99,13 +99,8 @@ jobs:
           echo "kolibri-server kolibri-server/port select ${KOLIBRI_SERVER_PORT}" | sudo debconf-set-selections
           echo "kolibri-server kolibri-server/zip_content_port select 8081" | sudo debconf-set-selections
       - name: Install the Kolibri and kolibri-server debs
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            "./debs/${{ needs.deb.outputs.deb-file-name }}" \
-            "./debs/${{ needs.server_deb.outputs.deb-file-name }}"
+        run: >-
+          .github/scripts/apt-install.sh "./debs/${{ needs.deb.outputs.deb-file-name }}" "./debs/${{ needs.server_deb.outputs.deb-file-name }}"
       - name: Start kolibri-server
         run: sudo service kolibri-server restart
       - name: Assert Kolibri is served through nginx

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -176,12 +176,11 @@ jobs:
           # or a script file, not here, and directory changes do not persist between
           # lines — reference platforms/android explicitly.
           script: |
-            # An emulator that goes offline mid-command leaves adb blocked with no
-            # ceiling of its own, so cap every call: observed as a 29 minute
-            # `adb install` on API 24 that ended only when the job timed out.
-            timeout 300 adb install -r platforms/android/dist/*.apk
-            timeout 60 adb shell am set-debug-app --persistent org.learningequality.Kolibri
-            timeout 120 adb wait-for-device
+            # Caps are ~30x the observed normal (6s install, under 1s for the rest);
+            # 3 attempts each still fit the job's cap after a 10 minute emulator boot.
+            platforms/android/scripts/adb-retry.sh 180 3 install -r platforms/android/dist/*.apk
+            platforms/android/scripts/adb-retry.sh 60 3 shell am set-debug-app --persistent org.learningequality.Kolibri
+            platforms/android/scripts/adb-retry.sh 120 3 wait-for-device
             timeout 300 sh -c 'until adb shell pm path org.learningequality.Kolibri >/dev/null 2>&1; do sleep 1; done'
             # Pre-grant so the WRITE_EXTERNAL_STORAGE dialog (API 24-28) never appears.
             # `|| true`: the permission doesn't exist on API 29+.

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -5,6 +5,7 @@ permissions:
 jobs:
   size-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Label the PR size
     permissions:
       contents: read
@@ -28,6 +29,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/labeler@v7
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -35,6 +36,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Set up uv

--- a/.github/workflows/pypi_packages_publish.yml
+++ b/.github/workflows/pypi_packages_publish.yml
@@ -37,6 +37,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       PYPI_TARGET: ${{ github.event.inputs.target }}
     permissions:

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -8,6 +8,7 @@ jobs:
   latest_release:
     name: Check if this release is the latest release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       is_latest_release: ${{ steps.is_latest_release.outputs.result }}
     steps:
@@ -156,6 +157,7 @@ jobs:
     name: Upload to TestPyPi
     needs: [whl]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write
     steps:
@@ -174,6 +176,7 @@ jobs:
   gcs_upload:
     name: Upload to Google Cloud Storage for LE Downloads
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [whl, pex, dmg, deb, exe, zip, apk]
     strategy:
       matrix:
@@ -198,6 +201,7 @@ jobs:
   bck_gcs_upload:
     name: Upload WHL file to Google Cloud Storage for BCK
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [whl]
     steps:
       - name: Download WHL artifact
@@ -241,6 +245,9 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     needs: [whl, pex, dmg, deb, exe, zip, apk, test_pypi_upload]
     runs-on: ubuntu-latest
+    # Only bounds the job once approval is granted; the approval wait itself
+    # happens before the job starts and is not subject to this timeout.
+    timeout-minutes: 10
     environment: release
     steps:
       - run: echo "Release now publishing!"
@@ -249,6 +256,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     needs: [whl, block_release_step]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -28,6 +28,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +72,7 @@ jobs:
   zizmor:
     name: Audit workflows with zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,7 @@ jobs:
   pre_job:
     name: Path match check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -35,6 +36,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -61,6 +63,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.11', '3.12', '3.13', '3.14']
@@ -89,6 +92,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.6, 3.7]
@@ -145,6 +149,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     services:
       # Label used to access the service container
       postgres:
@@ -193,6 +198,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ['3.9', '3.14']
@@ -236,6 +242,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: macos-14
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.10']
@@ -260,6 +267,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: windows-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.8]
@@ -289,6 +297,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -320,6 +329,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -354,6 +364,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -398,6 +409,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -423,6 +435,7 @@ jobs:
     needs: [pre_job, stage1_required_checks]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' && needs.stage1_required_checks.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Set up JDK 21
@@ -452,6 +465,7 @@ jobs:
       - unit_test_stage1
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Fail if any needed job failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -478,6 +492,7 @@ jobs:
       - android_jvm_tests
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Fail if any needed job failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -105,9 +105,17 @@ jobs:
         run: |
           echo "deb http://archive.debian.org/debian-archive/debian/ buster main" > /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
-          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
-          apt-get -y -qq update
-          apt-get install -y git git-lfs
+          # archive.debian.org regularly stalls mid-transfer, and apt bounds a
+          # single stalled connection but never its own total runtime — long
+          # enough to hold the job open for hours rather than failing it.
+          cat > /etc/apt/apt.conf.d/99archive <<'EOF'
+          Acquire::Check-Valid-Until "false";
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+          timeout 300 apt-get -y -qq update
+          timeout 300 apt-get install -y git git-lfs
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
@@ -372,9 +380,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Install system dependencies
         if: ${{ matrix.system-packages }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.system-packages }}
+        run: .github/scripts/apt-install.sh ${{ matrix.system-packages }}
       - name: Install dependencies
         # --all-packages keeps root kolibri's runtime deps in the shared venv;
         # see the sync_extras_plugin_tests note above.

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-python@v7

--- a/.github/workflows/upload_github_release_asset.yml
+++ b/.github/workflows/upload_github_release_asset.yml
@@ -14,6 +14,7 @@ jobs:
   github_upload:
     name: Upload to Github release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Download ${{ inputs.filename }} artifact

--- a/platforms/android/Makefile
+++ b/platforms/android/Makefile
@@ -36,6 +36,7 @@ AVD_NAME := kolibri-test
 SYSTEM_IMAGE := system-images;android-$(ANDROID_API);default;x86_64
 
 ADB := adb
+ADB_RETRY := scripts/adb-retry.sh
 
 # Environment variable check helper
 guard-%:
@@ -248,8 +249,8 @@ smoke-test-with-retry: maestro-install
 			exit 1; \
 		fi; \
 		echo "Smoke test attempt $$attempt failed; resetting app state and retrying"; \
-		$(ADB) shell am force-stop org.learningequality.Kolibri || true; \
-		$(ADB) shell pm clear org.learningequality.Kolibri || true; \
+		$(ADB_RETRY) 60 2 shell am force-stop org.learningequality.Kolibri || true; \
+		$(ADB_RETRY) 60 2 shell pm clear org.learningequality.Kolibri || true; \
 		sleep 3; \
 	done
 

--- a/platforms/android/scripts/adb-retry.sh
+++ b/platforms/android/scripts/adb-retry.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Run an adb command under a per-attempt timeout, restarting the adb server
+# between attempts.
+#
+# Usage: adb-retry.sh TIMEOUT ATTEMPTS ADB_ARG [ADB_ARG ...]
+#
+# adb has no timeout of its own, so an emulator that drops to `device offline`
+# mid-command blocks the call until something else kills it — observed as a 29
+# minute `adb install` on CI's API 24 image that ended only when the job hit
+# its own cap. The emulator process usually survives the dropped connection,
+# so restarting the adb server and re-running recovers the run.
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 TIMEOUT ATTEMPTS ADB_ARG [ADB_ARG ...]" >&2
+  exit 2
+fi
+
+attempt_timeout=$1
+attempts=$2
+shift 2
+
+# Cap on each step of the recovery itself, which can wedge the same way.
+RECOVERY_TIMEOUT=60
+
+# macOS has no timeout(1); coreutils installs it as gtimeout. Fail loudly
+# rather than silently running uncapped.
+TIMEOUT=$(command -v timeout || command -v gtimeout || true)
+if [ -z "$TIMEOUT" ]; then
+  echo "$0: no timeout(1) on PATH (macOS: brew install coreutils)" >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  status=0
+  "$TIMEOUT" "$attempt_timeout" adb "$@" || status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  echo "$0: adb $* failed (exit $status) on attempt $attempt of $attempts" >&2
+  if [ "$attempt" -ge "$attempts" ]; then
+    exit "$status"
+  fi
+  attempt=$((attempt + 1))
+  "$TIMEOUT" "$RECOVERY_TIMEOUT" adb kill-server || true
+  "$TIMEOUT" "$RECOVERY_TIMEOUT" adb wait-for-device || true
+done

--- a/platforms/debian-server/Makefile
+++ b/platforms/debian-server/Makefile
@@ -3,8 +3,12 @@
 
 # Auto-detect sudo: empty in containers (root), "sudo" on dev machines
 SUDO := $(shell [ "$$(id -u)" = "0" ] && echo "" || echo "sudo")
-APT_UPDATE := $(SUDO) apt-get update
-APT_INSTALL := $(SUDO) apt-get install -y
+# apt bounds a single stalled connection but never its own total runtime, so an
+# unresponsive mirror holds a CI build open for hours instead of failing it.
+APT_OPTS := -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30
+APT_TIMEOUT := timeout 600
+APT_UPDATE := $(APT_TIMEOUT) $(SUDO) apt-get $(APT_OPTS) update
+APT_INSTALL := $(APT_TIMEOUT) $(SUDO) apt-get $(APT_OPTS) install -y
 
 help:
 	@echo "changelog          - prepare debian/changelog file with the new version number"

--- a/platforms/desktop-app/tests/test_installer_language_files.py
+++ b/platforms/desktop-app/tests/test_installer_language_files.py
@@ -88,7 +88,8 @@ def test_crowdin_messages_are_ignored_where_inno_translates_them(locale_dir):
 
 def test_inno_tag_matches_the_compiler_version_the_build_installs():
     version = re.search(
-        r"innosetup --version=(\S+)", BUILD_WORKFLOW.read_text(encoding="utf-8")
+        r"innosetup[^\n\d]*--version=([\d.]+)",
+        BUILD_WORKFLOW.read_text(encoding="utf-8"),
     ).group(1)
     assert INNO_TAG == f"is-{version.replace('.', '_')}"
 

--- a/platforms/raspberry-pi/Makefile
+++ b/platforms/raspberry-pi/Makefile
@@ -2,6 +2,11 @@
 
 DIST_DIR := dist
 
+# apt bounds a single stalled connection but never its own total runtime, so an
+# unresponsive mirror holds a CI build open for hours instead of failing it.
+APT_OPTS := -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30
+APT_TIMEOUT := timeout 600
+
 SOURCE_FILE = images/source.xz
 SOURCE_URL = https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-12-04/2025-12-04-raspios-trixie-arm64-lite.img.xz
 
@@ -41,8 +46,8 @@ pimod:
 	git clone --depth=1 https://github.com/Nature40/pimod.git -b v0.9.1
 
 install-dependencies:
-	sudo apt-get update -y
-	sudo apt-get install -y fdisk file kpartx qemu-utils qemu-user-static unzip p7zip-full wget xz-utils units
+	$(APT_TIMEOUT) sudo apt-get $(APT_OPTS) update -y
+	$(APT_TIMEOUT) sudo apt-get $(APT_OPTS) install -y fdisk file kpartx qemu-utils qemu-user-static unzip p7zip-full wget xz-utils units
 	$(MAKE) pimod
 
 images/base.img: images/source.img

--- a/platforms/raspberry-pi/base.Pifile
+++ b/platforms/raspberry-pi/base.Pifile
@@ -4,6 +4,11 @@ TO images/base.img
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# apt bounds a single stalled connection but never its own total runtime, so a
+# mirror that stops responding holds the image build open until the job's cap.
+apt_opts="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+apt_timeout="timeout 600"
+
 user=pi
 
 # Enable SSH
@@ -30,8 +35,8 @@ RUN chmod -R +rwx /KOLIBRI_DATA
 RUN chown -R ${user}:${user} /home/${user}
 RUN chmod -R +rwx /home/${user}
 
-RUN apt-get update
-RUN apt-get install -y nginx-full uwsgi uwsgi-plugin-python3 redis-server dnsmasq
+RUN ${apt_timeout} apt-get ${apt_opts} update
+RUN ${apt_timeout} apt-get ${apt_opts} install -y nginx-full uwsgi uwsgi-plugin-python3 redis-server dnsmasq
 
 RUN debconf-set-selections <<EOF
 $(cat files/debconf)

--- a/platforms/raspberry-pi/kolibri.Pifile
+++ b/platforms/raspberry-pi/kolibri.Pifile
@@ -5,6 +5,12 @@ PUMP 500M
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# apt bounds a single stalled connection but never its own total runtime, so a
+# mirror that stops responding holds the image build open until the job's cap.
+# The debs are local, but their dependencies still come from the network.
+apt_opts="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
+apt_timeout="timeout 600"
+
 echo "--- Using Kolibri deb"
 
 # Preseeding package config
@@ -19,7 +25,7 @@ RUN apt-get clean
 # All files copied at build stage to /pi-gen
 INSTALL dist/kolibri_*.deb /tmp/kolibri.deb
 
-RUN apt-get install -y /tmp/kolibri.deb
+RUN ${apt_timeout} apt-get ${apt_opts} install -y /tmp/kolibri.deb
 RUN rm /tmp/kolibri.deb
 
 RUN ls -la /home/pi/.kolibri/options.ini
@@ -28,7 +34,7 @@ RUN ls -la /home/pi/.kolibri/options.ini
 # released APT source is still added in base.Pifile, so it is upgraded from there
 # on later apt updates, the same as the kolibri deb.
 INSTALL dist/kolibri-server_*.deb /tmp/kolibri-server.deb
-RUN apt-get install -y /tmp/kolibri-server.deb
+RUN ${apt_timeout} apt-get ${apt_opts} install -y /tmp/kolibri-server.deb
 RUN rm /tmp/kolibri-server.deb
 
 RUN systemctl enable kolibri-server


### PR DESCRIPTION
## Summary

* Many of our GHA runs can get stalled at various points
* Rather than failing fast, this can leave jobs running for up to 5 hours
* Add shorter timeouts to GHA jobs/steps to ensure against this
* For specific things that have led to long timeouts (Ubuntu apt installs, adb commands) add specific timeout behaviour to ensure they fail faster.
* Where the stall is recoverable — choco 504s, dodgy adb connection — retry instead of only failing faster.

## References

## Reviewer guidance

CI on this PR exercises every workflow that runs on `pull_request`, including the platform builds `pr_build_kolibri` calls (whl, pex, dmg, deb, exe, apk, pi img).

Open risks:
- Release- and dispatch-only workflows (`release_kolibri`, `npm_publish`, `pypi_packages_publish`, apt-repo publish, Android release) are not tested in PR
- `adb-retry.sh` assumes the emulator survives a dropped adb connection: it restarts the adb server and re-runs. A wedge that survives three attempts still fails the leg.
- apt now runs under an overall `timeout`, so a kill lands mid-transaction. Fine on a disposable runner; the Pi image build discards the image on failure.

## AI usage

Used Claude Code to survey the workflows for missing ceilings and to draft the apt wrapper, choco retry, and the adb cap/retry wrapper. Verified with self-review of the full diff, a fake-`adb` harness exercising the retry script's success/failure/timeout paths, and CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pmVwHFRw4t2XtGmQKGvrx
